### PR TITLE
minSdk 16 + fix Settings crash on older Android + prevent SDK16 crash (mic fix)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,7 +47,7 @@ android {
 
     defaultConfig {
         applicationId = "com.andrerinas.headunitrevived"
-        minSdk = 17
+        minSdk = 16
         //minSdk = 21 // 21 only for google play console. App should work in minSDK 19 or maybe 17
         targetSdk = 36
         versionCode = 27

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/SystemUI.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/SystemUI.kt
@@ -6,6 +6,8 @@ import android.view.Window
 import android.view.WindowInsets
 import android.view.WindowInsetsController
 import android.view.WindowManager
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 object SystemUI {
 
@@ -45,34 +47,18 @@ object SystemUI {
             }
         }
 
-        // Manual Inset Handling for Edge-to-Edge (Android 15+)
-        root.setOnApplyWindowInsetsListener { v, insets ->
+        // Manual Inset Handling using compat APIs (safe on API < 21)
+        ViewCompat.setOnApplyWindowInsetsListener(root) { v, insetsCompat ->
             if (fullscreen) {
                 v.setPadding(0, 0, 0, 0)
             } else {
-                val left: Int
-                val top: Int
-                val right: Int
-                val bottom: Int
-
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    val bars = insets.getInsets(WindowInsets.Type.systemBars())
-                    left = bars.left
-                    top = bars.top
-                    right = bars.right
-                    bottom = bars.bottom
-                } else {
-                    left = insets.systemWindowInsetLeft
-                    top = insets.systemWindowInsetTop
-                    right = insets.systemWindowInsetRight
-                    bottom = insets.systemWindowInsetBottom
-                }
-                v.setPadding(left, top, right, bottom)
+                val bars = insetsCompat.getInsets(WindowInsetsCompat.Type.systemBars())
+                v.setPadding(bars.left, bars.top, bars.right, bars.bottom)
             }
-            insets
+            insetsCompat
         }
-        
-        root.requestApplyInsets()
+
+        ViewCompat.requestApplyInsets(root)
     }
     
     // Compatibility method for SurfaceActivity (if we keep it calling hide)

--- a/app/src/main/res/layout/layout_category_header.xml
+++ b/app/src/main/res/layout/layout_category_header.xml
@@ -8,7 +8,7 @@
     android:paddingEnd="16dp"
     android:paddingTop="16dp"
     android:paddingBottom="8dp"
-    android:textColor="?android:attr/colorAccent"
+    android:textColor="?attr/colorAccent"
     android:textSize="14sp"
     android:textStyle="bold"
     tools:text="KATEGORIE ÜBERSCHRIFT" />


### PR DESCRIPTION
- Updated minimum supported Android version to SDK 16.
- Fixed app crash on lower Android versions when opening Settings.
- Fixed crash on SDK 16; app no longer crashes after the microphone-related fix.