### PR TITLE
Fix blurry icon on Android 4.4 KitKat

### DIFF
--- a/app/src/main/res/drawable/ic_usb_white.xml
+++ b/app/src/main/res/drawable/ic_usb_white.xml
@@ -1,8 +1,8 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt"
     android:viewportWidth="540.6"
     android:viewportHeight="540.6"
-    android:width="24dp"
-    android:height="24dp">
+    android:width="64dp"
+    android:height="64dp">
   <path
       android:pathData="M349.35 153v102h25.5v51h-76.5V102h51L272.85 0l-76.5 102h51v204h-76.5v-53.55c17.85 -7.65 30.6 -28.05 30.6 -48.45c0 -30.6 -25.5 -56.1 -56.1 -56.1s-56.1 25.5 -56.1 56.1c0 20.4 12.75 40.8 30.6 48.45V306c0 28.05 22.95 51 51 51h76.5v79.05c-17.85 10.2 -30.6 28.05 -30.6 48.45c0 30.6 25.5 56.1 56.1 56.1s56.1 -25.5 56.1 -56.1c0 -22.95 -12.75 -40.8 -30.6 -48.45V357h76.5c28.051 0 51 -22.95 51 -51v-51h25.5V153H349.35z"
       android:fillColor="#fff" />


### PR DESCRIPTION
KitKat does not support vector graphics, but the compatibility libraries generate the corresponding bitmap based on the vector definition. 
The USB icon appears blurry compared to the other icons because of the vector's width and height. 
I changed it to 64dp, like the other icon vectors, to fix the issue.