### PR TITLE
Correction for Chinese Mediatek Headunit Connection

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/SocketAccessoryConnection.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/SocketAccessoryConnection.kt
@@ -98,7 +98,18 @@ class SocketAccessoryConnection(private val ip: String, private val port: Int, p
                 }
                 
                 transport.soTimeout = 15000
-                transport.connect(InetSocketAddress(ip, port), 5000)
+                // Chinese Headunit Mediatek Correction
+                try {
+                    transport.connect(InetSocketAddress(ip, port), 5000)
+                } catch (e: Throwable) {
+                    val errorMessage = e.message ?: e.toString()
+                    if (errorMessage.contains("com.mediatek.cta.CtaHttp") || errorMessage.contains("CtaHttp")) {
+                        AppLog.e("HUR_DEBUG: MediaTek crash intercepted.")
+                    } else {
+                        throw java.io.IOException(e)
+                    }
+                }
+                // Chinese Headunit Mediatek Correction
             }
             transport.tcpNoDelay = true
             transport.keepAlive = true


### PR DESCRIPTION
An error(System.out: e:java.lang.ClassNotFoundException: com.mediatek.cta.CtaHttp W System : ClassLoader referenced unknown path: system/framework/mediatek-cta.jar) generated by some headunit devices with a Mediatek processor prevents connection to Android Auto. The added code prevents this error from dropping the connection.