### PR TITLE
Fix: return to active Android Auto session when app is reopened

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/main/MainActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.activity.viewModels
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.andrerinas.headunitrevived.R
+import com.andrerinas.headunitrevived.aap.AapProjectionActivity
 import com.andrerinas.headunitrevived.aap.AapService
 import com.andrerinas.headunitrevived.app.BaseActivity
 import com.andrerinas.headunitrevived.utils.AppLog
@@ -109,6 +110,16 @@ class MainActivity : BaseActivity() {
     override fun onResume() {
         super.onResume()
         setFullscreen()
+
+        // If an Android Auto session is active, bring the projection activity to front
+        if (AapService.isConnected) {
+            AppLog.i("MainActivity: Active session detected, bringing projection to front")
+            val aapIntent = AapProjectionActivity.intent(this).apply {
+                putExtra(AapProjectionActivity.EXTRA_FOCUS, true)
+                addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+            }
+            startActivity(aapIntent)
+        }
     }
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/UsbListFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/UsbListFragment.kt
@@ -165,9 +165,11 @@ class UsbListFragment : Fragment() {
                 notifyDataSetChanged()
             } else {
                 if (AapService.isConnected) {
-                    // Already connected -> just open UI
-                    val aapIntent = Intent(mContext, AapProjectionActivity::class.java)
-                    aapIntent.putExtra(AapProjectionActivity.EXTRA_FOCUS, true)
+                    // Already connected -> bring existing projection to front
+                    val aapIntent = AapProjectionActivity.intent(mContext).apply {
+                        putExtra(AapProjectionActivity.EXTRA_FOCUS, true)
+                        addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+                    }
                     mContext.startActivity(aapIntent)
                 } else if (device.isInAccessoryMode) {
                     // Device is in Accessory Mode but we are NOT connected.


### PR DESCRIPTION
## Problem
When Android Auto is running (`AapProjectionActivity` visible) and the user minimizes the app then taps the launcher icon, `MainActivity` is brought to front via its `singleTask` launch mode. Neither `onCreate()` nor `onResume()` check if there's an active AAP session, so the user sees the home screen instead of the running Android Auto projection. The connection is still alive (green status in USB list), but there's no way to get back to it without disconnecting and reconnecting.

Additionally, tapping a connected (green) device in `UsbListFragment` creates a bare `Intent` without proper flags, which may not bring the existing `AapProjectionActivity` instance to front correctly.

## Summary
- When an AA session is running and the user minimizes then taps the launcher icon, `MainActivity` now detects the active connection in `onResume()` and brings `AapProjectionActivity` back to front
- Fixes the USB list connected-device tap to use `AapProjectionActivity.intent()` factory method with `FLAG_ACTIVITY_REORDER_TO_FRONT` so the existing projection instance is reused

## Test plan
- [ ] Connect phone via USB, start Android Auto session
- [ ] Press Home to minimize, then tap launcher icon — should return to AA projection
- [ ] Verify normal connection flow still works when no session is active