### PR TITLE
Fix stale accessory reconnection on wireless AA dongles

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
@@ -788,9 +788,9 @@ class AapService : Service(), UsbReceiver.Listener {
 
              if (lastType == Settings.CONNECTION_TYPE_USB &&
                  (settings.autoConnectLastSession || settings.autoConnectSingleUsbDevice)) {
-                 AppLog.i("AapService: USB disconnect. Scheduling reconnect check in 3s...")
+                 AppLog.i("AapService: USB disconnect. Scheduling reconnect check in ${USB_RECONNECT_DELAY_MS}ms...")
                  serviceScope.launch {
-                     delay(3000)
+                     delay(USB_RECONNECT_DELAY_MS)
                      if (!isConnected) checkAlreadyConnectedUsb()
                  }
              }
@@ -1023,10 +1023,14 @@ class AapService : Service(), UsbReceiver.Listener {
             accessoryHandshakeFailures = 0
             val usbMode = UsbAccessoryMode(usbManager)
             serviceScope.launch(Dispatchers.IO) {
-                if (usbMode.connectAndSwitch(accessoryDevice)) {
-                    AppLog.i("AOA re-enumeration requested for stale device $deviceName")
-                } else {
-                    AppLog.w("AOA re-enumeration failed for $deviceName")
+                try {
+                    if (usbMode.connectAndSwitch(accessoryDevice)) {
+                        AppLog.i("AOA re-enumeration requested for stale device $deviceName")
+                    } else {
+                        AppLog.w("AOA re-enumeration failed for $deviceName")
+                    }
+                } catch (e: Exception) {
+                    AppLog.e("AOA re-enumeration for $deviceName failed with exception", e)
                 }
             }
         }
@@ -1053,6 +1057,7 @@ class AapService : Service(), UsbReceiver.Listener {
         private const val TYPE_USB = 1;
         private const val TYPE_WIFI = 2;
         private const val MAX_STALE_ACCESSORY_RETRIES = 1
+        private const val USB_RECONNECT_DELAY_MS = 3000L
         private const val EXTRA_CONNECTION_TYPE = "extra_connection_type";
         private const val EXTRA_IP = "extra_ip";
 


### PR DESCRIPTION
## Summary

Wireless AA dongles (e.g. Carlinkit) stay in accessory mode (Google `18D1:2D00`) after a session ends, but the USB endpoints contain leftover data from the previous SSL session. The app tried to reconnect directly to the stale device, read garbage instead of `VERSION_RESPONSE`, and failed every time — requiring the user to manually unplug and replug the dongle.

- **Stale accessory detection:** After 1 consecutive handshake failure on an accessory-mode device, forces AOA re-enumeration by sending AOA descriptors. This makes the dongle reboot as its native identity (e.g. Xiaomi `2717:FF40`) with clean USB buffers, then a fresh AOA switch succeeds automatically.
- **USB auto-reconnect on disconnect:** When a USB session ends unexpectedly and auto-connect is enabled, schedules a reconnect attempt after 3 seconds. This catches dongles that re-enumerate as their native identity after the stale session fails.
- **Counter reset on success:** Resets the handshake failure counter when a connection succeeds to prevent false positives on subsequent sessions.

> **Note:** This PR will have merge conflicts with #185 (USB permission fix) since both modify `AapService.kt`. Once #185 is merged, I'll rebase this branch to resolve the conflicts.

## Test plan

- [ ] Connect via wireless AA dongle, end session, verify automatic reconnection without manual unplug/replug
- [ ] Connect via direct USB phone, verify normal connection flow is unaffected
- [ ] Verify handshake failure counter resets after a successful connection
- [ ] Verify USB auto-reconnect fires after unexpected disconnect with auto-connect enabled