### PR TITLE
Add Bluetooth SCO microphone support and clarify mic source labels

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/decoder/MicRecorder.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/decoder/MicRecorder.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.media.AudioFormat
+import android.media.AudioManager
 import android.media.AudioRecord
 import android.media.MediaRecorder
 import androidx.core.content.PermissionChecker
@@ -40,6 +41,14 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
     private var threadMicAudio: Thread? = null
     var listener: Listener? = null
 
+    // Tracks whether this instance started Bluetooth SCO so we can clean it up
+    private var bluetoothScoStarted = false
+
+    companion object {
+        // Sentinel value stored in settings to indicate Bluetooth SCO mode
+        const val SOURCE_BLUETOOTH_SCO = 100
+    }
+
     interface Listener {
         fun onMicDataAvailable(mic_buf: ByteArray, mic_audio_len: Int)
     }
@@ -57,6 +66,15 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
             audioRecord!!.stop()
             audioRecord!!.release()                                     // Release AudioTrack resources
             audioRecord = null
+        }
+
+        if (bluetoothScoStarted) {
+            val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+            audioManager.stopBluetoothSco()
+            @Suppress("DEPRECATION")
+            audioManager.isBluetoothScoOn = false
+            bluetoothScoStarted = false
+            AppLog.i("MicRecorder: Bluetooth SCO stopped")
         }
     }
 
@@ -90,7 +108,20 @@ class MicRecorder(private val micSampleRate: Int, private val context: Context) 
                 audioRecord = null
                 return -3
             }
-            audioRecord = AudioRecord(settings.micInputSource, micSampleRate, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT, micBufferSize)
+            val configuredSource = settings.micInputSource
+            val actualSource: Int
+            if (configuredSource == SOURCE_BLUETOOTH_SCO) {
+                val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+                audioManager.startBluetoothSco()
+                @Suppress("DEPRECATION")
+                audioManager.isBluetoothScoOn = true
+                bluetoothScoStarted = true
+                actualSource = MediaRecorder.AudioSource.VOICE_COMMUNICATION
+                AppLog.i("MicRecorder: Bluetooth SCO started, using VOICE_COMMUNICATION source")
+            } else {
+                actualSource = configuredSource
+            }
+            audioRecord = AudioRecord(actualSource, micSampleRate, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT, micBufferSize)
             audioRecord!!.startRecording()
             // Start input
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
@@ -807,7 +807,7 @@ class SettingsFragment : Fragment() {
         ))
 
         val micSources = resources.getStringArray(R.array.mic_input_sources)
-        val micSourceValues = intArrayOf(0, 1, 6, 7) // DEFAULT, MIC, VOICE_RECOGNITION, VOICE_COMMUNICATION
+        val micSourceValues = intArrayOf(0, 1, 6, 7, 100) // DEFAULT, MIC, VOICE_RECOGNITION, VOICE_COMMUNICATION, BT_SCO
         val currentSourceIndex = micSourceValues.indexOf(pendingMicInputSource ?: 0).coerceAtLeast(0)
 
         items.add(SettingItem.SettingEntry(

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -180,10 +180,11 @@
     <string name="mic_input_source">Fonte de entrada do microfone</string>
     <string name="mic_input_source_description">Escolha a fonte de áudio para o microfone.</string>
     <string-array name="mic_input_sources">
-        <item>Padrão</item>
-        <item>Microfone</item>
-        <item>Reconhecimento de voz</item>
-        <item>Comunicação de voz</item>
+        <item>Padrão (sistema decide)</item>
+        <item>Microfone embutido (entrada bruta)</item>
+        <item>Reconhecimento de voz (redução de ruído)</item>
+        <item>Comunicação de voz (cancelamento de eco e ruído)</item>
+        <item>Fone Bluetooth (SCO)</item>
     </string-array>
 
     <!-- Info Settings -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -189,10 +189,11 @@
     <string name="mic_input_source">Microphone Input Source</string>
     <string name="mic_input_source_description">Choose the audio source for the microphone.</string>
     <string-array name="mic_input_sources">
-        <item>Default</item>
-        <item>Microphone</item>
-        <item>Voice Recognition</item>
-        <item>Voice Communication</item>
+        <item>Default (System decides)</item>
+        <item>Built-in Microphone (Raw input)</item>
+        <item>Voice Recognition (Noise reduced)</item>
+        <item>Voice Communication (Echo + noise cancelled)</item>
+        <item>Bluetooth Headset (SCO)</item>
     </string-array>
 
     <!-- Info Settings -->


### PR DESCRIPTION
## Summary

- **New option: Bluetooth Headset (SCO)** — `MicRecorder` now calls `AudioManager.startBluetoothSco()` before starting `AudioRecord` when this source is selected, routing audio through the `VOICE_COMMUNICATION` source. SCO is properly stopped when recording ends.
- **Clearer mic source labels** — each option now includes a brief description of what it does (e.g. noise reduction, echo cancellation), in both English and pt-BR, making the setting self-explanatory without needing external documentation.

## Changes

| File | Change |
|------|--------|
| `MicRecorder.kt` | Start/stop Bluetooth SCO around `AudioRecord`; sentinel value `100` triggers SCO mode |
| `SettingsFragment.kt` | Added value `100` to `micSourceValues` array |
| `values/strings.xml` | Renamed mic source options with descriptions + added BT SCO entry |
| `values-pt-rBR/strings.xml` | Same updates in Brazilian Portuguese |

## Notes

- `startBluetoothSco()` is asynchronous — the headset may take ~500ms to connect. If audio is not captured immediately after selecting this option, that is expected behavior. A follow-up improvement could listen for `ACTION_SCO_AUDIO_STATE_CHANGED` before starting the `AudioRecord`.
- No new permissions required — `BLUETOOTH`, `BLUETOOTH_CONNECT`, and `MODIFY_AUDIO_SETTINGS` are already declared in the manifest.

## Test plan

- [ ] Select **Bluetooth Headset (SCO)** with a paired BT headset connected → voice input works in Android Auto
- [ ] Switch back to any other source → SCO is released, built-in mic works normally
- [ ] Verify all existing mic source options still function correctly
- [ ] Verify updated labels display correctly in pt-BR locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)