### PR TITLE
Fix scaler Y

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/HeadUnitScreenConfig.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/HeadUnitScreenConfig.kt
@@ -212,7 +212,7 @@ object HeadUnitScreenConfig {
 
     fun getScaleY(): Float {
         if (getNegotiatedHeight() > screenHeightPx) {
-            return divideOrOne(getNegotiatedHeight().toFloat(), screenHeightPx.toFloat())
+            return divideOrOne((screenWidthPx.toFloat() / screenHeightPx.toFloat()), getAspectRatio())
         }
         if (isPortraitScaled) {
             return 1.0f


### PR DESCRIPTION
When using non-standard resolutions, artifacts such as padding or stretching would occur if the target Y-resolution was smaller than the codec's resolution. This fix corrects the display behavior