### PR TITLE
Remove appCategory="maps" from manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,7 +62,6 @@
         android:largeHeap="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/title"
-        android:appCategory="maps"
         tools:ignore="GoogleAppIndexingWarning">
 
         <activity


### PR DESCRIPTION
Removes `android:appCategory="maps"` from the manifest so hardware nav buttons recognize the app again, like they did in v1.15.

Fixes #231