### PR TITLE
Kill app on disconnect feature

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/CommManager.kt
@@ -341,6 +341,11 @@ class CommManager(
         _connectionState.value = ConnectionState.Disconnected(isClean, isUserExit = wasUserExit)
         // Transport already quit on its own — no ByeByeRequest needed (connection is dead).
         _disconnectJob = _scope.launch { doDisconnect(sendByeBye = false) }
+        if (settings.killOnDisconnect) {
+            android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
+                android.os.Process.killProcess(android.os.Process.myPid())
+            }, 500)
+        }
     }
 
     // -----------------------------------------------------------------------------------------
@@ -384,6 +389,11 @@ class CommManager(
 
         _connectionState.value = ConnectionState.Disconnected()
         _disconnectJob = _scope.launch { doDisconnect(sendByeBye) }
+        if (settings.killOnDisconnect) {
+            android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
+                android.os.Process.killProcess(android.os.Process.myPid())
+            }, 500)
+        }
     }
 
     /**

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
@@ -83,6 +83,8 @@ class SettingsFragment : Fragment() {
     
     // Flag to determine if the projection should stretch to fill the screen
     private var pendingStretchToFill: Boolean? = null
+
+    private var pendingKillOnDisconnect: Boolean? = null
     
     // Custom Insets
     private var pendingInsetLeft: Int? = null
@@ -135,6 +137,8 @@ class SettingsFragment : Fragment() {
         
         // Initialize local state for stretch to fill
         pendingStretchToFill = settings.stretchToFill
+
+        pendingKillOnDisconnect = settings.killOnDisconnect
         
         pendingInsetLeft = settings.insetLeft
         pendingInsetTop = settings.insetTop
@@ -259,6 +263,8 @@ class SettingsFragment : Fragment() {
 
         // Save the stretch to fill preference
         pendingStretchToFill?.let { settings.stretchToFill = it }
+
+        pendingKillOnDisconnect?.let { settings.killOnDisconnect = it }
         
         pendingInsetLeft?.let { settings.insetLeft = it }
         pendingInsetTop?.let { settings.insetTop = it }
@@ -345,7 +351,8 @@ class SettingsFragment : Fragment() {
                         pendingInsetBottom != settings.insetBottom ||
                         pendingMediaVolumeOffset != settings.mediaVolumeOffset ||
                         pendingAssistantVolumeOffset != settings.assistantVolumeOffset ||
-                        pendingNavigationVolumeOffset != settings.navigationVolumeOffset
+                        pendingNavigationVolumeOffset != settings.navigationVolumeOffset ||
+                        pendingKillOnDisconnect != settings.killOnDisconnect
 
         hasChanges = anyChange
 
@@ -457,6 +464,18 @@ class SettingsFragment : Fragment() {
             isChecked = pendingAutoStartOnUsb!!,
             onCheckedChanged = { isChecked ->
                 pendingAutoStartOnUsb = isChecked
+                checkChanges()
+                updateSettingsList()
+            }
+        ))
+
+        items.add(SettingItem.ToggleSettingEntry(
+            stableId = "killOnDisconnect",
+            nameResId = R.string.kill_on_disconnect,
+            descriptionResId = R.string.kill_on_disconnect_description,
+            isChecked = pendingKillOnDisconnect!!,
+            onCheckedChanged = { isChecked ->
+                pendingKillOnDisconnect = isChecked
                 checkChanges()
                 updateSettingsList()
             }

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
@@ -527,4 +527,8 @@ class Settings(context: Context) {
         get() = prefs.getBoolean("enable-rotary", false)
         set(value) { prefs.edit().putBoolean("enable-rotary", value).apply() }
 
+    var killOnDisconnect: Boolean
+        get() = prefs.getBoolean("kill-on-disconnect", false)
+        set(value) { prefs.edit().putBoolean("kill-on-disconnect", value).apply() }
+
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -352,4 +352,8 @@
     <string name="category_input">Input Settings</string>
     <string name="enable_rotary">Enable Rotary Controller</string>
     <string name="enable_rotary_description">Announce support for physical rotary knobs and wheels. Disable this if your touch screen is not working correctly.</string>
+
+    <string name="kill_on_disconnect">Kill app on disconnect</string>
+    <string name="kill_on_disconnect_description">Automatically close the app when Android Auto disconnects</string>
+
 </resources>


### PR DESCRIPTION
Hi! I'm not a developer but I'm a user of this app and wanted to add a feature that I felt was missing.

I used AI to help me write this code as I have no coding experience. So I'd really appreciate if you could review the code quality and suggest any improvements or changes needed.

The feature adds a toggle setting called "Kill app on disconnect" in the General settings section. When enabled, the app automatically closes itself 500ms after Android Auto projection disconnects. This works for all disconnect types — phone disconnecting, USB unplugging, or manual disconnect.

Changes made:
- Settings.kt: Added killOnDisconnect boolean preference
- CommManager.kt: Added kill logic in transportedQuited() and disconnect()
- SettingsFragment.kt: Added toggle UI in General settings
- strings.xml: Added string resources for the new setting

Happy to make any changes you suggest!