### PR TITLE
Fix layout crash on Android 4.2 with versioned drawable

### DIFF
--- a/app/src/main/res/drawable-v21/selectable_borderless.xml
+++ b/app/src/main/res/drawable-v21/selectable_borderless.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?android:attr/colorControlHighlight">
+    <item android:drawable="@android:color/transparent" />
+</ripple>

--- a/app/src/main/res/drawable/selectable_borderless.xml
+++ b/app/src/main/res/drawable/selectable_borderless.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="oval">
+            <solid android:color="#20000000" />
+        </shape>
+    </item>
+    <item android:drawable="@android:color/transparent" />
+</selector>

--- a/app/src/main/res/layout/item_auto_connect.xml
+++ b/app/src/main/res/layout/item_auto_connect.xml
@@ -83,7 +83,7 @@
             android:layout_width="36dp"
             android:layout_height="36dp"
             android:src="@drawable/ic_arrow_up"
-            android:background="?attr/selectableItemBackgroundBorderless"
+            android:background="@drawable/selectable_borderless"
             android:contentDescription="@string/move_up" />
 
         <ImageButton
@@ -91,7 +91,7 @@
             android:layout_width="36dp"
             android:layout_height="36dp"
             android:src="@drawable/ic_arrow_down"
-            android:background="?attr/selectableItemBackgroundBorderless"
+            android:background="@drawable/selectable_borderless"
             android:contentDescription="@string/move_down" />
 
         <Switch


### PR DESCRIPTION
## Summary
- The `selectableItemBackgroundBorderless` attribute in `item_auto_connect.xml` causes an `InflateException` on Android 4.2 (API 17) since it only exists from API 21+
- My previous fix (#289) used the AppCompat version of the attr thinking it would resolve to a safe fallback, but it doesn't — it still crashes on pre-Lollipop
- This replaces the attr reference with a versioned drawable resource: `drawable-v21/` provides a native borderless ripple, while the base `drawable/` provides a simple pressed-state selector for older devices

Fixes #273