### PR TITLE
feat: add "Wireless Helper via Hotspot" connection mode (mode 3)

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
@@ -408,7 +408,12 @@ class AapService : Service(), UsbReceiver.Listener {
         AppLog.i("Auto-started continuous log capture")
 
         startService(GpsLocationService.intent(this))
-        wifiDirectManager = WifiDirectManager(this)
+        // In Hotspot Helper mode (mode 3), skip WiFi Direct entirely: On devices like
+        // Samsung Galaxy Tab S6 Lite, initializing WifiP2pManager when WiFi is off
+        // (because Hotspot is active) causes the system to open the WiFi settings page.
+        if (!App.provide(this).settings.isHotspotHelperMode) {
+            wifiDirectManager = WifiDirectManager(this)
+        }
         initWifiMode()
         checkAlreadyConnectedUsb()
         registerNetworkMonitor()
@@ -787,17 +792,23 @@ class AapService : Service(), UsbReceiver.Listener {
         }
     }
 
-    /** Starts [WirelessServer] if the user has configured server WiFi mode (mode == 2). */
+    /** Starts [WirelessServer] if the user has configured a Helper WiFi mode (mode 2 or 3). */
     private fun initWifiMode() {
-        if (App.provide(this).settings.wifiConnectionMode == 2) {
+        val settings = App.provide(this).settings
+        if (settings.isHelperMode) {
             startWirelessServer()
-            if (App.provide(this).settings.autoEnableHotspot) {
-                // Run on background thread since hotspot enable may sleep briefly
+            if (settings.isHotspotHelperMode) {
+                // Hotspot Helper (mode 3): WiFi is off, hotspot is managed externally (e.g. Tasker).
+                // Skip WiFi Direct entirely — it's not available without WiFi.
+                AppLog.i("AapService: Hotspot Helper mode — skipping WiFi Direct.")
+            } else if (settings.autoEnableHotspot) {
+                // Standard Helper (mode 2) with auto-hotspot: let HotspotManager handle it
                 Thread {
                     AppLog.i("AapService: Auto-enabling hotspot...")
                     HotspotManager.setHotspotEnabled(this, true)
                 }.start()
             } else {
+                // Standard Helper (mode 2) without auto-hotspot: try WiFi Direct
                 val wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as android.net.wifi.WifiManager
                 if (wifiManager.isWifiEnabled) {
                     wifiDirectManager?.makeVisible()
@@ -809,6 +820,11 @@ class AapService : Service(), UsbReceiver.Listener {
     }
 
     private fun acquireWifiLock() {
+        // In Hotspot Helper mode or with auto-hotspot, WiFi is off; the hotspot keeps
+        // the radio active, so a WifiLock is unnecessary (and may throw on some devices).
+        val settings = App.provide(this).settings
+        if (settings.isHotspotHelperMode || settings.autoEnableHotspot) return
+
         if (wifiLock == null) {
             val wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
             wifiLock = wifiManager.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, "HeadunitRevived:Connection")
@@ -895,8 +911,8 @@ class AapService : Service(), UsbReceiver.Listener {
             ACTION_START_SELF_MODE       -> startSelfMode()
             ACTION_START_WIRELESS        -> startWirelessServer()
             ACTION_START_WIRELESS_SCAN   -> {
-                val mode = App.provide(this).settings.wifiConnectionMode
-                startDiscovery(oneShot = (mode != 2))
+                val settings = App.provide(this).settings
+                startDiscovery(oneShot = !settings.isHelperMode)
             }
             ACTION_STOP_WIRELESS         -> stopWirelessServer()
             ACTION_DISCONNECT            -> {

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NetworkDiscovery.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NetworkDiscovery.kt
@@ -97,47 +97,46 @@ class NetworkDiscovery(private val context: Context, private val listener: Liste
     }
 
     private suspend fun scanSubnet() {
-        val subnet = getSubnet()
-        if (subnet == null) {
-            AppLog.e("NetworkDiscovery: Could not determine subnet for deep scan")
+        val subnets = getAllSubnets()
+        if (subnets.isEmpty()) {
+            AppLog.e("NetworkDiscovery: Could not determine any subnet for deep scan")
             return
         }
 
-        val myIp = getLocalIpAddress()
-        AppLog.i("NetworkDiscovery: Scanning subnet: $subnet.*")
+        val localIps = getAllLocalIpAddresses()
 
         val tasks = mutableListOf<Deferred<Boolean>>()
 
-        // Scan range 1..254
-        for (i in 1..254) {
-            val ip = "$subnet.$i"
-            if (ip == myIp) continue // Skip self
-
-            tasks.add(CoroutineScope(Dispatchers.IO).async {
-                checkAndReport(ip)
-            })
+        for (subnet in subnets) {
+            AppLog.i("NetworkDiscovery: Scanning subnet: $subnet.*")
+            for (i in 1..254) {
+                val ip = "$subnet.$i"
+                if (ip in localIps) continue // Skip own addresses
+                tasks.add(CoroutineScope(Dispatchers.IO).async {
+                    checkAndReport(ip)
+                })
+            }
         }
 
         tasks.awaitAll()
     }
 
-    private fun getLocalIpAddress(): String? {
+    private fun getAllLocalIpAddresses(): Set<String> {
+        val ips = mutableSetOf<String>()
         try {
             val interfaces = Collections.list(NetworkInterface.getNetworkInterfaces())
             for (intf in interfaces) {
                 if (intf.isLoopback || !intf.isUp) continue
-
-                val addrs = Collections.list(intf.inetAddresses)
-                for (addr in addrs) {
-                    if (addr is java.net.Inet4Address) {
-                        return addr.hostAddress
+                for (addr in Collections.list(intf.inetAddresses)) {
+                    if (addr is Inet4Address) {
+                        addr.hostAddress?.let { ips.add(it) }
                     }
                 }
             }
         } catch (e: Exception) {
-            AppLog.e("NetworkDiscovery: Error getting local IP", e)
+            AppLog.e("NetworkDiscovery: Error getting local IPs", e)
         }
-        return null
+        return ips
     }
 
     private suspend fun checkAndReport(ip: String): Boolean {
@@ -205,27 +204,26 @@ class NetworkDiscovery(private val context: Context, private val listener: Liste
         }
     }
 
-    private fun getSubnet(): String? {
-        // Reuse similar logic to collectInterfaceSuspects but return subnet string
+    private fun getAllSubnets(): Set<String> {
+        val subnets = mutableSetOf<String>()
         try {
-             val interfaces = Collections.list(NetworkInterface.getNetworkInterfaces())
-             for (networkInterface in interfaces) {
-                 if (!networkInterface.isUp || networkInterface.isLoopback) continue
-                 
-                 for (addr in Collections.list(networkInterface.inetAddresses)) {
-                     if (addr is Inet4Address) {
-                         val host = addr.hostAddress
-                         val lastDot = host.lastIndexOf('.')
-                         if (lastDot > 0) {
-                             return host.substring(0, lastDot)
-                         }
-                     }
-                 }
-             }
+            val interfaces = Collections.list(NetworkInterface.getNetworkInterfaces())
+            for (networkInterface in interfaces) {
+                if (!networkInterface.isUp || networkInterface.isLoopback) continue
+                for (addr in Collections.list(networkInterface.inetAddresses)) {
+                    if (addr is Inet4Address) {
+                        val host = addr.hostAddress ?: continue
+                        val lastDot = host.lastIndexOf('.')
+                        if (lastDot > 0) {
+                            subnets.add(host.substring(0, lastDot))
+                        }
+                    }
+                }
+            }
         } catch (e: Exception) {
-            AppLog.e("NetworkDiscovery: Failed to get subnet", e)
+            AppLog.e("NetworkDiscovery: Failed to get subnets", e)
         }
-        return null
+        return subnets
     }
 
     fun stop() {

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/HomeFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/HomeFragment.kt
@@ -314,9 +314,10 @@ class HomeFragment : Fragment() {
         }
 
         wifi.setOnClickListener {
-            val mode = App.provide(requireContext()).settings.wifiConnectionMode
-            when (mode) {
-                1 -> { // Auto (Headunit Server) - One-Shot Scan
+            val appSettings = App.provide(requireContext()).settings
+            val mode = appSettings.wifiConnectionMode
+            when {
+                mode == 1 -> { // Auto (Headunit Server) - One-Shot Scan
                     if (commManager.isConnected) {
                         // Already connected, no toast needed
                     } else if (AapService.scanningState.value) {
@@ -329,7 +330,7 @@ class HomeFragment : Fragment() {
                         ContextCompat.startForegroundService(requireContext(), intent)
                     }
                 }
-                2 -> { // Helper (Wireless Launcher)
+                appSettings.isHelperMode -> { // Helper (Wireless Launcher) or Helper via Hotspot
                     if (commManager.isConnected) {
                         // Already connected, no toast needed
                     } else if (AapService.scanningState.value) {

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
@@ -247,7 +247,7 @@ class SettingsFragment : Fragment() {
         pendingWifiConnectionMode?.let { mode ->
             settings.wifiConnectionMode = mode
             val intent = Intent(requireContext(), AapService::class.java).apply {
-                action = if (mode == 2) AapService.ACTION_START_WIRELESS else AapService.ACTION_STOP_WIRELESS
+                action = if (settings.isHelperMode) AapService.ACTION_START_WIRELESS else AapService.ACTION_STOP_WIRELESS
             }
             ContextCompat.startForegroundService(requireContext(), intent)
         }
@@ -403,8 +403,9 @@ class SettingsFragment : Fragment() {
             }
         ))
 
-        // Auto-Enable Hotspot Toggle (only visible if not in Manual Mode)
-        if (pendingWifiConnectionMode != 0) {
+        // Auto-Enable Hotspot Toggle (only visible if not in Manual Mode and not in Hotspot Helper mode)
+        // In Hotspot Helper mode (3), the hotspot is managed externally (e.g. by Tasker).
+        if (pendingWifiConnectionMode != 0 && pendingWifiConnectionMode != 3) {
             items.add(SettingItem.ToggleSettingEntry(
                 stableId = "autoEnableHotspot",
                 nameResId = R.string.auto_enable_hotspot,

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
@@ -205,7 +205,7 @@ class Settings(context: Context) {
         get() = prefs.getBoolean("right-hand-drive", false)
         set(value) { prefs.edit().putBoolean("right-hand-drive", value).apply() }
 
-    // 0 = Manual, 1 = Auto (Headunit Server), 2 = Helper (Wifi Launcher)
+    // 0 = Manual, 1 = Auto (Headunit Server), 2 = Helper (Wifi Launcher), 3 = Helper via Hotspot
     var wifiConnectionMode: Int
         get() {
             // Migration: Check if old boolean exists
@@ -219,6 +219,12 @@ class Settings(context: Context) {
             return prefs.getInt("wifi-connection-mode", 1) // Default 1 (Auto)
         }
         set(value) { prefs.edit().putInt("wifi-connection-mode", value).apply() }
+
+    /** True for any Helper mode (WiFi Direct or Hotspot). */
+    val isHelperMode: Boolean get() = wifiConnectionMode == 2 || wifiConnectionMode == 3
+
+    /** True only for Helper via Hotspot mode (skip WiFi Direct, no WiFi required). */
+    val isHotspotHelperMode: Boolean get() = wifiConnectionMode == 3
 
     var videoCodec: String
         get() = prefs.getString("video-codec", "Auto")!!

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -180,6 +180,7 @@
         <item>يدوي (قائمة)</item>
         <item>بحث تلقائي (خادم Headunit)</item>
         <item>مساعد لاسلكي (في انتظار الهاتف)</item>
+        <item>Wireless Helper via Hotspot</item>
     </string-array>
     <string name="auto_connect_last_session">الاتصال التلقائي بالجلسة الأخيرة</string>
     <string name="auto_connect_last_session_description">إعادة الاتصال تلقائيا بآخر جهاز مستخدم عند بدء التطبيق</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -180,6 +180,7 @@
         <item>Ručně (seznam)</item>
         <item>Automatické vyhledávání (Headunit Server)</item>
         <item>Bezdrátový pomocník (čekání na telefon)</item>
+        <item>Wireless Helper via Hotspot</item>
     </string-array>
     <string name="auto_connect_last_session">Automaticky připojit poslední relaci</string>
     <string name="auto_connect_last_session_description">Při spuštění aplikace se automaticky znovu připojit k naposledy použitému zařízení</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -183,6 +183,7 @@
         <item>Manuell (Liste)</item>
         <item>Auto-Suche (Headunit Server)</item>
         <item>Wireless Helper (Warten auf Handy)</item>
+        <item>Wireless Helper über Hotspot</item>
     </string-array>
     <string name="auto_connect_last_session">Auto-Connect letzte Sitzung</string>
     <string name="auto_connect_last_session_description">Verbindet beim App-Start automatisch mit dem zuletzt genutzten Gerät</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -180,6 +180,7 @@
         <item>Manual (Lista)</item>
         <item>Auto (Headunit Server)</item>
         <item>Wireless Helper</item>
+        <item>Wireless Helper via Hotspot</item>
     </string-array>
     <string name="auto_connect_last_session">Auto-conectar última sesión</string>
     <string name="auto_connect_last_session_description">Conectar automáticamente al último dispositivo al iniciar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -180,6 +180,7 @@
         <item>Manual (lista)</item>
         <item>Búsqueda automática (Headunit Server)</item>
         <item>Wireless Helper (esperando al teléfono)</item>
+        <item>Wireless Helper via Hotspot</item>
     </string-array>
     <string name="auto_connect_last_session">Conectar automáticamente a la última sesión</string>
     <string name="auto_connect_last_session_description">Reconecta automáticamente al último dispositivo usado al iniciar la app</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -179,6 +179,7 @@
         <item>Kézi (Lista)</item>
         <item>Auto-keresés (fejegység szerver)</item>
         <item>Wireless Helper (Várakozás a telefonra)</item>
+        <item>Wireless Helper via Hotspot</item>
     </string-array>
     <string name="auto_connect_last_session">Automatikus folytatás</string>
     <string name="auto_connect_last_session_description">Indításkor automatikus újracsatlakozás a legutóbb használt eszközhöz.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -179,6 +179,7 @@
         <item>Handmatig (lijst)</item>
         <item>Automatisch zoeken (Headunit Server)</item>
         <item>Draadloze helper (wachten op telefoon)</item>
+        <item>Wireless Helper via Hotspot</item>
     </string-array>
     <string name="auto_connect_last_session">Auto-Connect laatste Sessie</string>
     <string name="auto_connect_last_session_description">Automatisch opnieuw verbinding maken met het laatst gebruikte apparaat bij het opstarten van de app.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -180,6 +180,7 @@
         <item>Ręcznie (lista)</item>
         <item>Auto-wyszukiwanie (Headunit Server)</item>
         <item>Pomocnik bezprzewodowy (oczekiwanie na telefon)</item>
+        <item>Wireless Helper via Hotspot</item>
     </string-array>
     <string name="auto_connect_last_session">Auto-łączenie ostatniej sesji</string>
     <string name="auto_connect_last_session_description">Automatycznie połącz z ostatnio używanym urządzeniem przy starcie aplikacji</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -180,6 +180,7 @@
         <item>Manual (Lista)</item>
         <item>Busca automática (Headunit Server)</item>
         <item>Auxiliar sem fio (Aguardando telefone)</item>
+        <item>Wireless Helper via Hotspot</item>
     </string-array>
     <string name="auto_connect_last_session">Conectar automaticamente à última sessão</string>
     <string name="auto_connect_last_session_description">Reconecta automaticamente ao último dispositivo usado ao iniciar o app</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -189,6 +189,7 @@
         <item>Manual (Listă)</item>
         <item>Căutare automată (Server Headunit)</item>
         <item>Asistent Wireless (Așteaptă telefonul)</item>
+        <item>Wireless Helper via Hotspot</item>
     </string-array>
     <string name="auto_connect_last_session">Conectare automată la ultima sesiune</string>
     <string name="auto_connect_last_session_description">Reconectează automat ultimul dispozitiv la pornirea aplicației</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -180,6 +180,7 @@
         <item>Вручную (список)</item>
         <item>Автопоиск (Headunit Server)</item>
         <item>Wireless Helper (ожидание телефона)</item>
+        <item>Wireless Helper via Hotspot</item>
     </string-array>
     <string name="auto_connect_last_session">Автоподключение последней сессии</string>
     <string name="auto_connect_last_session_description">Автоматически подключаться к последнему использованному устройству при запуске приложения</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -180,6 +180,7 @@
         <item>Вручну (список)</item>
         <item>Автопошук (Headunit Server)</item>
         <item>Бездротовий помічник (очікування телефону)</item>
+        <item>Wireless Helper via Hotspot</item>
     </string-array>
     <string name="auto_connect_last_session">Автоматично підключатися до останньої сесії</string>
     <string name="auto_connect_last_session_description">Автоматично підключатися до останнього використаного пристрою під час запуску програми</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -179,6 +179,7 @@
         <item>手動 (列表)</item>
         <item>自動搜尋 (Headunit Server)</item>
         <item>無線助手 (等待手機)</item>
+        <item>Wireless Helper via Hotspot</item>
     </string-array>
     <string name="auto_connect_last_session">自動連接上次會話</string>
     <string name="auto_connect_last_session_description">應用程式啟動時自動重新連線到上次使用的裝置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,6 +193,7 @@
         <item>Manual (List)</item>
         <item>Auto-search (Headunit Server)</item>
         <item>Wireless Helper (Waiting for Phone)</item>
+        <item>Wireless Helper via Hotspot</item>
     </string-array>
     <string name="auto_connect_last_session">Auto-Connect Last Session</string>
     <string name="auto_connect_last_session_description">Automatically reconnect to the last used device on app startup</string>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,9 @@ pluginManagement {
         mavenCentral()
     }
 }
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+}
 
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)


### PR DESCRIPTION
Adds a new wireless connection mode for devices where WiFi and Hotspot cannot coexist (e.g. Samsung Galaxy Tab S6 Lite).

Mode 3 behaves like the standard Wireless Helper (mode 2) but:
- Skips WifiDirectManager initialization to prevent Samsung OneUI from opening the WiFi settings page when WiFi is off
- Skips WifiLock (hotspot keeps the radio active)
- Hides the "Auto-Enable Hotspot" toggle (hotspot is managed externally)

Also improves NetworkDiscovery to scan all local subnets instead of only the first interface, ensuring the phone is found on the Hotspot subnet even when an LTE interface is also present.

Based on beta-2.1.1.