### PR TITLE
Fix: Improve focus management and physical button handling in Self Mode

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapProjectionActivity.kt
@@ -167,9 +167,14 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         }
 
         setContentView(R.layout.activity_headunit)
+        takeKeyEvents(true)
+
+        val mainContainer = findViewById<FrameLayout>(R.id.container)
+        mainContainer.descendantFocusability = android.view.ViewGroup.FOCUS_AFTER_DESCENDANTS
+        mainContainer.isFocusable = true
+        mainContainer.requestFocus()
 
         if (settings.showFpsCounter) {
-            val container = findViewById<FrameLayout>(R.id.container)
             val fpsText = TextView(this).apply {
                 setTextColor(Color.YELLOW)
                 textSize = 12f
@@ -190,7 +195,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
                 gravity = Gravity.TOP or Gravity.START
                 setMargins(20, 20, 0, 0)
             }
-            container.addView(fpsText, params)
+            mainContainer.addView(fpsText, params)
 
             videoDecoder.onFpsChanged = { fps ->
                 runOnUiThread { fpsText.text = "FPS: $fps" }
@@ -228,7 +233,6 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
 
         AppLog.i("HeadUnit for Android Auto (tm) - Copyright 2011-2015 Michael A. Reid., since 2025 André Rinas All Rights Reserved...")
 
-        val container = findViewById<android.widget.FrameLayout>(R.id.container)
         val displayMetrics = resources.displayMetrics
 
         if (settings.viewMode == Settings.ViewMode.TEXTURE) {
@@ -239,7 +243,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
                 FrameLayout.LayoutParams.MATCH_PARENT
             )
             projectionView = textureView
-            container.setBackgroundColor(android.graphics.Color.BLACK)
+            mainContainer.setBackgroundColor(android.graphics.Color.BLACK)
         } else if (settings.viewMode == Settings.ViewMode.GLES) {
             AppLog.i("Using GlProjectionView")
             val glView = com.andrerinas.headunitrevived.view.GlProjectionView(this)
@@ -248,7 +252,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
                 FrameLayout.LayoutParams.MATCH_PARENT
             )
             projectionView = glView
-            container.setBackgroundColor(android.graphics.Color.BLACK)
+            mainContainer.setBackgroundColor(android.graphics.Color.BLACK)
         } else {
             AppLog.i("Using SurfaceView")
             projectionView = ProjectionView(this)
@@ -261,7 +265,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         HeadUnitScreenConfig.init(this, displayMetrics, settings)
 
         val view = projectionView as android.view.View
-        container.addView(view)
+        mainContainer.addView(view)
 
         projectionView.addCallback(this)
 
@@ -281,7 +285,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
                 true
             }
 
-        container.addView(overlayView)
+        mainContainer.addView(overlayView)
         overlayView.requestFocus()
         setFullscreen() // Call setFullscreen here as well
 
@@ -304,9 +308,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
     override fun onPause() {
         AppLog.i("AapProjectionActivity: onPause")
         super.onPause()
-        watchdogHandler.removeCallbacks(watchdogRunnable)
-        watchdogHandler.removeCallbacks(videoWatchdogRunnable)
-        watchdogHandler.removeCallbacks(reconnectingWatchdog)
+        watchdogHandler.removeCallbacksAndMessages(null)
         unregisterReceiver(keyCodeReceiver)
         unregisterReceiver(nightModeReceiver)
     }
@@ -341,7 +343,20 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         super.onWindowFocusChanged(hasFocus)
 
         if (hasFocus) {
-            setFullscreen() // Reapply fullscreen mode if window gains focus
+            setFullscreen()
+            findViewById<View>(R.id.container)?.requestFocus()
+        } else {
+            if (!isFinishing) {
+                watchdogHandler.postDelayed({
+                    if (!hasWindowFocus() && !isFinishing) {
+                        android.util.Log.e("AapProjectionActivity", "Wysyłanie Intentu o powrót na front...")
+                        val intent = Intent(this, AapProjectionActivity::class.java)
+                        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+                        intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                        startActivity(intent)
+                    }
+                }, 1000)
+            }
         }
     }
 
@@ -500,19 +515,15 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         commManager.send(TouchEvent(ts, action, event.actionIndex, pointerData))
     }
 
-    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
-        if (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN || keyCode == KeyEvent.KEYCODE_VOLUME_MUTE) {
-            return super.onKeyDown(keyCode, event)
-        }
-        onKeyEvent(keyCode, true)
-        return true
-    }
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        val keyCode = event.keyCode
+        val isPress = event.action == KeyEvent.ACTION_DOWN
 
-    override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
         if (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN || keyCode == KeyEvent.KEYCODE_VOLUME_MUTE) {
-            return super.onKeyUp(keyCode, event)
+            return super.dispatchKeyEvent(event)
         }
-        onKeyEvent(keyCode, false)
+        if (isPress && event.repeatCount > 0) return true
+        onKeyEvent(keyCode, isPress)
         return true
     }
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapProjectionActivity.kt
@@ -349,7 +349,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
             if (!isFinishing) {
                 watchdogHandler.postDelayed({
                     if (!hasWindowFocus() && !isFinishing) {
-                        android.util.Log.e("AapProjectionActivity", "Wysyłanie Intentu o powrót na front...")
+                        AppLog.i("AapProjectionActivity: Sending intent to bring activity to front...")
                         val intent = Intent(this, AapProjectionActivity::class.java)
                         intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
                         intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)

--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapTransport.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapTransport.kt
@@ -385,7 +385,7 @@ class AapTransport(
                 send(ScrollWheelEvent(ts, 1))
                 return
             }
-            if (aapKeyCode == KeyEvent.KEYCODE_DPAD_CENTER || aapKeyCode == KeyEvent.KEYCODE_ENTER) {
+            if (aapKeyCode == KeyEvent.KEYCODE_DPAD_CENTER) {
                 send(KeyCodeEvent(ts, KeyEvent.KEYCODE_DPAD_CENTER, isPress))
                 return
             }

--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapTransport.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapTransport.kt
@@ -374,6 +374,22 @@ class AapTransport(
     fun send(keyCode: Int, isPress: Boolean) {
         val mapped = keyCodes[keyCode] ?: keyCode
         val aapKeyCode = KeyCode.convert(mapped)
+        val ts = SystemClock.elapsedRealtime()
+
+        if (settings.enableRotary) {
+            if (aapKeyCode == KeyEvent.KEYCODE_DPAD_UP && isPress) {
+                send(ScrollWheelEvent(ts, -1))
+                return
+            }
+            if (aapKeyCode == KeyEvent.KEYCODE_DPAD_DOWN && isPress) {
+                send(ScrollWheelEvent(ts, 1))
+                return
+            }
+            if (aapKeyCode == KeyEvent.KEYCODE_DPAD_CENTER || aapKeyCode == KeyEvent.KEYCODE_ENTER) {
+                send(KeyCodeEvent(ts, KeyEvent.KEYCODE_DPAD_CENTER, isPress))
+                return
+            }
+        }
 
         if (mapped == KeyEvent.KEYCODE_GUIDE) {
             // Hack for navigation button to simulate touch
@@ -394,7 +410,6 @@ class AapTransport(
             AppLog.i("Unknown: $keyCode")
         }
 
-        val ts = SystemClock.elapsedRealtime()
         if (aapKeyCode == KeyEvent.KEYCODE_SOFT_LEFT || aapKeyCode == KeyEvent.KEYCODE_SOFT_RIGHT) {
             if (isPress) {
                 val delta = if (aapKeyCode == KeyEvent.KEYCODE_SOFT_LEFT) -1 else 1


### PR DESCRIPTION
## Context
I’ve implemented a fix for issues encountered when using the **Self Mode** configuration with physical (Bluetooth) controllers. I decided to base my changes on the `v2.1.1` tag, as it was the most recent version that remained stable and functional for my setup.

## Changes
* **KeyEvent Handling**: Replaced standard `onKeyDown` and `onKeyUp` handling with `dispatchKeyEvent`. Previously, only the side arrows were working, and the Enter/D-Pad Center button was not being detected because it wasn't captured on standard key events. This change ensures that all button presses are correctly intercepted.
* **Focus Management**: Modified the focus logic to ensure it stays locked on the top-level application (Android Auto projection). 
    * This allows for immediate use of physical buttons right after the app starts.
    * It prevents focus loss that occasionally occurred when navigating through or exiting menus.

These changes significantly improve the stability and usability of the interface when using external Bluetooth controllers.