### PR TITLE
Create configurable audio queue and audio buffer in settings

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapAudio.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapAudio.kt
@@ -126,8 +126,8 @@ internal class AapAudio(
             }
             val gain = (1.0f + (offset / 100.0f)).coerceIn(0.0f, 2.0f)
 
-            AppLog.i("AudioDecoder.start: channel=$channel, stream=$stream, gain=$gain, sampleRate=${config.sampleRate}, numberOfBits=${config.numberOfBits}, numberOfChannels=${config.numberOfChannels}, isAac=${settings.useAacAudio}")
-            audioDecoder.start(channel, stream, config.sampleRate, config.numberOfBits, config.numberOfChannels, settings.useAacAudio, gain)
+            AppLog.i("AudioDecoder.start: channel=$channel, stream=$stream, gain=$gain, sampleRate=${config.sampleRate}, numberOfBits=${config.numberOfBits}, numberOfChannels=${config.numberOfChannels}, isAac=${settings.useAacAudio}, latencyMultiplier=${settings.audioLatencyMultiplier}, queueCapacity=${settings.audioQueueCapacity}")
+            audioDecoder.start(channel, stream, config.sampleRate, config.numberOfBits, config.numberOfChannels, settings.useAacAudio, gain, settings.audioLatencyMultiplier, settings.audioQueueCapacity)
         }
 
         audioDecoder.decode(channel, buf, start, length)

--- a/app/src/main/java/com/andrerinas/headunitrevived/decoder/AudioDecoder.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/decoder/AudioDecoder.kt
@@ -27,7 +27,7 @@ class AudioDecoder {
         audioTracks.put(chan, null)
     }
 
-    fun start(channel: Int, stream: Int, sampleRate: Int, numberOfBits: Int, numberOfChannels: Int, isAac: Boolean = false, gain: Float = 1.0f, audioLatencyMultiplier: Int = 2, audioQueueCapacity: Int = 20) {
+    fun start(channel: Int, stream: Int, sampleRate: Int, numberOfBits: Int, numberOfChannels: Int, isAac: Boolean = false, gain: Float = 1.0f, audioLatencyMultiplier: Int = 8, audioQueueCapacity: Int = 0) {
         val thread = AudioTrackWrapper(stream, sampleRate, numberOfBits, numberOfChannels, isAac, gain, audioLatencyMultiplier, audioQueueCapacity)
         audioTracks.put(channel, thread)
     }

--- a/app/src/main/java/com/andrerinas/headunitrevived/decoder/AudioDecoder.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/decoder/AudioDecoder.kt
@@ -27,8 +27,8 @@ class AudioDecoder {
         audioTracks.put(chan, null)
     }
 
-    fun start(channel: Int, stream: Int, sampleRate: Int, numberOfBits: Int, numberOfChannels: Int, isAac: Boolean = false, gain: Float = 1.0f) {
-        val thread = AudioTrackWrapper(stream, sampleRate, numberOfBits, numberOfChannels, isAac, gain)
+    fun start(channel: Int, stream: Int, sampleRate: Int, numberOfBits: Int, numberOfChannels: Int, isAac: Boolean = false, gain: Float = 1.0f, audioLatencyMultiplier: Int = 2, audioQueueCapacity: Int = 20) {
+        val thread = AudioTrackWrapper(stream, sampleRate, numberOfBits, numberOfChannels, isAac, gain, audioLatencyMultiplier, audioQueueCapacity)
         audioTracks.put(channel, thread)
     }
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/decoder/AudioTrackWrapper.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/decoder/AudioTrackWrapper.kt
@@ -282,7 +282,7 @@ class AudioTrackWrapper(
 
         val minBufferSize = AudioTrack.getMinBufferSize(sampleRateInHz, channelConfig, dataFormat)
         // Adjust buffer size based on user preference to balance latency and stutter
-        val bufferSize = minBufferSize * multiplier
+        val bufferSize = if (minBufferSize > 0) minBufferSize * multiplier else minBufferSize
 
         AppLog.i("Audio stream: $stream buffer size: $bufferSize (min: $minBufferSize) sampleRateInHz: $sampleRateInHz channelCount: $channelCount")
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/decoder/AudioTrackWrapper.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/decoder/AudioTrackWrapper.kt
@@ -22,8 +22,8 @@ class AudioTrackWrapper(
     channelCount: Int,
     private val isAac: Boolean = false,
     gain: Float,
-    private val audioLatencyMultiplier: Int = 2,
-    private val audioQueueCapacity: Int = 20
+    private val audioLatencyMultiplier: Int = 8,
+    private val audioQueueCapacity: Int = 0
 ) : Thread() {
 
     private val audioTrack: AudioTrack

--- a/app/src/main/java/com/andrerinas/headunitrevived/decoder/AudioTrackWrapper.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/decoder/AudioTrackWrapper.kt
@@ -320,10 +320,13 @@ class AudioTrackWrapper(
         if (!isRunning) return
 
         try {
-            // put() blocks if queue is full (Backpressure)
-            dataQueue.put(buffer.copyOfRange(offset, offset + size))
+            // offer() doesn't block if the queue is full. This prevents the network thread from blocking.
+            val success = dataQueue.offer(buffer.copyOfRange(offset, offset + size), 5, TimeUnit.MILLISECONDS)
+            if (!success) {
+                AppLog.w("Audio queue is full, dropping audio frame to prevent stalling")
+            }
         } catch (e: InterruptedException) {
-            AppLog.w("Interrupted while putting audio data to queue")
+            AppLog.w("Interrupted while offering audio data to queue")
         }
     }
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/decoder/AudioTrackWrapper.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/decoder/AudioTrackWrapper.kt
@@ -21,7 +21,9 @@ class AudioTrackWrapper(
     bitDepth: Int,
     channelCount: Int,
     private val isAac: Boolean = false,
-    gain: Float
+    gain: Float,
+    private val audioLatencyMultiplier: Int = 2,
+    private val audioQueueCapacity: Int = 20
 ) : Thread() {
 
     private val audioTrack: AudioTrack
@@ -31,7 +33,7 @@ class AudioTrackWrapper(
     private val writeExecutor = Executors.newSingleThreadExecutor()
 
     // Limit queue capacity to provide backpressure to the network thread if audio playback is slow
-    private val dataQueue = LinkedBlockingQueue<ByteArray>()
+    private val dataQueue = if (audioQueueCapacity > 0) LinkedBlockingQueue<ByteArray>(audioQueueCapacity) else LinkedBlockingQueue<ByteArray>()
     @Volatile
     private var isRunning = true
 
@@ -43,7 +45,7 @@ class AudioTrackWrapper(
 
     init {
         this.name = "AudioPlaybackThread"
-        audioTrack = createAudioTrack(stream, sampleRateInHz, bitDepth, channelCount)
+        audioTrack = createAudioTrack(stream, sampleRateInHz, bitDepth, channelCount, audioLatencyMultiplier)
         audioTrack.play()
 
         if (isAac) {
@@ -270,7 +272,8 @@ class AudioTrackWrapper(
         stream: Int,
         sampleRateInHz: Int,
         bitDepth: Int,
-        channelCount: Int
+        channelCount: Int,
+        multiplier: Int
     ): AudioTrack {
         val channelConfig =
             if (channelCount == 2) AudioFormat.CHANNEL_OUT_STEREO else AudioFormat.CHANNEL_OUT_MONO
@@ -278,8 +281,8 @@ class AudioTrackWrapper(
             if (bitDepth == 16) AudioFormat.ENCODING_PCM_16BIT else AudioFormat.ENCODING_PCM_8BIT
 
         val minBufferSize = AudioTrack.getMinBufferSize(sampleRateInHz, channelConfig, dataFormat)
-        // Larger buffer (8x) to prevent stuttering on jittery connections
-        val bufferSize = minBufferSize * 8
+        // Adjust buffer size based on user preference to balance latency and stutter
+        val bufferSize = minBufferSize * multiplier
 
         AppLog.i("Audio stream: $stream buffer size: $bufferSize (min: $minBufferSize) sampleRateInHz: $sampleRateInHz channelCount: $channelCount")
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
@@ -848,7 +848,7 @@ class SettingsFragment : Fragment() {
             onClick = { _ ->
                 val options = arrayOf("1x (Lowest Latency)", "2x (Low Latency)", "4x (High Latency)", "8x (Very High Latency)")
                 val values = intArrayOf(1, 2, 4, 8)
-                val currentIndex = values.indexOf(pendingAudioLatencyMultiplier ?: 2).coerceAtLeast(0)
+                val currentIndex = values.indexOf(pendingAudioLatencyMultiplier ?: 8).coerceAtLeast(0)
                 AlertDialog.Builder(requireContext())
                     .setTitle(R.string.audio_latency_multiplier)
                     .setSingleChoiceItems(options, currentIndex) { dialog, which ->
@@ -868,7 +868,7 @@ class SettingsFragment : Fragment() {
             onClick = { _ ->
                 val options = arrayOf("10 chunks (Low Latency)", "20 chunks (Balanced)", "50 chunks (High Latency)", "Unbounded (Max Backlog)")
                 val values = intArrayOf(10, 20, 50, 0)
-                val currentIndex = values.indexOf(pendingAudioQueueCapacity ?: 20).coerceAtLeast(0)
+                val currentIndex = values.indexOf(pendingAudioQueueCapacity ?: 0).coerceAtLeast(0)
                 AlertDialog.Builder(requireContext())
                     .setTitle(R.string.audio_queue_capacity)
                     .setSingleChoiceItems(options, currentIndex) { dialog, which ->

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
@@ -51,6 +51,8 @@ class SettingsFragment : Fragment() {
     private var pendingMicInputSource: Int? = null
     private var pendingUseNativeSsl: Boolean? = null
     private var pendingEnableRotary: Boolean? = null
+    private var pendingAudioLatencyMultiplier: Int? = null
+    private var pendingAudioQueueCapacity: Int? = null
     private var pendingShowFpsCounter: Boolean? = null
     private var pendingScreenOrientation: Settings.ScreenOrientation? = null
     private var pendingAppLanguage: String? = null
@@ -103,6 +105,8 @@ class SettingsFragment : Fragment() {
         pendingMicInputSource = settings.micInputSource
         pendingUseNativeSsl = settings.useNativeSsl
         pendingEnableRotary = settings.enableRotary
+        pendingAudioLatencyMultiplier = settings.audioLatencyMultiplier
+        pendingAudioQueueCapacity = settings.audioQueueCapacity
         pendingShowFpsCounter = settings.showFpsCounter
         pendingScreenOrientation = settings.screenOrientation
         pendingAppLanguage = settings.appLanguage
@@ -223,6 +227,8 @@ class SettingsFragment : Fragment() {
         pendingMicInputSource?.let { settings.micInputSource = it }
         pendingUseNativeSsl?.let { settings.useNativeSsl = it }
         pendingEnableRotary?.let { settings.enableRotary = it }
+        pendingAudioLatencyMultiplier?.let { settings.audioLatencyMultiplier = it }
+        pendingAudioQueueCapacity?.let { settings.audioQueueCapacity = it }
         pendingShowFpsCounter?.let { settings.showFpsCounter = it }
         pendingScreenOrientation?.let { settings.screenOrientation = it }
 
@@ -288,6 +294,8 @@ class SettingsFragment : Fragment() {
                         pendingMicInputSource != settings.micInputSource ||
                         pendingUseNativeSsl != settings.useNativeSsl ||
                         pendingEnableRotary != settings.enableRotary ||
+                        pendingAudioLatencyMultiplier != settings.audioLatencyMultiplier ||
+                        pendingAudioQueueCapacity != settings.audioQueueCapacity ||
                         pendingShowFpsCounter != settings.showFpsCounter ||
                         pendingScreenOrientation != settings.screenOrientation ||
                         pendingAppLanguage != settings.appLanguage ||
@@ -314,6 +322,8 @@ class SettingsFragment : Fragment() {
                           pendingEnableRotary != settings.enableRotary ||
                           pendingEnableAudioSink != settings.enableAudioSink ||
                           pendingUseAacAudio != settings.useAacAudio ||
+                          pendingAudioLatencyMultiplier != settings.audioLatencyMultiplier ||
+                          pendingAudioQueueCapacity != settings.audioQueueCapacity ||
                           pendingUseNativeSsl != settings.useNativeSsl ||
                           pendingInsetLeft != settings.insetLeft ||
                           pendingInsetTop != settings.insetTop ||
@@ -828,6 +838,46 @@ class SettingsFragment : Fragment() {
             value = "${(100 + (pendingMediaVolumeOffset ?: 0))}% / ${(100 + (pendingAssistantVolumeOffset ?: 0))}% / ${(100 + (pendingNavigationVolumeOffset ?: 0))}%",
             onClick = {
                 showAudioOffsetsDialog()
+            }
+        ))
+
+        items.add(SettingItem.SettingEntry(
+            stableId = "audioLatencyMultiplier",
+            nameResId = R.string.audio_latency_multiplier,
+            value = "${pendingAudioLatencyMultiplier}x",
+            onClick = { _ ->
+                val options = arrayOf("1x (Lowest Latency)", "2x (Low Latency)", "4x (High Latency)", "8x (Very High Latency)")
+                val values = intArrayOf(1, 2, 4, 8)
+                val currentIndex = values.indexOf(pendingAudioLatencyMultiplier ?: 2).coerceAtLeast(0)
+                AlertDialog.Builder(requireContext())
+                    .setTitle(R.string.audio_latency_multiplier)
+                    .setSingleChoiceItems(options, currentIndex) { dialog, which ->
+                        pendingAudioLatencyMultiplier = values[which]
+                        checkChanges()
+                        dialog.dismiss()
+                        updateSettingsList()
+                    }
+                    .show()
+            }
+        ))
+
+        items.add(SettingItem.SettingEntry(
+            stableId = "audioQueueCapacity",
+            nameResId = R.string.audio_queue_capacity,
+            value = if (pendingAudioQueueCapacity == 0) "Unbounded (Legacy)" else "${pendingAudioQueueCapacity} chunks",
+            onClick = { _ ->
+                val options = arrayOf("10 chunks (Low Latency)", "20 chunks (Balanced)", "50 chunks (High Latency)", "Unbounded (Max Backlog)")
+                val values = intArrayOf(10, 20, 50, 0)
+                val currentIndex = values.indexOf(pendingAudioQueueCapacity ?: 20).coerceAtLeast(0)
+                AlertDialog.Builder(requireContext())
+                    .setTitle(R.string.audio_queue_capacity)
+                    .setSingleChoiceItems(options, currentIndex) { dialog, which ->
+                        pendingAudioQueueCapacity = values[which]
+                        checkChanges()
+                        dialog.dismiss()
+                        updateSettingsList()
+                    }
+                    .show()
             }
         ))
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
@@ -327,11 +327,11 @@ class Settings(context: Context) {
         set(value) { prefs.edit().putInt("mic-input-source", value).apply() }
 
     var audioLatencyMultiplier: Int
-        get() = prefs.getInt("audio-latency-multiplier", 2)
+        get() = prefs.getInt("audio-latency-multiplier", 8)
         set(value) { prefs.edit().putInt("audio-latency-multiplier", value).apply() }
     
     var audioQueueCapacity: Int
-        get() = prefs.getInt("audio-queue-capacity", 20)
+        get() = prefs.getInt("audio-queue-capacity", 0)
         set(value) { prefs.edit().putInt("audio-queue-capacity", value).apply() }
 
     var useAacAudio: Boolean

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
@@ -326,6 +326,14 @@ class Settings(context: Context) {
         get() = prefs.getInt("mic-input-source", 0) // Default: DEFAULT
         set(value) { prefs.edit().putInt("mic-input-source", value).apply() }
 
+    var audioLatencyMultiplier: Int
+        get() = prefs.getInt("audio-latency-multiplier", 2)
+        set(value) { prefs.edit().putInt("audio-latency-multiplier", value).apply() }
+    
+    var audioQueueCapacity: Int
+        get() = prefs.getInt("audio-queue-capacity", 20)
+        set(value) { prefs.edit().putInt("audio-queue-capacity", value).apply() }
+
     var useAacAudio: Boolean
         get() = prefs.getBoolean("use-aac-audio", false)
         set(value) { prefs.edit().putBoolean("use-aac-audio", value).apply() }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -441,4 +441,7 @@
     <string name="exit_dialog_pip">Picture-in-Picture</string>
     <string name="exit_dialog_background">Move to Background</string>
     <string name="gesture_hint">Tip: Swipe from the left edge with 2 fingers to open the exit menu.</string>
+    <string name="audio_latency_multiplier">Audio Latency Multiplier</string>
+    <string name="audio_latency_multiplier_description">Adjust audio buffer size (Lower = Less Lag, Higher = Less Stutter)</string>
+    <string name="audio_queue_capacity">Audio Queue Capacity (Backpressure)</string>
 </resources>

--- a/patch_settings.sh
+++ b/patch_settings.sh
@@ -1,1 +1,0 @@
-sed -i '/var useAacAudio/i \    var audioLatencyMultiplier: Int\n        get() = prefs.getInt("audio-latency-multiplier", 2)\n        set(value) { prefs.edit().putInt("audio-latency-multiplier", value).apply() }\n' app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt

--- a/patch_settings.sh
+++ b/patch_settings.sh
@@ -1,0 +1,1 @@
+sed -i '/var useAacAudio/i \    var audioLatencyMultiplier: Int\n        get() = prefs.getInt("audio-latency-multiplier", 2)\n        set(value) { prefs.edit().putInt("audio-latency-multiplier", value).apply() }\n' app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt


### PR DESCRIPTION
I've noticed a few spots in AudioTrackWrapper.kt where hardcoded values were causing some audio lag for some users. This PR makes those values configurable so people can tune the performance to their specific setup.

1. Audio Queue Limit (Line 33)
Right now, the audio queue is essentially bottomless. For a lot of users, this leads to a massive delay where the audio falls way behind the action. I’ve made the queue limit configurable. I kept the default behavior exactly as it is now so nothing changes for the average user, but power users can now tighten this up in the Audio settings to cut down that latency.

2. Buffer Size (Line 281)
We’ve been using a hardcoded buffer size of 8. It’s great for stability, but it creates a noticeable gap between a user’s interaction and the actual sound coming out. Like the queue limit, I’ve made this adjustable. It still defaults to 8 to keep things stable out of the box, but users can now lower it if they want a more responsive, "snappier" experience.

Overall, this should give users a lot more control over their audio sync without breaking the experience for everyone else. I test this with Audio Queue Limit to 20, and Buffer Size to 2 on my chinese headunit.

Audio Queue 20, Buffer 2x

https://github.com/user-attachments/assets/06d8d871-a6a4-4a4f-bd50-ebc04e04547d



Audio Queue Unlimited, Buffer 8x

https://github.com/user-attachments/assets/36381df0-089e-4c61-8fd8-9962383a09e5



Thank You!