### PR TITLE
Fix wired USB permission/connect flow when auto-start on USB is disabled

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
@@ -57,7 +57,6 @@ import android.graphics.PixelFormat
 import android.provider.Settings as AndroidSettings
 import android.view.View
 import android.view.WindowManager
-import com.andrerinas.headunitrevived.app.UsbAttachedActivity
 import android.media.AudioManager
 import com.andrerinas.headunitrevived.utils.HotspotManager
 import com.andrerinas.headunitrevived.utils.VpnControl
@@ -1392,13 +1391,8 @@ class AapService : Service(), UsbReceiver.Listener {
                 val deviceName = UsbDeviceCompat(device).uniqueName
                 AppLog.i("Found device already in accessory mode: $deviceName")
                 if (!usbManager.hasPermission(device)) {
-                    AppLog.i("Accessory-mode device has no permission (re-enumerated); launching UsbAttachedActivity: $deviceName")
-                    // Launch UsbAttachedActivity to handle permission request from foreground
-                    startActivity(Intent(this, UsbAttachedActivity::class.java).apply {
-                        action = UsbManager.ACTION_USB_DEVICE_ATTACHED
-                        putExtra(UsbManager.EXTRA_DEVICE, device)
-                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    })
+                    AppLog.i("Accessory-mode device has no permission (re-enumerated); requesting permission: $deviceName")
+                    requestUsbPermission(device)
                     return
                 }
                 isSwitchingToAccessory.set(true)

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/UsbListFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/UsbListFragment.kt
@@ -189,6 +189,7 @@ class UsbListFragment : Fragment() {
                         notifyDataSetChanged()
                     } else {
                         Toast.makeText(mContext, R.string.requesting_usb_permission, Toast.LENGTH_SHORT).show()
+                        ContextCompat.startForegroundService(mContext, Intent(mContext, AapService::class.java))
                         usbManager.requestPermission(
                             device.wrappedDevice,
                             UsbReceiver.createPermissionPendingIntent(mContext)

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/UsbListFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/UsbListFragment.kt
@@ -1,10 +1,8 @@
 package com.andrerinas.headunitrevived.main
 
-import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.hardware.usb.UsbManager
-import android.os.Build
 import android.os.Bundle
 import android.os.SystemClock
 import android.text.Html
@@ -27,12 +25,11 @@ import com.andrerinas.headunitrevived.App
 import com.andrerinas.headunitrevived.R
 import com.andrerinas.headunitrevived.aap.AapProjectionActivity
 import com.andrerinas.headunitrevived.aap.AapService
-import com.andrerinas.headunitrevived.app.UsbAttachedActivity
 import com.andrerinas.headunitrevived.connection.UsbAccessoryMode
 import com.andrerinas.headunitrevived.connection.UsbDeviceCompat
+import com.andrerinas.headunitrevived.connection.UsbReceiver
 import com.andrerinas.headunitrevived.utils.Settings
 import com.google.android.material.appbar.MaterialToolbar
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 class UsbListFragment : Fragment() {
     private lateinit var adapter: DeviceAdapter
@@ -192,9 +189,10 @@ class UsbListFragment : Fragment() {
                         notifyDataSetChanged()
                     } else {
                         Toast.makeText(mContext, R.string.requesting_usb_permission, Toast.LENGTH_SHORT).show()
-                        usbManager.requestPermission(device.wrappedDevice, PendingIntent.getActivity(
-                            mContext, 500, Intent(mContext, UsbAttachedActivity::class.java),
-                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE else PendingIntent.FLAG_UPDATE_CURRENT))
+                        usbManager.requestPermission(
+                            device.wrappedDevice,
+                            UsbReceiver.createPermissionPendingIntent(mContext)
+                        )
                     }
                 }
             }


### PR DESCRIPTION
## Summary

This fixes a regression introduced by `55e81c2` (`Disable USB system modal when auto-start on USB is off`).

That change correctly stopped Android from showing the "Open with Headunit Revived?" modal for unrelated USB devices when USB auto-start is disabled, but it also broke non-auto-start USB flows that still depended on `UsbAttachedActivity`.

With this patch:
- manual USB connect works again even when `Auto-start on USB` is off
- accessory-mode permission recovery after re-enumeration works without launching `UsbAttachedActivity`
- the no-modal behavior from `55e81c2` is preserved

## Root Cause

`UsbAttachedActivity` is now disabled unless `Auto-start on USB` is enabled, but two non-auto-start paths still relied on it:

- `UsbListFragment` requested USB permission with a `PendingIntent` targeting `UsbAttachedActivity`
- `AapService.checkAlreadyConnectedUsb()` launched `UsbAttachedActivity` when an accessory-mode device re-enumerated without permission

That made USB attach/manual-connect stall after detection, with no permission request or AOA switch.

## Fix

- `UsbListFragment` now requests USB permission via `UsbReceiver.createPermissionPendingIntent(...)`
- `AapService.checkAlreadyConnectedUsb()` now calls `requestUsbPermission(device)` for accessory-mode devices that re-enumerate without permission
- `UsbAttachedActivity` remains reserved for the opt-in USB auto-start attach flow

## Behavior After This Change

- `Auto-start on USB = OFF`
  - no system USB chooser/modal for unrelated peripherals
  - manual USB connect still works
  - accessory re-enumeration permission recovery still works

- `Auto-start on USB = ON`
  - existing auto-start behavior remains intact

## Testing

Local Android build verification was not possible in this workspace because the Android SDK path is not configured (`ANDROID_HOME` / `local.properties` missing).

Static verification performed:
- traced the regression to `55e81c2`
- verified earlier revisions used `UsbAttachedActivity` as the working permission entrypoint before component gating
- updated non-auto-start permission flows to use the existing runtime receiver/service path instead of the disabled activity
