### PR TITLE
Fix: Auto Light/Dark Mode timings are offset by ~3 hours in the UK Fixes #422

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/location/GpsLocation.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/location/GpsLocation.kt
@@ -31,9 +31,7 @@ class GpsLocation constructor(private val context: Context): LocationListener {
     }
 
     override fun onLocationChanged(location: Location) {
-        val intent = LocationUpdateIntent(location)
-        intent.setPackage(context.packageName)
-        context.sendBroadcast(intent)
+        context.sendBroadcast(LocationUpdateIntent(location).setPackage(context.packageName))
     }
 
     override fun onStatusChanged(provider: String, status: Int, extras: Bundle) {

--- a/app/src/main/java/com/andrerinas/headunitrevived/location/GpsLocation.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/location/GpsLocation.kt
@@ -31,7 +31,9 @@ class GpsLocation constructor(private val context: Context): LocationListener {
     }
 
     override fun onLocationChanged(location: Location) {
-        context.sendBroadcast(LocationUpdateIntent(location))
+        val intent = LocationUpdateIntent(location)
+        intent.setPackage(context.packageName)
+        context.sendBroadcast(intent)
     }
 
     override fun onStatusChanged(provider: String, status: Int, extras: Bundle) {


### PR DESCRIPTION
**Context**
I’ve implemented a fix for issue with automatic switching between Light and Dark mode. User in the UK (and likely other regions has the same issue) reported that automatic day/night theme switching is inaccurate – dark mode activates about 3 hours before actual sunset. I found that the app always falls back to hardcoded coordinates (32.000000, 34.000000) instead of the user's real GPS location.

**Root clause**
- LocationUpdateIntent sent from GpsLocation.onLocationChanged() was not being received by AapBroadcastReceiver. As a result, lastKnownLocation never updated from its default value, causing TwilightCalculator to compute sunrise/sunset for the wrong geographic location.

**Changes**
- I made the intent explicit and added the package name to it.

**Testing**
-  Verified on nothing phone 1, Android 15.