### PR TITLE
UI Scale and disable auto start for native

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapProjectionActivity.kt
@@ -172,7 +172,6 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         override fun onReceive(context: Context, intent: Intent) {
             val event: KeyEvent? = IntentCompat.getParcelableExtra(intent, KeyIntent.extraEvent, KeyEvent::class.java)
             event?.let {
-                AppLog.i("AapProjectionActivity: Received key from broadcast: code=${it.keyCode} (isDown=${it.action == KeyEvent.ACTION_DOWN})")
                 onKeyEvent(it.keyCode, it.action == KeyEvent.ACTION_DOWN)
             }
         }
@@ -826,26 +825,22 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
     }
 
 
-    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
-        if (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN || keyCode == KeyEvent.KEYCODE_VOLUME_MUTE) {
-            return super.onKeyDown(keyCode, event)
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        // 1. Let the system handle volume and back keys
+        if (event.keyCode == KeyEvent.KEYCODE_BACK || 
+            event.keyCode == KeyEvent.KEYCODE_VOLUME_UP || 
+            event.keyCode == KeyEvent.KEYCODE_VOLUME_DOWN || 
+            event.keyCode == KeyEvent.KEYCODE_VOLUME_MUTE) {
+            return super.dispatchKeyEvent(event)
         }
-        // Always pass keys to AA during projection, unless they are handled by super (volume/back)
-        commManager.sendKey(keyCode, true)
-        return true
-    }
 
-    override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
-        if (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN || keyCode == KeyEvent.KEYCODE_VOLUME_MUTE) {
-            return super.onKeyUp(keyCode, event)
-        }
-        commManager.sendKey(keyCode, false)
+        // 2. Funnel all other keys to CommManager
+        commManager.sendKey(event.keyCode, event.action == KeyEvent.ACTION_DOWN)
         return true
     }
 
     private fun onKeyEvent(keyCode: Int, isPress: Boolean) {
-        // All key events are now funneled through CommManager for centralized 
-        // remapping, state tracking, and debouncing.
+        // Broadcasts (e.g. from CarKeyReceiver) still use this path.
         commManager.sendKey(keyCode, isPress)
     }
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapProjectionActivity.kt
@@ -826,6 +826,11 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
 
 
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        val action = event.action
+        if (action != KeyEvent.ACTION_DOWN && action != KeyEvent.ACTION_UP) {
+            return super.dispatchKeyEvent(event)
+        }
+
         // 1. Let the system handle volume and back keys
         if (event.keyCode == KeyEvent.KEYCODE_BACK || 
             event.keyCode == KeyEvent.KEYCODE_VOLUME_UP || 

--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
@@ -680,7 +680,7 @@ class AapService : Service(), UsbReceiver.Listener {
             }
         }
         
-        initWifiModeWithOptionalWait()
+        initWifiModeWithOptionalWait(settings.autoConnectNative)
         wifiDirectManager?.setCredentialsListener { ssid, psk, ip, bssid ->
             val settings = App.provide(this).settings
             if (settings.wifiConnectionMode == 3) {
@@ -1233,11 +1233,11 @@ class AapService : Service(), UsbReceiver.Listener {
      *
      * When the setting is disabled, or the mode is not 2, [initWifiMode] runs immediately.
      */
-    private fun initWifiModeWithOptionalWait() {
+    private fun initWifiModeWithOptionalWait(allowAutoNative: Boolean = true) {
         val settings = App.provide(this).settings
 
         if (settings.wifiConnectionMode != 2 || !settings.waitForWifiBeforeWifiDirect) {
-            initWifiMode()
+            initWifiMode(allowAutoNative = allowAutoNative)
             return
         }
 
@@ -1259,7 +1259,7 @@ class AapService : Service(), UsbReceiver.Listener {
             else AppLog.i("WifiWait: Legacy device (API < 21), skipping wait.")
 
             wifiModeInitialized = true
-            initWifiMode()
+            initWifiMode(allowAutoNative = allowAutoNative)
             return
         }
 
@@ -1313,7 +1313,7 @@ class AapService : Service(), UsbReceiver.Listener {
     }
 
     /** Starts [WirelessServer] if the user has configured server WiFi mode. */
-    private fun initWifiMode(force: Boolean = false) {
+    private fun initWifiMode(force: Boolean = false, allowAutoNative: Boolean = true) {
         val settings = App.provide(this).settings
         val mode = settings.wifiConnectionMode
         val strategy = settings.helperConnectionStrategy
@@ -1371,10 +1371,18 @@ class AapService : Service(), UsbReceiver.Listener {
                 val wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as android.net.wifi.WifiManager
                 if (wifiManager.isWifiEnabled) {
                     // Start WiFi Direct as a "quiet host" (P2P Group for phone to join)
-                    wifiDirectManager?.startNativeAaQuietHost()
+                    if (allowAutoNative) {
+                        wifiDirectManager?.startNativeAaQuietHost()
+                    } else {
+                        AppLog.i("AapService: autoConnectNative disabled — skipping startNativeAaQuietHost on startup")
+                    }
                 }
                 // Start the official Bluetooth handshake servers
-                nativeAaHandshakeManager?.start()
+                if (allowAutoNative) {
+                    nativeAaHandshakeManager?.start()
+                } else {
+                    AppLog.i("AapService: autoConnectNative disabled — skipping Native AA handshake start on startup")
+                }
             }
         }
         

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/CommManager.kt
@@ -398,12 +398,13 @@ class CommManager(
      * This is the single entry point for all key events in the application.
      */
     fun sendKey(keyCode: Int, isPress: Boolean) {
-        if (_connectionState.value !is ConnectionState.TransportStarted) return
+        if (_connectionState.value !is ConnectionState.TransportStarted) {
+            return
+        }
 
         // 1. Remapping (Physical -> Logical)
-        // We find the AA logical code (key) that corresponds to this hardware keyCode (value).
         var logicalCode = settings.keyCodes.entries.find { it.value == keyCode }?.key ?: keyCode
-
+        
         // [FIX] BMW/Rotary Enter remapping: Most AA apps expect DPAD_CENTER (23) for selection,
         // but physical rotary knobs often send ENTER (66). Remap 66 -> 23 to ensure selection works.
         if (logicalCode == KeyEvent.KEYCODE_ENTER) {
@@ -413,27 +414,18 @@ class CommManager(
         // 2. State Tracking & De-duplication
         val isCurrentlyDown = keyStates[logicalCode] ?: false
         if (isPress == isCurrentlyDown) {
-            // Already in this state (e.g., duplicate DOWN or duplicate UP) - drop it.
-            // This catches redundant triggers from multiple receivers (CarKey, MediaSession, etc.)
             return
         }
 
-        // 3. Time-based Debouncing (Improved for "Double Key" issues)
-        // We debounce based on the LOGICAL code to catch cases where multiple physical sources
-        // (e.g. proprietary intent + standard MEDIA_BUTTON) trigger the same action.
+        // 3. Time-based Debouncing
         val now = SystemClock.elapsedRealtime()
-        
         if (isPress) {
             val lastPressTime = lastKeyEvents[logicalCode] ?: 0L
-            // Use a 300ms window to ignore duplicate "DOWN" events for the same logical action.
             if (now - lastPressTime < 300) {
-                AppLog.i("CommManager: Debouncing logical key $logicalCode (DOWN) - dropped duplicate trigger within ${now - lastPressTime}ms (likely multi-intent source)")
+                AppLog.i("CommManager: Debouncing logical key $logicalCode (DOWN) - dropped duplicate trigger within ${now - lastPressTime}ms")
                 return
             }
             lastKeyEvents[logicalCode] = now
-        } else {
-            // For UP events, if we don't have a record of a recent DOWN event that wasn't filtered,
-            // the state tracking above (isPress == isCurrentlyDown) already handles dropping the UP.
         }
 
         // Update state

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/MainActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/MainActivity.kt
@@ -39,6 +39,7 @@ class MainActivity : BaseActivity() {
     
     private var isOrientationReceiverRegistered = false
     private var isFinishReceiverRegistered = false
+    private var isRecreateReceiverRegistered = false
 
     private val viewModel: MainViewModel by viewModels()
 
@@ -47,6 +48,17 @@ class MainActivity : BaseActivity() {
             if (intent.action == "com.andrerinas.headunitrevived.ACTION_FINISH_ACTIVITIES") {
                 AppLog.i("MainActivity: Received finish request. Closing.")
                 finishAffinity()
+            }
+        }
+    }
+
+    private val recreateReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            if (intent.action == ACTION_RECREATE_MAIN) {
+                AppLog.i("MainActivity: Received recreate request. Recreating.")
+                try {
+                    runOnUiThread { recreate() }
+                } catch (_: Exception) { }
             }
         }
     }
@@ -61,6 +73,20 @@ class MainActivity : BaseActivity() {
                 AppLog.i("MainActivity: Orientation change broadcast received. Updating.")
                 requestedOrientation = Settings(this@MainActivity).screenOrientation.androidOrientation
             }
+        }
+    }
+
+    override fun attachBaseContext(newBase: Context) {
+        val settings  = Settings(newBase)
+        val scale = settings.uiScaleHomePercent / 100.0f
+        if (scale != 1.0f && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            val cfg = Configuration(newBase.resources.configuration)
+            val metrics = newBase.resources.displayMetrics
+            cfg.densityDpi = (metrics.densityDpi * scale).toInt()
+            val ctx = newBase.createConfigurationContext(cfg)
+            super.attachBaseContext(ctx)
+        } else {
+            super.attachBaseContext(newBase)
         }
     }
 
@@ -149,6 +175,14 @@ class MainActivity : BaseActivity() {
             ContextCompat.RECEIVER_NOT_EXPORTED
         )
         isFinishReceiverRegistered = true
+
+        // Register recreate receiver so SettingsFragment can request MainActivity recreate
+        ContextCompat.registerReceiver(
+            this, recreateReceiver,
+            android.content.IntentFilter(ACTION_RECREATE_MAIN),
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
+        isRecreateReceiverRegistered = true
     }
 
     private fun showSplashWithDelay(delayMs: Long) {
@@ -389,6 +423,10 @@ class MainActivity : BaseActivity() {
             unregisterReceiver(finishReceiver)
             isFinishReceiverRegistered = false
         }
+        if (isRecreateReceiverRegistered) {
+            unregisterReceiver(recreateReceiver)
+            isRecreateReceiverRegistered = false
+        }
         if (isFinishing) {
             AppLog.i("MainActivity finishing, resetting auto-start flag.")
             HomeFragment.resetAutoStart()
@@ -398,5 +436,6 @@ class MainActivity : BaseActivity() {
     companion object {
         private const val permissionRequestCode = 97
         const val EXTRA_LAUNCH_SOURCE = "launch_source"
+        const val ACTION_RECREATE_MAIN = "com.andrerinas.headunitrevived.ACTION_RECREATE_MAIN"
     }
 }

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsActivity.kt
@@ -1,16 +1,33 @@
 package com.andrerinas.headunitrevived.main
 
+import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.activity.enableEdgeToEdge
 import androidx.navigation.fragment.NavHostFragment
 import android.content.res.Configuration
+import android.os.Build
 import com.andrerinas.headunitrevived.R
 import com.andrerinas.headunitrevived.app.BaseActivity
 import com.andrerinas.headunitrevived.utils.Settings
 import com.andrerinas.headunitrevived.utils.SystemUI
 
 class SettingsActivity : BaseActivity() {
+
+    override fun attachBaseContext(newBase: Context) {
+        val settings  = Settings(newBase)
+        val scale = settings.uiScaleSettingsPercent / 100.0f
+        if (scale != 1.0f && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            val cfg = Configuration(newBase.resources.configuration)
+            val metrics = newBase.resources.displayMetrics
+            cfg.densityDpi = (metrics.densityDpi * scale).toInt()
+            val ctx = newBase.createConfigurationContext(cfg)
+            super.attachBaseContext(ctx)
+        } else {
+            super.attachBaseContext(newBase)
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
@@ -68,6 +68,7 @@ class SettingsFragment : Fragment() {
     private var pendingWifiConnectionMode: Int? = null
     private var pendingHelperConnectionStrategy: Int? = null
     private var pendingAutoEnableHotspot: Boolean? = null
+    private var pendingAutoConnectNative: Boolean? = null
     private var pendingWaitForWifi: Boolean? = null
     private var pendingWaitForWifiTimeout: Int? = null
 
@@ -137,6 +138,7 @@ class SettingsFragment : Fragment() {
 
         pendingKillOnDisconnect = settings.killOnDisconnect
         pendingAutoEnableHotspot = settings.autoEnableHotspot
+        pendingAutoConnectNative = settings.autoConnectNative
         pendingFakeSpeed = settings.fakeSpeed
 
         pendingWifiConnectionMode = settings.wifiConnectionMode
@@ -278,7 +280,8 @@ class SettingsFragment : Fragment() {
         pendingHelperConnectionStrategy?.let { settings.helperConnectionStrategy = it }
         pendingWaitForWifi?.let { settings.waitForWifiBeforeWifiDirect = it }
         pendingWaitForWifiTimeout?.let { settings.waitForWifiTimeout = it }
-        
+        pendingAutoConnectNative?.let { settings.autoConnectNative = it }
+
         pendingInsetLeft?.let { settings.insetLeft = it }
         pendingInsetTop?.let { settings.insetTop = it }
         pendingInsetRight?.let { settings.insetRight = it }
@@ -356,7 +359,8 @@ class SettingsFragment : Fragment() {
                         pendingWifiConnectionMode != settings.wifiConnectionMode ||
                         pendingHelperConnectionStrategy != settings.helperConnectionStrategy ||
                         pendingWaitForWifi != settings.waitForWifiBeforeWifiDirect ||
-                        pendingWaitForWifiTimeout != settings.waitForWifiTimeout
+                        pendingWaitForWifiTimeout != settings.waitForWifiTimeout ||
+                        pendingAutoConnectNative != settings.autoConnectNative
 
         hasChanges = anyChange
 
@@ -497,6 +501,22 @@ class SettingsFragment : Fragment() {
                 }
             }
         ))
+
+        // Sub-setting for Native Wireless mode
+        if (pendingWifiConnectionMode == 3) {
+            items.add(SettingItem.ToggleSettingEntry(
+                stableId = "nativeAutoConnect",
+                nameResId = R.string.auto_connect_native,
+                descriptionResId = R.string.auto_connect_native_description,
+                isChecked = pendingAutoConnectNative ?: true,
+                onCheckedChanged = { isChecked ->
+                    pendingAutoConnectNative = isChecked
+                    checkChanges()
+                    updateSettingsList()
+                }
+            ))
+        }
+
 
         // Sub-setting for Headunit Server (Manual vs Auto)
         if (pendingWifiConnectionMode == 0 || pendingWifiConnectionMode == 1) {

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
@@ -84,6 +84,9 @@ class SettingsFragment : Fragment() {
     private var pendingInsetRight: Int? = null
     private var pendingInsetBottom: Int? = null
 
+    private var pendingUiScaleHomePercent: Int? = null
+    private var pendingUiScaleSettingsPercent: Int? = null
+
     private var pendingMediaVolumeOffset: Int? = null
     private var pendingAssistantVolumeOffset: Int? = null
     private var pendingNavigationVolumeOffset: Int? = null
@@ -150,6 +153,9 @@ class SettingsFragment : Fragment() {
         pendingInsetTop = settings.insetTop
         pendingInsetRight = settings.insetRight
         pendingInsetBottom = settings.insetBottom
+        // UI Scale pending values (percent)
+        pendingUiScaleHomePercent = settings.uiScaleHomePercent
+        pendingUiScaleSettingsPercent = settings.uiScaleSettingsPercent
 
         pendingMediaVolumeOffset = settings.mediaVolumeOffset
         pendingAssistantVolumeOffset = settings.assistantVolumeOffset
@@ -449,6 +455,16 @@ class SettingsFragment : Fragment() {
                 try {
                     findNavController().navigate(R.id.action_settingsFragment_to_vehicleInfoFragment)
                 } catch (e: Exception) { }
+            }
+        ))
+
+        // UI Scale (example dialog similar to Custom Insets) - appear after vehicle info
+        items.add(SettingItem.SettingEntry(
+            stableId = "uiScale",
+            nameResId = R.string.ui_scale,
+            value = "${getString(R.string.ui_scale_home)}: ${pendingUiScaleHomePercent ?: 100}% · ${getString(R.string.ui_scale_settings)}: ${pendingUiScaleSettingsPercent ?: 100}%",
+            onClick = { _ ->
+                showUiScaleDialog()
             }
         ))
 
@@ -1411,6 +1427,99 @@ class SettingsFragment : Fragment() {
                 
                 dialog.dismiss()
             }
+            .show()
+    }
+
+    private fun showUiScaleDialog() {
+        val context = requireContext()
+        val density = context.resources.displayMetrics.density
+
+        val container = android.widget.LinearLayout(context).apply {
+            orientation = android.widget.LinearLayout.VERTICAL
+            val pad = (16 * density).toInt()
+            setPadding(pad, pad, pad, pad)
+        }
+
+        fun makeRow(labelText: String, initialPercent: Int): Triple<android.widget.TextView, android.widget.SeekBar, android.widget.TextView> {
+            val label = android.widget.TextView(context).apply {
+                text = labelText
+                setPadding(0, (8 * density).toInt(), 0, (4 * density).toInt())
+            }
+            val seek = android.widget.SeekBar(context).apply {
+                // Map 100..150 step 10 -> progress 0..5
+                max = 5
+                progress = ((initialPercent - 100) / 10).coerceIn(0, 5)
+            }
+            val value = android.widget.TextView(context).apply {
+                text = "$initialPercent%"
+                setPadding(0, (4 * density).toInt(), 0, (12 * density).toInt())
+            }
+            // Update value when seek changes
+            seek.setOnSeekBarChangeListener(object : android.widget.SeekBar.OnSeekBarChangeListener {
+                override fun onProgressChanged(sb: android.widget.SeekBar?, progress: Int, fromUser: Boolean) {
+                    val pct = 100 + progress * 10
+                    value.text = "$pct%"
+                }
+                override fun onStartTrackingTouch(sb: android.widget.SeekBar?) {}
+                override fun onStopTrackingTouch(sb: android.widget.SeekBar?) {}
+            })
+
+            return Triple(label, seek, value)
+        }
+
+        val homeInitial = pendingUiScaleHomePercent ?: settings.uiScaleHomePercent
+        val settingsInitial = pendingUiScaleSettingsPercent ?: settings.uiScaleSettingsPercent
+
+        val (homeLabel, homeSeek, homeValue) = makeRow(getString(R.string.ui_scale_home), homeInitial)
+        val (settingsLabel, settingsSeek, settingsValue) = makeRow(getString(R.string.ui_scale_settings), settingsInitial)
+
+        container.addView(homeLabel, android.widget.LinearLayout.LayoutParams(android.widget.LinearLayout.LayoutParams.MATCH_PARENT, android.widget.LinearLayout.LayoutParams.WRAP_CONTENT))
+        container.addView(homeSeek, android.widget.LinearLayout.LayoutParams(android.widget.LinearLayout.LayoutParams.MATCH_PARENT, android.widget.LinearLayout.LayoutParams.WRAP_CONTENT))
+        container.addView(homeValue, android.widget.LinearLayout.LayoutParams(android.widget.LinearLayout.LayoutParams.MATCH_PARENT, android.widget.LinearLayout.LayoutParams.WRAP_CONTENT))
+        container.addView(settingsLabel, android.widget.LinearLayout.LayoutParams(android.widget.LinearLayout.LayoutParams.MATCH_PARENT, android.widget.LinearLayout.LayoutParams.WRAP_CONTENT))
+        container.addView(settingsSeek, android.widget.LinearLayout.LayoutParams(android.widget.LinearLayout.LayoutParams.MATCH_PARENT, android.widget.LinearLayout.LayoutParams.WRAP_CONTENT))
+        container.addView(settingsValue, android.widget.LinearLayout.LayoutParams(android.widget.LinearLayout.LayoutParams.MATCH_PARENT, android.widget.LinearLayout.LayoutParams.WRAP_CONTENT))
+
+        // Wrap content in a ScrollView to ensure content is scrollable on small screens or when large scale is used
+        val scroll = android.widget.ScrollView(context).apply {
+            isFillViewport = true
+            addView(container, android.widget.FrameLayout.LayoutParams(android.widget.FrameLayout.LayoutParams.MATCH_PARENT, android.widget.FrameLayout.LayoutParams.WRAP_CONTENT))
+        }
+
+        MaterialAlertDialogBuilder(context, R.style.DarkAlertDialog)
+            .setTitle(R.string.ui_scale)
+            .setView(scroll)
+            .setPositiveButton(android.R.string.ok) { dialog, _ ->
+                val newHome = 100 + (homeSeek.progress * 10)
+                val newSettings = 100 + (settingsSeek.progress * 10)
+                val oldSettings = settings.uiScaleSettingsPercent
+                val oldHome = settings.uiScaleHomePercent
+
+                // Persist immediately (similar to Custom Insets behavior)
+                settings.uiScaleHomePercent = newHome
+                settings.uiScaleSettingsPercent = newSettings
+                settings.commit()
+
+                pendingUiScaleHomePercent = newHome
+                pendingUiScaleSettingsPercent = newSettings
+                checkChanges()
+                updateSettingsList()
+
+                dialog.dismiss()
+
+                // If Settings value changed, recreate activity as requested
+                if (newSettings != oldSettings) {
+                    requireActivity().recreate()
+                }
+                // If Home UI scale changed, request MainActivity to recreate
+                if (newHome != oldHome) {
+                    val intent = Intent(MainActivity.ACTION_RECREATE_MAIN).apply {
+                        setPackage(requireContext().packageName)
+                    }
+                    requireContext().sendBroadcast(intent)
+                }
+            }
+            .setNegativeButton(android.R.string.cancel, null)
             .show()
     }
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
@@ -76,6 +76,16 @@ class Settings(context: Context) {
         get() = prefs.getBoolean("forced_scale", false)
         set(value) { prefs.edit().putBoolean("forced_scale", value).apply() }
 
+    // UI Scale percentage for Home
+    var uiScaleHomePercent: Int
+        get() = prefs.getInt("ui-scale-home-percent", 100)
+        set(value) { prefs.edit().putInt("ui-scale-home-percent", value).apply() }
+
+    // UI Scale percentage for Settings
+    var uiScaleSettingsPercent: Int
+        get() = prefs.getInt("ui-scale-settings-percent", 100)
+        set(value) { prefs.edit().putInt("ui-scale-settings-percent", value).apply() }
+
     var micSampleRate: Int
         get() = prefs.getInt("mic-sample-rate", 16000)
         set(sampleRate) {

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
@@ -330,6 +330,11 @@ class Settings(context: Context) {
         get() = prefs.getBoolean("auto-connect-single-usb", false)
         set(value) { prefs.edit().putBoolean("auto-connect-single-usb", value).apply() }
 
+    /** Whether automatic connect should be attempted when using Native Wireless mode (Native AA). */
+    var autoConnectNative: Boolean
+        get() = prefs.getBoolean("auto-connect-native", true)
+        set(value) { prefs.edit().putBoolean("auto-connect-native", value).apply() }
+
     var lastConnectionType: String
         get() = prefs.getString("last-connection-type", "")!!
         set(value) { prefs.edit().putString("last-connection-type", value).apply() }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -210,6 +210,8 @@
     <string name="auto_connect_help">تعمل هذه الطرق تلقائيا عند فتح التطبيق. قم بتمكين الطرق التي تريدها، ثم اسحب لضبط الترتيب. سيتم استخدام أول طريقة ممكّنة تنجح.</string>
     <string name="auto_connect_priority">الأولوية %d</string>
     <string name="auto_connect_all_disabled">الكل معطل</string>
+    <string name="auto_connect_native">الاتصال التلقائي (Native)</string>
+    <string name="auto_connect_native_description">يتصل تلقائيًا بالهاتف عند استخدام وضع الوايرلس الأصلي.</string>
     <string name="drag_to_reorder">اسحب لإعادة الترتيب</string>
     <string name="move_up">تحريك للأعلى</string>
     <string name="move_down">تحريك للأسفل</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -415,6 +415,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">معلومات المركبة</string>
     <string name="vehicle_info_settings_description">خصص كيف تظهر مركبتك على هاتفك</string>
+    <string name="ui_scale">مقياس واجهة المستخدم</string>
+    <string name="ui_scale_home">الشاشة الرئيسية</string>
+    <string name="ui_scale_settings">شاشة الإعدادات</string>
     <string name="category_vehicle">المركبة</string>
     <string name="category_head_unit">وحدة الوسائط</string>
     <string name="vehicle_display_name_label">اسم العرض</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -415,6 +415,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Informace o vozidle</string>
     <string name="vehicle_info_settings_description">Přizpůsobte, jak se vaše vozidlo zobrazuje na telefonu</string>
+    <string name="ui_scale">Měřítko rozhraní</string>
+    <string name="ui_scale_home">Hlavní obrazovka</string>
+    <string name="ui_scale_settings">Obrazovka nastavení</string>
     <string name="category_vehicle">Vozidlo</string>
     <string name="category_head_unit">Autorádio</string>
     <string name="vehicle_display_name_label">Zobrazovaný název</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -210,6 +210,8 @@
     <string name="auto_connect_help">Tyto metody se spouští automaticky při otevření aplikace. Povolte ty, které chcete, a přetažením nastavte pořadí. Použije se první povolená metoda, která uspěje.</string>
     <string name="auto_connect_priority">Priorita %d</string>
     <string name="auto_connect_all_disabled">Vše vypnuto</string>
+    <string name="auto_connect_native">Automatické připojení (Native)</string>
+    <string name="auto_connect_native_description">Automaticky se připojí k telefonu při použití nativního bezdrátového režimu.</string>
     <string name="drag_to_reorder">Přetáhněte pro změnu pořadí</string>
     <string name="move_up">Posunout nahoru</string>
     <string name="move_down">Posunout dolů</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -425,6 +425,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Fahrzeuginformationen</string>
     <string name="vehicle_info_settings_description">Passen Sie an, wie Ihr Fahrzeug auf Ihrem Telefon angezeigt wird</string>
+    <string name="ui_scale">UI-Skalierung</string>
+    <string name="ui_scale_home">Startbildschirm</string>
+    <string name="ui_scale_settings">Einstellungsbildschirm</string>
     <string name="category_vehicle">Fahrzeug</string>
     <string name="category_head_unit">Autoradio</string>
     <string name="vehicle_display_name_label">Anzeigename</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -226,6 +226,8 @@
     <string name="auto_connect_help">Diese Methoden werden beim Öffnen der App automatisch ausgeführt. Aktivieren Sie die gewünschten und ziehen Sie sie in die gewünschte Reihenfolge. Die erste erfolgreiche aktivierte Methode wird verwendet.</string>
     <string name="auto_connect_priority">Priorität %d</string>
     <string name="auto_connect_all_disabled">Alle deaktiviert</string>
+    <string name="auto_connect_native">Automatisch verbinden (Native)</string>
+    <string name="auto_connect_native_description">Automatisch mit dem Telefon verbinden, wenn der Native Wireless-Modus verwendet wird.</string>
     <string name="drag_to_reorder">Zum Sortieren ziehen</string>
     <string name="move_up">Nach oben</string>
     <string name="move_down">Nach unten</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -210,6 +210,8 @@
     <string name="auto_connect_help">Estos métodos se ejecutan automáticamente al abrir la app. Active los que desee y arrastre para establecer el orden. Se usará el primer método activo que tenga éxito.</string>
     <string name="auto_connect_priority">Prioridad %d</string>
     <string name="auto_connect_all_disabled">Todos desactivados</string>
+    <string name="auto_connect_native">Conexión automática (Nativa)</string>
+    <string name="auto_connect_native_description">Conectarse automáticamente al teléfono al usar el modo Wireless nativo.</string>
     <string name="drag_to_reorder">Arrastra para reordenar</string>
     <string name="move_up">Subir</string>
     <string name="move_down">Bajar</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -415,6 +415,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Información del vehículo</string>
     <string name="vehicle_info_settings_description">Personaliza cómo aparece tu vehículo en tu móvil</string>
+    <string name="ui_scale">Escala de la interfaz</string>
+    <string name="ui_scale_home">Pantalla de inicio</string>
+    <string name="ui_scale_settings">Pantalla de ajustes</string>
     <string name="category_vehicle">Vehículo</string>
     <string name="category_head_unit">Radio</string>
     <string name="vehicle_display_name_label">Nombre para mostrar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -210,6 +210,8 @@
     <string name="auto_connect_help">Estos métodos se ejecutan automáticamente al abrir la app. Active los que desee y arrastre para establecer el orden. Se usará el primer método activo que tenga éxito.</string>
     <string name="auto_connect_priority">Prioridad %d</string>
     <string name="auto_connect_all_disabled">Todos desactivados</string>
+    <string name="auto_connect_native">Conexión automática (Nativa)</string>
+    <string name="auto_connect_native_description">Conectarse automáticamente al teléfono al usar el modo Wireless nativo.</string>
     <string name="drag_to_reorder">Arrastra para reordenar</string>
     <string name="move_up">Subir</string>
     <string name="move_down">Bajar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -415,6 +415,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Información del vehículo</string>
     <string name="vehicle_info_settings_description">Personaliza cómo aparece tu vehículo en tu teléfono</string>
+    <string name="ui_scale">Escala de la interfaz</string>
+    <string name="ui_scale_home">Pantalla de inicio</string>
+    <string name="ui_scale_settings">Pantalla de ajustes</string>
     <string name="category_vehicle">Vehículo</string>
     <string name="category_head_unit">Radio</string>
     <string name="vehicle_display_name_label">Nombre para mostrar</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -414,6 +414,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Járműinformáció</string>
     <string name="vehicle_info_settings_description">Testreszabhatja, hogyan jelenik meg járműve a telefonján</string>
+    <string name="ui_scale">UI méretezés</string>
+    <string name="ui_scale_home">Kezdőképernyő</string>
+    <string name="ui_scale_settings">Beállítások képernyő</string>
     <string name="category_vehicle">Jármű</string>
     <string name="category_head_unit">Fejegység</string>
     <string name="vehicle_display_name_label">Megjelenítési név</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -210,6 +210,8 @@
     <string name="auto_connect_help">Ezek a módszerek automatikusan futnak az alkalmazás megnyitásakor. Engedélyezze a kívántakat, majd húzza őket a sorrend beállításához. Az első sikeres engedélyezett módszer kerül felhasználásra.</string>
     <string name="auto_connect_priority">Prioritás %d</string>
     <string name="auto_connect_all_disabled">Mind letiltva</string>
+    <string name="auto_connect_native">Automatikus csatlakozás (Native)</string>
+    <string name="auto_connect_native_description">Automatikusan csatlakozik a telefonhoz, amikor a natív vezeték nélküli mód aktív.</string>
     <string name="drag_to_reorder">Húzza az átrendezéshez</string>
     <string name="move_up">Felfelé</string>
     <string name="move_down">Lefelé</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -420,6 +420,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Informazioni veicolo</string>
     <string name="vehicle_info_settings_description">Personalizza come il tuo veicolo appare sul telefono</string>
+    <string name="ui_scale">Scala UI</string>
+    <string name="ui_scale_home">Schermata Home</string>
+    <string name="ui_scale_settings">Schermata Impostazioni</string>
     <string name="category_vehicle">Veicolo</string>
     <string name="category_head_unit">Head Unit</string>
     <string name="vehicle_display_name_label">Nome visualizzato</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -226,6 +226,8 @@
     <string name="auto_connect_help">Questi metodi vengono eseguiti automaticamente all\'apertura dell\'app. Abilita quelli che desideri, quindi trascina per impostare l\'ordine. Verrà utilizzato il primo metodo abilitato che ha successo.</string>
     <string name="auto_connect_priority">Priorità %d</string>
     <string name="auto_connect_all_disabled">Tutti disabilitati</string>
+    <string name="auto_connect_native">Connessione automatica (Nativa)</string>
+    <string name="auto_connect_native_description">Connette automaticamente al telefono quando si utilizza la modalità Wireless nativa.</string>
     <string name="drag_to_reorder">Trascina per riordinare</string>
     <string name="move_up">Sposta su</string>
     <string name="move_down">Sposta giù</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -225,6 +225,8 @@
     <string name="auto_connect_help">これらのメソッドはアプリ起動時に自動的に実行されます。必要なメソッドを有効にし、ドラッグして実行順序を設定してください。最初に有効になり、かつ正常に実行されたメソッドが使用されます。</string>
     <string name="auto_connect_priority">優先度 %d</string>
     <string name="auto_connect_all_disabled">すべて無効</string>
+    <string name="auto_connect_native">自動接続（ネイティブ）</string>
+    <string name="auto_connect_native_description">ネイティブのワイヤレスモードを使用しているときに、電話に自動的に接続します。</string>
     <string name="drag_to_reorder">ドラッグして並べ替える</string>
     <string name="move_up">上に移動</string>
     <string name="move_down">下に移動</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -421,6 +421,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">車両情報</string>
     <string name="vehicle_info_settings_description">お使いのスマートフォン上で、車両情報の表示方法をカスタマイズできます。</string>
+    <string name="ui_scale">UI スケール</string>
+    <string name="ui_scale_home">ホーム画面</string>
+    <string name="ui_scale_settings">設定画面</string>
     <string name="category_vehicle">車両</string>
     <string name="category_head_unit">車載機</string>
     <string name="vehicle_display_name_label">表示ネーム</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -225,6 +225,8 @@
     <string name="auto_connect_help">애플리케이션이 열릴 때 자동으로 실행되는 방법입니다. 원하는 방법을 활성화하고 순서를 설정하세요. 첫 번째 활성화된 방법이 성공하면 사용됩니다.</string>
     <string name="auto_connect_priority">우선순위 %d</string>
     <string name="auto_connect_all_disabled">모두 비활성화</string>
+    <string name="auto_connect_native">자동 연결 (네이티브)</string>
+    <string name="auto_connect_native_description">네이티브 무선 모드를 사용할 때 전화에 자동으로 연결합니다.</string>
     <string name="drag_to_reorder">드래그하여 순서를 변경합니다</string>
     <string name="move_up">위로 이동</string>
     <string name="move_down">아래로 이동</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -422,6 +422,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">차량 정보</string>
     <string name="vehicle_info_settings_description">차량이 휴대폰에 표시되는 방식을 사용자 정의합니다</string>
+    <string name="ui_scale">UI 배율</string>
+    <string name="ui_scale_home">홈 화면</string>
+    <string name="ui_scale_settings">설정 화면</string>
     <string name="category_vehicle">차량</string>
     <string name="category_head_unit">헤드유닛</string>
     <string name="vehicle_display_name_label">표시 이름</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -120,6 +120,7 @@
     <string name="log_level_description">내보낼 때 로그 레벨을 필터링합니다.</string>
     <string name="start_log_capture">로그 캡처 시작</string>
     <string name="start_log_capture_description">디버깅을 위해 전체 로그를 기록합니다.</string>
+    <string name="start_log_capture_in_silent">녹화를 시작할 수 없습니다: 로그 레벨이 \'무음\'으로 설정되어 있습니다</string>
     <string name="stop_log_capture">로그 캡처 중지</string>
     <string name="stop_log_capture_description">녹화 중… 멈추려면 탭하세요.</string>
     <string name="export_logs">로그 내보내기</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -209,6 +209,8 @@
     <string name="auto_connect_help">Deze methoden worden automatisch uitgevoerd bij het openen van de app. Schakel de gewenste in en sleep om de volgorde te bepalen. De eerste ingeschakelde methode die slaagt, wordt gebruikt.</string>
     <string name="auto_connect_priority">Prioriteit %d</string>
     <string name="auto_connect_all_disabled">Alles uitgeschakeld</string>
+    <string name="auto_connect_native">Automatisch verbinden (Native)</string>
+    <string name="auto_connect_native_description">Automatisch verbinden met de telefoon wanneer de Native Wireless-modus wordt gebruikt.</string>
     <string name="drag_to_reorder">Sleep om te herschikken</string>
     <string name="move_up">Omhoog</string>
     <string name="move_down">Omlaag</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -412,6 +412,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Voertuiginformatie</string>
     <string name="vehicle_info_settings_description">Pas aan hoe uw voertuig op uw telefoon wordt weergegeven</string>
+    <string name="ui_scale">UI-schaal</string>
+    <string name="ui_scale_home">Startscherm</string>
+    <string name="ui_scale_settings">Instellingen scherm</string>
     <string name="category_vehicle">Voertuig</string>
     <string name="category_head_unit">Headunit</string>
     <string name="vehicle_display_name_label">Weergavenaam</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -210,6 +210,8 @@
     <string name="auto_connect_help">Te metody uruchamiają się automatycznie przy otwieraniu aplikacji. Włącz te, które chcesz, i przeciągnij, aby ustawić kolejność. Zostanie użyta pierwsza włączona metoda, która się powiedzie.</string>
     <string name="auto_connect_priority">Priorytet %d</string>
     <string name="auto_connect_all_disabled">Wszystkie wyłączone</string>
+    <string name="auto_connect_native">Automatyczne łączenie (Natywne)</string>
+    <string name="auto_connect_native_description">Automatycznie łączy z telefonem podczas korzystania z natywnego trybu bezprzewodowego.</string>
     <string name="drag_to_reorder">Przeciągnij, aby zmienić kolejność</string>
     <string name="move_up">Przesuń w górę</string>
     <string name="move_down">Przesuń w dół</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -413,6 +413,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Informacje o pojeździe</string>
     <string name="vehicle_info_settings_description">Dostosuj, jak pojazd jest wyświetlany na telefonie</string>
+    <string name="ui_scale">Skalowanie interfejsu</string>
+    <string name="ui_scale_home">Ekran główny</string>
+    <string name="ui_scale_settings">Ekran ustawień</string>
     <string name="category_vehicle">Pojazd</string>
     <string name="category_head_unit">Radio</string>
     <string name="vehicle_display_name_label">Nazwa wyświetlana</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -210,6 +210,8 @@
     <string name="auto_connect_help">Estes métodos são executados automaticamente ao abrir o app. Ative os que desejar e arraste para definir a ordem. O primeiro método ativo que tiver sucesso será usado.</string>
     <string name="auto_connect_priority">Prioridade %d</string>
     <string name="auto_connect_all_disabled">Todos desativados</string>
+    <string name="auto_connect_native">Conectar automaticamente (Nativo)</string>
+    <string name="auto_connect_native_description">Conectar automaticamente ao telefone ao usar o modo Wireless nativo.</string>
     <string name="drag_to_reorder">Arraste para reordenar</string>
     <string name="move_up">Mover para cima</string>
     <string name="move_down">Mover para baixo</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -413,6 +413,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Informações do veículo</string>
     <string name="vehicle_info_settings_description">Personalize como seu veículo aparece no celular</string>
+    <string name="ui_scale">Escala da interface</string>
+    <string name="ui_scale_home">Tela inicial</string>
+    <string name="ui_scale_settings">Tela de configurações</string>
     <string name="category_vehicle">Veículo</string>
     <string name="category_head_unit">Central multimídia</string>
     <string name="vehicle_display_name_label">Nome de exibição</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -413,6 +413,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Informații vehicul</string>
     <string name="vehicle_info_settings_description">Personalizați cum apare vehiculul dvs. pe telefon</string>
+    <string name="ui_scale">Scală UI</string>
+    <string name="ui_scale_home">Ecran principal</string>
+    <string name="ui_scale_settings">Ecranul de setări</string>
     <string name="category_vehicle">Vehicul</string>
     <string name="category_head_unit">Unitate principală</string>
     <string name="vehicle_display_name_label">Nume afișat</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -222,6 +222,8 @@
     <string name="auto_connect_help">Aceste metode rulează automat la deschiderea aplicației. Activează-le pe cele dorite, apoi trage de ele pentru a le ordona. Se va folosi prima metodă reușită.</string>
     <string name="auto_connect_priority">Prioritate %d</string>
     <string name="auto_connect_all_disabled">Toate dezactivate</string>
+    <string name="auto_connect_native">Conectare automată (Nativă)</string>
+    <string name="auto_connect_native_description">Conectează automat la telefon când este folosit modul Wireless nativ.</string>
     <string name="drag_to_reorder">Trage pentru a reordona</string>
     <string name="move_up">Mută mai sus</string>
     <string name="move_down">Mută mai jos</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -416,6 +416,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Информация о транспортном средстве</string>
     <string name="vehicle_info_settings_description">Настройте, как ваш автомобиль отображается на телефоне</string>
+    <string name="ui_scale">Масштаб интерфейса</string>
+    <string name="ui_scale_home">Главный экран</string>
+    <string name="ui_scale_settings">Экран настроек</string>
     <string name="category_vehicle">Транспортное средство</string>
     <string name="category_head_unit">Головное устройство</string>
     <string name="vehicle_display_name_label">Отображаемое имя</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -210,6 +210,8 @@
     <string name="auto_connect_help">Эти методы запускаются автоматически при открытии приложения. Включите нужные и перетащите для установки порядка. Будет использован первый включённый метод, который сработает.</string>
     <string name="auto_connect_priority">Приоритет %d</string>
     <string name="auto_connect_all_disabled">Все отключены</string>
+    <string name="auto_connect_native">Автоподключение (Нативное)</string>
+    <string name="auto_connect_native_description">Автоматически подключаться к телефону при использовании нативного беспроводного режима.</string>
     <string name="drag_to_reorder">Перетащите для изменения порядка</string>
     <string name="move_up">Вверх</string>
     <string name="move_down">Вниз</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -413,6 +413,9 @@
 
     <string name="vehicle_info_settings">Araç bilgileri</string>
     <string name="vehicle_info_settings_description">Aracınızın telefonunuzda nasıl görüneceğini özelleştirin</string>
+    <string name="ui_scale">UI Ölçeği</string>
+    <string name="ui_scale_home">Ana ekran</string>
+    <string name="ui_scale_settings">Ayarlar ekranı</string>
     <string name="category_vehicle">Araç</string>
     <string name="category_head_unit">Multimedya Sistemi</string>
     <string name="vehicle_display_name_label">Görünen ad</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -224,6 +224,8 @@
     <string name="auto_connect_help">Bu yöntemler uygulama açıldığında otomatik olarak çalışır. İstediklerinizi etkinleştirin, ardından sırayı ayarlamak için sürükleyin. Başarılı olan ilk etkin yöntem kullanılacaktır.</string>
     <string name="auto_connect_priority">Öncelik %d</string>
     <string name="auto_connect_all_disabled">Hepsi devre dışı</string>
+    <string name="auto_connect_native">Otomatik bağlan (Native)</string>
+    <string name="auto_connect_native_description">Native Kablosuz modu kullanılırken telefona otomatik bağlanır.</string>
     <string name="drag_to_reorder">Yeniden sıralamak için sürükleyin</string>
     <string name="move_up">Yukarı taşı</string>
     <string name="move_down">Aşağı taşı</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -210,6 +210,8 @@
     <string name="auto_connect_help">Ці методи запускаються автоматично при відкритті застосунку. Увімкніть потрібні та перетягніть для встановлення порядку. Буде використано перший увімкнений метод, який спрацює.</string>
     <string name="auto_connect_priority">Пріоритет %d</string>
     <string name="auto_connect_all_disabled">Все вимкнено</string>
+    <string name="auto_connect_native">Автопідключення (Нативне)</string>
+    <string name="auto_connect_native_description">Автоматично підключатися до телефону при використанні нативного бездротового режиму.</string>
     <string name="drag_to_reorder">Перетягніть для зміни порядку</string>
     <string name="move_up">Вгору</string>
     <string name="move_down">Вниз</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -413,6 +413,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Інформація про транспортний засіб</string>
     <string name="vehicle_info_settings_description">Налаштуйте, як ваш автомобіль відображається на телефоні</string>
+    <string name="ui_scale">Масштаб інтерфейсу</string>
+    <string name="ui_scale_home">Головний екран</string>
+    <string name="ui_scale_settings">Екран налаштувань</string>
     <string name="category_vehicle">Транспортний засіб</string>
     <string name="category_head_unit">Головний пристрій</string>
     <string name="vehicle_display_name_label">Відображуване ім\'я</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -412,6 +412,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">車輛資訊</string>
     <string name="vehicle_info_settings_description">自訂您的車輛在手機上的顯示方式</string>
+    <string name="ui_scale">UI 縮放</string>
+    <string name="ui_scale_home">主畫面</string>
+    <string name="ui_scale_settings">設定畫面</string>
     <string name="category_vehicle">車輛</string>
     <string name="category_head_unit">車機</string>
     <string name="vehicle_display_name_label">顯示名稱</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -209,6 +209,8 @@
     <string name="auto_connect_help">這些方式會在開啟應用程式時自動執行。啟用您想要的方式，然後拖曳以設定順序。系統會使用第一個成功的已啟用方式。</string>
     <string name="auto_connect_priority">優先順序 %d</string>
     <string name="auto_connect_all_disabled">全部停用</string>
+    <string name="auto_connect_native">自動連線（原生）</string>
+    <string name="auto_connect_native_description">在使用原生無線模式時自動連線至手機。</string>
     <string name="drag_to_reorder">拖曳以重新排序</string>
     <string name="move_up">上移</string>
     <string name="move_down">下移</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -430,6 +430,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Vehicle information</string>
     <string name="vehicle_info_settings_description">Customize how your vehicle appears on your phone</string>
+    <string name="ui_scale">UI Scale</string>
+    <string name="ui_scale_home">Home screen</string>
+    <string name="ui_scale_settings">Settings screen</string>
     <string name="category_vehicle">Vehicle</string>
     <string name="category_head_unit">Head Unit</string>
     <string name="vehicle_display_name_label">Display name</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,6 +224,8 @@
     <string name="auto_connect_help">These methods run automatically when the app opens. Enable the ones you want, then drag to set the order. The first enabled method that succeeds will be used.</string>
     <string name="auto_connect_priority">Priority %d</string>
     <string name="auto_connect_all_disabled">All disabled</string>
+    <string name="auto_connect_native">Auto-connect (Native)</string>
+    <string name="auto_connect_native_description">Automatically connect to the phone when using Native Wireless mode.</string>
     <string name="drag_to_reorder">Drag to reorder</string>
     <string name="move_up">Move up</string>
     <string name="move_down">Move down</string>


### PR DESCRIPTION
I apologize for the slightly suboptimal implementation and have added two changes to a single pull request.

1. UI Scale allows you to adjust the scale for the main activity and the settings activity. The problem is that my HU has a weird dpi, so everything is small on the main screen and in the settings, which is annoying for people like me with poor eyesight. Now you can adjust the scale to make everything larger (AA projection itself is unaffected).
2. Second, I want to use native AA, but not always, only occasionally, and launch it manually. Right now, it starts automatically. So, I added a setting for AA autostart so I can switch AA to manual mode.

before scale:
<img width="1280" height="960" alt="photo_2026-05-11_12-35-13" src="https://github.com/user-attachments/assets/9e52f3d4-9a53-4d50-8a88-f711afaed3a9" />
<img width="1280" height="960" alt="photo_2026-05-11_12-35-13 (2)" src="https://github.com/user-attachments/assets/e9e88dad-abab-46e8-a1a0-782c9e25e8f2" />

after scale:
<img width="1280" height="960" alt="photo_2026-05-11_12-15-18" src="https://github.com/user-attachments/assets/fbcf739a-9c04-4666-aac8-923078576d7f" />
<img width="1280" height="960" alt="photo_2026-05-11_12-15-18 (2)" src="https://github.com/user-attachments/assets/efa725e6-c518-4e9d-b0d8-233e7c645032" />
