### PR TITLE
Add UI scale settings

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/main/MainActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/MainActivity.kt
@@ -39,6 +39,7 @@ class MainActivity : BaseActivity() {
     
     private var isOrientationReceiverRegistered = false
     private var isFinishReceiverRegistered = false
+    private var isRecreateReceiverRegistered = false
 
     private val viewModel: MainViewModel by viewModels()
 
@@ -47,6 +48,19 @@ class MainActivity : BaseActivity() {
             if (intent.action == "com.andrerinas.headunitrevived.ACTION_FINISH_ACTIVITIES") {
                 AppLog.i("MainActivity: Received finish request. Closing.")
                 finishAffinity()
+            }
+        }
+    }
+
+    private val recreateReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            if (intent.action == ACTION_RECREATE_MAIN) {
+                AppLog.i("MainActivity: Received recreate request. Recreating.")
+                try {
+                    runOnUiThread { recreate() }
+                } catch (e: Exception) {
+                    AppLog.e("MainActivity: Failed to recreate activity", e)
+                }
             }
         }
     }
@@ -61,6 +75,20 @@ class MainActivity : BaseActivity() {
                 AppLog.i("MainActivity: Orientation change broadcast received. Updating.")
                 requestedOrientation = Settings(this@MainActivity).screenOrientation.androidOrientation
             }
+        }
+    }
+
+    override fun attachBaseContext(newBase: Context) {
+        val settings  = Settings(newBase)
+        val scale = settings.uiScaleHomePercent / 100.0f
+        if (scale != 1.0f && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            val cfg = Configuration(newBase.resources.configuration)
+            val metrics = newBase.resources.displayMetrics
+            cfg.densityDpi = (metrics.densityDpi * scale).toInt()
+            val ctx = newBase.createConfigurationContext(cfg)
+            super.attachBaseContext(ctx)
+        } else {
+            super.attachBaseContext(newBase)
         }
     }
 
@@ -149,6 +177,14 @@ class MainActivity : BaseActivity() {
             ContextCompat.RECEIVER_NOT_EXPORTED
         )
         isFinishReceiverRegistered = true
+
+        // Register recreate receiver so SettingsFragment can request MainActivity recreate
+        ContextCompat.registerReceiver(
+            this, recreateReceiver,
+            android.content.IntentFilter(ACTION_RECREATE_MAIN),
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
+        isRecreateReceiverRegistered = true
     }
 
     private fun showSplashWithDelay(delayMs: Long) {
@@ -389,6 +425,10 @@ class MainActivity : BaseActivity() {
             unregisterReceiver(finishReceiver)
             isFinishReceiverRegistered = false
         }
+        if (isRecreateReceiverRegistered) {
+            unregisterReceiver(recreateReceiver)
+            isRecreateReceiverRegistered = false
+        }
         if (isFinishing) {
             AppLog.i("MainActivity finishing, resetting auto-start flag.")
             HomeFragment.resetAutoStart()
@@ -398,5 +438,6 @@ class MainActivity : BaseActivity() {
     companion object {
         private const val permissionRequestCode = 97
         const val EXTRA_LAUNCH_SOURCE = "launch_source"
+        const val ACTION_RECREATE_MAIN = "com.andrerinas.headunitrevived.ACTION_RECREATE_MAIN"
     }
 }

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/MainActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/MainActivity.kt
@@ -57,7 +57,7 @@ class MainActivity : BaseActivity() {
             if (intent.action == ACTION_RECREATE_MAIN) {
                 AppLog.i("MainActivity: Received recreate request. Recreating.")
                 try {
-                    runOnUiThread { recreate() }
+                    recreate()
                 } catch (e: Exception) {
                     AppLog.e("MainActivity: Failed to recreate activity", e)
                 }

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsActivity.kt
@@ -1,16 +1,33 @@
 package com.andrerinas.headunitrevived.main
 
+import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.activity.enableEdgeToEdge
 import androidx.navigation.fragment.NavHostFragment
 import android.content.res.Configuration
+import android.os.Build
 import com.andrerinas.headunitrevived.R
 import com.andrerinas.headunitrevived.app.BaseActivity
 import com.andrerinas.headunitrevived.utils.Settings
 import com.andrerinas.headunitrevived.utils.SystemUI
 
 class SettingsActivity : BaseActivity() {
+
+    override fun attachBaseContext(newBase: Context) {
+        val settings  = Settings(newBase)
+        val scale = settings.uiScaleSettingsPercent / 100.0f
+        if (scale != 1.0f && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            val cfg = Configuration(newBase.resources.configuration)
+            val metrics = newBase.resources.displayMetrics
+            cfg.densityDpi = (metrics.densityDpi * scale).toInt()
+            val ctx = newBase.createConfigurationContext(cfg)
+            super.attachBaseContext(ctx)
+        } else {
+            super.attachBaseContext(newBase)
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
@@ -83,6 +83,9 @@ class SettingsFragment : Fragment() {
     private var pendingInsetRight: Int? = null
     private var pendingInsetBottom: Int? = null
 
+    private var pendingUiScaleHomePercent: Int? = null
+    private var pendingUiScaleSettingsPercent: Int? = null
+
     private var pendingMediaVolumeOffset: Int? = null
     private var pendingAssistantVolumeOffset: Int? = null
     private var pendingNavigationVolumeOffset: Int? = null
@@ -148,6 +151,9 @@ class SettingsFragment : Fragment() {
         pendingInsetTop = settings.insetTop
         pendingInsetRight = settings.insetRight
         pendingInsetBottom = settings.insetBottom
+        // UI Scale pending values (percent)
+        pendingUiScaleHomePercent = settings.uiScaleHomePercent
+        pendingUiScaleSettingsPercent = settings.uiScaleSettingsPercent
 
         pendingMediaVolumeOffset = settings.mediaVolumeOffset
         pendingAssistantVolumeOffset = settings.assistantVolumeOffset
@@ -445,6 +451,16 @@ class SettingsFragment : Fragment() {
                 try {
                     findNavController().navigate(R.id.action_settingsFragment_to_vehicleInfoFragment)
                 } catch (e: Exception) { }
+            }
+        ))
+
+        // UI Scale (example dialog similar to Custom Insets) - appear after vehicle info
+        items.add(SettingItem.SettingEntry(
+            stableId = "uiScale",
+            nameResId = R.string.ui_scale,
+            value = "${getString(R.string.ui_scale_home)}: ${pendingUiScaleHomePercent ?: 100}% · ${getString(R.string.ui_scale_settings)}: ${pendingUiScaleSettingsPercent ?: 100}%",
+            onClick = { _ ->
+                showUiScaleDialog()
             }
         ))
 
@@ -1391,6 +1407,99 @@ class SettingsFragment : Fragment() {
                 
                 dialog.dismiss()
             }
+            .show()
+    }
+
+    private fun showUiScaleDialog() {
+        val context = requireContext()
+        val density = context.resources.displayMetrics.density
+
+        val container = android.widget.LinearLayout(context).apply {
+            orientation = android.widget.LinearLayout.VERTICAL
+            val pad = (16 * density).toInt()
+            setPadding(pad, pad, pad, pad)
+        }
+
+        fun makeRow(labelText: String, initialPercent: Int): Triple<android.widget.TextView, android.widget.SeekBar, android.widget.TextView> {
+            val label = android.widget.TextView(context).apply {
+                text = labelText
+                setPadding(0, (8 * density).toInt(), 0, (4 * density).toInt())
+            }
+            val seek = android.widget.SeekBar(context).apply {
+                // Map 100..150 step 10 -> progress 0..5
+                max = 5
+                progress = ((initialPercent - 100) / 10).coerceIn(0, 5)
+            }
+            val value = android.widget.TextView(context).apply {
+                text = "$initialPercent%"
+                setPadding(0, (4 * density).toInt(), 0, (12 * density).toInt())
+            }
+            // Update value when seek changes
+            seek.setOnSeekBarChangeListener(object : android.widget.SeekBar.OnSeekBarChangeListener {
+                override fun onProgressChanged(sb: android.widget.SeekBar?, progress: Int, fromUser: Boolean) {
+                    val pct = 100 + progress * 10
+                    value.text = "$pct%"
+                }
+                override fun onStartTrackingTouch(sb: android.widget.SeekBar?) {}
+                override fun onStopTrackingTouch(sb: android.widget.SeekBar?) {}
+            })
+
+            return Triple(label, seek, value)
+        }
+
+        val homeInitial = pendingUiScaleHomePercent ?: settings.uiScaleHomePercent
+        val settingsInitial = pendingUiScaleSettingsPercent ?: settings.uiScaleSettingsPercent
+
+        val (homeLabel, homeSeek, homeValue) = makeRow(getString(R.string.ui_scale_home), homeInitial)
+        val (settingsLabel, settingsSeek, settingsValue) = makeRow(getString(R.string.ui_scale_settings), settingsInitial)
+
+        container.addView(homeLabel, android.widget.LinearLayout.LayoutParams(android.widget.LinearLayout.LayoutParams.MATCH_PARENT, android.widget.LinearLayout.LayoutParams.WRAP_CONTENT))
+        container.addView(homeSeek, android.widget.LinearLayout.LayoutParams(android.widget.LinearLayout.LayoutParams.MATCH_PARENT, android.widget.LinearLayout.LayoutParams.WRAP_CONTENT))
+        container.addView(homeValue, android.widget.LinearLayout.LayoutParams(android.widget.LinearLayout.LayoutParams.MATCH_PARENT, android.widget.LinearLayout.LayoutParams.WRAP_CONTENT))
+        container.addView(settingsLabel, android.widget.LinearLayout.LayoutParams(android.widget.LinearLayout.LayoutParams.MATCH_PARENT, android.widget.LinearLayout.LayoutParams.WRAP_CONTENT))
+        container.addView(settingsSeek, android.widget.LinearLayout.LayoutParams(android.widget.LinearLayout.LayoutParams.MATCH_PARENT, android.widget.LinearLayout.LayoutParams.WRAP_CONTENT))
+        container.addView(settingsValue, android.widget.LinearLayout.LayoutParams(android.widget.LinearLayout.LayoutParams.MATCH_PARENT, android.widget.LinearLayout.LayoutParams.WRAP_CONTENT))
+
+        // Wrap content in a ScrollView to ensure content is scrollable on small screens or when large scale is used
+        val scroll = android.widget.ScrollView(context).apply {
+            isFillViewport = true
+            addView(container, android.widget.FrameLayout.LayoutParams(android.widget.FrameLayout.LayoutParams.MATCH_PARENT, android.widget.FrameLayout.LayoutParams.WRAP_CONTENT))
+        }
+
+        MaterialAlertDialogBuilder(context, R.style.DarkAlertDialog)
+            .setTitle(R.string.ui_scale)
+            .setView(scroll)
+            .setPositiveButton(android.R.string.ok) { dialog, _ ->
+                val newHome = 100 + (homeSeek.progress * 10)
+                val newSettings = 100 + (settingsSeek.progress * 10)
+                val oldSettings = settings.uiScaleSettingsPercent
+                val oldHome = settings.uiScaleHomePercent
+
+                // Persist immediately (similar to Custom Insets behavior)
+                settings.uiScaleHomePercent = newHome
+                settings.uiScaleSettingsPercent = newSettings
+                settings.commit()
+
+                pendingUiScaleHomePercent = newHome
+                pendingUiScaleSettingsPercent = newSettings
+                checkChanges()
+                updateSettingsList()
+
+                dialog.dismiss()
+
+                // If Settings value changed, recreate activity as requested
+                if (newSettings != oldSettings) {
+                    requireActivity().recreate()
+                }
+                // If Home UI scale changed, request MainActivity to recreate
+                if (newHome != oldHome) {
+                    val intent = Intent(MainActivity.ACTION_RECREATE_MAIN).apply {
+                        setPackage(requireContext().packageName)
+                    }
+                    requireContext().sendBroadcast(intent)
+                }
+            }
+            .setNegativeButton(android.R.string.cancel, null)
             .show()
     }
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
@@ -76,6 +76,16 @@ class Settings(context: Context) {
         get() = prefs.getBoolean("forced_scale", false)
         set(value) { prefs.edit().putBoolean("forced_scale", value).apply() }
 
+    // UI Scale percentage for Home
+    var uiScaleHomePercent: Int
+        get() = prefs.getInt("ui-scale-home-percent", 100)
+        set(value) { prefs.edit().putInt("ui-scale-home-percent", value).apply() }
+
+    // UI Scale percentage for Settings
+    var uiScaleSettingsPercent: Int
+        get() = prefs.getInt("ui-scale-settings-percent", 100)
+        set(value) { prefs.edit().putInt("ui-scale-settings-percent", value).apply() }
+
     var micSampleRate: Int
         get() = prefs.getInt("mic-sample-rate", 16000)
         set(sampleRate) {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -413,6 +413,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">معلومات المركبة</string>
     <string name="vehicle_info_settings_description">خصص كيف تظهر مركبتك على هاتفك</string>
+    <string name="ui_scale">مقياس واجهة المستخدم</string>
+    <string name="ui_scale_home">الشاشة الرئيسية</string>
+    <string name="ui_scale_settings">شاشة الإعدادات</string>
     <string name="category_vehicle">المركبة</string>
     <string name="category_head_unit">وحدة الوسائط</string>
     <string name="vehicle_display_name_label">اسم العرض</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -413,6 +413,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Informace o vozidle</string>
     <string name="vehicle_info_settings_description">Přizpůsobte, jak se vaše vozidlo zobrazuje na telefonu</string>
+    <string name="ui_scale">Měřítko rozhraní</string>
+    <string name="ui_scale_home">Hlavní obrazovka</string>
+    <string name="ui_scale_settings">Obrazovka nastavení</string>
     <string name="category_vehicle">Vozidlo</string>
     <string name="category_head_unit">Autorádio</string>
     <string name="vehicle_display_name_label">Zobrazovaný název</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -423,6 +423,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Fahrzeuginformationen</string>
     <string name="vehicle_info_settings_description">Passen Sie an, wie Ihr Fahrzeug auf Ihrem Telefon angezeigt wird</string>
+    <string name="ui_scale">UI-Skalierung</string>
+    <string name="ui_scale_home">Startbildschirm</string>
+    <string name="ui_scale_settings">Einstellungsbildschirm</string>
     <string name="category_vehicle">Fahrzeug</string>
     <string name="category_head_unit">Autoradio</string>
     <string name="vehicle_display_name_label">Anzeigename</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -413,6 +413,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Información del vehículo</string>
     <string name="vehicle_info_settings_description">Personaliza cómo aparece tu vehículo en tu móvil</string>
+    <string name="ui_scale">Escala de la interfaz</string>
+    <string name="ui_scale_home">Pantalla de inicio</string>
+    <string name="ui_scale_settings">Pantalla de ajustes</string>
     <string name="category_vehicle">Vehículo</string>
     <string name="category_head_unit">Radio</string>
     <string name="vehicle_display_name_label">Nombre para mostrar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -413,6 +413,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Información del vehículo</string>
     <string name="vehicle_info_settings_description">Personaliza cómo aparece tu vehículo en tu teléfono</string>
+    <string name="ui_scale">Escala de la interfaz</string>
+    <string name="ui_scale_home">Pantalla de inicio</string>
+    <string name="ui_scale_settings">Pantalla de ajustes</string>
     <string name="category_vehicle">Vehículo</string>
     <string name="category_head_unit">Radio</string>
     <string name="vehicle_display_name_label">Nombre para mostrar</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -412,6 +412,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Járműinformáció</string>
     <string name="vehicle_info_settings_description">Testreszabhatja, hogyan jelenik meg járműve a telefonján</string>
+    <string name="ui_scale">UI méretezés</string>
+    <string name="ui_scale_home">Kezdőképernyő</string>
+    <string name="ui_scale_settings">Beállítások képernyő</string>
     <string name="category_vehicle">Jármű</string>
     <string name="category_head_unit">Fejegység</string>
     <string name="vehicle_display_name_label">Megjelenítési név</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -418,6 +418,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Informazioni veicolo</string>
     <string name="vehicle_info_settings_description">Personalizza come il tuo veicolo appare sul telefono</string>
+    <string name="ui_scale">Scala UI</string>
+    <string name="ui_scale_home">Schermata Home</string>
+    <string name="ui_scale_settings">Schermata Impostazioni</string>
     <string name="category_vehicle">Veicolo</string>
     <string name="category_head_unit">Head Unit</string>
     <string name="vehicle_display_name_label">Nome visualizzato</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -419,6 +419,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">車両情報</string>
     <string name="vehicle_info_settings_description">お使いのスマートフォン上で、車両情報の表示方法をカスタマイズできます。</string>
+    <string name="ui_scale">UI スケール</string>
+    <string name="ui_scale_home">ホーム画面</string>
+    <string name="ui_scale_settings">設定画面</string>
     <string name="category_vehicle">車両</string>
     <string name="category_head_unit">車載機</string>
     <string name="vehicle_display_name_label">表示ネーム</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -419,6 +419,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">차량 정보</string>
     <string name="vehicle_info_settings_description">차량이 휴대폰에 표시되는 방식을 사용자 정의합니다</string>
+    <string name="ui_scale">UI 배율</string>
+    <string name="ui_scale_home">홈 화면</string>
+    <string name="ui_scale_settings">설정 화면</string>
     <string name="category_vehicle">차량</string>
     <string name="category_head_unit">헤드유닛</string>
     <string name="vehicle_display_name_label">표시 이름</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -410,6 +410,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Voertuiginformatie</string>
     <string name="vehicle_info_settings_description">Pas aan hoe uw voertuig op uw telefoon wordt weergegeven</string>
+    <string name="ui_scale">UI-schaal</string>
+    <string name="ui_scale_home">Startscherm</string>
+    <string name="ui_scale_settings">Instellingen scherm</string>
     <string name="category_vehicle">Voertuig</string>
     <string name="category_head_unit">Headunit</string>
     <string name="vehicle_display_name_label">Weergavenaam</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -411,6 +411,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Informacje o pojeździe</string>
     <string name="vehicle_info_settings_description">Dostosuj, jak pojazd jest wyświetlany na telefonie</string>
+    <string name="ui_scale">Skalowanie interfejsu</string>
+    <string name="ui_scale_home">Ekran główny</string>
+    <string name="ui_scale_settings">Ekran ustawień</string>
     <string name="category_vehicle">Pojazd</string>
     <string name="category_head_unit">Radio</string>
     <string name="vehicle_display_name_label">Nazwa wyświetlana</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -411,6 +411,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Informações do veículo</string>
     <string name="vehicle_info_settings_description">Personalize como seu veículo aparece no celular</string>
+    <string name="ui_scale">Escala da interface</string>
+    <string name="ui_scale_home">Tela inicial</string>
+    <string name="ui_scale_settings">Tela de configurações</string>
     <string name="category_vehicle">Veículo</string>
     <string name="category_head_unit">Central multimídia</string>
     <string name="vehicle_display_name_label">Nome de exibição</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -411,6 +411,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Informații vehicul</string>
     <string name="vehicle_info_settings_description">Personalizați cum apare vehiculul dvs. pe telefon</string>
+    <string name="ui_scale">Scală UI</string>
+    <string name="ui_scale_home">Ecran principal</string>
+    <string name="ui_scale_settings">Ecranul de setări</string>
     <string name="category_vehicle">Vehicul</string>
     <string name="category_head_unit">Unitate principală</string>
     <string name="vehicle_display_name_label">Nume afișat</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -414,6 +414,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Информация о транспортном средстве</string>
     <string name="vehicle_info_settings_description">Настройте, как ваш автомобиль отображается на телефоне</string>
+    <string name="ui_scale">Масштаб интерфейса</string>
+    <string name="ui_scale_home">Главный экран</string>
+    <string name="ui_scale_settings">Экран настроек</string>
     <string name="category_vehicle">Транспортное средство</string>
     <string name="category_head_unit">Головное устройство</string>
     <string name="vehicle_display_name_label">Отображаемое имя</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -411,6 +411,9 @@
 
     <string name="vehicle_info_settings">Araç bilgileri</string>
     <string name="vehicle_info_settings_description">Aracınızın telefonunuzda nasıl görüneceğini özelleştirin</string>
+    <string name="ui_scale">UI Ölçeği</string>
+    <string name="ui_scale_home">Ana ekran</string>
+    <string name="ui_scale_settings">Ayarlar ekranı</string>
     <string name="category_vehicle">Araç</string>
     <string name="category_head_unit">Multimedya Sistemi</string>
     <string name="vehicle_display_name_label">Görünen ad</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -411,6 +411,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Інформація про транспортний засіб</string>
     <string name="vehicle_info_settings_description">Налаштуйте, як ваш автомобіль відображається на телефоні</string>
+    <string name="ui_scale">Масштаб інтерфейсу</string>
+    <string name="ui_scale_home">Головний екран</string>
+    <string name="ui_scale_settings">Екран налаштувань</string>
     <string name="category_vehicle">Транспортний засіб</string>
     <string name="category_head_unit">Головний пристрій</string>
     <string name="vehicle_display_name_label">Відображуване ім\'я</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -410,6 +410,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">車輛資訊</string>
     <string name="vehicle_info_settings_description">自訂您的車輛在手機上的顯示方式</string>
+    <string name="ui_scale">UI 縮放</string>
+    <string name="ui_scale_home">主畫面</string>
+    <string name="ui_scale_settings">設定畫面</string>
     <string name="category_vehicle">車輛</string>
     <string name="category_head_unit">車機</string>
     <string name="vehicle_display_name_label">顯示名稱</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -428,6 +428,9 @@
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">Vehicle information</string>
     <string name="vehicle_info_settings_description">Customize how your vehicle appears on your phone</string>
+    <string name="ui_scale">UI Scale</string>
+    <string name="ui_scale_home">Home screen</string>
+    <string name="ui_scale_settings">Settings screen</string>
     <string name="category_vehicle">Vehicle</string>
     <string name="category_head_unit">Head Unit</string>
     <string name="vehicle_display_name_label">Display name</string>


### PR DESCRIPTION

UI Scale allows you to adjust the scale for the main activity and the settings activity. The problem is that my HU has a weird dpi (I'm sure it's not just mine but also some other Chinese ones.), so everything is small on the main screen and in the settings (look to screenshots before and after), which is annoying for people like me with poor eyesight. Now we can adjust the scale to make everything larger (AA projection itself is unaffected).

Since I can't change this in the Android settings because it would break the Head Unit UI, I need to somehow address this in the app. Essentially, this simply increases the DPI density for activity. 

<details>
  <summary>Before (scale 100%)</summary>
<img width="1280" height="960" alt="photo_2026-05-11_12-35-13" src="https://github.com/user-attachments/assets/9f5957e6-8d03-49af-b030-106eb6b496af" />
<img width="1280" height="960" alt="photo_2026-05-11_12-35-13 (2)" src="https://github.com/user-attachments/assets/73ceff79-81b6-4e57-950a-e6a9dbccc2dc" />
</details>

<details>
  <summary>After (scale increased in settings)</summary>
<img width="1280" height="960" alt="photo_2026-05-11_12-15-18 (2)" src="https://github.com/user-attachments/assets/94ae5f80-bb31-4bb5-b08f-cca080951006" />
<img width="1280" height="960" alt="photo_2026-05-11_12-15-18" src="https://github.com/user-attachments/assets/074803c1-3e22-45c1-90dc-66a6396ad3c1" />
</details>