### PR TITLE
Improve Korean localization wording

### DIFF
--- a/app/src/main/res/values-ko/arrays.xml
+++ b/app/src/main/res/values-ko/arrays.xml
@@ -3,7 +3,7 @@
     <string-array name="night_mode">
         <item>자동(일출/일몰 시간 참조)</item>
         <item>라이트 모드</item>
-        <item>다크모드</item>
+        <item>다크 모드</item>
         <item>수동 설정 시간</item>
         <item>조도 센서</item>
         <item>화면 밝기</item>
@@ -12,8 +12,8 @@
     <string-array name="app_theme">
         <item>자동(시스템 설정 참조)</item>
         <item>라이트 모드</item>
-        <item>다크모드</item>
-        <item>진한 다크모드</item>
+        <item>다크 모드</item>
+        <item>완전 블랙 모드</item>
         <item>자동(일출/일몰 시간 참조)</item>
         <item>수동 설정 시간</item>
         <item>조도 센서</item>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -6,70 +6,70 @@
     <string name="title_activity_settings">SettingsActivity</string>
     <string name="dummy_button">Dummy Button</string>
     <string name="dummy_content">DUMMY\nCONTENT</string>
-    <string name="allowed">허용</string>
-    <string name="ignored">무시</string>
+    <string name="allowed">허용됨</string>
+    <string name="ignored">무시됨</string>
     <string name="exit">종료</string>
-    <string name="video">안드로이드 오토</string>
-    <string name="self_mode">셀프 모드</string>
-    <string name="to_android_auto">안드로이드 오토로 이동</string>
+    <string name="video">Android Auto</string>
+    <string name="self_mode">단독 모드</string>
+    <string name="to_android_auto">Android Auto로 전환</string>
     <string name="title">Headunit Revived</string>
     <string name="remove">제거</string>
     <string name="usb">USB</string>
     <string name="wifi">Wi-Fi</string>
-    <string name="dpi">픽셀 밀도 (DPI)</string>
-    <string name="mic_sample_rate">마이크 샘플 레이트</string>
-    <string name="keymap">키맵</string>
-    <string name="night_mode">다크모드 (안드로이드 오토)</string>
-    <string name="night_mode_threshold">다크모드 임계값</string>
+    <string name="dpi">픽셀 밀도(DPI)</string>
+    <string name="mic_sample_rate">마이크 샘플링 레이트</string>
+    <string name="keymap">키 매핑</string>
+    <string name="night_mode">다크 모드(Android Auto)</string>
+    <string name="night_mode_threshold">다크 모드 임계값</string>
     <string name="enter_threshold_value">임계값 입력</string>
-    <string name="threshold_lux_desc">조도 값 (0–10000). 이 값 이하 = 밤으로 간주</string>
-    <string name="threshold_brightness_desc">밝기 값 (0–255). 이 값 이하 = 밤으로 간주</string>
-    <string name="threshold_light_title">조명 감도</string>
-    <string name="threshold_brightness_title">밝기 레벨</string>
-    <string name="threshold_light_hint">다크모드는 주변 조도가 이 값 이하일 때 활성화됩니다</string>
-    <string name="threshold_brightness_hint">다크모드는 화면 밝기가 이 값 이하일 때 활성화됩니다. Android은 밝기를 0–255로 보고하지만, 실제 범위는 기기에 따라 다릅니다. 기기에 적합한 임계값을 찾기 위해 테스트가 필요할 수 있습니다.</string>
+    <string name="threshold_lux_desc">조도 값(0–10000). 이 값보다 낮으면 야간으로 판단합니다.</string>
+    <string name="threshold_brightness_desc">밝기 값(0–255). 이 값보다 낮으면 야간으로 판단합니다.</string>
+    <string name="threshold_light_title">주변 조도 감도</string>
+    <string name="threshold_brightness_title">화면 밝기</string>
+    <string name="threshold_light_hint">주변 조도가 이 값보다 낮아지면 다크 모드가 활성화됩니다.</string>
+    <string name="threshold_brightness_hint">다크 모드는 화면 밝기가 이 값 이하일 때 활성화됩니다. Android는 밝기를 0–255로 보고하지만, 실제 범위는 기기에 따라 다릅니다. 기기에 적합한 임계값을 찾기 위해 테스트가 필요할 수 있습니다.</string>
     <string name="current_light_reading">현재 조도: %d Lux</string>
-    <string name="enable_fine_lux_control">미세 조정 (0–100 Lux)</string>
-    <string name="night_mode_start">다크모드 시작 시간</string>
-    <string name="night_mode_end">다크모드 종료 시간</string>
+    <string name="enable_fine_lux_control">조도 미세 조정(0–100 Lux)</string>
+    <string name="night_mode_start">다크 모드 시작 시간</string>
+    <string name="night_mode_end">다크 모드 종료 시간</string>
 
-    <string name="app_theme">다크모드 (애플리케이션)</string>
-    <string name="app_theme_description">애플리케이션의 시각적 표현을 제어합니다</string>
-    <string name="change_app_theme">애플리케이션 테마 변경</string>
-    <string name="monochrome_icons">회색조 아이콘</string>
-    <string name="monochrome_icons_description">다크모드 또는 진한 다크모드 홈 화면에서 회색조 아이콘 사용</string>
-    <string name="use_extreme_dark">진한 다크모드 사용</string>
-    <string name="use_extreme_dark_description">다크모드가 활성화될 때 완전한 검정색 배경 사용</string>
+    <string name="app_theme">다크 모드(앱)</string>
+    <string name="app_theme_description">앱의 표시 방식을 설정합니다</string>
+    <string name="change_app_theme">앱 테마 변경</string>
+    <string name="monochrome_icons">흑백 아이콘</string>
+    <string name="monochrome_icons_description">다크 모드 또는 완전 블랙 모드에서 홈 화면 아이콘을 흑백으로 표시합니다</string>
+    <string name="use_extreme_dark">완전 블랙 모드 사용</string>
+    <string name="use_extreme_dark_description">다크 모드가 활성화되면 완전한 검은색 배경을 사용합니다</string>
     <string name="use_gradient_background">그라데이션 배경 사용</string>
-    <string name="use_gradient_background_description_on">애플리케이션은 자체 배경을 중앙에서 시작되는 원형 그라데이션를 사용합니다</string>
-    <string name="use_gradient_background_description_off">애플리케이션의 고전적인 배경이 사용됩니다</string>
-    <string name="use_gradient_background_description_on_auto">애플리케이션은 자체 배경을 중앙에서 시작되는 원형 그라데이션를 사용합니다. 진한 다크모드에는 적용되지 않습니다</string>
-    <string name="use_gradient_background_description_off_auto">애플리케이션의 고전적인 배경이 사용됩니다. 진한 다크모드에는 적용되지 않습니다</string>
+    <string name="use_gradient_background_description_on">앱에서 중앙 그라데이션 원 배경을 직접 렌더링합니다</string>
+    <string name="use_gradient_background_description_off">앱의 기본 배경이 사용됩니다</string>
+    <string name="use_gradient_background_description_on_auto">앱에서 중앙 그라데이션 원 배경을 직접 렌더링합니다. 완전 블랙 모드에는 적용되지 않습니다</string>
+    <string name="use_gradient_background_description_off_auto">앱의 기본 배경이 사용됩니다. 완전 블랙 모드에는 적용되지 않습니다</string>
     <string name="category_dark_mode">다크 모드</string>
     <string name="category_automation">자동화</string>
     <string name="dark_mode_settings">다크 모드 설정</string>
-    <string name="app_theme_short">애플리케이션</string>
-    <string name="night_mode_short">안드로이드 오토</string>
-    <string name="aa_monochrome">안드로이드 오토를 회색조로 만듭니다</string>
-    <string name="aa_monochrome_description">밤 드라이빙을 위해 안드로이드 오토 색상을 줄입니다. GLES 뷰 모드가 필요합니다. 다크모드가 활성화될 때만 적용됩니다</string>
+    <string name="app_theme_short">앱</string>
+    <string name="night_mode_short">Android Auto</string>
+    <string name="aa_monochrome">Android Auto 흑백 모드 적용</string>
+    <string name="aa_monochrome_description">야간 주행을 위해 Android Auto의 색감을 줄입니다. GLES 뷰 모드가 필요합니다. 다크 모드가 켜져 있을 때만 적용됩니다</string>
     <string name="aa_desaturation">채도 감소</string>
-    <string name="aa_desaturation_description">채도 감소 정도를 제어합니다. 다크모드가 활성화될 때만 적용됩니다</string>
+    <string name="aa_desaturation_description">채도 감소 정도를 제어합니다. 다크 모드가 켜져 있을 때만 적용됩니다</string>
     <string name="gles_required_title">GLES 필요</string>
-    <string name="gles_required_message">회색조 모드는 GLES 렌더링이 필요합니다. GLES를 활성화하시겠습니까?</string>
+    <string name="gles_required_message">흑백 모드는 비디오 출력에 그레이스케일 필터를 적용하기 위해 GLES 렌더링이 필요합니다. GLES를 활성화하시겠습니까?</string>
     <string name="enable_gles">GLES 활성화</string>
     <string name="category_navigation">내비게이션</string>
     <string name="category_wireless">무선 연결</string>
 
     <string name="reconnection_required_title">재연결 필요</string>
-    <string name="reconnection_required_message">기기는 대기 상태입니다. USB 케이블을 뽑고 다시 꽂아서 안드로이드 오토를 다시 시작하세요.</string>
+    <string name="reconnection_required_message">기기가 대기 상태입니다. Android Auto를 다시 시작하려면 USB 케이블을 뽑았다가 다시 연결하세요.</string>
 
     <string name="bluetooth_address_s">Bluetooth 주소</string>
     <string name="enter_bluetooth_mac">Bluetooth MAC 입력</string>
     <string name="reset">초기화</string>
-    <string name="gps_for_navigation">GPS 내비게이션</string>
-    <string name="gps_for_navigation_description">GPS를 사용하여 내비게이션을 사용합니다</string>
-    <string name="enabled">활성화</string>
-    <string name="disabled">비활성화</string>
+    <string name="gps_for_navigation">내비게이션용 GPS</string>
+    <string name="gps_for_navigation_description">내비게이션에 GPS를 사용합니다</string>
+    <string name="enabled">활성화됨</string>
+    <string name="disabled">비활성화됨</string>
     <string name="resolution">해상도</string>
     <string name="change_resolution">해상도 변경</string>
     <string name="change_dpi">DPI 변경</string>
@@ -82,399 +82,409 @@
     <string name="screen_orientation">화면 방향</string>
     <string name="change_screen_orientation">화면 방향 변경</string>
     <string name="orientation_system_default">시스템 기본값</string>
-    <string name="orientation_auto_sensor">자동 (센서)</string>
-    <string name="orientation_landscape">가로 (0°)</string>
-    <string name="orientation_landscape_reverse">가로 역방향 (180°)</string>
-    <string name="orientation_portrait">세로 (90°)</string>
-    <string name="orientation_portrait_reverse">세로 역방향 (270°)</string>
-    <string name="enter_dpi_value">DPI 값 입력 (0 자동)</string>
-    <string name="custom_margin">커스텀 마진 설정</string>
-    <string name="custom_margin_description">커스텀 디스플레이 마진을 설정합니다 (0 자동)</string>
-    <string name="enter_custom_margins">커스텀 마진 입력 (0 자동)</string>
+    <string name="orientation_auto_sensor">자동(센서)</string>
+    <string name="orientation_landscape">가로(0°)</string>
+    <string name="orientation_landscape_reverse">역방향 가로(180°)</string>
+    <string name="orientation_portrait">세로(90°)</string>
+    <string name="orientation_portrait_reverse">역방향 세로(270°)</string>
+    <string name="enter_dpi_value">DPI 값 입력(0은 자동)</string>
+    <string name="custom_margin">사용자 지정 여백</string>
+    <string name="custom_margin_description">화면 여백을 직접 설정합니다(0은 자동)</string>
+    <string name="enter_custom_margins">사용자 지정 여백 입력(0은 자동)</string>
     <string name="margin_left">왼쪽</string>
     <string name="margin_top">위쪽</string>
     <string name="margin_right">오른쪽</string>
     <string name="margin_bottom">아래쪽</string>
 
     <string name="start_in_fullscreen_mode">화면 모드</string>
-    <string name="start_in_fullscreen_mode_description">시스템 바 (상태 및 내비게이션)를 처리하는 방법을 선택합니다.</string>
-    <string name="fullscreen_none">기본 (모든 바 보임)</string>
-    <string name="fullscreen_immersive">Immersive (노치 오버레이)</string>
-    <string name="fullscreen_status_only">상태 바만 숨김</string>
-    <string name="fullscreen_immersive_avoid_notch">Immersive (노치 방지)</string>
-    <string name="fullscreen_immersive_avoid_notch_desc">모든 바를 숨기고 노치/커트아웃을 방지하기 위해 패딩을 추가합니다.</string>
+    <string name="start_in_fullscreen_mode_description">시스템 표시줄(상태 표시줄 및 내비게이션 바)을 처리하는 방식을 선택합니다.</string>
+    <string name="fullscreen_none">기본(모든 표시줄 보임)</string>
+    <string name="fullscreen_immersive">몰입형(노치 영역 사용)</string>
+    <string name="fullscreen_status_only">상태 표시줄만 숨김</string>
+    <string name="fullscreen_immersive_avoid_notch">몰입형(노치 피하기)</string>
+    <string name="fullscreen_immersive_avoid_notch_desc">모든 표시줄을 숨기고, 노치/컷아웃에 화면이 가려지지 않도록 여백을 추가합니다.</string>
 
     <string name="usb_status">USB 상태: %s</string>
     <string name="projection_status">프로젝션 상태: %s</string>
     <string name="connected">연결됨</string>
-    <string name="disconnected">연결 해제</string>
+    <string name="disconnected">연결 끊김</string>
     <string name="running">실행 중</string>
     <string name="not_running">실행 중이 아님</string>
-    <string name="no_android_auto_device_connected">안드로이드 오토 기기가 연결되지 않았습니다. USB 연결을 확인하세요.</string>
+    <string name="no_android_auto_device_connected">Android Auto 기기가 연결되지 않았습니다. USB 연결을 확인하세요.</string>
     <string name="no_usb_device_connected">USB 기기가 연결되지 않았습니다.</string>
-    <string name="press_back_again_to_exit">뒤로가기 버튼을 한 번 더 눌러서 종료합니다.</string>
-    <string name="back">뒤로가기</string>
+    <string name="press_back_again_to_exit">뒤로 버튼을 한 번 더 누르면 종료됩니다.</string>
+    <string name="back">뒤로</string>
     <string name="debug_mode">디버그 모드</string>
-    <string name="debug_mode_description">더 많은 로깅을 토글합니다.</string>
+    <string name="debug_mode_description">자세한 로깅을 활성화합니다.</string>
     <string name="log_level">로그 레벨</string>
-    <string name="log_level_description">내보낼 때 로그 레벨을 필터링합니다.</string>
+    <string name="log_level_description">내보낼 로그 레벨을 필터링합니다.</string>
     <string name="start_log_capture">로그 캡처 시작</string>
     <string name="start_log_capture_description">디버깅을 위해 전체 로그를 기록합니다.</string>
+    <string name="start_log_capture_in_silent">로그 기록을 시작할 수 없습니다. 무음 로그 레벨이 선택되어 있습니다.</string>
     <string name="stop_log_capture">로그 캡처 중지</string>
-    <string name="stop_log_capture_description">녹화 중… 멈추려면 탭하세요.</string>
+    <string name="stop_log_capture_description">로그 기록 중입니다… 중지하려면 탭하세요.</string>
     <string name="export_logs">로그 내보내기</string>
-    <string name="export_logs_description">디버깅을 위해 로그를 저장합니다.</string>
-    <string name="use_native_ssl">Native SSL 사용</string>
-    <string name="use_native_ssl_description">Native OpenSSL 라이브러리를 사용합니다 (이전 기기에서 더 빠릅니다). 재시작 후 적용됩니다.</string>
-    <string name="not_set">설정되지 않음</string>
-    <string name="keymap_description">헤드유닛의 키 바인딩을 변경합니다.</string>
+    <string name="export_logs_description">디버깅용 로그를 저장합니다.</string>
+    <string name="use_native_ssl">네이티브 SSL 사용</string>
+    <string name="use_native_ssl_description">네이티브 OpenSSL 라이브러리를 사용합니다(구형 기기에서 더 빠를 수 있음). 재시작이 필요합니다.</string>
+    <string name="not_set">설정 안 됨</string>
+    <string name="keymap_description">헤드 유닛의 키 바인딩을 변경합니다.</string>
 
-    <string name="key_soft_left">왼쪽</string>
-    <string name="key_soft_right">오른쪽</string>
+    <string name="key_soft_left">소프트 왼쪽</string>
+    <string name="key_soft_right">소프트 오른쪽</string>
     <string name="key_dpad_up">D-Pad 위쪽</string>
     <string name="key_dpad_down">D-Pad 아래쪽</string>
     <string name="key_dpad_left">D-Pad 왼쪽</string>
     <string name="key_dpad_right">D-Pad 오른쪽</string>
-    <string name="key_dpad_center">D-Pad 중앙 (OK)</string>
+    <string name="key_dpad_center">D-Pad 가운데(OK)</string>
     <string name="key_media_play">미디어 재생</string>
     <string name="key_media_pause">미디어 일시정지</string>
     <string name="key_media_play_pause">미디어 재생/일시정지</string>
     <string name="key_media_next">다음 트랙</string>
     <string name="key_media_prev">이전 트랙</string>
     <string name="key_search">음성 명령</string>
-    <string name="key_call">전화 (수락)</string>
-    <string name="key_endcall">전화 끝 (거절)</string>
+    <string name="key_call">전화 받기(수락)</string>
+    <string name="key_endcall">통화 종료(거절)</string>
     <string name="key_music">음악</string>
     <string name="key_nav">내비게이션</string>
-    <string name="key_night">다크모드 토글</string>
-    <string name="key_enter">엔터 (Enter)</string>
-    <string name="key_home">홈 (Home)</string>
-    <string name="key_app_switch">최근 앱</string>
-    <string name="key_button_a">A 버튼 (선택)</string>
-    <string name="key_button_b">B 버튼 (뒤로가기)</string>
+    <string name="key_night">다크 모드 전환</string>
+    <string name="key_enter">엔터(Enter)</string>
+    <string name="key_home">홈(Home)</string>
+    <string name="key_app_switch">앱 전환 / 최근 앱</string>
+    <string name="key_button_a">A 버튼(선택)</string>
+    <string name="key_button_b">B 버튼(뒤로)</string>
 
 
     <!-- Language Settings -->
-    <string name="app_language">애플리케이션 언어</string>
+    <string name="app_language">앱 언어</string>
     <string name="system_default">시스템 기본값</string>
     <string name="change_language">언어 변경</string>
 
     <!-- Categories for SettingsFragment -->
     <string name="category_general">일반</string>
-    <string name="auto_start_self_mode">셀프모드 자동시작</string>
-    <string name="auto_start_self_mode_description">애플리케이션이 시작될 때 셀프모드를 자동으로 시작합니다.</string>
-    <string name="usb_auto_connect">USB 자동연결</string>
-    <string name="usb_auto_connect_description">애플리케이션이 시작될 때 알려진 USB 기기에 자동으로 연결합니다.</string>
-    <string name="auto_start_bt_label">Bluetooth 자동시작</string>
-    <string name="auto_start_bt_description">특정 Bluetooth 기기가 연결될 때 Headunit Revived를 자동으로 열기.</string>
-    <string name="auto_start_wifi_label">Wi-Fi 자동 시작</string>
+    <string name="auto_start_self_mode">단독 모드 자동 시작</string>
+    <string name="auto_start_self_mode_description">앱이 열릴 때 단독 모드를 자동으로 시작합니다.</string>
+    <string name="usb_auto_connect">USB 자동 연결</string>
+    <string name="usb_auto_connect_description">앱이 열릴 때 알려진 USB 기기에 자동으로 연결합니다.</string>
+    <string name="auto_start_bt_label">Bluetooth 연결 시 자동 시작</string>
+    <string name="auto_start_bt_description">특정 Bluetooth 기기가 연결되면 Headunit Revived를 자동으로 엽니다.</string>
+    <string name="auto_start_wifi_label">Wi-Fi 연결 시 자동 시작</string>
     <string name="auto_start_wifi_description">특정 Wi-Fi SSID에 연결될 때 Headunit Revived를 자동으로 실행합니다.</string>
     <string name="auto_start_wifi_ssid_label">Wi-Fi SSID</string>
     <string name="auto_start_wifi_ssid_description">이 Wi-Fi SSID에 연결되어 있을 때만 연결을 시도합니다</string>
     <string name="auto_start_wifi_warning">레거시 기능: 백그라운드 제한으로 인해 Android 8 이상에서는 동작이 불안정할 수 있습니다. 앱을 배터리 최적화 대상에서 제외했는지 확인하세요.</string>
     <string name="enter_wifi_ssid">Wi-Fi SSID를 입력하세요</string>
-    <string name="wifi_ssid_not_set">설정되지 않음</string>
-
-    <string name="listen_for_usb_devices_label">USB 기기 수신</string>
-    <string name="listen_for_usb_devices_description">USB 기기가 연결될 때 Android 시스템 프롬프트를 표시합니다.</string>
-    <string name="auto_start_usb_label">USB 자동시작</string>
-    <string name="auto_start_usb_description">USB 기기가 연결될 때 애플리케이션을 자동으로 열고 연결을 시도합니다</string>
-    <string name="auto_start_settings">자동시작 설정</string>
-    <string name="auto_start_settings_description">애플리케이션이 자동으로 시작될 때를 설정합니다</string>
-    <string name="auto_start_oem_warning">이 기기는 자동시작을 활성화하고 배터리 최적화 또는 백그라운드 제한을 제거해야 할 수 있습니다.\n\nQuick Boot (빠른 부팅)가 있는 헤드유닛에서는 자동시작이 작동하지 않을 수 있습니다. 시스템 설정에서 \"DuraSpeed\"를 찾아 활성화하세요. 일부 헤드유닛에서는 DuraSpeed가 숨겨져 있으므로 \"Hidden Settings\"와 같은 앱을 사용하여 찾아야 합니다. DuraSpeed가 없으면 Quick Boot를 비활성화해보세요.</string>
-    <string name="auto_start_on_boot_label">부팅 시 시작</string>
-    <string name="auto_start_on_boot_description">기기가 부팅될 때 애플리케이션을 자동으로 엽니다. Android 10+에서는 \'화면 위에 표시\' 권한이 필요합니다</string>
-    <string name="auto_start_screen_on_label">화면 켜질 때 시작</string>
-    <string name="auto_start_screen_on_description">화면이 켜질 때마다 애플리케이션을 엽니다. 완전히 끄지 않는 헤드유닛이나 다른 자동시작 옵션이 작동하지 않는 빠른 부팅 모드에 적합합니다. 휴대폰이나 태블릿에는 권장하지 않습니다.</string>
+    <string name="wifi_ssid_not_set">설정 안 됨</string>
+    <string name="listen_for_usb_devices_label">USB 기기 감지</string>
+    <string name="listen_for_usb_devices_description">USB 기기가 연결되면 Android 시스템 프롬프트를 표시합니다.</string>
+    <string name="auto_start_usb_label">USB 연결 시 자동 시작</string>
+    <string name="auto_start_usb_description">USB 기기가 연결되면 앱을 자동으로 열고 연결을 시도합니다</string>
+    <string name="auto_start_settings">자동 시작 설정</string>
+    <string name="auto_start_settings_description">앱이 자동으로 시작되는 조건을 설정합니다</string>
+    <string name="auto_start_oem_warning">이 기기에서는 앱의 자동 시작을 허용하고, 배터리 최적화 또는 백그라운드 제한을 해제해야 할 수 있습니다.\n\nQuick Boot(빠른 부팅)를 사용하는 헤드 유닛에서는 자동 시작이 작동하지 않을 수 있습니다. 시스템 설정에서 \"DuraSpeed\"를 찾아 이 앱을 허용하세요. 일부 헤드 유닛에서는 DuraSpeed가 숨겨져 있어 \"Hidden Settings\" 같은 앱으로 찾아야 할 수 있습니다. DuraSpeed가 없으면 Quick Boot를 비활성화해 보세요.</string>
+    <string name="auto_start_on_boot_label">부팅 시 자동 시작</string>
+    <string name="auto_start_on_boot_description">기기가 부팅될 때 앱을 자동으로 실행합니다. Android 10 이상에서는 \'다른 앱 위에 표시\' 권한이 필요합니다</string>
+    <string name="auto_start_screen_on_label">화면 켜짐 시 자동 실행</string>
+    <string name="auto_start_screen_on_description">화면이 켜질 때마다 앱을 자동으로 실행합니다. 완전히 종료되지 않거나 빠른 부팅 모드를 사용해 다른 자동 실행 옵션이 작동하지 않는 헤드 유닛에 적합합니다. 휴대전화나 태블릿에서는 권장하지 않습니다.</string>
     <string name="select_bt_device">Bluetooth 기기 선택</string>
-    <string name="bt_device_not_set">설정되지 않음</string>
+    <string name="bt_device_not_set">설정 안 됨</string>
     <string name="bt_permission_denied_title">Bluetooth 권한 필요</string>
-    <string name="bt_permission_denied_message">Bluetooth 권한이 필요하여 페어링된 기기를 선택할 수 있습니다. 애플리케이션 설정에서 권한을 부여하세요.</string>
+    <string name="bt_permission_denied_message">페어링된 기기를 선택하려면 Bluetooth 권한이 필요합니다. 앱 설정에서 권한을 허용하세요.</string>
     <string name="overlay_permission_title">백그라운드 시작 권한</string>
-    <string name="overlay_permission_description">Bluetooth가 연결될 때 Headunit Revived를 자동으로 열 수 있도록 하려면 다음 화면에서 "화면 위에 표시" 권한을 활성화하세요.</string>
+    <string name="overlay_permission_description">Bluetooth 기기가 연결될 때 Headunit Revived를 자동으로 실행하려면 다음 화면에서 "다른 앱 위에 표시" 권한을 허용하세요.</string>
     <string name="open_settings">설정</string>
-    <string name="right_hand_drive">우측 좌석 운전</string>
-    <string name="right_hand_drive_description">우측 좌석 운전을 위해 UI를 배치합니다</string>
+    <string name="right_hand_drive">우핸들</string>
+    <string name="right_hand_drive_description">우핸들 차량에 맞게 UI를 배치합니다</string>
     <string name="wireless_connection_settings">무선 연결 설정</string>
     <string name="category_graphic">그래픽</string>
-    <string name="custom_insets">커스텀 Insets (마진)</string>
+    <string name="custom_insets">사용자 지정 인셋(여백)</string>
     <string name="inset_top">위쪽</string>
     <string name="inset_bottom">아래쪽</string>
     <string name="inset_left">왼쪽</string>
     <string name="inset_right">오른쪽</string>
-    <string name="category_debug">Debug</string>
+    <string name="category_debug">디버그</string>
 
     <!-- Video Settings -->
     <string name="category_video">비디오</string>
-    <string name="force_software_decoding">강제 소프트웨어 디코딩</string>
-    <string name="force_software_decoding_description">일부 기기에서 문제를 해결할 수 있지만 성능이 떨어질 수 있습니다</string>
+    <string name="force_software_decoding">소프트웨어 디코딩 강제 사용</string>
+    <string name="force_software_decoding_description">일부 기기에서 문제를 해결할 수 있지만 성능이 저하될 수 있습니다</string>
     <string name="wireless_mode">무선 모드</string>
-    <string name="wireless_mode_description">애플리케이션이 무선으로 연결되는 방법을 선택합니다 (수동 목록, 자동 검색 또는 무선 런처 모드)</string>
+    <string name="wireless_mode_description">앱이 무선으로 연결되는 방법을 선택합니다(수동 목록, 휴대폰 자동 검색 또는 Wireless Helper 모드)</string>
     <string-array name="wireless_connection_modes">
-        <item>수동 (목록)</item>
-        <item>자동 검색 (헤드유닛 서버)</item>
-        <item>Wireless Helper (휴대폰 대기)</item>
-        <item>Native Android Auto (공식 Handshakeing)</item>
+        <item>수동(목록)</item>
+        <item>자동 검색(헤드 유닛 서버)</item>
+        <item>Wireless Helper(휴대폰 대기)</item>
+        <item>Native Android Auto(공식 핸드셰이크)</item>
     </string-array>
-    <string name="auto_connect_last_session">자동 연결 마지막 세션</string>
-    <string name="auto_connect_last_session_description">애플리케이션이 시작될 때 마지막으로 사용된 기기에 자동으로 연결합니다</string>
-    <string name="auto_connect_single_usb">USB 기기 자동연결</string>
+    <string name="auto_connect_last_session">최근 세션 자동 연결</string>
+    <string name="auto_connect_last_session_description">앱 시작 시 마지막으로 사용한 기기에 자동으로 다시 연결합니다</string>
+    <string name="auto_connect_single_usb">USB 기기 자동 연결</string>
     <string name="auto_connect_single_usb_description">호환되는 기기가 하나만 있을 때 자동으로 연결합니다</string>
-    <string name="auto_connect_settings">자동연결 설정</string>
-    <string name="auto_connect_settings_description">자동연결 방법과 우선순위를 설정합니다</string>
-    <string name="auto_connect_help">애플리케이션이 열릴 때 자동으로 실행되는 방법입니다. 원하는 방법을 활성화하고 순서를 설정하세요. 첫 번째 활성화된 방법이 성공하면 사용됩니다.</string>
+    <string name="auto_connect_settings">자동 연결 설정</string>
+    <string name="auto_connect_settings_description">자동 연결 방법과 우선순위를 설정합니다</string>
+    <string name="auto_connect_help">앱이 열릴 때 자동으로 실행되는 연결 방법입니다. 원하는 방법을 활성화한 뒤 드래그하여 순서를 설정하세요. 활성화된 방법 중 먼저 성공한 방법이 사용됩니다.</string>
     <string name="auto_connect_priority">우선순위 %d</string>
-    <string name="auto_connect_all_disabled">모두 비활성화</string>
-    <string name="drag_to_reorder">드래그하여 순서를 변경합니다</string>
+    <string name="auto_connect_all_disabled">모두 비활성화됨</string>
+    <string name="drag_to_reorder">드래그하여 순서 변경</string>
     <string name="move_up">위로 이동</string>
     <string name="move_down">아래로 이동</string>
-    <string name="auto_connecting_single_usb">USB 기기에 자동으로 연결…</string>
+    <string name="auto_connecting_single_usb">USB 기기에 자동으로 연결 중…</string>
     <string name="video_codec">비디오 코덱</string>
-    <string name="fps_limit">FPS Limit</string>
+    <string name="fps_limit">FPS 제한</string>
     <string name="save">저장</string>
-    <string name="save_and_restart">저장 (재연결 필요)</string>
+    <string name="save_and_restart">저장(재연결 필요)</string>
     <string name="add_new">새로 추가</string>
     <string name="cancel">취소</string>
     <string name="enable">활성화</string>
-    <string name="pref_stretch_screen_title">화면을 채우기 위해 늘립니다</string>
-    <string name="pref_stretch_screen_summary">비율을 무시하고 전체 디스플레이를 채웁니다 (검정색 바 제거)</string>
-    <string name="forced_scale">강제 스케일 (레거시 수정)</string>
-    <string name="forced_scale_description">SurfaceView를 사용하는 일부 이전 기기의 스케일링 문제를 수정합니다. 이미지가 깨져 있거나 이동하면 사용하세요.</string>
+    <string name="pref_stretch_screen_title">화면에 맞게 늘리기</string>
+    <string name="pref_stretch_screen_summary">화면 비율을 무시하고 전체 디스플레이를 채웁니다(검정색 바 제거)</string>
+    <string name="forced_scale">강제 화면 크기 조정(레거시 수정)</string>
+    <string name="forced_scale_description">SurfaceView를 사용하는 일부 구형 기기에서 화면 크기 조정 문제를 보정합니다. 이미지가 왜곡되거나 위치가 어긋나 보일 때만 사용하세요.</string>
 
 
     <!-- Audio Settings -->
     <string name="category_audio">오디오</string>
-    <string name="enable_audio_sink">오디오 싱크</string>
-    <string name="enable_audio_sink_description">비활성화되면 헤드유닛이 오디오를 수신하지 않습니다. 소리는 휴대폰에서 재생됩니다.</string>
+    <string name="enable_audio_sink">오디오 수신</string>
+    <string name="enable_audio_sink_description">비활성화되면 헤드 유닛이 오디오를 수신하지 않습니다. 소리는 휴대폰에서 재생됩니다.</string>
     <string name="separate_audio_streams">오디오 스트림 분리</string>
-    <string name="separate_audio_streams_description">단일 멀티미디어 스트림 대신 음악, 통화 및 알림에 대해 별도의 오디오 채널을 사용합니다 (일부 기기에서 제대로 작동하지 않을 수 있음).</string>
+    <string name="separate_audio_streams_description">하나의 멀티미디어 스트림 대신 음악, 통화, 알림에 별도의 오디오 채널을 사용합니다(일부 기기에서는 정상적으로 작동하지 않을 수 있음).</string>
     <string name="use_aac_audio">AAC 오디오 사용</string>
-    <string name="use_aac_audio_description">AAC 코덱을 사용하여 대역폭을 절약합니다 (실험적).</string>
+    <string name="use_aac_audio_description">대역폭을 절약하기 위해 오디오에 AAC 코덱을 사용합니다(실험적).</string>
     <string name="audio_volume_offset">오디오 볼륨 오프셋</string>
     <string name="media_volume_offset">미디어 볼륨 오프셋</string>
     <string name="assistant_volume_offset">어시스턴트 볼륨 오프셋</string>
     <string name="navigation_volume_offset">내비게이션 볼륨 오프셋</string>
+    <string name="microphone_settings">마이크 설정</string>
+    <string name="microphone_settings_description">마이크 입력 및 오디오 처리를 설정합니다.</string>
     <string name="mic_input_source">마이크 입력 소스</string>
-    <string name="mic_input_source_description">마이크의 오디오 소스를 선택합니다.</string>
+    <string name="mic_input_source_description">마이크에 사용할 오디오 소스를 선택합니다.</string>
     <string-array name="mic_input_sources">
-        <item>기본 (시스템 결정)</item>
-        <item>내장 마이크 (Raw input)</item>
-        <item>음성 인식 (노이즈 감소)</item>
-        <item>음성 통신 (에코 + 노이즈 취소)</item>
-        <item>Bluetooth 헤드셋 (SCO)</item>
+        <item>기본값(시스템에서 결정)</item>
+        <item>내장 마이크(원시 입력)</item>
+        <item>음성 인식(노이즈 감소)</item>
+        <item>음성 통화(에코 및 노이즈 제거)</item>
+        <item>Bluetooth 헤드셋(SCO)</item>
     </string-array>
+    <string name="mic_echo_canceler">에코 제거(AEC)</string>
+    <string name="mic_echo_canceler_description">마이크의 에코 제거를 시도합니다. 소리가 들리지 않거나 왜곡되면 비활성화하세요.</string>
+    <string name="mic_noise_suppressor">노이즈 억제(NS)</string>
+    <string name="mic_noise_suppressor_description">배경 소음을 줄입니다. 목소리가 먹먹하게 들리면 비활성화하세요.</string>
+    <string name="mic_auto_gain_control">자동 게인 제어(AGC)</string>
+    <string name="mic_auto_gain_control_description">마이크 음량을 자동으로 조절합니다. 음량이 불안정하면 비활성화하세요.</string>
 
     <!-- Info Settings -->
     <string name="category_info">정보</string>
-    <string name="about">About &amp; Support</string>
-    <string name="about_description">Get more information about Headunit Revived</string>
-    <string name="version">Version</string>
-    <string name="about_title">About Headunit Revived</string>
+    <string name="about">정보 &amp; 지원</string>
+    <string name="about_description">Headunit Revived에 대한 자세한 정보를 확인하세요</string>
+    <string name="version">버전</string>
+    <string name="about_title">Headunit Revived에 대해</string>
     <string name="copyright">© 2025-%d André Rinas</string>
 
     <!-- Safety Disclaimer -->
-    <string name="disclaimer_title">안전 &amp; 책임</string>
+    <string name="disclaimer_title">안전 및 책임</string>
     <string name="disclaimer_header">중요 경고</string>
     <string name="disclaimer_accept">이해하고 동의합니다</string>
     <string name="disclaimer_text"><![CDATA[
-        <b>1. 도로에 집중하세요</b><br/>
-        운전하면서 이 소프트웨어를 사용하는 것은 주의를 분산시켜 위험할 수 있습니다. 항상 안전 운전을 우선시하고 모든 지역 교통 규정을 준수하세요. 이 애플리케이션은 안전할 때만 사용하세요.<br/><br/>
+        <b>1. 운전에 집중하세요</b><br/>
+        운전 중 이 소프트웨어를 조작하면 주의가 분산되어 위험할 수 있습니다. 항상 안전 운전을 최우선으로 하고, 모든 현지 교통 법규를 준수하세요. 이 앱은 안전한 상황에서만 사용하세요.<br/><br/>
         <b>2. 책임 제한</b><br/>
-        Headunit Revived는 모든 종류의 보증 없이 "있는 그대로" 제공됩니다. 개발자는 이 소프트웨어를 사용하여 발생한 사고, 차량/기기 손상 또는 법적 결과에 대한 책임을 지지 않습니다.<br/><br/>
-        <b>3. 무관</b><br/>
-        이 프로젝트는 독립적인 오픈소스 이니셔티브이며 Google LLC 또는 Android Auto 브랜드와 연관되어 있지 않습니다.
+        Headunit Revived는 어떠한 종류의 보증도 없이 "있는 그대로" 제공됩니다. 개발자는 이 소프트웨어 사용으로 인해 발생한 사고, 차량/기기 손상 또는 법적 결과에 대한 책임을 지지 않습니다.<br/><br/>
+        <b>3. 제휴 없음</b><br/>
+        이 프로젝트는 독립적인 오픈소스 프로젝트이며, Google LLC 또는 Android Auto 브랜드와 제휴, 보증 또는 관련이 없습니다.
     ]]></string>
 
     <!-- Toast Messages -->
     <string name="searching">검색 중…</string>
-    <string name="auto_connecting_to">%s에 자동으로 연결…</string>
-    <string name="auto_connecting_usb">USB 기기에 자동으로 연결…</string>
+    <string name="auto_connecting_to">%s에 자동 연결 중…</string>
+    <string name="auto_connecting_usb">USB 기기에 자동 연결 중…</string>
     <string name="already_connected">이미 연결됨</string>
     <string name="already_scanning">이미 검색 중…</string>
-    <string name="searching_headunit_server">헤드유닛 서버 검색 중…</string>
-    <string name="already_searching_phone">이미 휴대폰 검색 중…</string>
+    <string name="searching_headunit_server">헤드 유닛 서버 검색 중…</string>
+    <string name="already_searching_phone">이미 휴대폰을 검색 중입니다…</string>
     <string name="searching_phone">휴대폰 검색 중…</string>
     <string name="key_mappings_reset">키 매핑 초기화</string>
     <string name="press_key_to_assign">\'%s\'에 할당할 키를 누르세요…</string>
-    <string name="key_assigned">\'%1$s\'이(가) \'%2$s\'에 할당됨</string>
-    <string name="last_key_press">마지막 키 누름: %1$s (%2$d)</string>
+    <string name="key_assigned">\'%1$s\'이(가) \'%2$s\'에 할당되었습니다</string>
+    <string name="last_key_press">마지막으로 누른 키: %1$s(%2$d)</string>
     <string name="scan">검색</string>
     <string name="scanning_network">네트워크 검색 중…</string>
-    <string name="found_connecting">%s 찾음, 연결 중…</string>
-    <string name="no_devices_found">기기 없음</string>
+    <string name="found_connecting">%s 발견, 연결 중…</string>
+    <string name="no_devices_found">발견된 기기 없음</string>
     <string name="unsaved_changes">저장되지 않은 변경사항</string>
-    <string name="unsaved_changes_message">저장되지 않은 변경사항이 있습니다. 설정값을 폐기하시겠습니까?</string>
-    <string name="discard">폐기</string>
-    <string name="stopping_service">변경사항을 적용하기 위해 서비스를 중지…</string>
-    <string name="settings_saved">설정 저장됨</string>
-    <string name="logs_exported">로그 내보내기</string>
-    <string name="log_saved_to">로그 저장됨:\n%s</string>
+    <string name="unsaved_changes_message">저장되지 않은 변경사항이 있습니다. 변경사항을 버리시겠습니까?</string>
+    <string name="discard">버리기</string>
+    <string name="stopping_service">변경사항을 적용하기 위해 서비스를 중지하는 중…</string>
+    <string name="settings_saved">설정이 저장되었습니다</string>
+    <string name="logs_exported">로그 내보내기 완료</string>
+    <string name="log_saved_to">로그 저장 위치:\n%s</string>
     <string name="share">공유</string>
     <string name="close">닫기</string>
     <string name="failed_export_logs">로그 내보내기 실패</string>
-    <string name="switching_to_android_auto">Android Auto로 전환…</string>
+    <string name="failed_export_in_silent_logs">로그를 내보낼 수 없습니다. 무음 로그 레벨이 선택되어 있습니다.</string>
+    <string name="switching_to_android_auto">Android Auto로 전환 중…</string>
     <string name="switch_failed">전환 실패</string>
-    <string name="requesting_usb_permission">USB 권한 요청…</string>
+    <string name="requesting_usb_permission">USB 권한 요청 중…</string>
     <string name="enter_ip_address">IP 주소 입력</string>
-    <string name="switching_usb_accessory_mode">USB 기기를 액세서리 모드로 전환 %s</string>
+    <string name="switching_usb_accessory_mode">USB 기기를 액세서리 모드로 전환 중: %s</string>
     <string name="success">성공</string>
     <string name="failed">실패</string>
     <string name="failed_start_android_auto">Android Auto 시작 실패</string>
-    <string name="failed_self_mode_android10">셀프모드는 Android 10 (AA 16.4+)에서 Google에 의해 차단될 수 있습니다.</string>
+    <string name="failed_self_mode_android10">Android 10(Android Auto 16.4 이상)에서는 Google에 의해 단독 모드가 차단될 수 있습니다.</string>
     <string name="android_auto_starting">Android Auto 시작 중…</string>
     <string name="connection_interrupted">연결 끊김</string>
     <string name="connection_interrupted_detail">다시 시도 중…</string>
-    <string name="wifi_disconnect_toast">Android Auto 연결 끊김: 무선 AA를 사용하는 경우, 휴대폰 WiFi 설정에서 \"네트워크 전환\" 또는 \"네트워크 가속\"을 비활성화하세요</string>
+    <string name="wifi_disconnect_toast">Android Auto 연결 끊김: 무선 Android Auto를 사용하는 경우 휴대폰 Wi-Fi 설정에서 \"네트워크 전환\" 또는 \"네트워크 가속\"을 비활성화하세요</string>
     <string name="reset_usb_option">USB 연결 초기화</string>
-    <string name="reset_usb_timeout">USB 기기 없음. 연결을 확인하세요.</string>
+    <string name="reset_usb_timeout">USB 기기를 찾을 수 없습니다. 연결을 확인하세요.</string>
     <string name="notification_service_running">Headunit Revived 실행 중</string>
-    <string name="notification_projection_active">Android Auto 프로젝션 중</string>
+    <string name="notification_projection_active">Android Auto가 프로젝션 중입니다</string>
     <string name="shortcut_connect_title">연결</string>
-    <string name="shortcut_connect_desc">마지막 휴대폰에 자동으로 연결</string>
-    <string name="shortcut_selfmode_title">셀프모드</string>
+    <string name="shortcut_connect_desc">마지막 휴대폰에 자동 연결</string>
+    <string name="shortcut_selfmode_title">단독 모드</string>
     <string name="shortcut_selfmode_desc">이 기기에서 Android Auto 시작</string>
     <string name="shortcut_disconnect_title">연결 끊기</string>
     <string name="shortcut_disconnect_desc">현재 세션 종료</string>
     <string name="shortcut_exit_title">앱 종료</string>
     <string name="shortcut_exit_desc">모든 서비스를 중지하고 앱을 닫습니다</string>
     <string name="shortcut_night_mode_auto_title">모드: 자동</string>
-    <string name="shortcut_night_mode_auto_desc">자동 나이트 모드 복원</string>
-    <string name="shortcut_night_mode_day_title">모드: 낮</string>
-    <string name="shortcut_night_mode_day_desc">낮 모드 강제</string>
-    <string name="shortcut_night_mode_night_title">모드: 밤</string>
-    <string name="shortcut_night_mode_night_desc">밤 모드 강제</string>
+    <string name="shortcut_night_mode_auto_desc">자동 야간 모드 복원</string>
+    <string name="shortcut_night_mode_day_title">모드: 주간</string>
+    <string name="shortcut_night_mode_day_desc">주간 모드로 강제 전환</string>
+    <string name="shortcut_night_mode_night_title">모드: 야간</string>
+    <string name="shortcut_night_mode_night_desc">야간 모드로 강제 전환</string>
     <string name="setup_welcome_title">빠른 설정</string>
-    <string name="setup_welcome_msg">이 마법사는 부드러운 Android Auto 경험을 위해 최적의 설정을 선택하는 데 도움이 됩니다.\n\n이러한 설정은 언제든지 변경할 수 있거나 앱 설정에서 이 마법사를 다시 시작할 수 있습니다.</string>
+    <string name="setup_welcome_msg">이 설정 마법사는 Android Auto를 더 원활하게 사용할 수 있도록 기기에 맞는 최적의 설정을 선택하는 데 도움을 줍니다.\n\n이 설정은 나중에 언제든지 변경할 수 있으며, 앱 설정에서 이 마법사를 다시 시작할 수도 있습니다.</string>
     <string name="setup_start">시작</string>
     <string name="setup_size_title">디스플레이 크기</string>
-    <string name="setup_size_phone">작은 폰 화면 (4-6\")</string>
-    <string name="setup_size_small">작은 태블릿 화면 (7-8\")</string>
-    <string name="setup_size_standard">표준 화면 (9-10\")</string>
-    <string name="setup_size_large">큰 화면 (11\"+)</string>
+    <string name="setup_size_phone">휴대폰 / 소형(4-6\")</string>
+    <string name="setup_size_small">소형 태블릿(7-8\")</string>
+    <string name="setup_size_standard">표준(9-10\")</string>
+    <string name="setup_size_large">대형(11\" 이상)</string>
     <string name="setup_orientation_title">기기 방향</string>
-    <string name="setup_orientation_landscape">가로 (Horizontal)</string>
-    <string name="setup_orientation_portrait">세로 (Vertical)</string>
+    <string name="setup_orientation_landscape">가로(Horizontal)</string>
+    <string name="setup_orientation_portrait">세로(Vertical)</string>
     <string name="setup_result_title">최적화 완료</string>
     <string name="setup_apply">적용</string>
-    <string name="setup_widescreen_detected">넓은 화면 탐지됨.</string>
-    <string name="auto_optimize">자동 최적화 설정</string>
-    <string name="auto_optimize_desc">시스템 체크를 실행하여 기기에 대한 최적의 설정을 찾습니다.</string>
+    <string name="setup_widescreen_detected">와이드스크린 디스플레이가 감지되었습니다.</string>
+    <string name="auto_optimize">설정 자동 최적화</string>
+    <string name="auto_optimize_desc">시스템 검사를 실행하여 기기에 가장 적합한 설정을 찾습니다.</string>
 
     <!-- Navigation notifications (from any AA nav app) -->
     <string name="show_navigation_notifications">내비게이션 알림</string>
-    <string name="show_navigation_notifications_description">\"X 미터에서 Y로 이동\"과 현재 도로를 알림에 표시합니다 (디버깅용)</string>
+    <string name="show_navigation_notifications_description">알림에 \"X m 후 Y\" 형식의 길 안내와 현재 도로를 표시합니다(디버깅용)</string>
     <string name="media_session_aa_status_placeholder">연결됨</string>
-    <string name="sync_media_session_aa_metadata">AA 현재 재생중인 미디어 세션 정보 표시</string>
-    <string name="sync_media_session_aa_metadata_description">트랙 제목, 아티스트, 재생 시간 및 앨범 아트를 휴대폰에서 시스템 미디어 세션과 미디어 알림에 표시합니다</string>
+    <string name="sync_media_session_aa_metadata">Android Auto 재생 정보를 미디어 세션에 표시</string>
+    <string name="sync_media_session_aa_metadata_description">휴대폰의 트랙 제목, 아티스트, 재생 시간, 앨범 아트를 시스템 미디어 세션과 미디어 알림에 표시합니다.</string>
     <string name="nav_notification_channel_name">내비게이션</string>
-    <string name="nav_notification_channel_description">Android Auto에서 전환 내비게이션 업데이트</string>
-    <string name="nav_notification_title_format">%1$d — %2$s 미터 이내</string>
-    <string name="nav_notification_street_format">도로: %1$s</string>
-    <string name="nav_action_unknown">알 수 없음</string>
+    <string name="nav_notification_channel_description">Android Auto의 길 안내 업데이트</string>
+    <string name="nav_notification_title_format">%1$d m 후 %2$s</string>
+    <string name="nav_notification_street_format">현재 도로: %1$s</string>
+    <string name="nav_action_unknown">안내</string>
     <string name="nav_action_depart">출발</string>
-    <string name="nav_action_name_change">이름 변경</string>
-    <string name="nav_action_slight_turn">약간의 회전</string>
+    <string name="nav_action_name_change">도로명 변경</string>
+    <string name="nav_action_slight_turn">완만한 회전</string>
     <string name="nav_action_turn">회전</string>
-    <string name="nav_action_sharp_turn">급한 회전</string>
-    <string name="nav_action_uturn">U-회전</string>
+    <string name="nav_action_sharp_turn">급회전</string>
+    <string name="nav_action_uturn">유턴</string>
     <string name="nav_action_on_ramp">도로 진입</string>
-    <string name="nav_action_off_ramp">도로 이탈</string>
-    <string name="nav_action_merge">병합</string>
-    <string name="nav_action_roundabout_enter">원형 교차로 진입</string>
-    <string name="nav_action_roundabout_exit">원형 교차로 이탈</string>
-    <string name="nav_action_roundabout">원형 교차로</string>
+    <string name="nav_action_off_ramp">진출로로 나가기</string>
+    <string name="nav_action_merge">합류</string>
+    <string name="nav_action_roundabout_enter">회전교차로 진입</string>
+    <string name="nav_action_roundabout_exit">회전교차로 진출</string>
+    <string name="nav_action_roundabout">회전교차로</string>
     <string name="nav_action_straight">직진</string>
     <string name="nav_action_ferry">페리</string>
-    <string name="nav_action_ferry_train">페리 / 기차</string>
+    <string name="nav_action_ferry_train">페리/열차</string>
     <string name="nav_action_destination">도착</string>
     <string name="show_fps_counter">FPS 카운터 표시</string>
-    <string name="show_fps_counter_description">프로젝션 중 좌상단에 실시간 FPS 오버레이를 표시합니다.</string>
+    <string name="show_fps_counter_description">프로젝션 중 왼쪽 상단에 실시간 FPS 오버레이를 표시합니다.</string>
 
     <!-- Auto-start permission strings -->
     <string name="reopen_on_reconnection_label">재연결 시 다시 열기</string>
-    <string name="reopen_on_reconnection_description">Exit 버튼을 누르면 앱은 백그라운드에서 실행되며 USB 연결을 계속 모니터링합니다. 기기가 재연결되면 앱이 자동으로 다시 열립니다.</string>
-    <string name="overlay_permission_required">자동 시작은 \'다른 앱 위에 표시\' 권한이 필요합니다</string>
-    <string name="usb_permission_denied">USB 권한이 거절되었습니다. 자동 연결을 위해 USB 접근을 허용하세요.</string>
-    <string name="overlay_permission_denied_auto_start_disabled">Overlay 권한이 거절되었습니다. 자동 시작이 비활성화되었습니다.</string>
+    <string name="reopen_on_reconnection_description">종료 버튼을 누르면 앱이 백그라운드에서 계속 실행되며 USB 연결을 계속 감시합니다. 기기가 다시 연결되면 앱이 자동으로 다시 열립니다.</string>
+    <string name="overlay_permission_required">자동 시작에는 \'다른 앱 위에 표시\' 권한이 필요합니다</string>
+    <string name="usb_permission_denied">USB 권한이 거부되었습니다. 자동으로 연결하려면 USB 접근을 허용하세요.</string>
+    <string name="overlay_permission_denied_auto_start_disabled">\'다른 앱 위에 표시\' 권한이 허용되지 않아 자동 시작이 비활성화되었습니다.</string>
 
     <!-- Theme -->
     <string name="use_white_background">흰색 홈 화면 배경 사용</string>
     <string name="category_input">입력 설정</string>
     <string name="enable_rotary">로터리 컨트롤러 활성화</string>
-    <string name="enable_rotary_description">물리적 로터리 컨트롤러와 휠을 지원합니다. 터치 스크린이 제대로 작동하지 않는 경우 비활성화하세요.</string>
+    <string name="enable_rotary_description">물리적 로터리 컨트롤러와 휠을 지원합니다. 터치스크린이 제대로 작동하지 않으면 비활성화하세요.</string>
 
-    <string name="kill_on_disconnect">연결 끊기 시 앱 닫기</string>
-    <string name="kill_on_disconnect_description">Android Auto 연결 끊기 시 자동으로 앱을 닫습니다</string>
+    <string name="kill_on_disconnect">연결 해제 시 앱 닫기</string>
+    <string name="kill_on_disconnect_description">Android Auto 연결이 해제되면 앱을 자동으로 닫습니다</string>
     <string name="kill_on_disconnect_warning_title">경고</string>
-    <string name="kill_on_disconnect_warning">다음 재연결 설정은 \'연결 끊기 시 앱 닫기\'와 함께 사용하면 충돌합니다:\n\n%1$s\n\n헤드유닛이 켜질 때의 초기 연결 설정(자동 연결, 자동 시작)은 그대로 동작합니다. 다만 첫 연결 해제 이후에는 재연결을 시도하지 않고 앱이 바로 종료됩니다.\n\n참고: 일부 애프터마켓 헤드유닛은 완전히 전원이 꺼지지 않고 절전·대기만 하는 경우가 많습니다. 화면만 잠그고 실제로 끄지 않는 휴대전화와 비슷합니다. 이 옵션을 켜면 첫 연결 해제 후 앱이 닫히며, 다음 시동 주기에서 자동으로 다시 열리지 않을 수 있습니다.\n\n위에 나열된 재연결 설정을 끄시겠습니까?</string>
-    <string name="kill_on_disconnect_disable_and_enable">비활성화 및 활성화</string>
-    <string name="kill_on_disconnect_enable_anyway">활성화 하려면 무시</string>
+    <string name="kill_on_disconnect_warning">다음 재연결 설정은 \'연결 해제 시 앱 닫기\'와 함께 사용하면 충돌합니다:\n\n%1$s\n\n헤드 유닛이 켜질 때의 초기 연결 설정(자동 연결, 자동 시작)은 그대로 동작합니다. 하지만 첫 연결 해제 후에는 재연결을 시도하지 않고 앱이 즉시 종료됩니다.\n\n참고: 일부 애프터마켓 헤드 유닛은 완전히 종료되지 않고 절전 상태로 전환됩니다. 화면만 잠기고 실제로 전원이 꺼지지 않는 휴대전화와 비슷합니다. 이 옵션을 켜면 첫 연결 해제 후 앱이 닫히며, 다음 시동 주기에서 자동으로 다시 열리지 않을 수 있습니다.\n\n위에 나열된 재연결 설정을 비활성화하시겠습니까?</string>
+    <string name="kill_on_disconnect_disable_and_enable">비활성화 후 활성화</string>
+    <string name="kill_on_disconnect_enable_anyway">그래도 활성화</string>
     <string name="kill_on_disconnect_conflicts_disabled">충돌하는 설정이 비활성화되었습니다</string>
-    <string name="kill_on_disconnect_boot_warning">\"시동 켜기\" 설정이 활성화되어 있습니다. 앱이 연결 끊기 시 닫히고 이 기기가 전원을 끄지 않고 절전·대기만 하는 경우, 다음 시동 주기에서 앱이 자동으로 다시 열리지 않을 수 있습니다. 시동 이벤트가 발생하지 않기 때문입니다. — 기기는 단순히 절전·대기 상태에서 깨어납니다.</string>
-    <string name="kill_on_disconnect_screen_on_warning">\"화면 켜기\" 설정이 활성화되어 있습니다. 이 설정은 화면이 켜질 때마다 앱을 엽니다. 연결 끊기 시 닫기와 결합하면, 앱은 연결 끊기 후 닫히지만 화면이 켜지면 자동으로 다시 열리며, 다시 시작 루프를 생성합니다.</string>
+    <string name="kill_on_disconnect_boot_warning">\"부팅 시 자동 시작\" 설정이 활성화되어 있습니다. 연결 해제 시 앱이 닫히고 이 기기가 종료되지 않고 절전 상태로 전환되는 경우, 부팅 이벤트가 발생하지 않기 때문에 다음 시동 주기에서 앱이 자동으로 다시 열리지 않을 수 있습니다. 기기는 단순히 절전 상태에서 깨어납니다.</string>
+    <string name="kill_on_disconnect_screen_on_warning">\"화면 켜짐 시 자동 실행\" 설정이 활성화되어 있습니다. 이 설정은 화면이 켜질 때마다 앱을 엽니다. 연결 해제 시 앱 닫기와 함께 사용하면, 연결 해제 후 앱이 닫혔다가 화면이 다시 켜질 때 즉시 다시 열려 재시작 루프가 발생할 수 있습니다.</string>
 
-    <string name="wifi_disabled_info">정보: Wi-Fi가 비활성화되었습니다.</string>
-    <string name="bt_not_enabled">Bluetooth가 비활성화되었습니다</string>
+    <string name="wifi_disabled_info">정보: Wi-Fi가 비활성화되어 있습니다.</string>
+    <string name="bt_not_enabled">Bluetooth가 비활성화되어 있습니다</string>
+    <string name="bt_permission_denied">Bluetooth 권한이 거부되었습니다. 기기를 검색할 수 없습니다.</string>
 
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">차량 정보</string>
-    <string name="vehicle_info_settings_description">차량이 휴대폰에 표시되는 방식을 사용자 정의합니다</string>
+    <string name="vehicle_info_settings_description">휴대폰에 차량이 표시되는 방식을 설정합니다</string>
     <string name="ui_scale">UI 배율</string>
     <string name="ui_scale_home">홈 화면</string>
     <string name="ui_scale_settings">설정 화면</string>
     <string name="category_vehicle">차량</string>
-    <string name="category_head_unit">헤드유닛</string>
+    <string name="category_head_unit">헤드 유닛</string>
     <string name="vehicle_display_name_label">표시 이름</string>
-    <string name="vehicle_display_name_description">차량에 대한 이름을 휴대폰에 표시합니다</string>
-    <string name="vehicle_make_label">제조사 정보</string>
-    <string name="vehicle_make_description">차량 제조사 (예: Honda, Toyota)</string>
+    <string name="vehicle_display_name_description">휴대폰에 표시될 이 차량의 이름입니다</string>
+    <string name="vehicle_make_label">제조사</string>
+    <string name="vehicle_make_description">차량 제조사(예: Honda, Toyota)</string>
     <string name="vehicle_model_label">모델</string>
-    <string name="vehicle_model_description">차량 모델 (예: Civic, Corolla)</string>
+    <string name="vehicle_model_description">차량 모델(예: Civic, Corolla)</string>
     <string name="vehicle_year_label">연식</string>
     <string name="vehicle_year_description">차량 연식</string>
     <string name="vehicle_id_label">차량 ID</string>
-    <string name="vehicle_id_description">내부 식별자만 사용합니다. 이를 변경하면 휴대폰은 이를 다른 차량으로 취급하여 이 차량의 Android Auto 설정을 초기화합니다.</string>
-    <string name="head_unit_make_label">제조사 정보</string>
-    <string name="head_unit_make_description">헤드유닛 제조사</string>
-    <string name="head_unit_make_hint">휴대폰에서 이 이름을 Android Auto 설정에 표시합니다.</string>
+    <string name="vehicle_id_description">내부 식별자로만 사용됩니다. 이 값을 변경하면 휴대폰이 다른 차량으로 인식하여 이 차량의 Android Auto 설정이 초기화됩니다.</string>
+    <string name="head_unit_make_label">제조사</string>
+    <string name="head_unit_make_description">헤드 유닛 제조사</string>
+    <string name="head_unit_make_hint">휴대폰의 Android Auto 설정에 이 이름이 표시됩니다.</string>
     <string name="head_unit_model_label">모델</string>
-    <string name="head_unit_model_description">헤드유닛 모델</string>
+    <string name="head_unit_model_description">헤드 유닛 모델</string>
     <string name="vehicle_year_error_invalid">유효한 연식을 입력하세요</string>
-    <string name="vehicle_year_error_max">연식은 %1$d 이후일 수 없습니다</string>
+    <string name="vehicle_year_error_max">연식은 %1$d년보다 이후일 수 없습니다</string>
     <string name="vehicle_info_restart_note">이 데이터는 연결할 때마다 Android Auto로 전송됩니다.</string>
 
-    <string name="auto_enable_hotspot">자동 Wi-Fi 핫스팟 활성화</string>
-    <string name="auto_enable_hotspot_description">이 기기에서 자동으로 Wi-Fi 핫스팟을 시작합니다. (모든 기기에서 작동하지 않습니다)</string>
+    <string name="auto_enable_hotspot">Wi-Fi 핫스팟 자동 활성화</string>
+    <string name="auto_enable_hotspot_description">이 기기에서 자동으로 Wi-Fi 핫스팟을 시작합니다. 모든 기기에서 작동하지는 않습니다</string>
     <string name="hotspot_warning_title">실험적 기능</string>
-    <string name="hotspot_warning_message">이 기능은 리플렉션을 사용하므로 모든 기기에서 작동하지 않을 수 있습니다. 또한 "시스템 설정 수정" 권한이 수동으로 부여되어야 할 수 있습니다.</string>
+    <string name="hotspot_warning_message">이 기능은 리플렉션 방식을 사용하므로 일부 기기에서는 작동하지 않을 수 있습니다. 또한 "시스템 설정 변경" 권한을 수동으로 허용해야 할 수 있습니다.</string>
     <string name="hotspot_permission_title">권한 필요</string>
-    <string name="hotspot_permission_message">핫스팟 기능은 \"시스템 설정 수정\" 권한이 필요합니다. 다음 화면에서 활성화하세요.</string>
+    <string name="hotspot_permission_message">핫스팟 기능은 \"시스템 설정 변경\" 권한이 필요합니다. 다음 화면에서 허용하세요.</string>
 
     <string name="supported_nativeaa">향상된 무선 지원</string>
-    <string name="supported_nativeaa_desc">기기가 \"Native Wireless\" 모드를 지원하며, 더 매끄러운 Android Auto 경험을 제공합니다. \n\n이를 활성화하기 위해서는 Bluetooth 캐시를 새로 고쳐야 합니다. 다음 작업을 수행하세요: \n1. 휴대폰에서 기존 페어링 제거 \n2. Bluetooth 재시작 확인 \n3. 휴대폰 재페어링 \n\n지금 Native AA 모드로 전환하시겠습니까?</string>
-    <string name="not_supported_nativeaa">Native Wireless 지원되지 않음</string>
-    <string name="not_supported_nativeaa_desc">기기가 Native Wireless에 필요한 Bluetooth 또는 Wi-Fi 기능을 지원하지 않을 수 있습니다. 시도해볼 수 있지만, 실패하면 \"Wireless Helper\" 또는 \"Auto (Headunit Server)\" 모드를 사용하세요.</string>
+    <string name="supported_nativeaa_desc">이 기기는 더 매끄러운 Android Auto 경험을 제공하는 \"Native Wireless\" 모드를 지원합니다.\n\n이 기능을 활성화하려면 Bluetooth 캐시를 새로 고쳐야 합니다. 다음 작업을 수행하세요:\n1. 휴대폰에서 기존 페어링 제거\n2. 확인을 눌러 Bluetooth 재시작\n3. 휴대폰 다시 페어링\n\n지금 Native Android Auto 모드로 전환하시겠습니까?</string>
+    <string name="not_supported_nativeaa">Native Wireless가 지원되지 않는 것으로 보임</string>
+    <string name="not_supported_nativeaa_desc">이 기기는 Native Wireless에 필요한 Bluetooth 또는 Wi-Fi 기능을 지원하지 않을 수 있습니다. 그래도 시도할 수는 있지만, 실패하면 \"Wireless Helper\" 또는 \"Auto(헤드 유닛 서버)\" 모드를 사용하세요.</string>
 
-    <string name="wait_for_wifi">WiFi Direct 시작 전 WiFi 대기</string>
-    <string name="wait_for_wifi_description">부팅 시 WiFi가 연결될 때까지 대기합니다. 헤드유닛이 전원 켜진 후 WiFi에 연결하는데 몇 초가 걸리는 경우 활성화하세요.</string>
-    <string name="wait_for_wifi_timeout">WiFi 대기 시간 초과</string>
-    <string name="wireless_24ghz_warning">참고: 2.4GHz 기기에서 무선 Android Auto는 지연, 끊임 없는 연결 문제를 일으킬 수 있습니다. 문제가 발생하면 USB를 통해 테스트하여 네트워크 제한이 있는지 확인하세요.</string>
-    <string name="fake_speed_title">비디오 잠금 비활성화 (가짜 속도)</string>
-    <string name="fake_speed_description">드라이빙 중 비디오 콘텐츠가 차단되는 것을 방지하기 위해 휴대폰에 일정한 저속(0.5 m/s)을 보고합니다. 주의해서 사용하세요.</string>
+    <string name="wait_for_wifi">Wi-Fi Direct 시작 전 Wi-Fi 대기</string>
+    <string name="wait_for_wifi_description">부팅 시 Wi-Fi Direct를 시작하기 전에 Wi-Fi가 연결될 때까지 대기합니다. 헤드 유닛이 전원 켜진 후 Wi-Fi에 연결하는 데 몇 초가 걸리는 경우 활성화하세요.</string>
+    <string name="wait_for_wifi_timeout">Wi-Fi 대기 시간 초과</string>
+    <string name="wireless_24ghz_warning">참고: 2.4GHz 기기에서 무선 Android Auto를 사용하면 지연, 끊김, 연결 해제가 발생할 수 있습니다. 문제가 발생하면 USB로 테스트하여 네트워크 제한이 원인인지 확인하세요.</string>
+    <string name="fake_speed_title">비디오 잠금 비활성화(가짜 속도)</string>
+    <string name="fake_speed_description">주행 중 비디오 콘텐츠가 차단되지 않도록 휴대폰에 일정한 저속(0.5 m/s)을 보고합니다. 주의해서 사용하세요.</string>
     <string name="wireless_mode_helper">Wireless Helper</string>
     <string name="wireless_mode_native">Native</string>
     <string name="wireless_mode_server">Headunit Server</string>
-    <string name="server_mode_label">Server Mode</string>
+    <string name="server_mode_label">서버 모드</string>
     <string name="server_mode_manual">수동</string>
     <string name="server_mode_auto">자동</string>
 
     <string name="helper_strategy_label">Helper 연결 방법</string>
     <string-array name="helper_strategies">
-        <item>Common Wifi (NSD)</item>
-        <item>WiFi Direct (P2P)</item>
-        <item>Google Nearby (Beta)</item>
-        <item>Phone Hotspot (Host)</item>
-        <item>Headunit Hotspot (Passive)</item>
+        <item>범용 Wi-Fi(NSD)</item>
+        <item>Wi-Fi Direct(P2P)</item>
+        <item>Google Nearby(Beta)</item>
+        <item>휴대폰 핫스팟(Host)</item>
+        <item>헤드 유닛 핫스팟(Passive)</item>
     </string-array>
 
     <string name="select_nearby_device">Nearby 기기 선택</string>
@@ -485,13 +495,15 @@
     <string name="exit_dialog_stop">연결 중지</string>
     <string name="exit_dialog_pip">PIP 모드</string>
     <string name="exit_dialog_background">백그라운드로 이동</string>
-    <string name="gesture_hint">팁: 왼쪽 가장자리에서 2개의 손가락을 스와이프하여 종료 메뉴를 엽니다.</string>
-    <string name="audio_latency_multiplier">오디오 지연 팩터</string>
-    <string name="audio_latency_multiplier_description">오디오 버퍼 크기를 조정합니다 (낮음 = 지연 감소, 높음 = 끊임 없는 연결 감소)</string>
-    <string name="audio_queue_capacity">오디오 큐 용량 (Backpressure)</string>
+    <string name="gesture_hint">팁: 왼쪽 가장자리에서 두 손가락으로 스와이프하면 종료 메뉴가 열립니다</string>
+    <string name="audio_latency_multiplier">오디오 지연 배율</string>
+    <string name="audio_latency_multiplier_description">오디오 버퍼 크기를 조정합니다(낮음 = 지연 감소, 높음 = 끊김 감소)</string>
+    <string name="audio_queue_capacity">오디오 큐 용량(백프레셔)</string>
     <string name="media_action_previous">이전</string>
     <string name="media_action_play">재생</string>
     <string name="media_action_pause">일시정지</string>
     <string name="media_action_next">다음</string>
-    <string name="error_usb_permission_failed">시스템 오류: USB 권한 대화 상자를 요청하지 못했습니다.</string>
+    <string name="error_usb_permission_failed">시스템 오류: USB 권한 대화상자를 요청하지 못했습니다.</string>
+    <string name="wifi_autostart_title">Wi-Fi 자동 시작</string>
+    <string name="wifi_autostart_content">%s에 연결되었습니다. Android Auto를 시작하려면 탭하세요.</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -107,7 +107,7 @@
     <string name="usb_status">USB 상태: %s</string>
     <string name="projection_status">프로젝션 상태: %s</string>
     <string name="connected">연결됨</string>
-    <string name="disconnected">연결 끊김</string>
+    <string name="disconnected">연결 해제됨</string>
     <string name="running">실행 중</string>
     <string name="not_running">실행 중이 아님</string>
     <string name="no_android_auto_device_connected">Android Auto 기기가 연결되지 않았습니다. USB 연결을 확인하세요.</string>
@@ -342,7 +342,7 @@
     <string name="shortcut_connect_desc">마지막 휴대폰에 자동 연결</string>
     <string name="shortcut_selfmode_title">단독 모드</string>
     <string name="shortcut_selfmode_desc">이 기기에서 Android Auto 시작</string>
-    <string name="shortcut_disconnect_title">연결 끊기</string>
+    <string name="shortcut_disconnect_title">연결 해제</string>
     <string name="shortcut_disconnect_desc">현재 세션 종료</string>
     <string name="shortcut_exit_title">앱 종료</string>
     <string name="shortcut_exit_desc">모든 서비스를 중지하고 앱을 닫습니다</string>
@@ -492,7 +492,7 @@
     <string name="connecting_to_nearby">%s에 연결 중…</string>
 
     <string name="exit_dialog_title">Android Auto 종료</string>
-    <string name="exit_dialog_stop">연결 중지</string>
+    <string name="exit_dialog_stop">연결 해제</string>
     <string name="exit_dialog_pip">PIP 모드</string>
     <string name="exit_dialog_background">백그라운드로 이동</string>
     <string name="gesture_hint">팁: 왼쪽 가장자리에서 두 손가락으로 스와이프하면 종료 메뉴가 열립니다</string>


### PR DESCRIPTION
## Summary

Improves Korean localization wording throughout the app.

## Details

- Refines awkward or literal Korean translations
- Adds missing Korean string resources
- Normalizes terminology such as Android Auto, Wi-Fi, Head Unit, Auto-start, and Auto-connect
- Improves consistency across settings, notifications, navigation, wireless, audio, vehicle info, and permission-related strings
- Fixes spacing and wording inconsistencies in Korean UI text

## Notes

No functional code changes.