### PR TITLE
Disable mic's features in settings if it's not supported.

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/main/MicSettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/MicSettingsFragment.kt
@@ -192,7 +192,7 @@ class MicSettingsFragment : Fragment() {
         items.add(SettingItem.ToggleSettingEntry(
             stableId = "micEchoCanceler",
             nameResId = R.string.mic_echo_canceler,
-            descriptionResId = if (NoiseSuppressor.isAvailable())
+            descriptionResId = if (AcousticEchoCanceler.isAvailable())
                 R.string.mic_echo_canceler_description else R.string.mic_feature_unsupported,
             isChecked = pendingMicEchoCanceler!!,
             isEnabled = AcousticEchoCanceler.isAvailable(),

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/MicSettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/MicSettingsFragment.kt
@@ -21,6 +21,9 @@ import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import android.content.Intent
+import android.media.audiofx.AcousticEchoCanceler
+import android.media.audiofx.AutomaticGainControl
+import android.media.audiofx.NoiseSuppressor
 
 class MicSettingsFragment : Fragment() {
     private lateinit var settings: Settings
@@ -189,8 +192,10 @@ class MicSettingsFragment : Fragment() {
         items.add(SettingItem.ToggleSettingEntry(
             stableId = "micEchoCanceler",
             nameResId = R.string.mic_echo_canceler,
-            descriptionResId = R.string.mic_echo_canceler_description,
+            descriptionResId = if (NoiseSuppressor.isAvailable())
+                R.string.mic_echo_canceler_description else R.string.mic_feature_unsupported,
             isChecked = pendingMicEchoCanceler!!,
+            isEnabled = AcousticEchoCanceler.isAvailable(),
             onCheckedChanged = { isChecked ->
                 pendingMicEchoCanceler = isChecked
                 checkChanges()
@@ -202,8 +207,10 @@ class MicSettingsFragment : Fragment() {
         items.add(SettingItem.ToggleSettingEntry(
             stableId = "micNoiseSuppressor",
             nameResId = R.string.mic_noise_suppressor,
-            descriptionResId = R.string.mic_noise_suppressor_description,
+            descriptionResId = if (NoiseSuppressor.isAvailable())
+                R.string.mic_noise_suppressor_description else R.string.mic_feature_unsupported,
             isChecked = pendingMicNoiseSuppressor!!,
+            isEnabled = NoiseSuppressor.isAvailable(),
             onCheckedChanged = { isChecked ->
                 pendingMicNoiseSuppressor = isChecked
                 checkChanges()
@@ -215,8 +222,10 @@ class MicSettingsFragment : Fragment() {
         items.add(SettingItem.ToggleSettingEntry(
             stableId = "micAutoGainControl",
             nameResId = R.string.mic_auto_gain_control,
-            descriptionResId = R.string.mic_auto_gain_control_description,
+            descriptionResId = if (AutomaticGainControl.isAvailable())
+                R.string.mic_auto_gain_control_description else R.string.mic_feature_unsupported,
             isChecked = pendingMicAutoGainControl!!,
+            isEnabled = AutomaticGainControl.isAvailable(),
             onCheckedChanged = { isChecked ->
                 pendingMicAutoGainControl = isChecked
                 checkChanges()

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -496,6 +496,7 @@
     <string name="mic_noise_suppressor_description">يحاول تقليل ضوضاء الخلفية. قم بتعطيله إذا كان صوتك يبدو مكتوماً.</string>
     <string name="mic_auto_gain_control">التحكم التلقائي في الكسب (AGC)</string>
     <string name="mic_auto_gain_control_description">يضبط مستوى صوت الميكروفون تلقائياً. قم بتعطيله إذا كان مستوى الصوت غير مستقر.</string>
+    <string name="mic_feature_unsupported">هذه الميزة غير مدعومة على جهازك.</string>
     <string name="bt_permission_denied">تم رفض إذن البلوتوث. لا يمكن مسح الأجهزة.</string>
     <string name="wifi_autostart_title">بدء تشغيل WiFi تلقائياً</string>
     <string name="wifi_autostart_content">متصل بـ %s. اضغط لبدء أندرويد أوتو.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -496,6 +496,7 @@
     <string name="mic_noise_suppressor_description">Pokusí se snížit hluk na pozadí. Vypněte, pokud váš hlas zní tlumeně.</string>
     <string name="mic_auto_gain_control">Automatické řízení zesílení (AGC)</string>
     <string name="mic_auto_gain_control_description">Automaticky upravuje hlasitost mikrofonu. Vypněte, pokud je hlasitost nestabilní.</string>
+    <string name="mic_feature_unsupported">Tato funkce není na vašem zařízení podporována.</string>
     <string name="bt_permission_denied">Oprávnění Bluetooth bylo zamítnuto. Nelze skenovat zařízení.</string>
     <string name="wifi_autostart_title">Automatické spuštění WiFi</string>
     <string name="wifi_autostart_content">Připojeno k %s. Klepnutím spustíte Android Auto.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -271,6 +271,7 @@
     <string name="mic_noise_suppressor_description">Versucht, Hintergrundgeräusche zu reduzieren. Deaktivieren, wenn die Stimme dumpf klingt.</string>
     <string name="mic_auto_gain_control">Automatische Pegelanpassung (AGC)</string>
     <string name="mic_auto_gain_control_description">Passt die Mikrofonlautstärke automatisch an. Deaktivieren bei instabiler Lautstärke.</string>
+    <string name="mic_feature_unsupported">Diese Funktion wird auf Ihrem Gerät nicht unterstützt.</string>
 
     <!-- Info Settings -->
     <string name="category_info">Info</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -496,6 +496,7 @@
     <string name="mic_noise_suppressor_description">Intenta reducir el ruido de fondo. Desactívalo si tu voz suena apagada.</string>
     <string name="mic_auto_gain_control">Control automático de ganancia (AGC)</string>
     <string name="mic_auto_gain_control_description">Ajusta automáticamente el volumen del micrófono. Desactívalo si el volumen es inestable.</string>
+    <string name="mic_feature_unsupported">Esta función no es compatible con tu dispositivo.</string>
     <string name="bt_permission_denied">Permiso de Bluetooth denegado. No se pueden escanear dispositivos.</string>
     <string name="wifi_autostart_title">Inicio automático de WiFi</string>
     <string name="wifi_autostart_content">Conectado a %s. Pulsa para iniciar Android Auto.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -496,6 +496,7 @@
     <string name="mic_noise_suppressor_description">Intenta reducir el ruido de fondo. Desactívalo si tu voz suena apagada.</string>
     <string name="mic_auto_gain_control">Control automático de ganancia (AGC)</string>
     <string name="mic_auto_gain_control_description">Ajusta automáticamente el volumen del micrófono. Desactívalo si el volumen es inestable.</string>
+    <string name="mic_feature_unsupported">Esta función no es compatible con tu dispositivo.</string>
     <string name="bt_permission_denied">Permiso de Bluetooth denegado. No se pueden escanear dispositivos.</string>
     <string name="wifi_autostart_title">Inicio automático de WiFi</string>
     <string name="wifi_autostart_content">Conectado a %s. Pulsa para iniciar Android Auto.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -495,6 +495,7 @@
     <string name="mic_noise_suppressor_description">Megpróbálja csökkenteni a háttérzajt. Kapcsolja ki, ha a hangja tompának tűnik.</string>
     <string name="mic_auto_gain_control">Automatikus erősítésszabályozás (AGC)</string>
     <string name="mic_auto_gain_control_description">Automatikusan szabályozza a mikrofon hangerejét. Kapcsolja ki, ha a hangerő instabil.</string>
+    <string name="mic_feature_unsupported">Ez a funkció nem támogatott az eszközén.</string>
     <string name="bt_permission_denied">Bluetooth engedély megtagadva. Nem lehet eszközöket keresni.</string>
     <string name="wifi_autostart_title">WiFi automatikus indítás</string>
     <string name="wifi_autostart_content">Csatlakozva a következőhöz: %s. Koppintson az Android Auto indításához.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -503,6 +503,7 @@
     <string name="mic_noise_suppressor_description">Tenta di ridurre il rumore di fondo. Disabilita se la tua voce risulta ovattata.</string>
     <string name="mic_auto_gain_control">Controllo automatico del guadagno (AGC)</string>
     <string name="mic_auto_gain_control_description">Regola automaticamente il volume del microfono. Disabilita se il volume è instabile.</string>
+    <string name="mic_feature_unsupported">Questa funzionalità non è supportata sul tuo dispositivo.</string>
     <string name="bt_permission_denied">Autorizzazione Bluetooth negata. Impossibile scansionare i dispositivi.</string>
     <string name="wifi_autostart_title">Avvio automatico WiFi</string>
     <string name="wifi_autostart_content">Connesso a %s. Tocca per avviare Android Auto.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -504,6 +504,7 @@
     <string name="mic_noise_suppressor_description">背景のノイズを低減します。声がこもって聞こえる場合は無効にしてください。</string>
     <string name="mic_auto_gain_control">自動ゲイン制御 (AGC)</string>
     <string name="mic_auto_gain_control_description">マイクの音量を自動的に調整します。音量が不安定な場合は無効にしてください。</string>
+    <string name="mic_feature_unsupported">この機能はお使いのデバイスでサポートされていません。</string>
     <string name="bt_permission_denied">Bluetooth権限が拒否されました。デバイスのスキャンができません。</string>
     <string name="wifi_autostart_title">WiFi自動起動</string>
     <string name="wifi_autostart_content">%s に接続されました。タップしてAndroid Autoを開始します。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -271,6 +271,7 @@
     <string name="mic_noise_suppressor_description">배경 소음을 줄입니다. 목소리가 먹먹하게 들리면 비활성화하세요.</string>
     <string name="mic_auto_gain_control">자동 게인 제어(AGC)</string>
     <string name="mic_auto_gain_control_description">마이크 음량을 자동으로 조절합니다. 음량이 불안정하면 비활성화하세요.</string>
+    <string name="mic_feature_unsupported">이 기능은 사용 중인 기기에서 지원되지 않습니다.</string>
 
     <!-- Info Settings -->
     <string name="category_info">정보</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -496,6 +496,7 @@
     <string name="mic_noise_suppressor_description">Probeert achtergrondgeluid te verminderen. Schakel dit uit als uw stem gedempt klinkt.</string>
     <string name="mic_auto_gain_control">Automatische versterkingsregeling (AGC)</string>
     <string name="mic_auto_gain_control_description">Past automatisch het microfoonvolume aan. Schakel dit uit als het volume onstabiel is.</string>
+    <string name="mic_feature_unsupported">Deze functie wordt niet ondersteund op uw apparaat.</string>
     <string name="bt_permission_denied">Bluetooth-toestemming geweigerd. Kan niet scannen naar apparaten.</string>
     <string name="wifi_autostart_title">WiFi Auto-Start</string>
     <string name="wifi_autostart_content">Verbonden met %s. Tik om Android Auto te starten.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -497,6 +497,7 @@
     <string name="mic_noise_suppressor_description">Próbuje zredukować hałas w tle. Wyłącz, jeśli Twój głos brzmi przytłumiony.</string>
     <string name="mic_auto_gain_control">Automatyczna regulacja wzmocnienia (AGC)</string>
     <string name="mic_auto_gain_control_description">Automatycznie dostosowuje głośność mikrofonu. Wyłącz, jeśli głośność jest niestabilna.</string>
+    <string name="mic_feature_unsupported">Ta funkcja nie jest obsługiwana na Twoim urządzeniu.</string>
     <string name="bt_permission_denied">Odmowa uprawnień Bluetooth. Nie można skanować urządzeń.</string>
     <string name="wifi_autostart_title">Auto-Start WiFi</string>
     <string name="wifi_autostart_content">Połączono z %s. Dotknij, aby uruchomić Android Auto.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -497,6 +497,7 @@
     <string name="mic_noise_suppressor_description">Tenta reduzir o ruído de fundo. Desative se a sua voz soar abafada.</string>
     <string name="mic_auto_gain_control">Controle automático de ganho (AGC)</string>
     <string name="mic_auto_gain_control_description">Ajusta automaticamente o volume do microfone. Desative se o volume estiver instável.</string>
+    <string name="mic_feature_unsupported">Este recurso não é compatível com seu dispositivo.</string>
     <string name="bt_permission_denied">Permissão Bluetooth negada. Não é possível escanear dispositivos.</string>
     <string name="wifi_autostart_title">Início automático de WiFi</string>
     <string name="wifi_autostart_content">Conectado a %s. Toque para iniciar o Android Auto.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -497,6 +497,7 @@
     <string name="mic_noise_suppressor_description">Încearcă să reducă zgomotul de fundal. Dezactivați dacă vocea dvs. sună înfundat.</string>
     <string name="mic_auto_gain_control">Control automat al amplificării (AGC)</string>
     <string name="mic_auto_gain_control_description">Reglează automat volumul microfonului. Dezactivați dacă volumul este instabil.</string>
+    <string name="mic_feature_unsupported">Această funcție nu este acceptată pe dispozitivul dvs.</string>
     <string name="bt_permission_denied">Permisiunea Bluetooth a fost refuzată. Nu se pot scana dispozitive.</string>
     <string name="wifi_autostart_title">Pornire automată WiFi</string>
     <string name="wifi_autostart_content">Conectat la %s. Atingeți pentru a porni Android Auto.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -497,6 +497,7 @@
     <string name="mic_noise_suppressor_description">Попытка уменьшить фоновый шум. Отключите, если ваш голос звучит приглушенно.</string>
     <string name="mic_auto_gain_control">Автоматическая регулировка усиления (AGC)</string>
     <string name="mic_auto_gain_control_description">Автоматически регулирует громкость микрофона. Отключите, если громкость нестабильна.</string>
+    <string name="mic_feature_unsupported">Эта функция не поддерживается на вашем устройстве.</string>
     <string name="bt_permission_denied">В разрешении Bluetooth отказано. Невозможно сканировать устройства.</string>
     <string name="wifi_autostart_title">Автозапуск WiFi</string>
     <string name="wifi_autostart_content">Подключено к %s. Нажмите, чтобы запустить Android Auto.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -494,6 +494,7 @@
     <string name="mic_noise_suppressor_description">Arka plan gürültüsünü azaltmaya çalışır. Sesiniz boğuk geliyorsa bunu devre dışı bırakın.</string>
     <string name="mic_auto_gain_control">Otomatik kazanç kontrolü (AGC)</string>
     <string name="mic_auto_gain_control_description">Mikrofon ses seviyesini otomatik olarak ayarlar. Ses seviyesi dengesizse bunu devre dışı bırakın.</string>
+    <string name="mic_feature_unsupported">Bu özellik cihazınızda desteklenmiyor.</string>
     <string name="bt_permission_denied">Bluetooth izni reddedildi. Cihazlar taranamıyor.</string>
     <string name="wifi_autostart_title">WiFi Otomatik Başlatma</string>
     <string name="wifi_autostart_content">%s ağına bağlandı. Android Auto\'yu başlatmak için dokunun.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -497,6 +497,7 @@
     <string name="mic_noise_suppressor_description">Спроба зменшити фоновий шум. Вимкніть, якщо ваш голос звучить приглушено.</string>
     <string name="mic_auto_gain_control">Автоматичне регулювання посилення (AGC)</string>
     <string name="mic_auto_gain_control_description">Автоматично регулює гучність мікрофона. Вимкніть, якщо гучність нестабільна.</string>
+    <string name="mic_feature_unsupported">Ця функція не підтримується на вашому пристрої.</string>
     <string name="bt_permission_denied">У дозволі Bluetooth відмовлено. Неможливо сканувати пристрої.</string>
     <string name="wifi_autostart_title">Автозапуск WiFi</string>
     <string name="wifi_autostart_content">Підключено до %s. Натисніть, щоб запустити Android Auto.</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -496,6 +496,7 @@
     <string name="mic_noise_suppressor_description">嘗試降低背景雜音。若您的聲音聽起來很沉悶，請停用此功能。</string>
     <string name="mic_auto_gain_control">自動增益控制 (AGC)</string>
     <string name="mic_auto_gain_control_description">自動調整麥克風音量。若音量不穩定，請停用此功能。</string>
+    <string name="mic_feature_unsupported">此功能在您的裝置上不受支援。</string>
     <string name="bt_permission_denied">藍牙權限遭拒，無法掃描裝置。</string>
     <string name="wifi_autostart_title">WiFi 自動啟動</string>
     <string name="wifi_autostart_content">已連接至 %s。點擊以啟動 Android Auto。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -270,6 +270,7 @@
     <string name="mic_noise_suppressor_description">Attempts to reduce background noise. Disable if your voice sounds muffled.</string>
     <string name="mic_auto_gain_control">Automatic gain control (AGC)</string>
     <string name="mic_auto_gain_control_description">Automatically adjusts microphone volume. Disable if the volume is unstable.</string>
+    <string name="mic_feature_unsupported">This feature is not supported on your device.</string>
 
     <!-- Info Settings -->
     <string name="category_info">Info</string>


### PR DESCRIPTION
Disable mic features in settings if it's not supported. Without this, it's impossible to tell whether the feature is enabled on the device. It's too subjective by ear ;) This is more accurate.