### PR TITLE
fix: the headunitintent contract defines broadcast i... in...

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,10 @@
         android:name="android.hardware.bluetooth"
         android:required="false" />
 
+    <permission
+        android:name="com.andrerinas.headunitrevived.permission.NAVIGATION_UPDATE"
+        android:protectionLevel="signature" />
+
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>

--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapNavigationHelper.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapNavigationHelper.kt
@@ -81,7 +81,7 @@ class AapNavigationHelper(
             totalTimeSeconds = prepared.totalTimeSeconds,
             estimatedArrival = prepared.estimatedArrival
         )
-        context.applicationContext.sendBroadcast(intent)
+        context.applicationContext.sendBroadcast(intent, NavigationUpdateIntent.BROADCAST_PERMISSION)
     }
 
     fun showNotificationForSnapshot(snapshot: NavigationSnapshot, distanceMeters: Int?) {

--- a/contract/src/main/java/com/andrerinas/headunitrevived/contract/HeadUnitIntent.kt
+++ b/contract/src/main/java/com/andrerinas/headunitrevived/contract/HeadUnitIntent.kt
@@ -169,5 +169,12 @@ class NavigationUpdateIntent(
          * Estimated time at arrival as provided by the nav app (`estimated_time_at_arrival` string), or empty.
          */
         const val EXTRA_ESTIMATED_ARRIVAL = "estimated_arrival"
+
+        /**
+         * Signature-level permission required to receive or send [NavigationUpdateIntent] broadcasts.
+         * Senders must call sendBroadcast(intent, BROADCAST_PERMISSION).
+         * Receivers must declare this permission with protectionLevel="signature".
+         */
+        const val BROADCAST_PERMISSION = "${HeadUnit.packageName}.permission.NAVIGATION_UPDATE"
     }
 }

--- a/contract/src/main/java/com/andrerinas/headunitrevived/contract/HeadUnitIntent.kt
+++ b/contract/src/main/java/com/andrerinas/headunitrevived/contract/HeadUnitIntent.kt
@@ -173,7 +173,7 @@ class NavigationUpdateIntent(
         /**
          * Signature-level permission required to receive or send [NavigationUpdateIntent] broadcasts.
          * Senders must call sendBroadcast(intent, BROADCAST_PERMISSION).
-         * Receivers must declare this permission with protectionLevel="signature".
+         * Receivers must request this permission using <uses-permission> and should enforce it in their manifest declaration.
          */
         const val BROADCAST_PERMISSION = "${HeadUnit.packageName}.permission.NAVIGATION_UPDATE"
     }


### PR DESCRIPTION
## Summary
Fix high severity security issue in `contract/src/main/java/com/andrerinas/headunitrevived/contract/HeadUnitIntent.kt`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-003 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-003` |
| **File** | `contract/src/main/java/com/andrerinas/headunitrevived/contract/HeadUnitIntent.kt:78` |

**Description**: The HeadUnitIntent contract defines broadcast intents for navigation updates from Android Auto. If these broadcasts are sent as implicit broadcasts without signature-level permission protection, any malicious app on the device could register a receiver to intercept navigation data (enabling location tracking) or send spoofed navigation broadcasts to apps that consume them, potentially displaying false turn-by-turn directions to the driver.

## Changes
- ``contract/src/main/java/com/andrerinas/headunitrevived/contract/HeadUnitIntent.kt``
- ``app/src/main/java/com/andrerinas/headunitrevived/aap/AapNavigationHelper.kt``
- ``app/src/main/AndroidManifest.xml``

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
