### PR TITLE
Fixed status bar color on start app.

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -24,6 +24,8 @@
 
     <style name="SplashTheme" parent="AppTheme">
         <item name="android:windowBackground">@drawable/splash_background</item>
+        <item name="android:statusBarColor">@color/color_projection_blue</item>
+        <item name="android:navigationBarColor">@color/color_projection_blue</item>
     </style>
 
     <style name="SplashTheme.Fullscreen" parent="SplashTheme">


### PR DESCRIPTION
It's minor changes in stayles.xml to fix status color on start app.
After this change status bar will have the same color as splash screen

Gemini will most likely indicate that these properties are required by v21, but I didn't create a separate styles.xml with an overload for v21 because there are now other properties with the same warning 😁

How it looks before:
<img width="1280" height="960" alt="photo_2026-05-22_14-44-05" src="https://github.com/user-attachments/assets/afe5e7ca-4f6e-4d58-b817-341006460d19" />
