### PR TITLE
Fix BT auto-connect dragging phone into wireless flow during USB session (fixes #563)

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
@@ -717,9 +717,10 @@ class AapService : Service(), UsbReceiver.Listener {
             if (appSettings.wifiConnectionMode == 3) {
                 AppLog.i("AapService: Received WiFi credentials from manager (SSID=$ssid, IP=$ip). Updating and Triggering Poke.")
                 nativeAaHandshakeManager?.updateWifiCredentials(ssid, psk, ip, bssid)
-                // [FIX] Only auto-poke if the user didn't explicitly exit.
-                // If they did, they must click the "WiFi" button manually to poke.
-                if (!userExitedAA) {
+                if (commManager.isConnected ||
+                    commManager.connectionState.value is CommManager.ConnectionState.Connecting) {
+                    AppLog.i("AapService: USB/other session already active. Skipping auto-poke to avoid pulling phone into wireless flow.")
+                } else if (!userExitedAA) {
                     nativeAaHandshakeManager?.triggerPoke()
                 } else {
                     AppLog.i("AapService: userExitedAA is true. Skipping auto-poke.")

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
@@ -206,6 +206,13 @@ class NativeAaHandshakeManager(
             AppLog.d("NativeAA: triggerPoke() delay starting (2s)...")
             delay(2000) // Small safety delay before connecting
 
+            val comm = com.andrerinas.headunitrevived.App.provide(context).commManager
+            if (comm.isConnected ||
+                comm.connectionState.value is com.andrerinas.headunitrevived.connection.CommManager.ConnectionState.Connecting) {
+                AppLog.i("NativeAA: USB/other session became active during poke delay. Skipping poke.")
+                return@launch
+            }
+
             val devicesToPoke = if (lastMacs.isNotEmpty()) {
                 lastMacs.mapNotNull { mac ->
                     try {
@@ -226,6 +233,10 @@ class NativeAaHandshakeManager(
 
             for (device in devicesToPoke) {
                 if (!isRunning || !isActive) break
+                if (comm.isConnected) {
+                    AppLog.i("NativeAA: USB/other session became active mid-poke. Stopping poke loop.")
+                    break
+                }
                 AppLog.i("NativeAA: Attempting active A2DP poke to device: ${device.name} (${device.address})...")
                 var socket: BluetoothSocket? = null
                 try {
@@ -286,7 +297,15 @@ class NativeAaHandshakeManager(
         try {
             val device = socket.remoteDevice
             AppLog.i("NativeAA: Handling handshake for ${device.name} (${device.address})")
-            
+
+            val comm = com.andrerinas.headunitrevived.App.provide(context).commManager
+            if (comm.isConnected ||
+                comm.connectionState.value is com.andrerinas.headunitrevived.connection.CommManager.ConnectionState.Connecting) {
+                AppLog.i("NativeAA: USB/other session already active. Aborting BT handshake so phone does not start a parallel wireless attempt.")
+                try { socket.close() } catch (_: Exception) {}
+                return@withContext
+            }
+
             val macs = settings.autoStartBluetoothDeviceMacs
             if (!macs.contains(device.address)) {
                 AppLog.i("NativeAA: Saving ${device.address} (${device.name}) to the list of auto-start devices.")

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
@@ -55,6 +55,7 @@ class NativeAaHandshakeManager(
     }
 
     private val settings = com.andrerinas.headunitrevived.App.provide(context).settings
+    private val commManager = com.andrerinas.headunitrevived.App.provide(context).commManager
     private var aaServerSocket: BluetoothServerSocket? = null
     private var hfpServerSocket: BluetoothServerSocket? = null
     private var isRunning = false
@@ -206,9 +207,8 @@ class NativeAaHandshakeManager(
             AppLog.d("NativeAA: triggerPoke() delay starting (2s)...")
             delay(2000) // Small safety delay before connecting
 
-            val comm = com.andrerinas.headunitrevived.App.provide(context).commManager
-            if (comm.isConnected ||
-                comm.connectionState.value is com.andrerinas.headunitrevived.connection.CommManager.ConnectionState.Connecting) {
+            if (commManager.isConnected ||
+                commManager.connectionState.value is CommManager.ConnectionState.Connecting) {
                 AppLog.i("NativeAA: USB/other session became active during poke delay. Skipping poke.")
                 return@launch
             }
@@ -233,7 +233,7 @@ class NativeAaHandshakeManager(
 
             for (device in devicesToPoke) {
                 if (!isRunning || !isActive) break
-                if (comm.isConnected) {
+                if (commManager.isConnected) {
                     AppLog.i("NativeAA: USB/other session became active mid-poke. Stopping poke loop.")
                     break
                 }
@@ -298,9 +298,8 @@ class NativeAaHandshakeManager(
             val device = socket.remoteDevice
             AppLog.i("NativeAA: Handling handshake for ${device.name} (${device.address})")
 
-            val comm = com.andrerinas.headunitrevived.App.provide(context).commManager
-            if (comm.isConnected ||
-                comm.connectionState.value is com.andrerinas.headunitrevived.connection.CommManager.ConnectionState.Connecting) {
+            if (commManager.isConnected ||
+                commManager.connectionState.value is CommManager.ConnectionState.Connecting) {
                 AppLog.i("NativeAA: USB/other session already active. Aborting BT handshake so phone does not start a parallel wireless attempt.")
                 try { socket.close() } catch (_: Exception) {}
                 return@withContext


### PR DESCRIPTION
## Summary

Fixes #563.

On startup AapService unconditionally initializes Native AA wireless mode 3, which brings up the WiFi Direct group, the BT handshake server, and an A2DP poke job that wakes paired phones. When the user is connecting via USB, the BT poke still fires and the BT handshake still sends WiFi credentials, so the phone is dragged into a parallel wireless attempt that cannot complete because the phone is already projecting over USB. The reporter sees the head unit creating a 5GHz P2P network and the phone showing "connecting to Android Auto" forever.

## Root cause

`AapService.onCreate()` wires a WiFi Direct credentials listener that calls `nativeAaHandshakeManager.triggerPoke()` whenever credentials become available. The only guard there is `userExitedAA`, so a fresh service start always pokes paired devices regardless of whether a USB or other session is already active. Symmetrically, the BT handshake server (`NativeAaHandshakeManager.handleHandshake`) accepts incoming BT connections from paired phones and pushes WiFi credentials without checking the current connection state.

## Fix

Gate three places on `CommManager` state:

- Credentials listener in `AapService`: skip `triggerPoke()` when a session is already connected or in `Connecting` state.
- `triggerPoke()`: after the 2 s safety delay, re-check the state, and break out of the per-device loop if a session arrives mid-poke.
- `handleHandshake()`: if a session is already up, close the BT socket without sending WiFi credentials.

Manual paths (the "WiFi" button in the home screen and `manualPoke()` for the Native AA poke action) are unchanged, because the user explicitly chose to start a wireless connection.

## How to test

Pair the head unit tablet to two phones over Bluetooth, enable BT auto-connect for both phones, and set WiFi connection mode to Native AA in Settings. Plug the USB cable between the tablet and phone 1, then watch the logs. Before the fix the head unit creates a P2P group, BT-pokes the paired phones, and the BT handshake responder sends WiFi credentials in parallel to the USB handshake, leaving the phone stuck on "connecting to Android Auto". After the fix the head unit still brings up the wireless infrastructure (so a later wireless session works), but skips the BT poke and refuses the BT handshake while a session is active, so the USB session completes cleanly.

For BT-triggered scenarios, with USB already projecting, manually toggle the BT connection from the phone. The head unit logs "USB/other session already active. Aborting BT handshake..." and closes the BT socket without delivering credentials.