### PR TITLE
Persist Auto-Optimize wizard settings synchronously

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
@@ -516,6 +516,7 @@ class SettingsFragment : Fragment() {
                 com.andrerinas.headunitrevived.utils.SetupWizard(requireContext()) {
                     reloadPendingStateFromSettings()
                     checkChanges()
+                    updateSettingsList()
                     requireActivity().recreate()
                 }.start()
             }

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
@@ -514,6 +514,8 @@ class SettingsFragment : Fragment() {
             value = getString(R.string.auto_optimize_desc),
             onClick = { _ ->
                 com.andrerinas.headunitrevived.utils.SetupWizard(requireContext()) {
+                    reloadPendingStateFromSettings()
+                    checkChanges()
                     requireActivity().recreate()
                 }.start()
             }

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/SetupWizard.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/SetupWizard.kt
@@ -118,7 +118,8 @@ class SetupWizard(private val context: Context, private val onFinished: () -> Un
         settings.dpiPixelDensity = result.recommendedDpi
         settings.screenOrientation = result.suggestedOrientation
         settings.hasCompletedSetupWizard = true
-        
+        settings.commit()
+
         onFinished()
     }
 }


### PR DESCRIPTION
## Summary

Fixes issue #504: the Auto-Optimize wizard (Settings, General, "Optimize automatically") would sometimes lose the selected preset (Small Tablet, Phone, etc.) after the next app launch.

## Root cause

`SetupWizard.applySettings()` writes resolution, DPI, view mode, video codec, screen orientation, and the wizard-completed flag with `SharedPreferences.Editor.apply()`. That call returns immediately and the actual disk write happens on a background thread. When the user runs the wizard, hits Apply, and then starts Self Mode (which puts the rest of the app into the background, leaving the projection foreground service in charge), the system can reclaim the original process before the queued write reaches disk. The next launch reads the pre-wizard values and the preset appears to be gone. This matches the reporter's observation that "sometimes it opened with the right layout", which is the classic signature of an unflushed `apply()`.

Other immediate-persist settings in the same file (screen orientation in `SettingsFragment` line 977, fullscreen mode line 924) already follow the apply-then-commit pattern. The wizard did not, so it inherited the race.

## Fix

`SetupWizard.applySettings()` now calls `settings.commit()` after writing the six values, so the editor blocks until the write is durable.

`SettingsFragment` additionally reloads its `pending*` state from settings and re-runs `checkChanges()` once the wizard callback fires, before queueing `recreate()`. This protects the wizard's writes if the recreate is delayed and the user taps Save in the still-live old fragment, which would otherwise rewrite the stale pre-wizard pending values back over the wizard's result.

## How to test

Open Settings, General, "Optimize automatically". Pick a size that differs from the current configuration (for example Small Tablet 7-8") and finish the wizard. Confirm the new resolution, DPI, view mode, codec, and orientation are reflected. Start Self Mode, exit it, and force-stop the app from the system app info screen. Reopen the app and confirm those values are still set. Repeat a few times to rule out the intermittent loss the reporter described.