### PR TITLE
Feature/improve usb button auto connect

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/UsbDeviceCompat.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/UsbDeviceCompat.kt
@@ -34,8 +34,8 @@ class UsbDeviceCompat(val wrappedDevice: UsbDevice) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 val manufacturer = device.manufacturerName?.takeIf { it.isNotBlank() }
                 val product = device.productName?.takeIf { it.isNotBlank() }
-                if (manufacturer != null && product != null) {
-                    return "$manufacturer $product"
+                if (manufacturer != null || product != null) {
+                    return listOfNotNull(manufacturer, product).joinToString(" ")
                 }
             }
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/UsbDeviceCompat.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/UsbDeviceCompat.kt
@@ -1,6 +1,8 @@
 package com.andrerinas.headunitrevived.connection
 
+import android.hardware.usb.UsbConstants
 import android.hardware.usb.UsbDevice
+import android.os.Build
 import com.andrerinas.headunitrevived.aap.Utils
 import java.util.Locale
 
@@ -21,128 +23,98 @@ class UsbDeviceCompat(val wrappedDevice: UsbDevice) {
 
     companion object {
         private const val USB_VID_GOO = 0x18D1   // 6353   Nexus or ACC mode, see PID to distinguish
-        private const val USB_VID_HTC = 0x0bb4   // 2996
-        private const val USB_VID_SAM = 0x04e8   // 1256
-        private const val USB_VID_O1A = 0xfff6   // 65526    Samsung ?
-        private const val USB_VID_SON = 0x0fce   // 4046
-        private const val USB_VID_LGE = 0x1004   // 65525
-        private const val USB_VID_MOT = 0x22b8   // 8888
-        private const val USB_VID_ACE = 0x0502
-        private const val USB_VID_HUA = 0x12d1
-        private const val USB_VID_ZTE = 0x19d2
-        private const val USB_VID_XIA = 0x2717
-        private const val USB_VID_ASU = 0x0b05
-        private const val USB_VID_MEI = 0x2a45
-        private const val USB_VID_WIL = 0x4ee7
-
         private const val USB_PID_ACC = 0x2D00      // Accessory                  100
         private const val USB_PID_ACC_ADB = 0x2D01      // Accessory + ADB            110
-
-        private val VENDOR_NAMES = mapOf(
-            USB_VID_GOO to "Google",
-            USB_VID_HTC to "HTC",
-            USB_VID_SAM to "Samsung",
-            USB_VID_SON to "Sony",
-            USB_VID_MOT to "Motorola",
-            USB_VID_LGE to "LG",
-            USB_VID_O1A to "O1A",
-            USB_VID_HUA to "Huawei",
-            USB_VID_ACE to "Acer",
-            USB_VID_ZTE to "ZTE",
-            USB_VID_XIA to "Xiaomi",
-            USB_VID_ASU to "Asus",
-            USB_VID_MEI to "Meizu",
-            USB_VID_WIL to "Wileyfox"
-        )
+        private const val APPLE_VID = 0x05AC
 
         fun getUniqueName(device: UsbDevice): String {
-            val vendorId = device.vendorId  // mVendorId=2996               HTC
-            val productId = device.productId  // mProductId=1562              OneM8
+            val vendorId = device.vendorId
+            val productId = device.productId
 
-//            if (App.IS_LOLLIPOP) {                                 // Android 5.0+ only
-//                try {
-//                    dev_man = usb_man_get(device).toUpperCase(Locale.getDefault())                             // mManufacturerName=HTC
-//                    dev_prod = usb_pro_get(device).toUpperCase(Locale.getDefault())                                // mProductName=Android Phone
-//                    dev_ser = usb_ser_get(device).toUpperCase(Locale.getDefault())                              // mSerialNumber=FA46RWM22264
-//                } catch (e: Throwable) {
-//                    AppLog.e(e)
-//                }
-//            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                val manufacturer = device.manufacturerName?.takeIf { it.isNotBlank() }
+                val product = device.productName?.takeIf { it.isNotBlank() }
+                if (manufacturer != null && product != null) {
+                    return "$manufacturer $product"
+                }
+            }
 
-            var usb_dev_name = ""
-            usb_dev_name += VENDOR_NAMES[vendorId] ?: "$vendorId"
-            usb_dev_name += " "
-            usb_dev_name += Utils.hex_get(vendorId.toShort())
-            usb_dev_name += ":"
-            usb_dev_name += Utils.hex_get(productId.toShort())
-
-            return usb_dev_name
+            return "${Utils.hex_get(vendorId.toShort())}:${Utils.hex_get(productId.toShort())}"
         }
 
         fun isInAccessoryMode(device: UsbDevice): Boolean {
             val dev_vend_id = device.vendorId
             val dev_prod_id = device.productId
-            return dev_vend_id == UsbDeviceCompat.USB_VID_GOO &&
-                    (dev_prod_id == UsbDeviceCompat.USB_PID_ACC || dev_prod_id == UsbDeviceCompat.USB_PID_ACC_ADB)
+            return dev_vend_id == USB_VID_GOO &&
+                (dev_prod_id == USB_PID_ACC || dev_prod_id == USB_PID_ACC_ADB)
         }
 
-        private val ANDROID_VENDORS = setOf(
-            USB_VID_GOO, // Google (0x18D1)
-            USB_VID_HTC, // HTC (0x0BB4)
-            USB_VID_SAM, // Samsung (0x04E8)
-            USB_VID_O1A, // O1A (0xFFF6)
-            USB_VID_SON, // Sony Ericsson (0x0FCE)
-            USB_VID_LGE, // LG (0x1004)
-            USB_VID_MOT, // Motorola (0x22B8)
-            USB_VID_ACE, // Acer (0x0502)
-            USB_VID_ZTE, // ZTE (0x19D2)
-            USB_VID_XIA, // Xiaomi (0x2717)
-            USB_VID_ASU, // Asus (0x0B05)
-            USB_VID_MEI, // Meizu (0x2A45)
-            USB_VID_WIL, // Wileyfox (0x4EE7)
-            0x22D9,      // Oppo/OnePlus/Realme
-            0x2D95,      // Vivo
-            0x17EF,      // Lenovo
-            0x1EBF,      // OnePlus (alternate)
-            0x1782,      // Spreadtrum / Multilaser
-            0x0E8D,      // MediaTek
-            0x2E04,      // HMD Global (Nokia)
-            0x05C6,      // Qualcomm/LG reference designs
-            0x0FCA,      // Blackberry
-            0x2207,      // Fuzhou Rockchip
-            0x2E17,      // Essential
-            // Added from 51-android.rules
-            0x413C,      // Dell
-            0x0489,      // Foxconn
-            0x04C5,      // Fujitsu
-            0x091E,      // Garmin-Asus
-            0x201E,      // Haier
-            0x109B,      // Hisense
-            0x24E3,      // K-Touch
-            0x2116,      // KT Tech
-            0x0482,      // Kyocera
-            0x0409,      // NEC
-            0x2080,      // Nook
-            0x0955,      // Nvidia
-            0x2257,      // OTGV
-            0x10A9,      // Pantech
-            0x1D4D,      // Pegatron
-            0x0471,      // Philips
-            0x04DA,      // PMC-Sierra
-            0x1F53,      // SK Telesys
-            0x04DD,      // Sharp
-            0x054C,      // Sony (main)
-            0x2340,      // Teleepoch
-            0x0930,      // Toshiba
-            0x0414,      // Gigabyte
-            0x1949       // Amazon
-        )
-
         fun isAndroidDevice(device: UsbDevice): Boolean {
+            // Apple does not support Android Auto
+            if (device.vendorId == APPLE_VID) return false
+
             if (isInAccessoryMode(device)) return true
-            // Explicitly ignore Apple devices (0x05AC) to prevent CarPlay interference
-            if (device.vendorId == 0x05AC) return false
-            return ANDROID_VENDORS.contains(device.vendorId)
+
+            return hasAndroidInterface(device)
+        }
+
+        /**
+         * Identifies an Android device by USB class/subclass
+         * More reliable than a VID list
+         */
+        private fun hasAndroidInterface(device: UsbDevice): Boolean {
+            for (i in 0 until device.interfaceCount) {
+                val usbInterface = device.getInterface(i)
+                val ifaceClass = usbInterface.interfaceClass
+                val ifaceSubclass = usbInterface.interfaceSubclass
+                val ifaceProtocol = usbInterface.interfaceProtocol
+
+                // AOAP (Android Open Accessory Protocol)
+                if (ifaceClass == 0xFF && ifaceSubclass == 0xFF && ifaceProtocol == 0x00) {
+                    if (hasBulkEndpoint(usbInterface)) return true
+                }
+
+                // MTP (Media Transfer Protocol)
+                if (ifaceClass == UsbConstants.USB_CLASS_MASS_STORAGE &&
+                    ifaceSubclass == 0x06 && ifaceProtocol == 0x01) {
+                    return true
+                }
+
+                // ADB (Android Debug Bridge)
+                if (ifaceClass == 0xFF && ifaceSubclass == 0x42 && ifaceProtocol == 0x01) {
+                    return true
+                }
+
+                // RNDIS (USB tethering)
+                if (ifaceClass == 0xE0 && ifaceSubclass == 0x01 && ifaceProtocol == 0x03) {
+                    return true
+                }
+
+                // IAD (Interface Association Descriptor) - современные Android
+                if (ifaceClass == 0xEF && ifaceSubclass == 0x04 && ifaceProtocol == 0x01) {
+                    return true
+                }
+
+                // PTP (Picture Transfer Protocol) - старые Android
+                if (ifaceClass == 0x06 && ifaceSubclass == 0x01 && ifaceProtocol == 0x01) {
+                    return true
+                }
+            }
+
+            return false
+        }
+
+        /**
+         * Checks for the presence of a bulk endpoint (needed for data transfer)
+         */
+        private fun hasBulkEndpoint(usbInterface: android.hardware.usb.UsbInterface): Boolean {
+            for (j in 0 until usbInterface.endpointCount) {
+                val endpoint = usbInterface.getEndpoint(j)
+                if (endpoint.type == UsbConstants.USB_ENDPOINT_XFER_BULK) {
+                    return true
+                }
+            }
+            return false
         }
     }
 }

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/HomeFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/HomeFragment.kt
@@ -41,6 +41,7 @@ import com.andrerinas.headunitrevived.utils.VpnControl
 import com.andrerinas.headunitrevived.utils.BluetoothHelper
 import com.andrerinas.headunitrevived.connection.UsbReceiver
 import com.andrerinas.headunitrevived.connection.UsbAccessoryMode
+import kotlinx.coroutines.withContext
 
 class HomeFragment : Fragment() {
 
@@ -391,10 +392,17 @@ class HomeFragment : Fragment() {
                 } else {
                     if (usbManager.hasPermission(device.wrappedDevice)) {
                         val usbMode = UsbAccessoryMode(usbManager)
-                        if (usbMode.connectAndSwitch(device.wrappedDevice)) {
-                            Toast.makeText(requireContext(), R.string.switching_to_android_auto, Toast.LENGTH_SHORT).show()
-                        } else {
-                            Toast.makeText(requireContext(), R.string.switch_failed, Toast.LENGTH_SHORT).show()
+                        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+                            val success = usbMode.connectAndSwitch(device.wrappedDevice)
+                            withContext(Dispatchers.Main) {
+                                context?.let { ctx ->
+                                    if (success) {
+                                        Toast.makeText(ctx, R.string.switching_to_android_auto, Toast.LENGTH_SHORT).show()
+                                    } else {
+                                        Toast.makeText(ctx, R.string.switch_failed, Toast.LENGTH_SHORT).show()
+                                    }
+                                }
+                            }
                         }
                     } else {
                         Toast.makeText(requireContext(), R.string.requesting_usb_permission, Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/HomeFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/HomeFragment.kt
@@ -39,6 +39,8 @@ import kotlinx.coroutines.flow.collect
 import com.andrerinas.headunitrevived.utils.Settings
 import com.andrerinas.headunitrevived.utils.VpnControl
 import com.andrerinas.headunitrevived.utils.BluetoothHelper
+import com.andrerinas.headunitrevived.connection.UsbReceiver
+import com.andrerinas.headunitrevived.connection.UsbAccessoryMode
 
 class HomeFragment : Fragment() {
 
@@ -362,9 +364,53 @@ class HomeFragment : Fragment() {
         }
 
         usb.setOnClickListener {
-            val controller = findNavController()
-            if (controller.currentDestination?.id == R.id.homeFragment) {
-                controller.navigate(R.id.action_homeFragment_to_usbListFragment)
+            // Already connected to Android Auto - just show projection
+            if (commManager.isConnected) {
+                val aapIntent = Intent(requireContext(), AapProjectionActivity::class.java)
+                aapIntent.putExtra(AapProjectionActivity.EXTRA_FOCUS, true)
+                startActivity(aapIntent)
+                return@setOnClickListener
+            }
+
+            // Get list of Android USB devices
+            val usbManager = requireContext().getSystemService(Context.USB_SERVICE) as UsbManager
+            val androidDevices = usbManager.deviceList.values
+                .filter { UsbDeviceCompat.isAndroidDevice(it) }
+
+            // If exactly one device found - auto-connect
+            if (androidDevices.size == 1) {
+                val device = UsbDeviceCompat(androidDevices[0])
+                AppLog.i("USB button: Single device found - ${device.uniqueName}, auto-connecting")
+                (requireActivity() as? MainActivity)?.beginAutoConnect("USB button auto-connect")
+
+                if (device.isInAccessoryMode) {
+                    ContextCompat.startForegroundService(requireContext(),
+                        Intent(requireContext(), AapService::class.java).apply {
+                            action = AapService.ACTION_CHECK_USB
+                        })
+                } else {
+                    if (usbManager.hasPermission(device.wrappedDevice)) {
+                        val usbMode = UsbAccessoryMode(usbManager)
+                        if (usbMode.connectAndSwitch(device.wrappedDevice)) {
+                            Toast.makeText(requireContext(), R.string.switching_to_android_auto, Toast.LENGTH_SHORT).show()
+                        } else {
+                            Toast.makeText(requireContext(), R.string.switch_failed, Toast.LENGTH_SHORT).show()
+                        }
+                    } else {
+                        Toast.makeText(requireContext(), R.string.requesting_usb_permission, Toast.LENGTH_SHORT).show()
+                        ContextCompat.startForegroundService(requireContext(), Intent(requireContext(), AapService::class.java))
+                        usbManager.requestPermission(
+                            device.wrappedDevice,
+                            UsbReceiver.createPermissionPendingIntent(requireContext())
+                        )
+                    }
+                }
+            } else {
+                // 0 or multiple devices - open the list
+                val controller = findNavController()
+                if (controller.currentDestination?.id == R.id.homeFragment) {
+                    controller.navigate(R.id.action_homeFragment_to_usbListFragment)
+                }
             }
         }
 


### PR DESCRIPTION

1. **feat**: auto-connect USB when single device detected

**Description**
What's changed:
USB button now auto-connects when exactly 1 Android device is present
Shows projection if already connected
Opens device list for 0 or multiple devices

**Why:** Better UX - no need to manually select when only one device is connected.

**Testing:** Single device auto-connects, multiple/zero devices show list, already connected shows projection.


2. **Refactor**: Detect Android devices via USB interface class instead of vendor whitelist

Replaced hardcoded ANDROID_VENDORS list  with protocol-based detection using USB interface class/subclass (AOAP, MTP, ADB, RNDIS, IAD, PTP). This makes detection future-proof, works with any Android device, and requires no maintenance. Apple devices are still explicitly excluded (0x05AC).