### PR TITLE
fix: classify FFmpeg OMX decoders as software in codec selection

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/decoder/VideoDecoder.kt
@@ -645,12 +645,20 @@ class VideoDecoder(private val settings: Settings) {
         val infos = codecInfos.filter { !it.isEncoder && it.supportedTypes.any { t -> t.equals(mimeType, true) } }
         val hw = infos.find { isHardwareAccelerated(it.name) }
         val sw = infos.find { !isHardwareAccelerated(it.name) }
-        return if (preferHardware && hw != null) hw.name else sw?.name ?: hw?.name
+        val selected = if (preferHardware && hw != null) hw.name else sw?.name ?: hw?.name
+        AppLog.i("findBestCodec: hw=${hw?.name}, sw=${sw?.name}, preferHardware=$preferHardware, selected=$selected")
+        return selected
     }
 
     private fun isHardwareAccelerated(name: String): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val codecList = MediaCodecList(MediaCodecList.ALL_CODECS)
+            val info = codecList.codecInfos.find { it.name.equals(name, ignoreCase = true) }
+            if (info != null) return info.isHardwareAccelerated
+        }
         val lower = name.lowercase(Locale.ROOT)
-        return !(lower.startsWith("omx.google.") || lower.startsWith("c2.android.") || lower.contains(".sw.") || lower.contains("software"))
+        return !(lower.startsWith("omx.google.") || lower.startsWith("c2.android.") ||
+                lower.startsWith("omx.ffmpeg.") || lower.contains(".sw.") || lower.contains("software"))
     }
 }
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/decoder/VideoDecoder.kt
@@ -643,20 +643,18 @@ class VideoDecoder(private val settings: Settings) {
         }
 
         val infos = codecInfos.filter { !it.isEncoder && it.supportedTypes.any { t -> t.equals(mimeType, true) } }
-        val hw = infos.find { isHardwareAccelerated(it.name) }
-        val sw = infos.find { !isHardwareAccelerated(it.name) }
+        val hw = infos.find { isHardwareAccelerated(it) }
+        val sw = infos.find { !isHardwareAccelerated(it) }
         val selected = if (preferHardware && hw != null) hw.name else sw?.name ?: hw?.name
         AppLog.i("findBestCodec: hw=${hw?.name}, sw=${sw?.name}, preferHardware=$preferHardware, selected=$selected")
         return selected
     }
 
-    private fun isHardwareAccelerated(name: String): Boolean {
+    private fun isHardwareAccelerated(info: MediaCodecInfo): Boolean {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            val codecList = MediaCodecList(MediaCodecList.ALL_CODECS)
-            val info = codecList.codecInfos.find { it.name.equals(name, ignoreCase = true) }
-            if (info != null) return info.isHardwareAccelerated
+            return info.isHardwareAccelerated
         }
-        val lower = name.lowercase(Locale.ROOT)
+        val lower = info.name.lowercase(Locale.ROOT)
         return !(lower.startsWith("omx.google.") || lower.startsWith("c2.android.") ||
                 lower.startsWith("omx.ffmpeg.") || lower.contains(".sw.") || lower.contains("software"))
     }


### PR DESCRIPTION
## Summary

- `isHardwareAccelerated()` doesn't recognize `OMX.ffmpeg.*` decoders as software, causing `findBestCodec()` to prefer FFmpeg over real hardware decoders (e.g. `OMX.MTK.VIDEO.DECODER.AVC`) on MediaTek devices
- Uses `MediaCodecInfo.isHardwareAccelerated()` API on Android 10+ for reliable detection
- Adds codec selection debug logging

## The Bug

`isHardwareAccelerated()` (line 651) checks for `omx.google.`, `c2.android.`, `.sw.`, and `software` — but misses `omx.ffmpeg.*`. This means `OMX.ffmpeg.h264.decoder` is treated as hardware.

Ironically, `isHevcSupported()` (line 71) already has the correct check:
```kotlin
val isSoftware = name.startsWith("omx.google.") ||
    name.startsWith("c2.android.") ||
    name.startsWith("omx.ffmpeg.") ||  // ← already correct here
    name.contains(".sw.") ||
    name.contains("software")
```

## Impact

On devices with both MTK hardware and FFmpeg software decoders, `findBestCodec()` may pick FFmpeg first (depending on `MediaCodecList` enumeration order), delivering software decoding performance while the app believes it's using hardware.

Tested on Amazon Fire 7 (MT8163, LineageOS 14.1):
- **Before:** `OMX.ffmpeg.h264.decoder` selected, ~50% CPU, green screen flashes
- **After:** `OMX.MTK.VIDEO.DECODER.AVC` selected, ~1-2% CPU, smooth playback

## Changes

- Add `omx.ffmpeg.*` to software decoder detection (matches existing `isHevcSupported()` logic)
- Use `MediaCodecInfo.isHardwareAccelerated()` on Android 10+ for proper API-based detection
- Add `AppLog.i` in `findBestCodec()` logging hw/sw candidates and selection result