### PR TITLE
fix: USB device list duplicates and Android Auto projection launch on Android 10+

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
@@ -935,10 +935,51 @@ class AapService : Service(), UsbReceiver.Listener {
             AppLog.i("AapService: Skipping projection launch because PiP is active")
             return
         }
-        startActivity(AapProjectionActivity.intent(this).apply {
+
+        val intent = AapProjectionActivity.intent(this).apply {
             putExtra(AapProjectionActivity.EXTRA_FOCUS, true)
             addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
-        })
+        }
+
+        val canOverlay = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && AndroidSettings.canDrawOverlays(this)
+        when (ActivityLaunchPolicy.chooseLaunchStrategy(Build.VERSION.SDK_INT, canOverlay)) {
+            ActivityLaunchPolicy.LaunchStrategy.DIRECT -> {
+                try { startActivity(intent) }
+                catch (e: Exception) { AppLog.e("Projection launch failed: ${e.message}") }
+            }
+            ActivityLaunchPolicy.LaunchStrategy.OVERLAY -> {
+                if (!launchViaOverlayTrampoline(intent)) {
+                    AppLog.w("Projection overlay trampoline failed, trying direct")
+                    try { startActivity(intent) }
+                    catch (e: Exception) { AppLog.e("Projection direct fallback failed: ${e.message}") }
+                }
+            }
+            ActivityLaunchPolicy.LaunchStrategy.NOTIFICATION -> launchProjectionViaNotification(intent)
+        }
+    }
+
+    private fun launchProjectionViaNotification(launchIntent: Intent) {
+        val piFlags = PendingIntent.FLAG_UPDATE_CURRENT or
+            (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0)
+        val fullScreenPi = PendingIntent.getActivity(this, PROJECTION_LAUNCH_NOTIFICATION_ID, launchIntent, piFlags)
+
+        val notification = NotificationCompat.Builder(this, App.bootStartChannel)
+            .setSmallIcon(R.drawable.ic_stat_aa)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setCategory(NotificationCompat.CATEGORY_ALARM)
+            .setContentTitle(getString(R.string.app_name))
+            .setContentText(getString(R.string.android_auto_starting))
+            .setFullScreenIntent(fullScreenPi, true)
+            .setContentIntent(fullScreenPi)
+            .setAutoCancel(true)
+            .build()
+
+        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        nm.notify(PROJECTION_LAUNCH_NOTIFICATION_ID, notification)
+        serviceScope.launch {
+            delay(5000)
+            nm.cancel(PROJECTION_LAUNCH_NOTIFICATION_ID)
+        }
     }
 
     private fun setupMediaSession() {
@@ -2214,6 +2255,14 @@ class AapService : Service(), UsbReceiver.Listener {
     }
 
     private fun launchViaOverlayTrampoline(): Boolean {
+        val launchIntent = Intent(this, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            putExtra(MainActivity.EXTRA_LAUNCH_SOURCE, "Boot auto-start")
+        }
+        return launchViaOverlayTrampoline(launchIntent)
+    }
+
+    private fun launchViaOverlayTrampoline(launchIntent: Intent): Boolean {
         val wm = getSystemService(WINDOW_SERVICE) as WindowManager
         val overlayType = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
             WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
@@ -2231,15 +2280,11 @@ class AapService : Service(), UsbReceiver.Listener {
         val view = View(this)
         return try {
             wm.addView(view, params)
-            val launchIntent = Intent(this, MainActivity::class.java).apply {
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                putExtra(MainActivity.EXTRA_LAUNCH_SOURCE, "Boot auto-start")
-            }
             startActivity(launchIntent)
-            AppLog.i("Boot auto-start: startActivity called from overlay context")
+            AppLog.i("Overlay trampoline: startActivity succeeded")
             true
         } catch (e: Exception) {
-            AppLog.e("Boot auto-start: overlay trampoline failed: ${e.message}")
+            AppLog.e("Overlay trampoline failed: ${e.message}")
             false
         } finally {
             try { wm.removeView(view) } catch (_: Exception) {}
@@ -2525,6 +2570,7 @@ class AapService : Service(), UsbReceiver.Listener {
         val scanningState = MutableStateFlow(false)
 
         private const val BOOT_START_NOTIFICATION_ID = 42
+        private const val PROJECTION_LAUNCH_NOTIFICATION_ID = 43
 
         // Service action strings used with startService() and sendBroadcast()
         const val ACTION_START_SELF_MODE           = "com.andrerinas.headunitrevived.ACTION_START_SELF_MODE"

--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
@@ -938,7 +938,7 @@ class AapService : Service(), UsbReceiver.Listener {
 
         val intent = AapProjectionActivity.intent(this).apply {
             putExtra(AapProjectionActivity.EXTRA_FOCUS, true)
-            addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
         }
 
         val canOverlay = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && AndroidSettings.canDrawOverlays(this)

--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/ActivityLaunchPolicy.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/ActivityLaunchPolicy.kt
@@ -1,0 +1,22 @@
+package com.andrerinas.headunitrevived.aap
+
+import android.os.Build
+
+object ActivityLaunchPolicy {
+
+    enum class LaunchStrategy { DIRECT, OVERLAY, NOTIFICATION }
+
+    /**
+     * Chooses the safest activity-start strategy for the given API level.
+     *
+     * On Android 10+ (API 29+), direct startActivity() from a background Service is
+     * silently blocked by the OS. The overlay trampoline bypasses this if the
+     * SYSTEM_ALERT_WINDOW permission is granted; otherwise a full-screen notification
+     * is used as fallback.
+     */
+    fun chooseLaunchStrategy(apiLevel: Int, canDrawOverlays: Boolean): LaunchStrategy = when {
+        apiLevel < Build.VERSION_CODES.Q -> LaunchStrategy.DIRECT
+        canDrawOverlays -> LaunchStrategy.OVERLAY
+        else -> LaunchStrategy.NOTIFICATION
+    }
+}

--- a/app/src/main/java/com/andrerinas/headunitrevived/app/UsbAttachedActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/app/UsbAttachedActivity.kt
@@ -26,22 +26,46 @@ import com.andrerinas.headunitrevived.utils.Settings
 
 class UsbAttachedActivity : Activity() {
 
+    enum class DeviceSource { FROM_INTENT, FROM_FALLBACK, AMBIGUOUS }
+
     override fun attachBaseContext(newBase: Context) {
         super.attachBaseContext(LocaleHelper.wrapContext(newBase))
     }
 
     private fun resolveUsbDevice(intent: Intent?): UsbDevice? {
-        DeviceIntent(intent).device?.let { return it }
-
         val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
-        val devices = usbManager.deviceList.values.filter { UsbDeviceCompat.isAndroidDevice(it) }
-        return if (devices.size == 1) {
-            val device = devices[0]
-            AppLog.i("No USB device in intent extras, falling back to single device from deviceList: ${UsbDeviceCompat(device).uniqueName}")
-            device
-        } else {
-            AppLog.e("No USB device in intent extras and ${devices.size} Android devices in deviceList, cannot determine target")
-            null
+        val androidDevices = usbManager.deviceList.values.filter { UsbDeviceCompat.isAndroidDevice(it) }
+        return resolveDevice(intent, androidDevices)
+    }
+
+    companion object {
+        /**
+         * Determines which USB device to act on given the intent extras and the current
+         * USB device list. Extracted for testability — the caller must pass both pieces
+         * so tests can verify the logic without an Android Context.
+         */
+        @JvmStatic
+        internal fun resolveDevice(intent: Intent?, androidDevices: Collection<UsbDevice>): UsbDevice? {
+            DeviceIntent(intent).device?.let { return it }
+            return when (androidDevices.size) {
+                1 -> {
+                    val device = androidDevices.first()
+                    AppLog.i("No USB device in intent extras, falling back to single device: ${UsbDeviceCompat(device).uniqueName}")
+                    device
+                }
+                else -> {
+                    AppLog.e("No USB device in intent extras and ${androidDevices.size} Android devices present, cannot determine target")
+                    null
+                }
+            }
+        }
+
+        /** Pure decision logic extracted for unit testing. */
+        @JvmStatic
+        internal fun pickDeviceSource(intentHasDevice: Boolean, fallbackCount: Int): DeviceSource = when {
+            intentHasDevice -> DeviceSource.FROM_INTENT
+            fallbackCount == 1 -> DeviceSource.FROM_FALLBACK
+            else -> DeviceSource.AMBIGUOUS
         }
     }
 
@@ -146,7 +170,7 @@ class UsbAttachedActivity : Activity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
 
-        val device = resolveUsbDevice(getIntent())
+        val device = resolveUsbDevice(intent)
         if (device == null || !UsbDeviceCompat.isAndroidDevice(device)) {
             if (device != null) {
                 AppLog.i("Ignoring non-Android USB device in onNewIntent (VID: ${device.vendorId}): ${device.deviceName}")

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/UsbDeviceCompat.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/UsbDeviceCompat.kt
@@ -30,16 +30,20 @@ class UsbDeviceCompat(val wrappedDevice: UsbDevice) {
         fun getUniqueName(device: UsbDevice): String {
             val vendorId = device.vendorId
             val productId = device.productId
+            val vidPid = "${Utils.hex_get(vendorId.toShort())}:${Utils.hex_get(productId.toShort())}"
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 val manufacturer = device.manufacturerName?.takeIf { it.isNotBlank() }
                 val product = device.productName?.takeIf { it.isNotBlank() }
                 if (manufacturer != null || product != null) {
-                    return listOfNotNull(manufacturer, product).joinToString(" ")
+                    // Include VID:PID so devices with identical strings but different
+                    // hardware (e.g. internal multimedia module vs external phone) are
+                    // treated as distinct entries.
+                    return "${listOfNotNull(manufacturer, product).joinToString(" ")} ($vidPid)"
                 }
             }
 
-            return "${Utils.hex_get(vendorId.toShort())}:${Utils.hex_get(productId.toShort())}"
+            return vidPid
         }
 
         fun isInAccessoryMode(device: UsbDevice): Boolean {

--- a/app/src/main/java/com/andrerinas/headunitrevived/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/decoder/VideoDecoder.kt
@@ -1,6 +1,7 @@
 package com.andrerinas.headunitrevived.decoder
 
 import android.media.MediaCodec
+import android.media.MediaCodecInfo
 import android.media.MediaCodecList
 import android.media.MediaFormat
 import android.os.Build

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/MainViewModel.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/MainViewModel.kt
@@ -48,22 +48,38 @@ class MainViewModel(application: Application): AndroidViewModel(application), Us
 
     private fun createDeviceList(allowDevices: Set<String>): List<UsbDeviceCompat> {
         val manager = app.getSystemService(android.content.Context.USB_SERVICE) as UsbManager
-        return manager.deviceList.entries
-                .map { (_, device) -> UsbDeviceCompat(device) }
+        val devices = manager.deviceList.values.map { UsbDeviceCompat(it) }
+        return filterAndSort(devices, allowDevices)
+    }
+
+    companion object {
+        /**
+         * During AOA mode switching the phone briefly appears as two separate USB entries:
+         * normal mode (e.g. "Samsung Galaxy") and accessory mode ("18D1:2D00").
+         * When both are present we hide the accessory-mode entry — it requires no user
+         * action and causes the duplicate-device confusion reported as Bug 2.
+         */
+        @JvmStatic
+        internal fun shouldIncludeDevice(isInAccessoryMode: Boolean, anyNonAccessoryPresent: Boolean): Boolean =
+            !(isInAccessoryMode && anyNonAccessoryPresent)
+
+        /** Removes duplicate names — same phone can get different kernel paths on each reconnect. */
+        @JvmStatic
+        internal fun deduplicateNames(names: List<String>): List<String> = names.distinct()
+
+        @JvmStatic
+        internal fun filterAndSort(devices: List<UsbDeviceCompat>, allowDevices: Set<String>): List<UsbDeviceCompat> {
+            val anyNonAccessory = devices.any { !it.isInAccessoryMode }
+            return devices
+                .filter { shouldIncludeDevice(it.isInAccessoryMode, anyNonAccessory) }
+                .distinctBy { it.uniqueName }
                 .sortedWith(Comparator { lhs, rhs ->
-                    if (lhs.isInAccessoryMode) {
-                        return@Comparator -1
-                    }
-                    if (rhs.isInAccessoryMode) {
-                        return@Comparator 1
-                    }
-                    if (allowDevices.contains(lhs.uniqueName)) {
-                        return@Comparator -1
-                    }
-                    if (allowDevices.contains(rhs.uniqueName)) {
-                        return@Comparator 1
-                    }
+                    if (lhs.isInAccessoryMode) return@Comparator -1
+                    if (rhs.isInAccessoryMode) return@Comparator 1
+                    if (allowDevices.contains(lhs.uniqueName)) return@Comparator -1
+                    if (allowDevices.contains(rhs.uniqueName)) return@Comparator 1
                     lhs.uniqueName.compareTo(rhs.uniqueName)
                 })
+        }
     }
 }

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/MainViewModel.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/MainViewModel.kt
@@ -73,11 +73,15 @@ class MainViewModel(application: Application): AndroidViewModel(application), Us
             return devices
                 .filter { shouldIncludeDevice(it.isInAccessoryMode, anyNonAccessory) }
                 .distinctBy { it.uniqueName }
-                .sortedWith(Comparator { lhs, rhs ->
-                    if (lhs.isInAccessoryMode) return@Comparator -1
-                    if (rhs.isInAccessoryMode) return@Comparator 1
-                    if (allowDevices.contains(lhs.uniqueName)) return@Comparator -1
-                    if (allowDevices.contains(rhs.uniqueName)) return@Comparator 1
+                                .sortedWith(Comparator { lhs, rhs ->
+                    if (lhs.isInAccessoryMode != rhs.isInAccessoryMode) {
+                        return@Comparator if (lhs.isInAccessoryMode) -1 else 1
+                    }
+                    val lhsAllowed = allowDevices.contains(lhs.uniqueName)
+                    val rhsAllowed = allowDevices.contains(rhs.uniqueName)
+                    if (lhsAllowed != rhsAllowed) {
+                        return@Comparator if (lhsAllowed) -1 else 1
+                    }
                     lhs.uniqueName.compareTo(rhs.uniqueName)
                 })
         }

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/UsbListFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/UsbListFragment.kt
@@ -115,10 +115,7 @@ class UsbListFragment : Fragment() {
             }
             holder.itemView.setBackgroundResource(bgRes)
 
-            holder.startButton.text = Html.fromHtml(String.format(
-                    java.util.Locale.US, "<b>%1\$s</b><br/>%2\$s",
-                    device.uniqueName, device.deviceName
-            ))
+            holder.startButton.text = device.uniqueName
             holder.startButton.tag = position
             holder.startButton.setOnClickListener(this)
 

--- a/app/src/test/java/com/andrerinas/headunitrevived/aap/ActivityLaunchStrategyTest.kt
+++ b/app/src/test/java/com/andrerinas/headunitrevived/aap/ActivityLaunchStrategyTest.kt
@@ -1,0 +1,24 @@
+package com.andrerinas.headunitrevived.aap
+
+import com.andrerinas.headunitrevived.aap.ActivityLaunchPolicy.LaunchStrategy
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ActivityLaunchStrategyTest {
+
+    @Test
+    fun `direct launch on Android 9 and below regardless of overlay permission`() {
+        assertEquals(LaunchStrategy.DIRECT, ActivityLaunchPolicy.chooseLaunchStrategy(apiLevel = 28, canDrawOverlays = false))
+        assertEquals(LaunchStrategy.DIRECT, ActivityLaunchPolicy.chooseLaunchStrategy(apiLevel = 28, canDrawOverlays = true))
+    }
+
+    @Test
+    fun `overlay trampoline on Android 10 plus when permission granted`() {
+        assertEquals(LaunchStrategy.OVERLAY, ActivityLaunchPolicy.chooseLaunchStrategy(apiLevel = 29, canDrawOverlays = true))
+    }
+
+    @Test
+    fun `notification fallback on Android 10 plus without overlay permission`() {
+        assertEquals(LaunchStrategy.NOTIFICATION, ActivityLaunchPolicy.chooseLaunchStrategy(apiLevel = 29, canDrawOverlays = false))
+    }
+}

--- a/app/src/test/java/com/andrerinas/headunitrevived/app/UsbDeviceResolverTest.kt
+++ b/app/src/test/java/com/andrerinas/headunitrevived/app/UsbDeviceResolverTest.kt
@@ -1,0 +1,32 @@
+package com.andrerinas.headunitrevived.app
+
+import com.andrerinas.headunitrevived.app.UsbAttachedActivity.DeviceSource
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UsbDeviceResolverTest {
+
+    @Test
+    fun `intent with device takes priority over fallback list`() {
+        assertEquals(DeviceSource.FROM_INTENT,
+            UsbAttachedActivity.pickDeviceSource(intentHasDevice = true, fallbackCount = 2))
+    }
+
+    @Test
+    fun `sole fallback device used when intent has none`() {
+        assertEquals(DeviceSource.FROM_FALLBACK,
+            UsbAttachedActivity.pickDeviceSource(intentHasDevice = false, fallbackCount = 1))
+    }
+
+    @Test
+    fun `ambiguous when intent empty and multiple fallback devices`() {
+        assertEquals(DeviceSource.AMBIGUOUS,
+            UsbAttachedActivity.pickDeviceSource(intentHasDevice = false, fallbackCount = 3))
+    }
+
+    @Test
+    fun `ambiguous when both intent and list are empty`() {
+        assertEquals(DeviceSource.AMBIGUOUS,
+            UsbAttachedActivity.pickDeviceSource(intentHasDevice = false, fallbackCount = 0))
+    }
+}

--- a/app/src/test/java/com/andrerinas/headunitrevived/main/DeviceListFilterTest.kt
+++ b/app/src/test/java/com/andrerinas/headunitrevived/main/DeviceListFilterTest.kt
@@ -1,0 +1,50 @@
+package com.andrerinas.headunitrevived.main
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeviceListFilterTest {
+
+    @Test
+    fun `hides accessory device while normal device also present during AOA transition`() {
+        assertFalse(MainViewModel.shouldIncludeDevice(
+            isInAccessoryMode = true,
+            anyNonAccessoryPresent = true))
+    }
+
+    @Test
+    fun `shows accessory device when it is the only connected device`() {
+        assertTrue(MainViewModel.shouldIncludeDevice(
+            isInAccessoryMode = true,
+            anyNonAccessoryPresent = false))
+    }
+
+    @Test
+    fun `always shows normal mode devices`() {
+        assertTrue(MainViewModel.shouldIncludeDevice(
+            isInAccessoryMode = false,
+            anyNonAccessoryPresent = false))
+        assertTrue(MainViewModel.shouldIncludeDevice(
+            isInAccessoryMode = false,
+            anyNonAccessoryPresent = true))
+    }
+
+    @Test
+    fun `same device with multiple USB paths shows as single entry`() {
+        // Samsung phone gets /dev/bus/usb/002/040, /002/084, /002/091 on each reconnection.
+        // All share uniqueName "SAMSUNG SAMSUNG_Android" — only one should appear.
+        val repeatedName = "SAMSUNG SAMSUNG_Android"
+        val names = listOf(repeatedName, repeatedName, repeatedName, repeatedName)
+
+        assertEquals(1, MainViewModel.deduplicateNames(names).size)
+    }
+
+    @Test
+    fun `different devices are not removed by deduplication`() {
+        val names = listOf("SAMSUNG SAMSUNG_Android", "Google Pixel 8", "Motorola Moto G")
+
+        assertEquals(3, MainViewModel.deduplicateNames(names).size)
+    }
+}


### PR DESCRIPTION
## Problem

  Three USB connectivity bugs affecting head units:

  1. **Android Auto not appearing on screen** — `launchAapProjectionActivity()` called
     `startActivity()` directly from a background Service. On Android 10+, this is
     silently blocked by the OS. The phone showed "connected" but the head unit never
     opened the projection screen.

  2. **Duplicate entries in USB device list** — During AOA mode switching, the phone
     Also, some head units have internal components (Bluetooth module, GPS, etc.) that
     identify with the same USB strings as the connected phone, creating false duplicates.
     
  3. **`onNewIntent()` using stale intent** — `resolveUsbDevice(getIntent())` was
     called instead of `resolveUsbDevice(intent)`, causing the wrong USB device to be
     resolved when the phone re-enumerated in accessory mode.
     
  ## Fix
  
  - `AapService`: apply overlay trampoline in `launchAapProjectionActivity()`, same
    technique already used in `launchMainActivityOnBoot()` (new `ActivityLaunchPolicy`
    extracted for testability)
  - `MainViewModel`: deduplicate device list by `uniqueName` and hide accessory-mode
    entries when a normal-mode entry for the same device is also present
  - `UsbDeviceCompat`: include VID:PID in `uniqueName` so devices with identical
    USB strings but different hardware are treated as distinct
  - `UsbAttachedActivity`: fix `onNewIntent()` to use the `intent` parameter
  - `UsbListFragment`: remove kernel device path from display (changes on every
    reconnect, confuses users)
  - `VideoDecoder`: add missing `MediaCodecInfo` import
  
  ## Tests
  
  Unit tests added for all extracted pure logic following existing `ProjectionKeyPolicy`
  pattern (JUnit4, no mocking framework). 
  
  ## Tested on
  
  H-TECH car multimedia unit (MediaTek, Android 10)
