### PR TITLE
Added support for manual BSSID configuration in wireless settings for Native mode.

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
@@ -14,11 +14,15 @@ import android.os.Handler
 import android.os.Looper
 import android.widget.Toast
 import androidx.core.content.ContextCompat
+import com.andrerinas.headunitrevived.App
 import com.andrerinas.headunitrevived.R
 import com.andrerinas.headunitrevived.aap.AapService
 import com.andrerinas.headunitrevived.utils.AppLog
+import com.andrerinas.headunitrevived.utils.Settings
 import java.net.InetSocketAddress
 import java.net.Socket
+
+
 
 class WifiDirectManager(private val context: Context) : WifiP2pManager.ConnectionInfoListener, WifiP2pManager.GroupInfoListener {
 
@@ -66,7 +70,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                         val commManager = com.andrerinas.headunitrevived.App.provide(context).commManager
                         val isConnectingOrConnected = commManager.isConnected ||
                             commManager.connectionState.value is com.andrerinas.headunitrevived.connection.CommManager.ConnectionState.Connecting
-                        
+
                         if (!isConnected && !isConnectingOrConnected) {
                             if (appSettings.wifiConnectionMode == 2 && appSettings.helperConnectionStrategy == 1) {
                                 AppLog.i("WifiDirectManager: P2P enabled, auto-starting WiFi Direct visibility")
@@ -78,6 +82,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                         }
                     }
                 }
+
                 WifiP2pManager.WIFI_P2P_THIS_DEVICE_CHANGED_ACTION -> {
                     val device = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                         intent.getParcelableExtra(WifiP2pManager.EXTRA_WIFI_P2P_DEVICE, WifiP2pDevice::class.java)
@@ -122,7 +127,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 AppLog.i("WifiDirectManager: Device supports WiFi Direct. Initializing...")
                 manager?.let { mgr ->
                     channel = mgr.initialize(context, context.mainLooper, null)
-                    
+
                     WifiDirectCompat.requestDeviceInfo(manager, channel) { address ->
                         AppLog.i("WifiDirectManager: requestDeviceInfo success: $address")
                         localDeviceAddress = address
@@ -164,7 +169,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             isConnected = true
             AapService.scanningState.value = false
             isGroupOwner = info.isGroupOwner
-            
+
             val goIp = info.groupOwnerAddress?.hostAddress ?: "unknown"
             AppLog.i("WifiDirectManager: Group formed. Owner: $isGroupOwner, GO IP: $goIp")
 
@@ -204,8 +209,9 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
 
     @SuppressLint("MissingPermission")
     override fun onGroupInfoAvailable(group: android.net.wifi.p2p.WifiP2pGroup?) {
+        val appSettings = com.andrerinas.headunitrevived.App.provide(context).settings
         if (group != null) {
-            // [FIX] Check if Location Services (GPS) are enabled. 
+            // [FIX] Check if Location Services (GPS) are enabled.
             // On Android 10+, BSSID is often masked if GPS is OFF.
             try {
                 val lm = context.getSystemService(android.content.Context.LOCATION_SERVICE) as android.location.LocationManager
@@ -251,13 +257,23 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 }
             }
             discoveredInterface = iface
-            var bssid = getWifiDirectMac(iface)
-            AppLog.i("WifiDirectManager: Initial BSSID from scan: $bssid")
+            val isBssidSet =  appSettings.staticBSSID != "0"
+
+            var bssid = if (appSettings.staticBSSID.equals("0")) {
+                getWifiDirectMac(iface)
+            } else {
+                appSettings.staticBSSID
+            }
+            if (isBssidSet) {
+                AppLog.i("WifiDirectManager: Initial BSSID from App settings: $bssid")
+            } else AppLog.i("WifiDirectManager: Initial BSSID from scan: $bssid")
+
+
 
             // [FIX] Robust BSSID detection for masked MACs (00:00 or 02:00)
             if (bssid == "00:00:00:00:00:00" || bssid == "02:00:00:00:00:00") {
                 AppLog.i("WifiDirectManager: BSSID is masked. Starting fallbacks...")
-                
+
                 // Fallback 1: Use last known valid BSSID
                 if (!lastKnownBssid.isNullOrEmpty() && lastKnownBssid != "00:00:00:00:00:00" && lastKnownBssid != "02:00:00:00:00:00") {
                     AppLog.i("WifiDirectManager: Fallback 1 - Using lastKnownBssid: $lastKnownBssid")
@@ -267,7 +283,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 else if (!localDeviceAddress.isNullOrEmpty() && localDeviceAddress != "00:00:00:00:00:00" && localDeviceAddress != "02:00:00:00:00:00") {
                     AppLog.i("WifiDirectManager: Fallback 2 - Using localDeviceAddress: $localDeviceAddress")
                     bssid = localDeviceAddress!!
-                } 
+                }
                 // Fallback 3: Use group.owner.deviceAddress
                 else {
                     val ownerAddr = group.owner?.deviceAddress
@@ -336,7 +352,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
 
                         // For Native AA, we almost always expect 192.168.49.1 if we are GO
                         val finalIp = ip ?: (if (isOwner) "192.168.49.1" else null)
-                        if (finalIp != null) {
+                        if (finalIp != null && bssid != null) {
                             AppLog.i("WifiDirectManager: SUCCESS - Providing credentials to listener. SSID=$ssid, IP=$finalIp, BSSID=$bssid")
                             onCredentialsReady?.invoke(ssid, psk, finalIp, bssid)
                         } else {
@@ -391,12 +407,12 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                     }
                     sb.toString()
                 } else "null"
-                
+
                 AppLog.i("WifiDirectManager: Found interface: ${iface.name}, MAC: $macStr")
 
                 // If we have a name, it must match.
                 if (ifaceName != null && iface.name != ifaceName) continue
-                
+
                 // If we don't have a name, look for common P2P interface patterns
                 if (ifaceName == null) {
                     val name = iface.name.lowercase()
@@ -426,7 +442,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                     if (!addr.isLoopbackAddress && addr is java.net.Inet4Address) {
                         // Prioritize explicitly requested interface
                         if (ifaceName != null && iface.name == ifaceName) return addr.hostAddress
-                        
+
                         // Fallback: search for 192.168.49.1 (Standard P2P GO IP)
                         if (addr.hostAddress == "192.168.49.1") return addr.hostAddress
 
@@ -486,7 +502,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     private fun createNewGroup(retryCount: Int) {
         val mgr = manager ?: return
         val ch = channel ?: return
-        
+
         mgr.createGroup(ch, object : WifiP2pManager.ActionListener {
             override fun onSuccess() {
                 AppLog.i("WifiDirectManager: P2P Group created.")
@@ -518,7 +534,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 AapService.scanningState.value = true
             }
             manager?.discoverPeers(ch, object : WifiP2pManager.ActionListener {
-                override fun onSuccess() { 
+                override fun onSuccess() {
                     AppLog.d("WifiDirectManager: Discovery active")
                     if (appSettings.wifiConnectionMode == 2 && appSettings.helperConnectionStrategy == 1) {
                         handler.postDelayed({
@@ -528,7 +544,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                         }, 2500L)
                     }
                 }
-                override fun onFailure(reason: Int) { 
+                override fun onFailure(reason: Int) {
                     AppLog.w("WifiDirectManager: Discovery failed: $reason")
                     AapService.scanningState.value = false
                 }
@@ -715,7 +731,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     private fun getMacFromShell(iface: String?): String? {
         // Fallback: If iface is null, try to find a p2p interface name
         val targetIface = iface ?: getInterfaceByIp("192.168.49.1") ?: discoveredInterface
-        
+
         if (targetIface != null) {
             // Try reading directly from sysfs
             try {

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
@@ -257,16 +257,18 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 }
             }
             discoveredInterface = iface
-            val isBssidSet =  appSettings.staticBSSID != "0"
+            val isBssidSet = appSettings.staticBSSID != "0"
 
-            var bssid = if (appSettings.staticBSSID.equals("0")) {
+            var bssid = if (appSettings.staticBSSID == "0" || appSettings.staticBSSID == null) {
                 getWifiDirectMac(iface)
             } else {
                 appSettings.staticBSSID
             }
             if (isBssidSet) {
                 AppLog.i("WifiDirectManager: Initial BSSID from App settings: $bssid")
-            } else AppLog.i("WifiDirectManager: Initial BSSID from scan: $bssid")
+            } else {
+                AppLog.i("WifiDirectManager: Initial BSSID from scan: $bssid")
+            }
 
 
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
@@ -40,6 +40,7 @@ import android.content.pm.PackageManager
 import com.andrerinas.headunitrevived.connection.NativeAaHandshakeManager
 import com.andrerinas.headunitrevived.utils.BluetoothHelper
 import androidx.lifecycle.lifecycleScope
+import com.andrerinas.headunitrevived.utils.DialogUtils
 import java.io.File
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -60,6 +61,7 @@ class SettingsFragment : Fragment() {
     private var pendingSyncMediaSessionAaMetadata: Boolean? = null
     private var pendingResolution: Int? = null
     private var pendingDpi: Int? = null
+    private var pendingStaticBSSID: String? = null
     private var pendingFullscreenMode: Settings.FullscreenMode? = null
     private var pendingViewMode: Settings.ViewMode? = null
     private var pendingForceSoftware: Boolean? = null
@@ -159,6 +161,7 @@ class SettingsFragment : Fragment() {
         pendingSyncMediaSessionAaMetadata = settings.syncMediaSessionWithAaMetadata
         pendingResolution = settings.resolutionId
         pendingDpi = settings.dpiPixelDensity
+        pendingStaticBSSID = settings.staticBSSID
         pendingFullscreenMode = settings.fullscreenMode
         pendingViewMode = settings.viewMode
         pendingForceSoftware = settings.forceSoftwareDecoding
@@ -348,6 +351,7 @@ class SettingsFragment : Fragment() {
         pendingSyncMediaSessionAaMetadata?.let { settings.syncMediaSessionWithAaMetadata = it }
         pendingResolution?.let { settings.resolutionId = it }
         pendingDpi?.let { settings.dpiPixelDensity = it }
+        pendingStaticBSSID?.let { settings.staticBSSID = it }
         pendingFullscreenMode?.let { settings.fullscreenMode = it }
         pendingViewMode?.let { settings.viewMode = it }
         pendingForceSoftware?.let { settings.forceSoftwareDecoding = it }
@@ -439,6 +443,7 @@ class SettingsFragment : Fragment() {
                         pendingSyncMediaSessionAaMetadata != settings.syncMediaSessionWithAaMetadata ||
                         pendingResolution != settings.resolutionId ||
                         pendingDpi != settings.dpiPixelDensity ||
+                        pendingStaticBSSID != settings.staticBSSID ||
                         pendingFullscreenMode != settings.fullscreenMode ||
                         pendingViewMode != settings.viewMode ||
                         pendingForceSoftware != settings.forceSoftwareDecoding ||
@@ -481,7 +486,8 @@ class SettingsFragment : Fragment() {
         requiresRestart = pendingResolution != settings.resolutionId ||
                           pendingVideoCodec != settings.videoCodec ||
                           pendingFpsLimit != settings.fpsLimit ||
-                          pendingDpi != settings.dpiPixelDensity ||
+                            pendingDpi != settings.dpiPixelDensity ||
+            pendingStaticBSSID != settings.staticBSSID ||
                           pendingForceSoftware != settings.forceSoftwareDecoding ||
                           pendingEnableRotary != settings.enableRotary ||
                           pendingEnableAudioSink != settings.enableAudioSink ||
@@ -754,6 +760,37 @@ class SettingsFragment : Fragment() {
                 }
             }
         }
+
+        items.add(SettingItem.SettingEntry(
+            stableId = "staticBSSID",
+            nameResId = R.string.static_bssid_title,
+            value = if (pendingStaticBSSID == 0.toString()) getString(R.string.auto) else pendingStaticBSSID.toString(),
+            onClick = { _ ->
+                DialogUtils.showTextInputDialog(
+                    requireContext(),
+                    R.string.static_bssid_enter_value,
+                    pendingStaticBSSID,
+                    { newVal ->
+                        pendingStaticBSSID = newVal
+                        checkChanges()
+                        updateSettingsList()
+                    }
+                )
+
+
+//                _ ->
+//                showNumericInputDialog(
+//                    title = getString(R.string.static_bssid_enter_value),
+//                    message = null,
+//                    initialValue = pendingStaticBSSID ?: 0,
+//                    onConfirm = { newVal ->
+//                        pendingStaticBSSID = newVal
+//                        checkChanges()
+//                        updateSettingsList()
+//                    }
+//                )
+            }
+        ))
 
         // --- Dark Mode ---
         items.add(SettingItem.CategoryHeader("darkMode", R.string.category_dark_mode))
@@ -2118,7 +2155,7 @@ class SettingsFragment : Fragment() {
             .create()
 
         dialog.window?.clearFlags(
-            android.view.WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or 
+            android.view.WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
             android.view.WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM
         )
         dialog.show()
@@ -2438,7 +2475,7 @@ class SettingsFragment : Fragment() {
             .create()
 
         dialog.window?.clearFlags(
-            android.view.WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or 
+            android.view.WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
             android.view.WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM
         )
         dialog.show()

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
@@ -191,7 +191,7 @@ class Settings(private val context: Context) {
             prefs.edit().putInt("dpi-pixel-density", value).apply()
         }
 
-    var staticBSSID : String?
+    var staticBSSID: String?
         get() = try { prefs.getString("static-bssid", "0") } catch (e: Exception) { "0" } // Default 0 for Auto
         set(value) {
             prefs.edit().putString("static-bssid", value).apply()

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
@@ -191,6 +191,12 @@ class Settings(private val context: Context) {
             prefs.edit().putInt("dpi-pixel-density", value).apply()
         }
 
+    var staticBSSID : String?
+        get() = try { prefs.getString("static-bssid", "0") } catch (e: Exception) { "0" } // Default 0 for Auto
+        set(value) {
+            prefs.edit().putString("static-bssid", value).apply()
+        }
+
     var fakeSpeed: Boolean
         get() = prefs.getBoolean("fake_speed", true)
         set(value) {
@@ -392,7 +398,7 @@ class Settings(private val context: Context) {
     var audioLatencyMultiplier: Int
         get() = prefs.getInt("audio-latency-multiplier", 8)
         set(value) { prefs.edit().putInt("audio-latency-multiplier", value).apply() }
-    
+
     var audioQueueCapacity: Int
         get() = prefs.getInt("audio-queue-capacity", 0)
         set(value) { prefs.edit().putInt("audio-queue-capacity", value).apply() }
@@ -440,7 +446,7 @@ class Settings(private val context: Context) {
     var autoStartWifiSsid: String
         get() = prefs.getString("auto-start-wifi-ssid", "")!!
         set(value) { prefs.edit().putString("auto-start-wifi-ssid", value).apply() }
-        
+
     var listenForUsbDevices: Boolean
         get() = prefs.getBoolean("listen-for-usb-devices", true)
         set(value) { prefs.edit().putBoolean("listen-for-usb-devices", value).apply() }
@@ -789,7 +795,7 @@ class Settings(private val context: Context) {
                     .apply()
             }
         }
-        
+
         fun isListenForUsbDevicesEnabled(context: Context): Boolean {
             val prefs = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 val deviceContext = context.createDeviceProtectedStorageContext()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -205,6 +205,10 @@
     <string name="wireless_connection_settings">Wireless Connection</string>
     <string name="category_graphic">Graphic</string>
 
+    <string name="static_bssid_title">Static BSSID</string>
+    <string name="static_bssid_enter_value">Enter BSSID (XX:XX:XX:XX:XX:XX)</string>
+    <string name="static_bssid_desc">Manually set the BSSID for the wireless handshake if auto-detection is blocked by system permissions</string>
+
     <string name="custom_insets">Custom Insets (Margins)</string>
     <string name="inset_top">Top</string>
     <string name="inset_bottom">Bottom</string>


### PR DESCRIPTION
Due to strict Android privacy restrictions regarding local network identifiers, the Headunit app cannot programmatically retrieve the Wi-Fi Direct BSSID while running in Native mode. This blocks the seamless automated connection flow.

To bypass this limitation and restore connectivity, this PR introduces a fallback manual configuration feature. Users can now manually retrieve the BSSID (e.g., via ADB or network tool applications) and input it directly into the Headunit app's settings. The app will then use this user-provided BSSID to establish a successful connection with the Android device.