### PR TITLE
i18n(ko): refine Korean localization after source string updates

### DIFF
--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -366,7 +366,7 @@
     <string name="share">공유</string>
     <string name="close">닫기</string>
     <string name="failed_export_logs">로그 내보내기 실패</string>
-    <string name="failed_export_in_silent_logs">로그를 내보낼 수 없습니다. 로그 레벨이 Silent로 설정되어 있습니다</string>
+    <string name="failed_export_in_silent_logs">로그를 내보낼 수 없습니다. 로그 레벨이 Silent로 설정되어 있습니다.</string>
     <string name="switching_to_android_auto">Android Auto로 전환 중…</string>
     <string name="switch_failed">전환 실패</string>
     <string name="requesting_usb_permission">USB 권한 요청 중…</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -20,54 +20,58 @@
     <string name="mic_sample_rate">마이크 샘플링 레이트</string>
     <string name="keymap">키 매핑</string>
     <string name="night_mode">다크 모드(Android Auto)</string>
-    <string name="night_mode_threshold">다크 모드 임계값</string>
-    <string name="enter_threshold_value">임계값 입력</string>
-    <string name="threshold_lux_desc">조도 값(0–10000). 이 값보다 낮으면 야간으로 판단합니다.</string>
-    <string name="threshold_brightness_desc">밝기 값(0–255). 이 값보다 낮으면 야간으로 판단합니다.</string>
+    <string name="night_mode_threshold">다크 모드 기준값</string>
+    <string name="enter_threshold_value">기준값 입력</string>
+    <string name="threshold_lux_desc">조도 기준값(0–10000). 이 값보다 낮으면 야간으로 판단합니다.</string>
+    <string name="threshold_brightness_desc">밝기 기준값(0–255). 이 값보다 낮으면 야간으로 판단합니다.</string>
     <string name="threshold_light_title">주변 조도 감도</string>
     <string name="threshold_brightness_title">화면 밝기</string>
     <string name="threshold_light_hint">주변 조도가 이 값보다 낮아지면 다크 모드가 활성화됩니다.</string>
-    <string name="threshold_brightness_hint">다크 모드는 화면 밝기가 이 값 이하일 때 활성화됩니다. Android는 밝기를 0–255로 보고하지만, 실제 범위는 기기에 따라 다릅니다. 기기에 적합한 임계값을 찾기 위해 테스트가 필요할 수 있습니다.</string>
+    <string name="threshold_brightness_hint">화면 밝기가 이 값 이하이면 다크 모드가 활성화됩니다. Android는 밝기를 0–255로 표시하지만, 실제 범위는 기기에 따라 다를 수 있습니다. 기기에 맞는 기준값을 찾으려면 테스트가 필요할 수 있습니다.</string>
     <string name="current_light_reading">현재 조도: %d Lux</string>
     <string name="enable_fine_lux_control">조도 미세 조정(0–100 Lux)</string>
+    <string name="current_brightness_reading">현재 밝기: %d / 255</string>
     <string name="night_mode_start">다크 모드 시작 시간</string>
     <string name="night_mode_end">다크 모드 종료 시간</string>
 
     <string name="app_theme">다크 모드(앱)</string>
-    <string name="app_theme_description">앱의 표시 방식을 설정합니다</string>
+    <string name="app_theme_description">앱 테마를 설정합니다</string>
     <string name="change_app_theme">앱 테마 변경</string>
     <string name="monochrome_icons">흑백 아이콘</string>
     <string name="monochrome_icons_description">다크 모드 또는 완전 블랙 모드에서 홈 화면 아이콘을 흑백으로 표시합니다</string>
     <string name="use_extreme_dark">완전 블랙 모드 사용</string>
-    <string name="use_extreme_dark_description">다크 모드가 활성화되면 완전한 검은색 배경을 사용합니다</string>
+    <string name="use_extreme_dark_description">다크 모드에서 완전히 검은 배경을 사용합니다</string>
     <string name="use_gradient_background">그라데이션 배경 사용</string>
-    <string name="use_gradient_background_description_on">앱에서 중앙 그라데이션 원 배경을 직접 렌더링합니다</string>
-    <string name="use_gradient_background_description_off">앱의 기본 배경이 사용됩니다</string>
-    <string name="use_gradient_background_description_on_auto">앱에서 중앙 그라데이션 원 배경을 직접 렌더링합니다. 완전 블랙 모드에는 적용되지 않습니다</string>
-    <string name="use_gradient_background_description_off_auto">앱의 기본 배경이 사용됩니다. 완전 블랙 모드에는 적용되지 않습니다</string>
+    <string name="use_gradient_background_description_on">앱에서 중앙 원형 그라데이션 배경을 직접 그립니다</string>
+    <string name="use_gradient_background_description_off">앱 기본 배경을 사용합니다</string>
+    <string name="use_gradient_background_description_on_auto">앱에서 중앙 그라데이션 원 배경을 직접 그립니다. 완전 블랙 모드에는 적용되지 않습니다</string>
+    <string name="use_gradient_background_description_off_auto">앱 기본 배경을 사용합니다. 완전 블랙 모드에는 적용되지 않습니다</string>
     <string name="category_dark_mode">다크 모드</string>
     <string name="category_automation">자동화</string>
     <string name="dark_mode_settings">다크 모드 설정</string>
     <string name="app_theme_short">앱</string>
     <string name="night_mode_short">Android Auto</string>
-    <string name="aa_monochrome">Android Auto 흑백 모드 적용</string>
-    <string name="aa_monochrome_description">야간 주행을 위해 Android Auto의 색감을 줄입니다. GLES 뷰 모드가 필요합니다. 다크 모드가 켜져 있을 때만 적용됩니다</string>
+    <string name="aa_monochrome">Android Auto 흑백 모드</string>
+    <string name="aa_monochrome_description">야간 주행을 위해 Android Auto 화면의 색감을 줄입니다. GLES 뷰 모드가 필요하며, 다크 모드가 켜져 있을 때만 적용됩니다</string>
     <string name="aa_desaturation">채도 감소</string>
-    <string name="aa_desaturation_description">채도 감소 정도를 제어합니다. 다크 모드가 켜져 있을 때만 적용됩니다</string>
+    <string name="aa_desaturation_description">채도를 얼마나 줄일지 설정합니다. 다크 모드가 켜져 있을 때만 적용됩니다</string>
     <string name="gles_required_title">GLES 필요</string>
-    <string name="gles_required_message">흑백 모드는 비디오 출력에 그레이스케일 필터를 적용하기 위해 GLES 렌더링이 필요합니다. GLES를 활성화하시겠습니까?</string>
+    <string name="gles_required_message">흑백 모드를 사용하려면 비디오 출력에 그레이스케일 필터를 적용할 수 있는 GLES 렌더링이 필요합니다. GLES를 활성화하시겠습니까?</string>
     <string name="enable_gles">GLES 활성화</string>
     <string name="category_navigation">내비게이션</string>
     <string name="category_wireless">무선 연결</string>
 
     <string name="reconnection_required_title">재연결 필요</string>
-    <string name="reconnection_required_message">기기가 대기 상태입니다. Android Auto를 다시 시작하려면 USB 케이블을 뽑았다가 다시 연결하세요.</string>
+    <string name="reconnection_required_message">기기가 대기 중입니다. Android Auto를 다시 시작하려면 USB 케이블을 뽑았다가 다시 연결하세요.</string>
 
-    <string name="bluetooth_address_s">Bluetooth 주소</string>
-    <string name="enter_bluetooth_mac">Bluetooth MAC 입력</string>
+    <string name="bluetooth_address_s">블루투스 주소</string>
+    <string name="enter_bluetooth_mac">블루투스 MAC 입력</string>
     <string name="reset">초기화</string>
-    <string name="gps_for_navigation">내비게이션용 GPS</string>
-    <string name="gps_for_navigation_description">내비게이션에 GPS를 사용합니다</string>
+    <string name="reset_settings">기본값으로 초기화</string>
+    <string name="reset_settings_confirm">모든 설정을 기본값으로 초기화하시겠습니까? 앱이 재시작됩니다.</string>
+    <string name="reset_settings_description">모든 설정, 캐시 데이터, 자동 연결 설정을 기본값으로 초기화합니다. 초기화 후 앱이 재시작됩니다.</string>
+    <string name="gps_for_navigation">헤드유닛 GPS 사용</string>
+    <string name="gps_for_navigation_description">헤드유닛의 GPS 위치를 Android Auto 내비게이션에서 사용합니다</string>
     <string name="enabled">활성화됨</string>
     <string name="disabled">비활성화됨</string>
     <string name="resolution">해상도</string>
@@ -97,7 +101,7 @@
     <string name="margin_bottom">아래쪽</string>
 
     <string name="start_in_fullscreen_mode">화면 모드</string>
-    <string name="start_in_fullscreen_mode_description">시스템 표시줄(상태 표시줄 및 내비게이션 바)을 처리하는 방식을 선택합니다.</string>
+    <string name="start_in_fullscreen_mode_description">시스템 표시줄(상태 표시줄 및 내비게이션 바)을 표시하는 방식을 선택합니다.</string>
     <string name="fullscreen_none">기본(모든 표시줄 보임)</string>
     <string name="fullscreen_immersive">몰입형(노치 영역 사용)</string>
     <string name="fullscreen_status_only">상태 표시줄만 숨김</string>
@@ -105,7 +109,7 @@
     <string name="fullscreen_immersive_avoid_notch_desc">모든 표시줄을 숨기고, 노치/컷아웃에 화면이 가려지지 않도록 여백을 추가합니다.</string>
 
     <string name="usb_status">USB 상태: %s</string>
-    <string name="projection_status">프로젝션 상태: %s</string>
+    <string name="projection_status">화면 출력 상태: %s</string>
     <string name="connected">연결됨</string>
     <string name="disconnected">연결 해제됨</string>
     <string name="running">실행 중</string>
@@ -115,27 +119,32 @@
     <string name="press_back_again_to_exit">뒤로 버튼을 한 번 더 누르면 종료됩니다.</string>
     <string name="back">뒤로</string>
     <string name="debug_mode">디버그 모드</string>
-    <string name="debug_mode_description">자세한 로깅을 활성화합니다.</string>
+    <string name="debug_mode_description">자세한 로그 기록을 활성화합니다.</string>
     <string name="log_level">로그 레벨</string>
-    <string name="log_level_description">내보낼 로그 레벨을 필터링합니다.</string>
-    <string name="start_log_capture">로그 캡처 시작</string>
+    <string name="log_level_description">내보낼 로그 레벨을 선택합니다.</string>
+    <string name="log_source">로그 수집 방식</string>
+    <string name="log_source_logcat">Logcat</string>
+    <string name="log_source_applog_file">앱 로그 파일</string>
+    <string name="start_log_capture">로그 기록 시작</string>
     <string name="start_log_capture_description">디버깅을 위해 전체 로그를 기록합니다.</string>
-    <string name="start_log_capture_in_applog_file">Log 메시지는 캡처가 활성화된 동안에만 파일에 기록됩니다</string>
-    <string name="start_log_capture_in_silent">로그 기록을 시작할 수 없습니다. 무음 로그 레벨이 선택되어 있습니다.</string>
-    <string name="stop_log_capture">로그 캡처 중지</string>
+    <string name="start_log_capture_in_applog_file">로그 기록을 켠 동안에만 로그가 파일에 저장됩니다</string>
+    <string name="start_log_capture_in_silent">로그 기록을 시작할 수 없습니다. 로그 레벨이 Silent로 설정되어 있습니다.</string>
+    <string name="stop_log_capture">로그 기록 중지</string>
     <string name="stop_log_capture_description">로그 기록 중입니다… 중지하려면 탭하세요.</string>
     <string name="export_logs">로그 내보내기</string>
     <string name="export_logs_description">디버깅용 로그를 저장합니다.</string>
-    <string name="not_set">설정 안 됨</string>
-    <string name="keymap_description">헤드 유닛의 키 바인딩을 변경합니다.</string>
 
-    <string name="key_soft_left">소프트 왼쪽</string>
-    <string name="key_soft_right">소프트 오른쪽</string>
+
+    <string name="not_set">설정 안 됨</string>
+    <string name="keymap_description">헤드유닛의 키 할당을 변경합니다.</string>
+
+    <string name="key_soft_left">왼쪽 소프트키</string>
+    <string name="key_soft_right">오른쪽 소프트키</string>
     <string name="key_dpad_up">D-Pad 위쪽</string>
     <string name="key_dpad_down">D-Pad 아래쪽</string>
     <string name="key_dpad_left">D-Pad 왼쪽</string>
     <string name="key_dpad_right">D-Pad 오른쪽</string>
-    <string name="key_dpad_center">D-Pad 가운데(OK)</string>
+    <string name="key_dpad_center">D-Pad 중앙(OK)</string>
     <string name="key_media_play">미디어 재생</string>
     <string name="key_media_pause">미디어 일시정지</string>
     <string name="key_media_play_pause">미디어 재생/일시정지</string>
@@ -153,7 +162,6 @@
     <string name="key_button_a">A 버튼(선택)</string>
     <string name="key_button_b">B 버튼(뒤로)</string>
 
-
     <!-- Language Settings -->
     <string name="app_language">앱 언어</string>
     <string name="system_default">시스템 기본값</string>
@@ -162,41 +170,46 @@
     <!-- Categories for SettingsFragment -->
     <string name="category_general">일반</string>
     <string name="auto_start_self_mode">단독 모드 자동 시작</string>
-    <string name="auto_start_self_mode_description">앱이 열릴 때 단독 모드를 자동으로 시작합니다.</string>
+    <string name="auto_start_self_mode_description">앱 실행 시 단독 모드를 자동으로 시작합니다.</string>
     <string name="usb_auto_connect">USB 자동 연결</string>
-    <string name="usb_auto_connect_description">앱이 열릴 때 알려진 USB 기기에 자동으로 연결합니다.</string>
-    <string name="auto_start_bt_label">Bluetooth 연결 시 자동 시작</string>
-    <string name="auto_start_bt_description">특정 Bluetooth 기기가 연결되면 Headunit Revived를 자동으로 엽니다.</string>
+    <string name="usb_auto_connect_description">앱 실행 시 알려진 USB 기기에 자동으로 연결합니다.</string>
+    <string name="auto_start_bt_label">블루투스 연결 시 자동 시작</string>
+    <string name="auto_start_bt_description">특정 블루투스 기기가 연결되면 Headunit Revived를 자동으로 실행합니다.</string>
     <string name="auto_start_wifi_label">Wi-Fi 연결 시 자동 시작</string>
     <string name="auto_start_wifi_description">특정 Wi-Fi SSID에 연결될 때 Headunit Revived를 자동으로 실행합니다.</string>
     <string name="auto_start_wifi_ssid_label">Wi-Fi SSID</string>
-    <string name="auto_start_wifi_ssid_description">이 Wi-Fi SSID에 연결되어 있을 때만 연결을 시도합니다</string>
+    <string name="auto_start_wifi_ssid_description">이 Wi-Fi SSID에 연결된 경우에만 자동 시작을 시도합니다</string>
     <string name="auto_start_wifi_warning">레거시 기능: 백그라운드 제한으로 인해 Android 8 이상에서는 동작이 불안정할 수 있습니다. 앱을 배터리 최적화 대상에서 제외했는지 확인하세요.</string>
     <string name="enter_wifi_ssid">Wi-Fi SSID를 입력하세요</string>
     <string name="wifi_ssid_not_set">설정 안 됨</string>
     <string name="listen_for_usb_devices_label">USB 기기 감지</string>
     <string name="listen_for_usb_devices_description">USB 기기가 연결되면 Android 시스템 프롬프트를 표시합니다.</string>
     <string name="auto_start_usb_label">USB 연결 시 자동 시작</string>
-    <string name="auto_start_usb_description">USB 기기가 연결되면 앱을 자동으로 열고 연결을 시도합니다</string>
+    <string name="auto_start_usb_description">USB 기기가 연결되면 앱을 자동으로 실행하고 연결을 시도합니다</string>
     <string name="auto_start_settings">자동 시작 설정</string>
-    <string name="auto_start_settings_description">앱이 자동으로 시작되는 조건을 설정합니다</string>
-    <string name="auto_start_oem_warning">이 기기에서는 앱의 자동 시작을 허용하고, 배터리 최적화 또는 백그라운드 제한을 해제해야 할 수 있습니다.\n\nQuick Boot(빠른 부팅)를 사용하는 헤드 유닛에서는 자동 시작이 작동하지 않을 수 있습니다. 시스템 설정에서 \"DuraSpeed\"를 찾아 이 앱을 허용하세요. 일부 헤드 유닛에서는 DuraSpeed가 숨겨져 있어 \"Hidden Settings\" 같은 앱으로 찾아야 할 수 있습니다. DuraSpeed가 없으면 Quick Boot를 비활성화해 보세요.</string>
+    <string name="auto_start_settings_description">앱 자동 시작 조건을 설정합니다</string>
+    <string name="auto_start_oem_warning">이 기기에서는 이 앱의 자동 시작을 허용하고, 배터리 최적화 대상에서 제외하거나 백그라운드 제한을 해제해야 할 수 있습니다.\n\nQuick Boot(빠른 부팅)를 사용하는 헤드유닛에서는 자동 시작이 작동하지 않을 수 있습니다. 시스템 설정에서 \"DuraSpeed\"를 찾아 이 앱을 허용하세요. 일부 헤드유닛에서는 DuraSpeed가 숨겨져 있어 \"Hidden Settings\" 같은 앱으로 찾아야 할 수 있습니다. DuraSpeed가 없으면 Quick Boot를 비활성화해 보세요.</string>
     <string name="auto_start_on_boot_label">부팅 시 자동 시작</string>
     <string name="auto_start_on_boot_description">기기가 부팅될 때 앱을 자동으로 실행합니다. Android 10 이상에서는 \'다른 앱 위에 표시\' 권한이 필요합니다</string>
     <string name="auto_start_screen_on_label">화면 켜짐 시 자동 실행</string>
-    <string name="auto_start_screen_on_description">화면이 켜질 때마다 앱을 자동으로 실행합니다. 완전히 종료되지 않거나 빠른 부팅 모드를 사용해 다른 자동 실행 옵션이 작동하지 않는 헤드 유닛에 적합합니다. 휴대전화나 태블릿에서는 권장하지 않습니다.</string>
-    <string name="select_bt_device">Bluetooth 기기 선택</string>
+    <string name="auto_start_screen_on_description">화면이 켜질 때마다 앱을 자동으로 실행합니다. 완전히 종료되지 않거나 빠른 부팅 모드를 사용해 다른 자동 실행 옵션이 작동하지 않는 헤드유닛에 적합합니다. 휴대폰이나 태블릿에서는 권장하지 않습니다.</string>
+    <string name="select_bt_device">블루투스 기기 선택</string>
     <string name="bt_device_not_set">설정 안 됨</string>
-    <string name="bt_permission_denied_title">Bluetooth 권한 필요</string>
-    <string name="bt_permission_denied_message">페어링된 기기를 선택하려면 Bluetooth 권한이 필요합니다. 앱 설정에서 권한을 허용하세요.</string>
-    <string name="overlay_permission_title">백그라운드 시작 권한</string>
-    <string name="overlay_permission_description">Bluetooth 기기가 연결될 때 Headunit Revived를 자동으로 실행하려면 다음 화면에서 \"다른 앱 위에 표시\" 권한을 허용하세요.</string>
+    <string name="bt_permission_denied_title">블루투스 권한 필요</string>
+    <string name="bt_permission_denied_message">페어링된 기기를 선택하려면 블루투스 권한이 필요합니다. 앱 설정에서 권한을 허용하세요.</string>
+    <string name="overlay_permission_title">백그라운드 실행 권한</string>
+    <string name="overlay_permission_description">블루투스 기기가 연결될 때 Headunit Revived를 자동으로 실행하려면 다음 화면에서 \"다른 앱 위에 표시\" 권한을 허용하세요.</string>
     <string name="open_settings">설정</string>
     <string name="right_hand_drive">우핸들</string>
     <string name="right_hand_drive_description">우핸들 차량에 맞게 UI를 배치합니다</string>
     <string name="wireless_connection_settings">무선 연결 설정</string>
     <string name="category_graphic">그래픽</string>
-    <string name="custom_insets">사용자 지정 인셋(여백)</string>
+
+    <string name="static_bssid_title">고정 BSSID</string>
+    <string name="static_bssid_enter_value">BSSID 입력(XX:XX:XX:XX:XX:XX)</string>
+    <string name="static_bssid_desc">시스템 권한에 의해 자동 감지가 차단된 경우 무선 핸드셰이크에 사용할 BSSID를 수동으로 설정합니다</string>
+
+    <string name="custom_insets">사용자 지정 화면 여백</string>
     <string name="inset_top">위쪽</string>
     <string name="inset_bottom">아래쪽</string>
     <string name="inset_left">왼쪽</string>
@@ -205,23 +218,26 @@
 
     <!-- Video Settings -->
     <string name="category_video">비디오</string>
-    <string name="force_software_decoding">소프트웨어 디코딩 강제 사용</string>
+    <string name="force_software_decoding">소프트웨어 디코딩 강제 적용</string>
     <string name="force_software_decoding_description">일부 기기에서 문제를 해결할 수 있지만 성능이 저하될 수 있습니다</string>
+    <string name="software_video_decoder">소프트웨어 디코더 선택</string>
+    <string name="software_video_decoder_bundled">내장 FFmpeg</string>
+    <string name="software_video_decoder_device">기기 MediaCodec</string>
     <string name="wireless_mode">무선 모드</string>
-    <string name="wireless_mode_description">앱이 무선으로 연결되는 방법을 선택합니다(수동 목록, 휴대폰 자동 검색 또는 Wireless Helper 모드)</string>
+    <string name="wireless_mode_description">무선 연결 방식을 선택합니다(수동 목록, 휴대폰 자동 검색 또는 Wireless Helper 모드)</string>
     <string-array name="wireless_connection_modes">
         <item>수동(목록)</item>
-        <item>자동 검색(헤드 유닛 서버)</item>
+        <item>자동 검색(헤드유닛 서버)</item>
         <item>Wireless Helper(휴대폰 대기)</item>
         <item>Native Android Auto(공식 핸드셰이크)</item>
     </string-array>
-    <string name="auto_connect_last_session">최근 세션 자동 연결</string>
-    <string name="auto_connect_last_session_description">앱 시작 시 마지막으로 사용한 기기에 자동으로 다시 연결합니다</string>
+    <string name="auto_connect_last_session">최근 기기 자동 연결</string>
+    <string name="auto_connect_last_session_description">앱 시작 시 최근 사용한 기기에 자동으로 다시 연결합니다</string>
     <string name="auto_connect_single_usb">USB 기기 자동 연결</string>
-    <string name="auto_connect_single_usb_description">호환되는 기기가 하나만 있을 때 자동으로 연결합니다</string>
+    <string name="auto_connect_single_usb_description">연결 가능한 USB 기기가 하나만 감지되면 자동으로 연결합니다</string>
     <string name="auto_connect_settings">자동 연결 설정</string>
     <string name="auto_connect_settings_description">자동 연결 방법과 우선순위를 설정합니다</string>
-    <string name="auto_connect_help">앱이 열릴 때 자동으로 실행되는 연결 방법입니다. 원하는 방법을 활성화한 뒤 드래그하여 순서를 설정하세요. 활성화된 방법 중 먼저 성공한 방법이 사용됩니다.</string>
+    <string name="auto_connect_help">앱 실행 시 사용할 자동 연결 방법입니다. 원하는 방법을 활성화한 뒤 드래그하여 순서를 설정하세요. 활성화된 방법 중 먼저 성공한 방법이 사용됩니다.</string>
     <string name="auto_connect_priority">우선순위 %d</string>
     <string name="auto_connect_all_disabled">모두 비활성화됨</string>
     <string name="drag_to_reorder">드래그하여 순서 변경</string>
@@ -236,37 +252,39 @@
     <string name="cancel">취소</string>
     <string name="enable">활성화</string>
     <string name="pref_stretch_screen_title">화면에 맞게 늘리기</string>
-    <string name="pref_stretch_screen_summary">화면 비율을 무시하고 전체 디스플레이를 채웁니다(검정색 바 제거)</string>
-    <string name="forced_scale">강제 화면 크기 조정(레거시 수정)</string>
+    <string name="pref_stretch_screen_summary">화면 비율을 무시하고 전체 화면을 채웁니다(검정색 바 제거)</string>
+    <string name="forced_scale">강제 화면 배율 조정(구형 기기 보정)</string>
     <string name="forced_scale_description">SurfaceView를 사용하는 일부 구형 기기에서 화면 크기 조정 문제를 보정합니다. 이미지가 왜곡되거나 위치가 어긋나 보일 때만 사용하세요.</string>
 
 
     <!-- Audio Settings -->
     <string name="category_audio">오디오</string>
     <string name="enable_audio_sink">오디오 수신</string>
-    <string name="enable_audio_sink_description">비활성화되면 헤드 유닛이 오디오를 수신하지 않습니다. 소리는 휴대폰에서 재생됩니다.</string>
+    <string name="enable_audio_sink_description">비활성화 시 헤드유닛이 오디오를 수신하지 않고, 소리는 휴대폰에서 재생됩니다.</string>
+    <string name="static_audio_focus">오디오 포커스 고정</string>
+    <string name="static_audio_focus_description">일반 헤드유닛에서 오디오 출력이 끊기는 문제를 방지하기 위해 휴대폰이 오디오 포커스를 항상 유지 중인 것으로 인식하게 합니다. 내비게이션 음성 안내 중에는 다른 오디오 볼륨을 자동으로 낮춥니다.</string>
     <string name="separate_audio_streams">오디오 스트림 분리</string>
     <string name="separate_audio_streams_description">하나의 멀티미디어 스트림 대신 음악, 통화, 알림에 별도의 오디오 채널을 사용합니다(일부 기기에서는 정상적으로 작동하지 않을 수 있음).</string>
     <string name="use_aac_audio">AAC 오디오 사용</string>
-    <string name="use_aac_audio_description">대역폭을 절약하기 위해 오디오에 AAC 코덱을 사용합니다(실험적).</string>
-    <string name="audio_volume_offset">오디오 볼륨 오프셋</string>
-    <string name="media_volume_offset">미디어 볼륨 오프셋</string>
-    <string name="assistant_volume_offset">어시스턴트 볼륨 오프셋</string>
-    <string name="navigation_volume_offset">내비게이션 볼륨 오프셋</string>
+    <string name="use_aac_audio_description">대역폭 절약을 위해 오디오에 AAC 코덱을 사용합니다(실험적).</string>
+    <string name="audio_volume_offset">오디오 볼륨 보정</string>
+    <string name="media_volume_offset">미디어 볼륨 보정</string>
+    <string name="assistant_volume_offset">어시스턴트 볼륨 보정</string>
+    <string name="navigation_volume_offset">내비게이션 볼륨 보정</string>
     <string name="microphone_settings">마이크 설정</string>
     <string name="microphone_settings_description">마이크 입력 및 오디오 처리를 설정합니다.</string>
     <string name="mic_input_source">마이크 입력 소스</string>
-    <string name="mic_input_source_description">마이크에 사용할 오디오 소스를 선택합니다.</string>
+    <string name="mic_input_source_description">마이크 입력에 사용할 오디오 소스를 선택합니다.</string>
     <string-array name="mic_input_sources">
         <item>기본값(시스템에서 결정)</item>
-        <item>내장 마이크(원시 입력)</item>
+        <item>내장 마이크(가공 없음)</item>
         <item>음성 인식(노이즈 감소)</item>
         <item>음성 통화(에코 및 노이즈 제거)</item>
-        <item>Bluetooth 헤드셋(SCO)</item>
+        <item>블루투스 헤드셋(SCO)</item>
     </string-array>
     <string name="mic_echo_canceler">에코 제거(AEC)</string>
-    <string name="mic_echo_canceler_description">마이크의 에코 제거를 시도합니다. 소리가 들리지 않거나 왜곡되면 비활성화하세요.</string>
-    <string name="mic_noise_suppressor">노이즈 억제(NS)</string>
+    <string name="mic_echo_canceler_description">마이크 입력의 에코를 줄입니다. 소리가 들리지 않거나 왜곡되면 비활성화하세요.</string>
+    <string name="mic_noise_suppressor">소음 억제(NS)</string>
     <string name="mic_noise_suppressor_description">배경 소음을 줄입니다. 목소리가 먹먹하게 들리면 비활성화하세요.</string>
     <string name="mic_auto_gain_control">자동 게인 제어(AGC)</string>
     <string name="mic_auto_gain_control_description">마이크 음량을 자동으로 조절합니다. 음량이 불안정하면 비활성화하세요.</string>
@@ -274,10 +292,10 @@
 
     <!-- Info Settings -->
     <string name="category_info">정보</string>
-    <string name="about">정보 &amp; 지원</string>
+    <string name="about">정보 및 지원</string>
     <string name="about_description">Headunit Revived에 대한 자세한 정보를 확인하세요</string>
     <string name="version">버전</string>
-    <string name="about_title">Headunit Revived에 대해</string>
+    <string name="about_title">Headunit Revived 정보</string>
     <string name="copyright">© 2025-%d André Rinas</string>
 
     <!-- Safety Disclaimer -->
@@ -299,28 +317,56 @@
     <string name="auto_connecting_usb">USB 기기에 자동 연결 중…</string>
     <string name="already_connected">이미 연결됨</string>
     <string name="already_scanning">이미 검색 중…</string>
-    <string name="searching_headunit_server">헤드 유닛 서버 검색 중…</string>
+    <string name="searching_headunit_server">헤드유닛 서버 검색 중…</string>
     <string name="already_searching_phone">이미 휴대폰을 검색 중입니다…</string>
     <string name="searching_phone">휴대폰 검색 중…</string>
     <string name="key_mappings_reset">키 매핑 초기화</string>
     <string name="press_key_to_assign">\'%s\'에 할당할 키를 누르세요…</string>
     <string name="key_assigned">\'%1$s\'이(가) \'%2$s\'에 할당되었습니다</string>
-    <string name="last_key_press">마지막으로 누른 키: %1$s(%2$d)</string>
+    <string name="last_key_press">마지막으로 누른 키: %1$s (%2$d)</string>
     <string name="scan">검색</string>
     <string name="scanning_network">네트워크 검색 중…</string>
     <string name="found_connecting">%s 발견, 연결 중…</string>
     <string name="no_devices_found">발견된 기기 없음</string>
-    <string name="unsaved_changes">저장되지 않은 변경사항</string>
-    <string name="unsaved_changes_message">저장되지 않은 변경사항이 있습니다. 변경사항을 버리시겠습니까?</string>
+    <string name="unsaved_changes">저장되지 않은 변경 사항</string>
+    <string name="unsaved_changes_message">저장되지 않은 변경 사항이 있습니다. 변경 사항을 버리시겠습니까?</string>
     <string name="discard">버리기</string>
-    <string name="stopping_service">변경사항을 적용하기 위해 서비스를 중지하는 중…</string>
+    <string name="stopping_service">변경 사항을 적용하기 위해 서비스를 중지하는 중…</string>
     <string name="settings_saved">설정이 저장되었습니다</string>
+    <string name="category_backup">백업 및 복원</string>
+    <string name="export_settings">설정 내보내기</string>
+    <string name="export_settings_description">현재 설정을 JSON 파일로 저장합니다</string>
+    <string name="export_settings_choose_location">저장 위치 선택</string>
+    <string name="export_settings_downloads">다운로드 폴더에 저장</string>
+    <string name="export_settings_app_folder">앱 백업 폴더에 저장</string>
+    <string name="import_settings">설정 가져오기</string>
+    <string name="import_settings_description">백업 파일에서 설정을 복원합니다</string>
+    <string name="import_settings_choose_file">백업 파일 선택</string>
+    <string name="import_settings_downloads">다운로드 폴더에서 가져오기</string>
+    <string name="import_settings_app_folder">앱 백업 폴더에서 가져오기</string>
+    <string name="settings_exported">설정 내보내기 완료</string>
+    <string name="settings_backup_saved_to">설정 백업 저장 위치:\n%1$s</string>
+    <string name="settings_export_failed">설정 내보내기 실패: %1$s</string>
+    <string name="settings_import_failed">설정 가져오기 실패: %1$s</string>
+    <string name="settings_imported">설정 가져오기 완료: %1$d개 적용됨, %2$d개 건너뜀</string>
+    <string name="import_settings_discard_pending">백업을 가져오면 저장되지 않은 설정 변경 사항이 취소됩니다. 계속하시겠습니까?</string>
+    <string name="reset_settings_confirm_message">모든 설정이 기본값으로 초기화됩니다. 백업과 앱 파일은 삭제되지 않습니다. 계속하시겠습니까?</string>
+    <string name="reset_settings_discard_pending">설정을 초기화하면 저장되지 않은 설정 변경 사항이 취소됩니다. 계속하시겠습니까?</string>
+    <string name="settings_reset">설정을 기본값으로 초기화했습니다</string>
+    <string name="settings_reset_failed">설정 초기화 실패: %1$s</string>
+    <string name="storage_permission_denied_backup">저장소 권한이 거부되었습니다. 다운로드 폴더를 사용할 수 없습니다.</string>
+    <string name="no_file_picker_title">사용 가능한 파일 선택 앱 없음</string>
+    <string name="no_file_picker_message">이 기기에는 호환되는 파일 선택 앱이 없습니다. 대신 다운로드 폴더 또는 앱 백업 폴더를 사용할 수 있습니다.</string>
+    <string name="no_settings_backups_title">백업을 찾을 수 없음</string>
+    <string name="no_settings_backups_message">앱 백업 폴더에서 Headunit Revived 백업을 찾을 수 없습니다. 먼저 앱 백업 폴더로 백업을 내보낸 뒤 다시 시도하세요.</string>
+    <string name="no_settings_backups_downloads_message">다운로드 폴더에서 Headunit Revived 백업을 찾을 수 없습니다. 먼저 다운로드 폴더로 백업을 내보낸 뒤 다시 시도하세요.</string>
+    <string name="share_settings_backup">설정 백업 공유</string>
     <string name="logs_exported">로그 내보내기 완료</string>
     <string name="log_saved_to">로그 저장 위치:\n%s</string>
     <string name="share">공유</string>
     <string name="close">닫기</string>
     <string name="failed_export_logs">로그 내보내기 실패</string>
-    <string name="failed_export_in_silent_logs">로그를 내보낼 수 없습니다. 무음 로그 레벨이 선택되어 있습니다.</string>
+    <string name="failed_export_in_silent_logs">로그를 내보낼 수 없습니다. 로그 레벨이 Silent로 설정되어 있습니다</string>
     <string name="switching_to_android_auto">Android Auto로 전환 중…</string>
     <string name="switch_failed">전환 실패</string>
     <string name="requesting_usb_permission">USB 권한 요청 중…</string>
@@ -329,7 +375,7 @@
     <string name="success">성공</string>
     <string name="failed">실패</string>
     <string name="failed_start_android_auto">Android Auto 시작 실패</string>
-    <string name="failed_self_mode_android10">Android 10(Android Auto 16.4 이상)에서는 Google에 의해 단독 모드가 차단될 수 있습니다.</string>
+    <string name="failed_self_mode_android10">Android 10(Android Auto 16.4 이상)에서는 Google 정책으로 단독 모드가 차단될 수 있습니다.</string>
     <string name="android_auto_starting">Android Auto 시작 중…</string>
     <string name="connection_interrupted">연결 끊김</string>
     <string name="connection_interrupted_detail">다시 시도 중…</string>
@@ -337,15 +383,15 @@
     <string name="reset_usb_option">USB 연결 초기화</string>
     <string name="reset_usb_timeout">USB 기기를 찾을 수 없습니다. 연결을 확인하세요.</string>
     <string name="notification_service_running">Headunit Revived 실행 중</string>
-    <string name="notification_projection_active">Android Auto가 프로젝션 중입니다</string>
+    <string name="notification_projection_active">Android Auto 화면 출력 중</string>
     <string name="shortcut_connect_title">연결</string>
-    <string name="shortcut_connect_desc">마지막 휴대폰에 자동 연결</string>
+    <string name="shortcut_connect_desc">최근 사용한 휴대폰에 자동 연결</string>
     <string name="shortcut_selfmode_title">단독 모드</string>
     <string name="shortcut_selfmode_desc">이 기기에서 Android Auto 시작</string>
     <string name="shortcut_disconnect_title">연결 해제</string>
     <string name="shortcut_disconnect_desc">현재 세션 종료</string>
     <string name="shortcut_exit_title">앱 종료</string>
-    <string name="shortcut_exit_desc">모든 서비스를 중지하고 앱을 닫습니다</string>
+    <string name="shortcut_exit_desc">모든 서비스를 중지하고 앱을 종료합니다</string>
     <string name="shortcut_night_mode_auto_title">모드: 자동</string>
     <string name="shortcut_night_mode_auto_desc">자동 야간 모드 복원</string>
     <string name="shortcut_night_mode_day_title">모드: 주간</string>
@@ -353,7 +399,7 @@
     <string name="shortcut_night_mode_night_title">모드: 야간</string>
     <string name="shortcut_night_mode_night_desc">야간 모드로 강제 전환</string>
     <string name="setup_welcome_title">빠른 설정</string>
-    <string name="setup_welcome_msg">이 설정 마법사는 Android Auto를 더 원활하게 사용할 수 있도록 기기에 맞는 최적의 설정을 선택하는 데 도움을 줍니다.\n\n이 설정은 나중에 언제든지 변경할 수 있으며, 앱 설정에서 이 마법사를 다시 시작할 수도 있습니다.</string>
+    <string name="setup_welcome_msg">빠른 설정 마법사는 Android Auto를 더 원활하게 사용할 수 있도록 기기에 맞는 최적의 설정을 선택하는 데 도움을 줍니다.\n\n이 설정은 나중에 언제든지 변경할 수 있으며, 앱 설정에서 이 마법사를 다시 시작할 수도 있습니다.</string>
     <string name="setup_start">시작</string>
     <string name="setup_size_title">디스플레이 크기</string>
     <string name="setup_size_phone">휴대폰 / 소형(4-6\")</string>
@@ -361,8 +407,8 @@
     <string name="setup_size_standard">표준(9-10\")</string>
     <string name="setup_size_large">대형(11\" 이상)</string>
     <string name="setup_orientation_title">기기 방향</string>
-    <string name="setup_orientation_landscape">가로(Horizontal)</string>
-    <string name="setup_orientation_portrait">세로(Vertical)</string>
+    <string name="setup_orientation_landscape">가로</string>
+    <string name="setup_orientation_portrait">세로</string>
     <string name="setup_result_title">최적화 완료</string>
     <string name="setup_apply">적용</string>
     <string name="setup_widescreen_detected">와이드스크린 디스플레이가 감지되었습니다.</string>
@@ -371,14 +417,14 @@
 
     <!-- Navigation notifications (from any AA nav app) -->
     <string name="show_navigation_notifications">내비게이션 알림</string>
-    <string name="show_navigation_notifications_description">알림에 \"X m 후 Y\" 형식의 길 안내와 현재 도로를 표시합니다(디버깅용)</string>
+    <string name="show_navigation_notifications_description">상단 알림창에 \"X m 후 Y\" 형식의 길 안내와 현재 도로명을 표시합니다(디버깅용)</string>
     <string name="media_session_aa_status_placeholder">연결됨</string>
     <string name="sync_media_session_aa_metadata">Android Auto 재생 정보를 미디어 세션에 표시</string>
-    <string name="sync_media_session_aa_metadata_description">휴대폰의 트랙 제목, 아티스트, 재생 시간, 앨범 아트를 시스템 미디어 세션과 미디어 알림에 표시합니다.</string>
+    <string name="sync_media_session_aa_metadata_description">휴대폰의 곡 제목, 아티스트, 재생 시간, 앨범 아트를 시스템 미디어 세션과 미디어 알림에 표시합니다.</string>
     <string name="nav_notification_channel_name">내비게이션</string>
     <string name="nav_notification_channel_description">Android Auto의 길 안내 업데이트</string>
     <string name="nav_notification_title_format">%1$d m 후 %2$s</string>
-    <string name="nav_notification_street_format">현재 도로: %1$s</string>
+    <string name="nav_notification_street_format">현재 주행 중인 도로: %1$s</string>
     <string name="nav_action_unknown">안내</string>
     <string name="nav_action_depart">출발</string>
     <string name="nav_action_name_change">도로명 변경</string>
@@ -386,8 +432,8 @@
     <string name="nav_action_turn">회전</string>
     <string name="nav_action_sharp_turn">급회전</string>
     <string name="nav_action_uturn">유턴</string>
-    <string name="nav_action_on_ramp">도로 진입</string>
-    <string name="nav_action_off_ramp">진출로로 나가기</string>
+    <string name="nav_action_on_ramp">진입로 진입</string>
+    <string name="nav_action_off_ramp">진출로 이용</string>
     <string name="nav_action_merge">합류</string>
     <string name="nav_action_roundabout_enter">회전교차로 진입</string>
     <string name="nav_action_roundabout_exit">회전교차로 진출</string>
@@ -397,13 +443,13 @@
     <string name="nav_action_ferry_train">페리/열차</string>
     <string name="nav_action_destination">도착</string>
     <string name="show_fps_counter">FPS 카운터 표시</string>
-    <string name="show_fps_counter_description">프로젝션 중 왼쪽 상단에 실시간 FPS 오버레이를 표시합니다.</string>
+    <string name="show_fps_counter_description">Android Auto 화면 출력 중 왼쪽 상단에 실시간 FPS 오버레이를 표시합니다.</string>
 
     <!-- Auto-start permission strings -->
-    <string name="reopen_on_reconnection_label">재연결 시 다시 열기</string>
-    <string name="reopen_on_reconnection_description">종료 버튼을 누르면 앱이 백그라운드에서 계속 실행되며 USB 연결을 계속 감시합니다. 기기가 다시 연결되면 앱이 자동으로 다시 열립니다.</string>
-    <string name="overlay_permission_required">자동 시작에는 \'다른 앱 위에 표시\' 권한이 필요합니다</string>
-    <string name="usb_permission_denied">USB 권한이 거부되었습니다. 자동으로 연결하려면 USB 접근을 허용하세요.</string>
+    <string name="reopen_on_reconnection_label">재연결 시 앱 다시 열기</string>
+    <string name="reopen_on_reconnection_description">종료 버튼을 누르면 앱이 백그라운드에서 계속 실행되며 USB 연결을 계속 확인합니다. 기기가 다시 연결되면 앱이 자동으로 다시 열립니다.</string>
+    <string name="overlay_permission_required">자동 시작을 사용하려면 \'다른 앱 위에 표시\' 권한이 필요합니다.</string>
+    <string name="usb_permission_denied">USB 권한이 거부되었습니다. 자동으로 연결하려면 USB 접근 권한을 허용하세요.</string>
     <string name="overlay_permission_denied_auto_start_disabled">\'다른 앱 위에 표시\' 권한이 허용되지 않아 자동 시작이 비활성화되었습니다.</string>
 
     <!-- Theme -->
@@ -412,30 +458,30 @@
     <string name="enable_rotary">로터리 컨트롤러 활성화</string>
     <string name="enable_rotary_description">물리적 로터리 컨트롤러와 휠을 지원합니다. 터치스크린이 제대로 작동하지 않으면 비활성화하세요.</string>
 
-    <string name="kill_on_disconnect">연결 해제 시 앱 닫기</string>
-    <string name="kill_on_disconnect_description">Android Auto 연결이 해제되면 앱을 자동으로 닫습니다</string>
+    <string name="kill_on_disconnect">연결 해제 시 앱 종료</string>
+    <string name="kill_on_disconnect_description">Android Auto 연결이 해제되면 앱을 자동으로 종료합니다</string>
     <string name="kill_on_disconnect_warning_title">경고</string>
-    <string name="kill_on_disconnect_warning">다음 재연결 설정은 \'연결 해제 시 앱 닫기\'와 함께 사용하면 충돌합니다:\n\n%1$s\n\n헤드 유닛이 켜질 때의 초기 연결 설정(자동 연결, 자동 시작)은 그대로 동작합니다. 하지만 첫 연결 해제 후에는 재연결을 시도하지 않고 앱이 즉시 종료됩니다.\n\n참고: 일부 애프터마켓 헤드 유닛은 완전히 종료되지 않고 절전 상태로 전환됩니다. 화면만 잠기고 실제로 전원이 꺼지지 않는 휴대전화와 비슷합니다. 이 옵션을 켜면 첫 연결 해제 후 앱이 닫히며, 다음 시동 주기에서 자동으로 다시 열리지 않을 수 있습니다.\n\n위에 나열된 재연결 설정을 비활성화하시겠습니까?</string>
+    <string name="kill_on_disconnect_warning">다음 재연결 설정은 \'연결 해제 시 앱 종료\'와 함께 사용하면 충돌합니다:\n\n%1$s\n\n헤드유닛이 켜질 때의 초기 연결 설정(자동 연결, 자동 시작)은 그대로 동작합니다. 하지만 첫 연결 해제 후에는 재연결을 시도하지 않고 앱이 즉시 종료됩니다.\n\n참고: 일부 애프터마켓 헤드유닛은 완전히 종료되지 않고 절전 상태로 전환됩니다. 화면만 잠기고 실제로 전원이 꺼지지 않는 휴대폰과 비슷합니다. 이 옵션을 켜면 첫 연결 해제 후 앱이 닫히며, 다음 시동 주기에서 자동으로 다시 열리지 않을 수 있습니다.\n\n위에 나열된 재연결 설정을 비활성화하시겠습니까?</string>
     <string name="kill_on_disconnect_disable_and_enable">비활성화 후 활성화</string>
     <string name="kill_on_disconnect_enable_anyway">그래도 활성화</string>
     <string name="kill_on_disconnect_conflicts_disabled">충돌하는 설정이 비활성화되었습니다</string>
     <string name="kill_on_disconnect_boot_warning">\"부팅 시 자동 시작\" 설정이 활성화되어 있습니다. 연결 해제 시 앱이 닫히고 이 기기가 종료되지 않고 절전 상태로 전환되는 경우, 부팅 이벤트가 발생하지 않기 때문에 다음 시동 주기에서 앱이 자동으로 다시 열리지 않을 수 있습니다. 기기는 단순히 절전 상태에서 깨어납니다.</string>
-    <string name="kill_on_disconnect_screen_on_warning">\"화면 켜짐 시 자동 실행\" 설정이 활성화되어 있습니다. 이 설정은 화면이 켜질 때마다 앱을 엽니다. 연결 해제 시 앱 닫기와 함께 사용하면, 연결 해제 후 앱이 닫혔다가 화면이 다시 켜질 때 즉시 다시 열려 재시작 루프가 발생할 수 있습니다.</string>
+    <string name="kill_on_disconnect_screen_on_warning">\"화면 켜짐 시 자동 실행\" 설정이 활성화되어 있습니다. 이 설정은 화면이 켜질 때마다 앱을 엽니다. 연결 해제 시 앱 종료와 함께 사용하면, 연결 해제 후 앱이 종료되었다가 화면이 다시 켜질 때 즉시 다시 열려 재시작 루프가 발생할 수 있습니다.</string>
 
-    <string name="wifi_disabled_info">정보: Wi-Fi가 비활성화되어 있습니다.</string>
-    <string name="bt_not_enabled">Bluetooth가 비활성화되어 있습니다</string>
-    <string name="bt_permission_denied">Bluetooth 권한이 거부되었습니다. 기기를 검색할 수 없습니다.</string>
+    <string name="wifi_disabled_info">Wi-Fi가 비활성화되어 있습니다.</string>
+    <string name="bt_not_enabled">블루투스가 비활성화되어 있습니다</string>
+    <string name="bt_permission_denied">블루투스 권한이 거부되었습니다. 기기를 검색할 수 없습니다.</string>
 
     <!-- Vehicle Info Settings -->
     <string name="vehicle_info_settings">차량 정보</string>
-    <string name="vehicle_info_settings_description">휴대폰에 차량이 표시되는 방식을 설정합니다</string>
+    <string name="vehicle_info_settings_description">휴대폰에 표시될 차량 정보를 설정합니다</string>
     <string name="ui_scale">UI 배율</string>
     <string name="ui_scale_home">홈 화면</string>
     <string name="ui_scale_settings">설정 화면</string>
     <string name="category_vehicle">차량</string>
-    <string name="category_head_unit">헤드 유닛</string>
+    <string name="category_head_unit">헤드유닛</string>
     <string name="vehicle_display_name_label">표시 이름</string>
-    <string name="vehicle_display_name_description">휴대폰에 표시될 이 차량의 이름입니다</string>
+    <string name="vehicle_display_name_description">휴대폰에 표시할 차량 이름입니다</string>
     <string name="vehicle_make_label">제조사</string>
     <string name="vehicle_make_description">차량 제조사(예: Honda, Toyota)</string>
     <string name="vehicle_model_label">모델</string>
@@ -445,32 +491,32 @@
     <string name="vehicle_id_label">차량 ID</string>
     <string name="vehicle_id_description">내부 식별자로만 사용됩니다. 이 값을 변경하면 휴대폰이 다른 차량으로 인식하여 이 차량의 Android Auto 설정이 초기화됩니다.</string>
     <string name="head_unit_make_label">제조사</string>
-    <string name="head_unit_make_description">헤드 유닛 제조사</string>
+    <string name="head_unit_make_description">헤드유닛 제조사</string>
     <string name="head_unit_make_hint">휴대폰의 Android Auto 설정에 이 이름이 표시됩니다.</string>
     <string name="head_unit_model_label">모델</string>
-    <string name="head_unit_model_description">헤드 유닛 모델</string>
+    <string name="head_unit_model_description">헤드유닛 모델</string>
     <string name="vehicle_year_error_invalid">유효한 연식을 입력하세요</string>
     <string name="vehicle_year_error_max">연식은 %1$d년보다 이후일 수 없습니다</string>
     <string name="vehicle_info_restart_note">이 데이터는 연결할 때마다 Android Auto로 전송됩니다.</string>
 
     <string name="auto_enable_hotspot">Wi-Fi 핫스팟 자동 활성화</string>
-    <string name="auto_enable_hotspot_description">이 기기에서 자동으로 Wi-Fi 핫스팟을 시작합니다. 모든 기기에서 작동하지는 않습니다</string>
+    <string name="auto_enable_hotspot_description">이 기기에서 Wi-Fi 핫스팟을 자동으로 시작합니다. 일부 기기에서는 작동하지 않을 수 있습니다</string>
     <string name="hotspot_warning_title">실험적 기능</string>
     <string name="hotspot_warning_message">이 기능은 리플렉션 방식을 사용하므로 일부 기기에서는 작동하지 않을 수 있습니다. 또한 \"시스템 설정 변경\" 권한을 수동으로 허용해야 할 수 있습니다.</string>
     <string name="hotspot_permission_title">권한 필요</string>
     <string name="hotspot_permission_message">핫스팟 기능은 \"시스템 설정 변경\" 권한이 필요합니다. 다음 화면에서 허용하세요.</string>
 
-    <string name="supported_nativeaa">향상된 무선 지원</string>
-    <string name="supported_nativeaa_desc">이 기기는 더 매끄러운 Android Auto 경험을 제공하는 \"Native Wireless\" 모드를 지원합니다.\n\n이 기능을 활성화하려면 Bluetooth 캐시를 새로 고쳐야 합니다. 다음 작업을 수행하세요:\n1. 휴대폰에서 기존 페어링 제거\n2. 확인을 눌러 Bluetooth 재시작\n3. 휴대폰 다시 페어링\n\n지금 Native Android Auto 모드로 전환하시겠습니까?</string>
-    <string name="not_supported_nativeaa">Native Wireless가 지원되지 않는 것으로 보임</string>
-    <string name="not_supported_nativeaa_desc">이 기기는 Native Wireless에 필요한 Bluetooth 또는 Wi-Fi 기능을 지원하지 않을 수 있습니다. 그래도 시도할 수는 있지만, 실패하면 \"Wireless Helper\" 또는 \"Auto(헤드 유닛 서버)\" 모드를 사용하세요.</string>
+    <string name="supported_nativeaa">향상된 무선 연결 지원</string>
+    <string name="supported_nativeaa_desc">이 기기는 더 원활한 Android Auto 경험을 제공하는 \"Native Wireless\" 모드를 지원합니다.\n\n이 기능을 활성화하려면 블루투스 캐시를 새로 고쳐야 합니다. 다음 작업을 수행하세요:\n1. 휴대폰에서 기존 페어링 제거\n2. 확인을 눌러 블루투스 재시작\n3. 휴대폰 다시 페어링\n\n지금 Native Android Auto 모드로 전환하시겠습니까?</string>
+    <string name="not_supported_nativeaa">Native Wireless를 지원하지 않는 것 같습니다</string>
+    <string name="not_supported_nativeaa_desc">이 기기는 Native Wireless에 필요한 블루투스 또는 Wi-Fi 기능을 지원하지 않을 수 있습니다. 그래도 시도할 수는 있지만, 실패하면 \"Wireless Helper\" 또는 \"Auto(헤드유닛 서버)\" 모드를 사용하세요.</string>
 
     <string name="wait_for_wifi">Wi-Fi Direct 시작 전 Wi-Fi 대기</string>
-    <string name="wait_for_wifi_description">부팅 시 Wi-Fi Direct를 시작하기 전에 Wi-Fi가 연결될 때까지 대기합니다. 헤드 유닛이 전원 켜진 후 Wi-Fi에 연결하는 데 몇 초가 걸리는 경우 활성화하세요.</string>
-    <string name="wait_for_wifi_timeout">Wi-Fi 대기 시간 초과</string>
+    <string name="wait_for_wifi_description">부팅 후 Wi-Fi가 연결될 때까지 기다린 다음 Wi-Fi Direct를 시작합니다. 전원을 켠 뒤 Wi-Fi 연결에 몇 초 걸리는 헤드유닛에서 사용하세요.</string>
+    <string name="wait_for_wifi_timeout">Wi-Fi 최대 대기 시간</string>
     <string name="wireless_24ghz_warning">참고: 2.4GHz 기기에서 무선 Android Auto를 사용하면 지연, 끊김, 연결 해제가 발생할 수 있습니다. 문제가 발생하면 USB로 테스트하여 네트워크 제한이 원인인지 확인하세요.</string>
-    <string name="fake_speed_title">비디오 잠금 비활성화(가짜 속도)</string>
-    <string name="fake_speed_description">주행 중 비디오 콘텐츠가 차단되지 않도록 휴대폰에 일정한 저속(0.5 m/s)을 보고합니다. 주의해서 사용하세요.</string>
+    <string name="fake_speed_title">주행 중 영상 제한 우회(가짜 속도)</string>
+    <string name="fake_speed_description">휴대폰에 일정한 저속(0.5 m/s)을 보고해 주행 중에도 영상 콘텐츠가 차단되지 않게 합니다. 주의해서 사용하세요.</string>
     <string name="wireless_mode_helper">Wireless Helper</string>
     <string name="wireless_mode_native">Native</string>
     <string name="wireless_mode_server">Headunit Server</string>
@@ -478,13 +524,13 @@
     <string name="server_mode_manual">수동</string>
     <string name="server_mode_auto">자동</string>
 
-    <string name="helper_strategy_label">Helper 연결 방법</string>
+    <string name="helper_strategy_label">Wireless Helper 연결 방식</string>
     <string-array name="helper_strategies">
         <item>범용 Wi-Fi(NSD)</item>
         <item>Wi-Fi Direct(P2P)</item>
         <item>Google Nearby(Beta)</item>
         <item>휴대폰 핫스팟(Host)</item>
-        <item>헤드 유닛 핫스팟(Passive)</item>
+        <item>헤드유닛 핫스팟(Passive)</item>
     </string-array>
 
     <string name="select_nearby_device">Nearby 기기 선택</string>
@@ -495,103 +541,57 @@
     <string name="exit_dialog_stop">연결 해제</string>
     <string name="exit_dialog_pip">PIP 모드</string>
     <string name="exit_dialog_background">백그라운드로 이동</string>
+    <string name="exit_dialog_settings">빠른 설정</string>
     <string name="gesture_hint">팁: 왼쪽 가장자리에서 두 손가락으로 스와이프하면 종료 메뉴가 열립니다</string>
     <string name="audio_latency_multiplier">오디오 지연 배율</string>
-    <string name="audio_latency_multiplier_description">오디오 버퍼 크기를 조정합니다(낮음 = 지연 감소, 높음 = 끊김 감소)</string>
-    <string name="audio_queue_capacity">오디오 큐 용량(백프레셔)</string>
+    <string name="audio_latency_multiplier_description">오디오 버퍼 크기를 조정합니다. 낮을수록 지연이 줄고, 높을수록 끊김이 줄어듭니다</string>
+    <string name="audio_queue_capacity">오디오 큐 용량</string>
+
+    <!-- Custom loading screen -->
+    <string name="loading_screen">로딩 화면</string>
+    <string name="loading_screen_default">기본</string>
+    <string name="loading_screen_custom">사용자 지정</string>
+    <string name="loading_screen_dialog_title">사용자 지정 로딩 화면</string>
+    <string name="loading_screen_select_file">파일 선택</string>
+    <string name="loading_screen_remove">제거</string>
+    <string name="loading_screen_recommendation">권장 해상도: %1$dx%2$d</string>
+    <string name="loading_screen_supported_formats">지원 형식: 이미지(PNG, JPG, BMP, WEBP, GIF) \u2022 동영상(MP4, MKV, WEBM, 3GP) \u2022 최대: 10 MB</string>
+    <string name="loading_screen_no_media">사용자 지정 미디어가 선택되지 않았습니다</string>
+    <string name="loading_screen_file_too_large">파일이 너무 큽니다(최대 10 MB)</string>
+    <string name="loading_screen_unsupported_format">지원되지 않는 형식입니다. 이미지 또는 동영상 파일을 사용하세요</string>
+    <string name="loading_screen_file_error">선택한 파일을 불러올 수 없습니다</string>
+    <string name="loading_screen_show_text">\"Android Auto 시작 중\" 텍스트 표시</string>
+    <string name="loading_screen_tap_preview">탭해서 전체 화면 미리보기</string>
+    <string name="loading_screen_tap_to_close">아무 곳이나 탭해서 닫기</string>
+    <string name="loading_screen_keep_aspect_ratio">비율 유지</string>
+    <string name="loading_screen_scale">크기 조정</string>
+    <string name="loading_screen_recommended_aspect_ratio">권장 종횡비: %1$d:%2$d</string>
+    <string name="loading_screen_tap_fullscreen_hint">탭해서 전체 화면 미리보기</string>
+    <string name="loading_screen_loop_video">반복 재생</string>
     <string name="media_action_previous">이전</string>
     <string name="media_action_play">재생</string>
     <string name="media_action_pause">일시정지</string>
     <string name="media_action_next">다음</string>
-    <string name="error_usb_permission_failed">시스템 오류: USB 권한 대화상자를 요청하지 못했습니다.</string>
+    <string name="error_usb_permission_failed">시스템 오류: USB 권한 요청 창을 열지 못했습니다.</string>
     <string name="wifi_autostart_title">Wi-Fi 자동 시작</string>
     <string name="wifi_autostart_content">%s에 연결되었습니다. Android Auto를 시작하려면 탭하세요.</string>
 
     <!-- New strings merged from 2.3.1 -->
-    <string name="bt_devices_selected">개 기기 선택됨</string>
-    <string name="static_audio_focus">정적 오디오 포커스</string>
-    <string name="static_audio_focus_description">휴대전화가 항상 오디오 포커스를 유지하고 있는 것으로 인식하도록 강제하여 범용 헤드유닛에서 오디오 라우팅이 끊기는 현상을 방지합니다. 내비게이션 음성 안내 시 소프트웨어 음량 감쇠(덕킹)도 수행합니다.</string>
-    <string name="bluetooth_adapter_label">Bluetooth 어댑터</string>
-    <string name="bluetooth_adapter_description">핸드셰이크에 사용할 Bluetooth 어댑터/컨트롤러를 선택합니다. 듀얼 Bluetooth 시스템에서 유용합니다.</string>
-    <string name="select_bt_adapter">Bluetooth 어댑터 선택</string>
-    <!-- QR Code Generator -->
-    <string name="share_hotspot_qr_title">Wireless Helper 구성</string>
-    <string name="share_hotspot_qr_desc">휴대전화 자동 연결을 위한 QR 코드 표시</string>
-    <string name="hotspot_qr_description">Wireless Helper 구성 QR 코드</string>
-    <string name="scan_with_wireless_helper">휴대전화의 Wireless Helper에 있는 QR 스캐너를 사용하여 이 QR 코드를 스캔하세요.</string>
-    <string name="share_hotspot_qr_error">활성 Wi-Fi 핫스팟 자격 증명을 가져올 수 없습니다. 핫스팟이 켜져 있고 위치 서비스가 활성화되어 있는지 확인하세요.</string>
-
-    <!-- Brightness, quick settings, key back, backup, wireless helper QR -->
-    <string name="current_brightness_reading">현재 밝기: %d / 255</string>
-    <string name="exit_dialog_settings">빠른 설정</string>
     <string name="key_back">뒤로</string>
-    <string name="category_backup">백업</string>
-    <string name="export_settings">설정 내보내기</string>
-    <string name="export_settings_description">설정 백업을 JSON 파일로 저장</string>
-    <string name="export_settings_app_folder">앱 백업 폴더에 저장</string>
-    <string name="export_settings_downloads">다운로드에 저장</string>
-    <string name="export_settings_choose_location">저장 위치 선택</string>
-    <string name="settings_exported">설정 내보내기 완료</string>
-    <string name="settings_export_failed">설정 내보내기 실패: %1$s</string>
-    <string name="settings_backup_saved_to">설정 백업이 저장된 위치:\n%1$s</string>
-    <string name="share_settings_backup">설정 백업 공유</string>
-    <string name="import_settings">설정 가져오기</string>
-    <string name="import_settings_description">Headunit Revived 백업에서 설정 복원</string>
-    <string name="import_settings_app_folder">앱 백업 폴더에서 가져오기</string>
-    <string name="import_settings_downloads">다운로드에서 가져오기</string>
-    <string name="import_settings_choose_file">백업 파일 선택</string>
-    <string name="import_settings_discard_pending">백업을 가져오면 저장되지 않은 설정 변경 사항이 삭제됩니다. 계속할까요?</string>
-    <string name="settings_imported">설정 가져오기 완료: %1$d개 적용, %2$d개 건너뜀</string>
-    <string name="settings_import_failed">설정 가져오기 실패: %1$s</string>
-    <string name="no_settings_backups_title">백업을 찾을 수 없음</string>
-    <string name="no_settings_backups_message">앱 백업 폴더에 Headunit Revived 백업이 없습니다. 먼저 백업을 내보낸 후 여기에서 가져오세요.</string>
-    <string name="no_settings_backups_downloads_message">다운로드에 Headunit Revived 백업이 없습니다. 먼저 백업을 다운로드로 내보낸 후 여기에서 가져오세요.</string>
-    <string name="no_file_picker_title">사용 가능한 파일 선택기 없음</string>
-    <string name="no_file_picker_message">이 기기에는 호환되는 파일 선택기가 없습니다. 대신 다운로드 또는 앱 백업 폴더를 사용할 수 있습니다.</string>
-    <string name="storage_permission_denied_backup">저장소 권한이 거부되었습니다. 다운로드를 사용할 수 없습니다.</string>
-    <string name="reset_settings">기본값으로 재설정</string>
-    <string name="reset_settings_description">모든 설정, 캐시 데이터 및 자동 연결 환경설정을 지웁니다. 기본값을 적용하기 위해 앱이 다시 시작됩니다.</string>
-    <string name="reset_settings_confirm">모든 설정을 기본값으로 재설정하시겠습니까? 이 작업은 앱을 다시 시작합니다.</string>
-    <string name="reset_settings_confirm_message">모든 설정이 기본값으로 재설정됩니다. 백업과 앱 파일은 삭제되지 않습니다. 계속할까요?</string>
-    <string name="reset_settings_discard_pending">설정을 재설정하면 저장되지 않은 변경 사항이 삭제됩니다. 계속할까요?</string>
-    <string name="settings_reset">설정이 기본값으로 재설정됨</string>
-    <string name="settings_reset_failed">설정 재설정 실패: %1$s</string>
+    <string name="bt_devices_selected">개 기기 선택됨</string>
+    <string name="bluetooth_adapter_label">블루투스 어댑터</string>
+    <string name="bluetooth_adapter_description">핸드셰이크에 사용할 블루투스 어댑터/컨트롤러를 선택합니다. 듀얼 블루투스 시스템에서 유용합니다.</string>
+    <string name="select_bt_adapter">블루투스 어댑터 선택</string>
+    <!-- QR Code Generator -->
+    <string name="share_hotspot_qr_title">Wireless Helper 설정</string>
+    <string name="share_hotspot_qr_desc">휴대폰 자동 연결용 QR 코드를 표시합니다</string>
     <string name="hotspot_ssid_hint">핫스팟 SSID</string>
     <string name="hotspot_pass_hint">핫스팟 비밀번호</string>
-
-    <!-- Loading screen -->
-    <string name="loading_screen">로딩 화면</string>
-    <string name="loading_screen_dialog_title">사용자 지정 로딩 화면</string>
-    <string name="loading_screen_default">기본</string>
-    <string name="loading_screen_custom">사용자 지정</string>
-    <string name="loading_screen_select_file">파일 선택</string>
-    <string name="loading_screen_remove">제거</string>
-    <string name="loading_screen_no_media">선택된 사용자 지정 미디어 없음</string>
-    <string name="loading_screen_tap_preview">탭하여 전체 화면 미리보기</string>
-    <string name="loading_screen_tap_fullscreen_hint">미리보기를 탭하여 전체 화면으로 보기</string>
-    <string name="loading_screen_tap_to_close">아무 곳이나 탭하여 닫기</string>
-    <string name="loading_screen_show_text">\"Android Auto가 시작 중\" 텍스트 표시</string>
-    <string name="loading_screen_keep_aspect_ratio">비율 유지</string>
-    <string name="loading_screen_scale">크기 조정</string>
-    <string name="loading_screen_loop_video">짧은 애니메이션 반복 재생</string>
-    <string name="loading_screen_recommendation">권장 해상도: %1$dx%2$d</string>
-    <string name="loading_screen_recommended_aspect_ratio">권장 종횡비: %1$d:%2$d</string>
-    <string name="loading_screen_supported_formats">지원: 이미지 (PNG, JPG, BMP, WEBP, GIF) \u2022 동영상 (MP4, MKV, WEBM, 3GP) \u2022 최대: 10 MB</string>
-    <string name="loading_screen_file_error">선택한 파일을 불러올 수 없습니다</string>
-    <string name="loading_screen_file_too_large">파일이 너무 큽니다 (최대 10 MB)</string>
-    <string name="loading_screen_unsupported_format">지원되지 않는 형식입니다. 이미지 또는 동영상 파일을 사용하세요</string>
-
-    <!-- Log source -->
-    <string name="log_source">로그 소스</string>
-    <string name="log_source_logcat">Logcat</string>
-    <string name="log_source_applog_file">파일로 직접 저장</string>
-    <!-- Native USB Driver -->
+    <string name="hotspot_qr_description">Wireless Helper 설정 QR 코드</string>
+    <string name="scan_with_wireless_helper">휴대폰의 Wireless Helper QR 스캐너로 이 QR 코드를 스캔하세요.</string>
+    <string name="share_hotspot_qr_error">현재 Wi-Fi 핫스팟 정보를 가져올 수 없습니다. 핫스팟이 켜져 있고 위치 서비스가 활성화되어 있는지 확인하세요.</string>
     <string name="use_libusb">네이티브 USB 드라이버 사용</string>
-    <string name="use_libusb_description">통신에 libusb를 사용합니다. Android의 표준 USB API를 사용하려면 비활성화하세요.</string>
+    <string name="use_libusb_description">USB 통신에 libusb를 사용합니다. 비활성화 시 Android 표준 USB API를 사용합니다.</string>
 
-    <string name="software_video_decoder">소프트웨어 디코더 소스</string>
-    <string name="software_video_decoder_bundled">내장 FFmpeg</string>
-    <string name="software_video_decoder_device">기기 MediaCodec</string>
-
-    <string name="btn_show_qr">QR 코드 표시</string>
+    <string name="btn_show_qr">QR 코드 보기</string>
 </resources>


### PR DESCRIPTION
## Summary

This updates the Korean localization after #497 and after new source strings were added.

It revisits wording that still felt awkward, translates newly added strings, and makes the app settings text read more naturally in Korean.

## Changes

- Refined existing Korean strings that still sounded awkward or unclear
- Added and polished Korean translations for newly added source strings
- Reordered Korean strings to match the English source string layout
- Normalized common terms such as Android Auto, Wi-Fi, Bluetooth, Headunit, auto-start, auto-connect, and log-related settings
- Clarified technical descriptions for headunit GPS, Wi-Fi Direct wait behavior, log source, backup/restore, loading screen, and fake speed settings

## Notes

No functional code changes.