### PR TITLE
fix(wifi): use public API for frequency

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectCompat.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectCompat.kt
@@ -24,6 +24,14 @@ object WifiDirectCompat {
         }
     }
 
+    fun getGroupFrequency(group: android.net.wifi.p2p.WifiP2pGroup?): Int {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && group != null) {
+            return Api29Impl.getGroupFrequency(group)
+        }
+        return 0
+    }
+
+
     @RequiresApi(Build.VERSION_CODES.Q)
     private object Api29Impl {
         fun requestDeviceInfo(
@@ -40,6 +48,10 @@ object WifiDirectCompat {
             } catch (e: Exception) {
                 AppLog.w("WifiDirectCompat: requestDeviceInfo failed: ${e.message}")
             }
+        }
+
+        fun getGroupFrequency(group: android.net.wifi.p2p.WifiP2pGroup): Int {
+            return group.frequency
         }
     }
 }

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
@@ -325,7 +325,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             var frequency = 0
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 // For Android 10 (API 29) and above, use the official public API
-                frequency = group.frequency
+                frequency = WifiDirectCompat.getGroupFrequency(group)
             } else {
                 try {
                     // Try several common field names used by different OEMs

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
@@ -324,7 +324,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             // Try to get frequency via reflection (hidden field in WifiP2pGroup)
             var frequency = 0
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                // For Android 10 (API 29) and above, use the official public API
+                // For Android 10 (API 29) and above, use the official public API via WifiDirectCompat
                 frequency = WifiDirectCompat.getGroupFrequency(group)
             } else {
                 try {

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
@@ -323,18 +323,25 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
 
             // Try to get frequency via reflection (hidden field in WifiP2pGroup)
             var frequency = 0
-            try {
-                // Try several common field names used by different OEMs
-                val fieldNames = arrayOf("frequency", "mFrequency")
-                for (name in fieldNames) {
-                    try {
-                        val field = group.javaClass.getDeclaredField(name)
-                        field.isAccessible = true
-                        frequency = field.getInt(group)
-                        if (frequency > 0) break
-                    } catch (e: Exception) {}
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                // For Android 10 (API 29) and above, use the official public API
+                frequency = group.frequency
+            } else {
+                try {
+                    // Try several common field names used by different OEMs
+                    val fieldNames = arrayOf("frequency", "mFrequency")
+                    for (name in fieldNames) {
+                        try {
+                            val field = group.javaClass.getDeclaredField(name)
+                            field.isAccessible = true
+                            frequency = field.getInt(group)
+                            if (frequency > 0) break
+                        } catch (e: Exception) {
+                        }
+                    }
+                } catch (e: Exception) {
                 }
-            } catch (e: Exception) {}
+            }
 
             val band = if (frequency > 4000) "5GHz" else if (frequency > 0) "2.4GHz" else "unknown"
             AppLog.i("WifiDirectManager: onGroupInfoAvailable: SSID: $ssid, BSSID: $bssid, GO: $isOwner, IFACE: ${iface ?: "null"}, Freq: $frequency MHz ($band)")


### PR DESCRIPTION
- For Android 10 (API 29) and above, utilize the official `group.frequency` API.
- Retain reflection-based approach for older Android versions to maintain compatibility.