### PR TITLE
Don't grab audio focus on connect in dynamic mode (#654)

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
@@ -804,10 +804,21 @@ class AapService : Service(), UsbReceiver.Listener {
      * This logic was previously executed in onCreate(); it has been moved here so
      * the caller can decide when to acquire focus (for example, immediately before
      * starting the AA handshake) to avoid stealing audio during autostart.
+     *
+     * The permanent AUDIOFOCUS_GAIN is only appropriate for Static Audio Focus mode,
+     * where the phone must believe focus is always held. In the default (dynamic) mode
+     * focus is instead acquired on demand via the AA protocol
+     * (AapControl.audioFocusRequest -> AapAudio.requestFocusChange), so grabbing a
+     * permanent gain here would needlessly evict other media (e.g. the car radio) the
+     * moment the phone connects, before AA plays anything.
      */
     private fun requestPermanentAudioFocus() {
         if (!settings.enableAudioSink) {
             AppLog.d("Audio Sink disabled - skipping permanent audio focus request.")
+            return
+        }
+        if (!settings.staticAudioFocus) {
+            AppLog.d("Static Audio Focus disabled - skipping permanent audio focus request; focus will be acquired on demand.")
             return
         }
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/CommManager.kt
@@ -341,7 +341,7 @@ class CommManager(
      * This ordering guarantees no video frame is ever decoded before a render target exists.
      *
      * On success:
-     * 1. Claims audio focus for `STREAM_MUSIC`.
+     * 1. In Static Audio Focus mode, claims permanent audio focus for `STREAM_MUSIC`.
      * 2. Starts the [AapTransport] read loop.
      * 3. Emits [ConnectionState.TransportStarted].
      */
@@ -349,11 +349,18 @@ class CommManager(
         if (_connectionState.value !is ConnectionState.HandshakeComplete) return@withContext
 
         try {
-            _transport?.aapAudio?.requestFocusChange(
-                AudioManager.STREAM_MUSIC,
-                AudioManager.AUDIOFOCUS_GAIN,
-                AudioManager.OnAudioFocusChangeListener { }
-            )
+            // Only grab permanent AUDIOFOCUS_GAIN in Static Audio Focus mode, matching the
+            // gating in AapService.requestPermanentAudioFocus and AapControl.audioFocusRequest.
+            // In the default (dynamic) mode focus is acquired on demand via the AA protocol, so
+            // an unconditional grab here would evict other media (e.g. the car radio) the moment
+            // the phone connects, before AA plays anything.
+            if (settings.enableAudioSink && settings.staticAudioFocus) {
+                _transport?.aapAudio?.requestFocusChange(
+                    AudioManager.STREAM_MUSIC,
+                    AudioManager.AUDIOFOCUS_GAIN,
+                    AudioManager.OnAudioFocusChangeListener { }
+                )
+            }
             _transport?.startReading()
             _connectionState.emit(ConnectionState.TransportStarted)
         } catch (e: Exception) {

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/CommManager.kt
@@ -349,19 +349,23 @@ class CommManager(
         if (_connectionState.value !is ConnectionState.HandshakeComplete) return@withContext
 
         try {
+            // Capture the @Volatile _transport once: it can be cleared concurrently by a
+            // disconnect, so a stable local reference avoids racing reads and lets us bail out
+            // early instead of emitting TransportStarted when no reading actually started.
+            val transport = _transport ?: return@withContext
             // Only grab permanent AUDIOFOCUS_GAIN in Static Audio Focus mode, matching the
             // gating in AapService.requestPermanentAudioFocus and AapControl.audioFocusRequest.
             // In the default (dynamic) mode focus is acquired on demand via the AA protocol, so
             // an unconditional grab here would evict other media (e.g. the car radio) the moment
             // the phone connects, before AA plays anything.
             if (settings.enableAudioSink && settings.staticAudioFocus) {
-                _transport?.aapAudio?.requestFocusChange(
+                transport.aapAudio?.requestFocusChange(
                     AudioManager.STREAM_MUSIC,
                     AudioManager.AUDIOFOCUS_GAIN,
                     AudioManager.OnAudioFocusChangeListener { }
                 )
             }
-            _transport?.startReading()
+            transport.startReading()
             _connectionState.emit(ConnectionState.TransportStarted)
         } catch (e: Exception) {
             _connectionState.emit(ConnectionState.Error("Start reading failed: ${e.message}"))


### PR DESCRIPTION
### Problem

Connecting Android Auto permanently stops existing car audio (e.g. the FM radio) — issue #654. On connect the app grabbed a permanent `AUDIOFOCUS_GAIN`, evicting other media before AA had played anything, and it did so regardless of the audio-sink / Static Audio Focus settings.

### Root cause

Two ungated connect-time permanent-focus grabs:

1. `CommManager.startReading()` unconditionally called `requestFocusChange(STREAM_MUSIC, AUDIOFOCUS_GAIN)` on every connect — ignoring both `enableAudioSink` and `staticAudioFocus`. **This was the actual culprit for #654.**
2. `AapService.requestPermanentAudioFocus()` grabbed permanent gain whenever the audio sink was enabled, in dynamic mode too.

### Fix

Gate both behind `enableAudioSink && staticAudioFocus`, matching `AapControlService.audioFocusRequest`. In the default dynamic mode the app no longer takes permanent focus at connect; focus is acquired on demand instead. Static Audio Focus mode is unchanged.

### Testing

Verified on a Rockchip/Microntek Android-4.x head unit: connecting AA no longer interrupts the FM radio (dynamic mode, audio sink on).

Closes #654.

---
⚠️ Note: CI/builds currently fail on a **pre-existing, unrelated** compile error on `main` (`SettingsFragment.kt:767`, see #659), not introduced by this PR. This branch compiles clean apart from that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)