### PR TITLE
Acquire transient audio focus while AA audio plays (dynamic mode)

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapAudio.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapAudio.kt
@@ -26,9 +26,21 @@ internal class AapAudio(
     private val audioLatencyMultiplier = settings.audioLatencyMultiplier
     private val useAacAudio = settings.useAacAudio
     private val audioQueueCapacity = settings.audioQueueCapacity
+    private val enableAudioSink = settings.enableAudioSink
 
     private var audioFocusRequest: AudioFocusRequest? = null
     private var legacyFocusListener: AudioManager.OnAudioFocusChangeListener? = null
+
+    // Dynamic-mode playback focus: some phones never send an AudioFocusRequestNotification(GAIN)
+    // when media starts (the always-grant handshake makes them assume the head unit always holds
+    // focus), so relying on the protocol notification alone leaves the car radio playing alongside
+    // AA audio. Instead we hold system audio focus for as long as any AA audio channel is actively
+    // playing and release it when the last one stops. Static mode manages focus permanently and is
+    // left untouched.
+    private val activeAudioChannels = mutableSetOf<Int>()
+    private val playbackFocusListener = AudioManager.OnAudioFocusChangeListener {
+        AppLog.i("AapAudio: playback audio focus changed: $it")
+    }
 
     @Volatile
     private var isDucked = false
@@ -127,6 +139,7 @@ internal class AapAudio(
 
     fun releaseAllFocus() {
         AppLog.i("AapAudio: Releasing all audio focus.")
+        synchronized(activeAudioChannels) { activeAudioChannels.clear() }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             audioFocusRequest?.let { audioManager.abandonAudioFocusRequest(it) }
             audioFocusRequest = null
@@ -176,6 +189,46 @@ internal class AapAudio(
 
         AppLog.i("AudioDecoder.start: channel=$channel, stream=$stream, gain=$gain, sampleRate=${config.sampleRate}, numberOfBits=${config.numberOfBits}, numberOfChannels=${config.numberOfChannels}, isAac=$useAacAudio, latencyMultiplier=$effectiveMultiplier, queueCapacity=$audioQueueCapacity")
         audioDecoder.start(channel, stream, config.sampleRate, config.numberOfBits, config.numberOfChannels, useAacAudio, gain, effectiveMultiplier, audioQueueCapacity, staticAudioFocus)
+        onAudioPlaybackStarted(channel)
+    }
+
+    /**
+     * Acquires system audio focus when the first AA audio channel starts playing (dynamic mode).
+     * No-op in static mode (permanent focus already held) or when the audio sink is disabled.
+     */
+    private fun onAudioPlaybackStarted(channel: Int) {
+        if (staticAudioFocus || !enableAudioSink || !Channel.isAudio(channel)) return
+        val shouldAcquire: Boolean
+        synchronized(activeAudioChannels) {
+            val wasEmpty = activeAudioChannels.isEmpty()
+            activeAudioChannels.add(channel)
+            shouldAcquire = wasEmpty
+        }
+        if (shouldAcquire) {
+            // Use GAIN_TRANSIENT, not GAIN: a permanent GAIN sends other players (e.g. the car
+            // radio) a permanent AUDIOFOCUS_LOSS, so they stop and do NOT resume when we later
+            // abandon focus. TRANSIENT sends AUDIOFOCUS_LOSS_TRANSIENT so they pause and resume
+            // once AA audio stops and we release focus.
+            AppLog.i("AapAudio: AA audio started (${Channel.name(channel)}) - acquiring transient system audio focus")
+            requestFocusChange(AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT, playbackFocusListener)
+        }
+    }
+
+    /**
+     * Releases system audio focus once the last active AA audio channel stops (dynamic mode),
+     * letting other local sources (e.g. the car radio) resume.
+     */
+    private fun onAudioPlaybackStopped(channel: Int) {
+        if (staticAudioFocus || !enableAudioSink || !Channel.isAudio(channel)) return
+        val shouldRelease: Boolean
+        synchronized(activeAudioChannels) {
+            activeAudioChannels.remove(channel)
+            shouldRelease = activeAudioChannels.isEmpty()
+        }
+        if (shouldRelease) {
+            AppLog.i("AapAudio: last AA audio channel stopped - releasing system audio focus")
+            releaseAllFocus()
+        }
     }
 
     fun precreateAudioTrack(channel: Int) {
@@ -228,6 +281,7 @@ internal class AapAudio(
             unduckMedia()
         } else {
             audioDecoder.stop(channel)
+            onAudioPlaybackStopped(channel)
         }
     }
 


### PR DESCRIPTION
### Problem

In dynamic mode, the app only acquired system audio focus in response to a protocol `AudioFocusRequestNotification(GAIN)`. Some phones never send `GAIN` when media starts (the always-grant handshake makes them assume the head unit permanently holds focus), so the head unit never grabbed focus and other local sources (e.g. the car radio) kept playing **alongside** AA audio. See #658.

### Fix

Track active AA audio channels in `AapAudio` and hold `AUDIOFOCUS_GAIN_TRANSIENT` while any channel is playing, releasing when the last one stops. `TRANSIENT` (not permanent `GAIN`) makes the other source **pause** during playback and **resume** afterwards, rather than being permanently stopped. Gated on `!staticAudioFocus && enableAudioSink`; composes idempotently with the existing protocol-driven focus path.

### Testing

Verified on a Rockchip/Microntek Android-4.x head unit: the FM radio pauses when a podcast plays and resumes when it stops.

Closes #658.

---
📚 **Stacked on #660.** This PR is based on the connect-time focus fix in #660; until that merges, the diff here also includes its two commits (`AapService` + `CommManager` gates). Only the final commit — `Acquire transient audio focus while AA audio plays` (touching `AapAudio.kt`) — is unique to this PR. I'll rebase once #660 merges.

⚠️ Note: CI/builds currently fail on a **pre-existing, unrelated** compile error on `main` (`SettingsFragment.kt:767`, see #659), not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)