### PR TITLE
Add GitHub Actions CI (build + unit tests)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,49 @@
+# Continuous Integration
+
+## `android-ci.yml` — Android CI
+
+Runs on every pull request and on pushes to `main`. Two parallel jobs:
+
+| Check                        | What it does                                   | Intended to block? |
+|------------------------------|------------------------------------------------|:------------------:|
+| **Build (github debug)**     | `./gradlew :app:assembleGithubDebug` — compiles the app (including native code and the `:contract` module) and uploads the debug APK as an artifact. | Yes |
+| **Unit tests (github debug)**| `./gradlew :app:testGithubDebugUnitTest` — runs the JVM unit tests and uploads the HTML/XML report. | Yes |
+
+"Intended to block" reflects the design; a failing check only actually
+prevents merge once the [branch-protection rule](#branch-protection) below is
+configured.
+
+The build is **debug, unsigned, and uses no repository secrets**, so it runs
+unchanged on pull requests opened from forks.
+
+### Branch protection
+
+To make CI enforce quality on `main`, add a branch-protection rule requiring
+these status checks:
+
+- `Build (github debug)`
+- `Unit tests (github debug)`
+
+### Notes
+
+- **`github` flavor only.** The `playstore` flavor is not built because it
+  cannot currently compile: `VpnControl.kt` lives only in the `github` source
+  set (`app/src/github/...`) but is imported by shared `main` code. Once that
+  split is resolved, add a `playstore` build to the `build` job.
+- **`main` may show red** on `Build`/`Unit tests` until the known
+  `SettingsFragment.kt:767` smart-cast compile error (issue #659) is fixed.
+  This is expected, not a CI misconfiguration.
+- **No lint job (yet).** Android Lint is intentionally not run in CI:
+  `:app:lintAnalyzeGithubDebug` hangs for many minutes on GitHub-hosted runners
+  and produces no report (likely choking on the large generated protobuf
+  sources). Run it locally instead — `./gradlew :app:lintGithubDebug` — and
+  note that the project sets `lint { abortOnError = false }`, so lint findings
+  are advisory by design. Re-adding a CI lint job is worthwhile once the hang
+  is diagnosed.
+- **Toolchain:** Temurin JDK 21 (Gradle 8.13 rejects Java 24+), plus the pinned
+  NDK `27.0.12077973` and CMake `3.22.1` installed via `sdkmanager`. The
+  `sdkmanager` install is retried up to three times because its downloads
+  occasionally arrive corrupt on GitHub-hosted runners.
+- **Action pinning:** all actions (GitHub first-party and third-party alike)
+  are pinned to major-version tags. Maintainers who want stricter supply-chain
+  hygiene can repin them to full commit SHAs.

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,107 @@
+name: Android CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+# Cancel superseded runs on the same ref (e.g. a new push to an open PR).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+# Read-only; this workflow needs no write scopes and touches no secrets,
+# so it runs unchanged on pull requests opened from forks.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build (github debug)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      # NDK/CMake versions are pinned in app/build.gradle.kts; install the
+      # exact versions rather than relying on whatever the runner ships.
+      # Retried because sdkmanager downloads occasionally arrive corrupt
+      # ("Error on ZipFile unknown archive") on GitHub-hosted runners.
+      - name: Install pinned NDK and CMake
+        run: |
+          for attempt in 1 2 3; do
+            sdkmanager "ndk;27.0.12077973" "cmake;3.22.1" && exit 0
+            echo "sdkmanager attempt $attempt failed; retrying in 15s..." >&2
+            sleep 15
+          done
+          echo "sdkmanager failed after 3 attempts" >&2
+          exit 1
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      # github flavor only: the playstore flavor cannot compile because
+      # VpnControl.kt lives solely in app/src/github. When that source-set
+      # split is fixed, add an assemblePlaystoreDebug build here.
+      - name: Assemble github debug APK
+        run: ./gradlew :app:assembleGithubDebug --stacktrace
+
+      - name: Upload debug APK
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-github-debug-apk
+          path: app/build/outputs/apk/github/debug/*.apk
+          if-no-files-found: warn
+
+  unit-test:
+    name: Unit tests (github debug)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      # See the build job for why NDK/CMake are pinned and the install is retried.
+      - name: Install pinned NDK and CMake
+        run: |
+          for attempt in 1 2 3; do
+            sdkmanager "ndk;27.0.12077973" "cmake;3.22.1" && exit 0
+            echo "sdkmanager attempt $attempt failed; retrying in 15s..." >&2
+            sleep 15
+          done
+          echo "sdkmanager failed after 3 attempts" >&2
+          exit 1
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run unit tests
+        run: ./gradlew :app:testGithubDebugUnitTest --stacktrace
+
+      - name: Upload unit test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-report
+          path: |
+            app/build/reports/tests/testGithubDebugUnitTest
+            app/build/test-results/testGithubDebugUnitTest
+          if-no-files-found: warn


### PR DESCRIPTION
## What

Adds a GitHub Actions CI workflow — the repo currently has none. On every pull
request and push to `main`, two parallel jobs run:

| Check | Command |
|---|---|
| **Build (github debug)** | `./gradlew :app:assembleGithubDebug` — compiles the app (native code + `:contract`) and uploads the debug APK |
| **Unit tests (github debug)** | `./gradlew :app:testGithubDebugUnitTest` — runs the JVM unit tests and uploads the report |

Plus a short `.github/workflows/README.md` documenting the jobs and how to wire
branch protection.

## Design notes

- **Fork-safe.** Debug, unsigned, `permissions: contents: read`, no repository
  secrets — so it runs unchanged on PRs from forks.
- **Toolchain.** Temurin JDK 21 (Gradle 8.13 rejects Java 24+); the pinned NDK
  `27.0.12077973` and CMake `3.22.1` are installed via `sdkmanager`. That
  install is retried up to 3× because hosted runners occasionally fetch a
  corrupt NDK archive (observed and recovered during testing).
- **`github` flavor only.** The `playstore` flavor doesn't compile
  (`VpnControl.kt` lives only in `app/src/github` but is imported by shared
  `main` code). A comment marks where to add a `playstore` build once that
  split is resolved.
- **No lint job (for now).** `:app:lintAnalyzeGithubDebug` hangs for many
  minutes on hosted runners and produces no report (likely the large generated
  protobuf sources). It's left out rather than shipping a check that always
  times out; run `./gradlew :app:lintGithubDebug` locally. Worth re-adding once
  the hang is diagnosed.

## Heads-up

`Build` / `Unit tests` will fail on `main` until the pre-existing
`SettingsFragment.kt:767` smart-cast compile error is fixed (a `String?` where
`SettingEntry.value` expects `String`). That's a real compile break on `main`,
not a CI issue.

## Validation

Verified on a fork PR against a compilable base: both checks pass in ~4–5 min
and upload their artifacts (debug APK, unit-test report). The `sdkmanager`
retry fired and recovered a corrupt-download flake in one of those runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
