### PR TITLE
Bug: AAP transport gets stuck after repeated reconnects because _tran…

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/CommManager.kt
@@ -313,7 +313,7 @@ class CommManager(
                         onAaMediaMetadata = { meta -> onAaMediaMetadata?.invoke(meta) },
                         onAaPlaybackStatus = { status -> onAaPlaybackStatus?.invoke(status) }
                     )
-                    _transport!!.onQuit = { isClean -> transportedQuited(isClean) }
+                    _transport!!.onQuit = { isClean -> try { transportedQuited(isClean) } finally { _transport = null } }
                     _transport!!.onAudioFocusStateChanged = { isPlaying -> onAudioFocusStateChanged?.invoke(isPlaying) }
                     _transport!!.onUpdateUiConfigReplyReceived = { onUpdateUiConfigReplyReceived?.invoke() }
                 }

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/CommManager.kt
@@ -313,7 +313,14 @@ class CommManager(
                         onAaMediaMetadata = { meta -> onAaMediaMetadata?.invoke(meta) },
                         onAaPlaybackStatus = { status -> onAaPlaybackStatus?.invoke(status) }
                     )
-                    _transport!!.onQuit = { isClean -> try { transportedQuited(isClean) } finally { _transport = null } }
+                    _transport!!.onQuit = { isClean ->
+                        val oldTransport = _transport
+                        _transport = null
+
+                        if (oldTransport != null) {
+                            transportedQuited(isClean)
+                        }
+                    }
                     _transport!!.onAudioFocusStateChanged = { isPlaying -> onAudioFocusStateChanged?.invoke(isPlaying) }
                     _transport!!.onUpdateUiConfigReplyReceived = { onUpdateUiConfigReplyReceived?.invoke() }
                 }


### PR DESCRIPTION
When using Android Auto wireless projection, the first disconnect works correctly. After reconnecting and disconnecting again, the application can enter a stuck state.

The issue appears after multiple connect/disconnect cycles. AapTransport.quit() is called, but the next quit attempt shows that onQuit callback is already null, while _transport still references the old AapTransport instance.