### PR TITLE
Transport.on quit

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/CommManager.kt
@@ -314,11 +314,11 @@ class CommManager(
                         onAaPlaybackStatus = { status -> onAaPlaybackStatus?.invoke(status) }
                     )
                     _transport!!.onQuit = { isClean ->
-                        val oldTransport = _transport
-                        _transport = null
-
-                        if (oldTransport != null) {
+                        try {
                             transportedQuited(isClean)
+                        } finally {
+                            AppLog.i("WS_DEBUG CLEAR TRANSPORT")
+                            _transport = null
                         }
                     }
                     _transport!!.onAudioFocusStateChanged = { isPlaying -> onAudioFocusStateChanged?.invoke(isPlaying) }

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/CommManager.kt
@@ -313,12 +313,17 @@ class CommManager(
                         onAaMediaMetadata = { meta -> onAaMediaMetadata?.invoke(meta) },
                         onAaPlaybackStatus = { status -> onAaPlaybackStatus?.invoke(status) }
                     )
-                    _transport!!.onQuit = { isClean ->
-                        try {
-                            transportedQuited(isClean)
-                        } finally {
-                            AppLog.i("WS_DEBUG CLEAR TRANSPORT")
-                            _transport = null
+                    _transport?.onQuit = { isClean ->
+                        val transport = _transport
+
+                        if (transport != null) {
+                            try {
+                                transportedQuited(isClean)
+                            } finally {
+                                if (_transport === transport) {
+                                    _transport = null
+                                }
+                            }
                         }
                     }
                     _transport!!.onAudioFocusStateChanged = { isPlaying -> onAudioFocusStateChanged?.invoke(isPlaying) }


### PR DESCRIPTION
Changed onQuit handling to keep the active transport reference available while executing the disconnect sequence. _transport is now cleared only after transportedQuited() finishes, preventing race conditions during audio/video decoder shutdown.