### PR TITLE
Fix WiFi Direct connection drops, stale BSSID caching, and delayed projection launch

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
@@ -2070,8 +2070,11 @@ class AapService : Service(), UsbReceiver.Listener {
         val mode = settings.wifiConnectionMode
         val strategy = settings.helperConnectionStrategy
 
-        // Only register NSD for Headunit Server (Auto) or Helper (Common Wifi NSD)
-        val shouldRegisterNsd = mode == 1 || (mode == 2 && strategy == 0)
+        // Register NSD for Headunit Server (Auto), Helper Common Wifi (NSD), and the Hotspot
+        // strategies (3, 4) — both devices share an IP network there too, and the companion
+        // "Wireless Helper" app's discovery relies on this service record to trigger the
+        // handoff instead of just blindly probing the TCP port.
+        val shouldRegisterNsd = mode == 1 || (mode == 2 && (strategy == 0 || strategy == 3 || strategy == 4))
 
         wirelessServer = WirelessServer().apply { start(registerNsd = shouldRegisterNsd) }
         if (shouldRegisterNsd) {

--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
@@ -1424,6 +1424,12 @@ class AapService : Service(), UsbReceiver.Listener {
         if (!usesWifiDirect) {
             AppLog.i("AapService: New mode does not use WiFi Direct. Stopping WifiDirectManager...")
             wifiDirectManager?.stop()
+        } else {
+            // This chipset can't run SoftAP and WiFi Direct concurrently — make sure hotspot is off before P2P starts.
+            Thread {
+                AppLog.i("AapService: Mode requires WiFi Direct — ensuring hotspot is disabled first...")
+                HotspotManager.setHotspotEnabled(this, false)
+            }.start()
         }
 
         // Mode 1: Auto (Headunit Server), Mode 2: Helper (Wireless Launcher), Mode 3: Native AA

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/SocketAccessoryConnection.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/SocketAccessoryConnection.kt
@@ -18,6 +18,11 @@ class SocketAccessoryConnection(private val ip: String, private val port: Int, p
     private var output: OutputStream? = null
     private var input: DataInputStream? = null
     private var transport: Socket
+    // Only true for genuine Nearby tunnels, where the handshake's AA-16.4+ settle delay
+    // and stale-byte drain must be skipped because every byte from the start matters.
+    // Regular WirelessServer-accepted sockets (Hotspot/WiFi Direct/Headunit Server) and
+    // manual-IP connections are NOT single-message and need those handshake safeguards.
+    private var singleMessage: Boolean = false
 
     init {
         transport = Socket()
@@ -25,6 +30,7 @@ class SocketAccessoryConnection(private val ip: String, private val port: Int, p
 
     constructor(socket: Socket, context: Context) : this(socket.inetAddress.hostAddress ?: "", socket.port, context) {
         this.transport = socket
+        this.singleMessage = socket is NearbySocket
         // Pre-connected sockets (like NearbySocket) need their streams initialized immediately
         // because connect() might not be called or might be bypassed.
         if (socket.isConnected) {
@@ -39,7 +45,7 @@ class SocketAccessoryConnection(private val ip: String, private val port: Int, p
 
 
     override val isSingleMessage: Boolean
-        get() = true
+        get() = singleMessage
 
     override fun sendBlocking(buf: ByteArray, length: Int, timeout: Int): Int {
         val out = output ?: return -1

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
@@ -540,6 +540,10 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     private fun removeGroupAndCreate() {
         isGroupOwner = false
         isConnected = false
+        // The next createGroup() call generates a brand-new GO interface with a new random
+        // MAC — a cached BSSID from the group we're tearing down is now stale and must never
+        // be delivered for the new one.
+        lastKnownBssid = null
         manager?.removeGroup(channel, object : WifiP2pManager.ActionListener {
             override fun onSuccess() { delayedCreateGroup(0) }
             override fun onFailure(reason: Int) { delayedCreateGroup(0) }
@@ -697,6 +701,10 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         AppLog.i("WifiDirectManager: startNativeAaQuietHost() requested. Removing old group if any...")
         nativeGroupCreationMode = NATIVE_GROUP_MODE_UNKNOWN
         lastNativeGroupStatusMessage = null
+        // The next createGroup() call generates a brand-new GO interface with a new random
+        // MAC — a cached BSSID from the group we're tearing down is now stale and must never
+        // be delivered for the new one.
+        lastKnownBssid = null
         mgr.removeGroup(ch, object : WifiP2pManager.ActionListener {
             override fun onSuccess() {
                 AppLog.d("WifiDirectManager: removeGroup SUCCESS. Creating quiet group...")
@@ -819,6 +827,10 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     private fun removeGroupAndRetryNative5Ghz() {
         val mgr = manager ?: return
         val ch = channel ?: return
+        // The next createGroup() call generates a brand-new GO interface with a new random
+        // MAC — a cached BSSID from the group we're tearing down is now stale and must never
+        // be delivered for the new one.
+        lastKnownBssid = null
         mgr.removeGroup(ch, object : WifiP2pManager.ActionListener {
             override fun onSuccess() { delayedCreateQuietGroup(0) }
             override fun onFailure(reason: Int) {

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
@@ -325,16 +325,30 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                             bssid = shellMac
                         } else {
                             // Fallback 5: Try Settings.Secure (Samsung/Pixel trick)
+                            var resolved = false
                             try {
                                 val secureMac = android.provider.Settings.Secure.getString(context.contentResolver, "wifi_p2p_device_address")
                                 if (!secureMac.isNullOrEmpty() && secureMac != "00:00:00:00:00:00" && secureMac != "02:00:00:00:00:00") {
                                     AppLog.i("WifiDirectManager: Fallback 5 - Selected MAC from Settings.Secure: $secureMac")
                                     bssid = secureMac
-                                } else {
-                                    AppLog.w("WifiDirectManager: All fallbacks failed! BSSID is still zeroed.")
+                                    resolved = true
                                 }
                             } catch (e: Exception) {
                                 AppLog.w("WifiDirectManager: Fallback 5 failed: ${e.message}")
+                            }
+
+                            // Fallback 6: Reflect over WifiP2pGroup/WifiP2pDevice hidden fields for
+                            // any unmasked MAC the public getters didn't expose (some OEM privacy
+                            // hardening masks NetworkInterface/deviceAddress but leaves other
+                            // internal fields populated).
+                            if (!resolved) {
+                                val reflectedMac = getMacFromReflection(group)
+                                if (reflectedMac != null) {
+                                    AppLog.i("WifiDirectManager: Fallback 6 - Selected MAC via reflection: $reflectedMac")
+                                    bssid = reflectedMac
+                                } else {
+                                    AppLog.w("WifiDirectManager: All fallbacks failed! BSSID is still zeroed.")
+                                }
                             }
                         }
                     }
@@ -854,6 +868,39 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         handler.post {
             ToastUtils.showToast(context, message, Toast.LENGTH_LONG)
         }
+    }
+
+    private val macRegex = Regex("^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$")
+    private val maskedMacs = setOf("00:00:00:00:00:00", "02:00:00:00:00:00")
+
+    /**
+     * Last-resort BSSID lookup: reflect over every declared field (including inherited ones) of
+     * the WifiP2pGroup and its owner WifiP2pDevice, looking for any String that looks like a MAC
+     * and isn't one of the known privacy-masked placeholders. Some OEM builds mask the public
+     * NetworkInterface/deviceAddress getters but leave other internal fields populated with the
+     * real value.
+     */
+    private fun getMacFromReflection(group: android.net.wifi.p2p.WifiP2pGroup): String? {
+        val candidates = listOfNotNull(group, group.owner)
+        for (obj in candidates) {
+            var klass: Class<*>? = obj.javaClass
+            while (klass != null) {
+                for (field in klass.declaredFields) {
+                    try {
+                        field.isAccessible = true
+                        val value = field.get(obj) as? String ?: continue
+                        if (macRegex.matches(value) && value !in maskedMacs) {
+                            AppLog.d("WifiDirectManager: getMacFromReflection found candidate in ${klass.simpleName}.${field.name}: $value")
+                            return value
+                        }
+                    } catch (e: Exception) {
+                        // Ignore inaccessible/incompatible fields and keep scanning.
+                    }
+                }
+                klass = klass.superclass
+            }
+        }
+        return null
     }
 
     private fun getMacFromShell(iface: String?): String? {

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
@@ -744,8 +744,13 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             try {
+                // Builder.build() requires networkName+passphrase (or a peer address) or it
+                // throws IllegalStateException — onGroupInfoAvailable() reads the real values
+                // back afterwards, same as the standard-fallback path.
                 val config = WifiP2pConfig.Builder()
                     .setGroupOperatingBand(WifiP2pConfig.GROUP_OWNER_BAND_5GHZ)
+                    .setNetworkName(generateP2pNetworkName())
+                    .setPassphrase(generateP2pPassphrase())
                     .build()
 
                 AppLog.i("WifiDirectManager: Requesting Native AA P2P group on 5GHz band.")
@@ -788,6 +793,20 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
 
         AppLog.i("WifiDirectManager: 5GHz P2P group request requires Android 10+. Using standard createGroup.")
         standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_LEGACY)
+    }
+
+    private fun generateP2pNetworkName(): String {
+        val suffix = AapService.wifiDirectName.value
+            ?.filter { it.isLetterOrDigit() }
+            ?.take(20)
+            ?.ifEmpty { null } ?: "HeadUnit"
+        val code = (('A'..'Z') + ('0'..'9')).let { pool -> "${pool.random()}${pool.random()}" }
+        return "DIRECT-$code-$suffix"
+    }
+
+    private fun generateP2pPassphrase(): String {
+        val pool = ('A'..'Z') + ('a'..'z') + ('0'..'9')
+        return (1..12).map { pool.random() }.joinToString("")
     }
 
     private fun getP2pErrorString(reason: Int): String {

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/MainActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/MainActivity.kt
@@ -375,9 +375,19 @@ class MainActivity : BaseActivity() {
         // Pill cleanup is cheap and safe to run regardless of mode.
         hideAutoConnectPill()
         if (success) {
-            // On success the projection activity will cover our overlay almost
-            // immediately. Hiding without an animation avoids the fade competing
-            // with the activity transition.
+            // Launch the projection activity directly rather than waiting for the
+            // phone to request video focus (AapControl.gainVideoFocus() -> AapBroadcastReceiver).
+            // That broadcast only fires once the phone gets around to its VIDEO
+            // mediaSinkSetupRequest, which can lag well behind HandshakeComplete -
+            // during that gap this overlay had already hidden itself, leaving the
+            // user stuck on HomeFragment with only a relabeled button to notice.
+            val aapIntent = AapProjectionActivity.intent(this).apply {
+                putExtra(AapProjectionActivity.EXTRA_FOCUS, true)
+                addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            }
+            startActivity(aapIntent)
+            // Hiding without an animation avoids the fade competing with the
+            // activity transition.
             findViewById<View>(R.id.auto_connect_loading_overlay)?.visibility = View.GONE
             stopAutoConnectVideo()
             autoConnectKenBurnsAnim?.cancel()


### PR DESCRIPTION
## Summary

WiFi Direct fixes, investigated from a "WiFi Direct method never connects in
WiFi mode" report — `dumpsys wifip2p` showed a repeating
AP_STA_CONNECTED -> REMOVE_GROUP -> CREATE_GROUP cycle, plus a masked-BSSID
failure on a Xiaomi/MIUI unit:

- Clear `lastKnownBssid` on every `removeGroup()` call site — `createGroup()`
  assigns a new random GO interface MAC each time, so a cached BSSID from the
  torn-down group is stale and must never be handed to the phone for the new
  one.
- Add a reflection-based BSSID fallback for OEM builds where
  `NetworkInterface`, cached/local/owner addresses, sysfs, and
  `Settings.Secure` all come back masked or permission-denied.
- Disable the hotspot before starting WiFi Direct — some chipsets can't run
  SoftAP and WiFi Direct concurrently.
- Register NSD for the Hotspot helper strategies (3, 4) too, not just Common
  WiFi/Auto server — Wireless Helper's discovery depends on that service
  record instead of blindly probing the TCP port.
- Only treat genuine `NearbySocket` transports as single-message; other
  transports (WirelessServer-accepted sockets, manual IP) still need the
  handshake settle-delay and stale-byte-drain safeguards.
- Fix `WifiP2pConfig.Builder` crash in Native AA's 5GHz group creation —
  `Builder.build()` requires networkName+passphrase (or a peer address) or it
  throws `IllegalStateException` unconditionally. Every 5GHz attempt was
  crashing before the async `createGroup` call even ran, burning the full
  retry budget (~8s) on every fresh connection before falling back to the
  standard path. Now supplies a valid autonomous-group name/passphrase so the
  5GHz request succeeds on the first attempt.

Also included: launch the projection activity directly on auto-connect
success, instead of waiting on the phone's `gainVideoFocus()` broadcast,
which can lag several seconds behind handshake completion and leave the
user stuck on the home screen.

## Testing

Manually tested on two physical setups:

- **Aftermarket Chinese head unit** (Unisoc/UIS7861 chipset, Android 14) —
  this unit cannot run SoftAP and WiFi Direct concurrently; its own Settings
  UI states "Once Wi-Fi Hotspot on, Wi-Fi Direct is unavailable". Confirmed
  the hotspot-disable-before-P2P fix resolves the connection failure on this
  hardware.
- **Xiaomi Phone (MIUI)** as head unit running this branch, phone-side
  Motorola edge 30 neo running Gearhead — confirmed via `dumpsys wifip2p`
  that the periodic-discovery-driven disconnect cycle
  (REMOVE_GROUP/CREATE_GROUP churn) is gone and the WiFi Direct Helper
  strategy connects reliably. The same Xiaomi/MIUI unit also reproduced and
  validated the BSSID-masking fix (reflection fallback) when used as the
  client phone in the Unisoc head unit test above.
- Projection auto-launch confirmed via timestamped logs:
  `AapProjectionActivity.onCreate` firing ~60ms after handshake completion,
  vs. multi-second delays previously observed waiting on the video-focus
  broadcast.
- 5GHz `createGroup` fix verified on the Unisoc head unit via logcat across
  repeated Native AA connections with two different phones (Poco X3 NFC and
  Motorola edge 30 neo): `5GHz createGroup SUCCESS!` now fires on the first
  attempt (~0.05-0.65s) instead of crashing 5 times in a row
  (`IllegalStateException` at `WifiP2pConfig$Builder.build`) and burning
  ~8 seconds before falling back to the standard path, on every single
  fresh connection.
