### PR TITLE
Fix WiFi Direct disconnect freeze by keying read-loop choice off transport shape

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapRead.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapRead.kt
@@ -2,6 +2,7 @@ package com.andrerinas.headunitrevived.aap
 
 import android.content.Context
 import com.andrerinas.headunitrevived.connection.AccessoryConnection
+import com.andrerinas.headunitrevived.connection.SocketAccessoryConnection
 import com.andrerinas.headunitrevived.decoder.MicRecorder
 import com.andrerinas.headunitrevived.utils.AppLog
 import com.andrerinas.headunitrevived.aap.protocol.proto.MediaPlayback
@@ -50,7 +51,14 @@ internal interface AapRead {
                 onAaPlaybackStatus
             )
 
-            return if (connection.isSingleMessage)
+            // Read framing is a transport-shape question, not a handshake-timing one:
+            // every socket-backed connection (Nearby, WiFi Direct, Hotspot, manual IP) frames
+            // one AA message per blocking read, same as it always has. Only USB/libusb bulk
+            // transfers can batch multiple messages into one read and need the FIFO reassembly
+            // in AapReadMultipleMessages. Do NOT key this off isSingleMessage - that flag only
+            // controls the Nearby-specific handshake settle-delay/drain skip in
+            // AapTransport.handshake() and is unrelated to read framing.
+            return if (connection is SocketAccessoryConnection)
                 AapReadSingleMessage(connection, transport.ssl, handler)
             else
                 AapReadMultipleMessages(connection, transport.ssl, handler)


### PR DESCRIPTION
## Summary
- 810c492 correctly scoped `isSingleMessage` to genuine Nearby sockets for the AA 16.4+ handshake settle-delay/drain skip, but `AapRead.Factory.create()` also keyed its read-loop choice (`AapReadSingleMessage` vs `AapReadMultipleMessages`) off that same flag. That silently moved WiFi Direct/Hotspot/manual-IP sockets onto `AapReadMultipleMessages`, which never had to recognize the Wireless Helper's Magic Garbage (16x `0xFF`) disconnect signal — so clicking Disconnect in the Helper over WiFi Direct freezes the AA screen instead of ending the session.
- Every socket-backed transport has used `AapReadSingleMessage` successfully for years; only USB/libusb ever needed `AapReadMultipleMessages`'s FIFO reassembly. So this keys the Factory choice on transport shape (`connection is SocketAccessoryConnection`) instead of `isSingleMessage`, restoring that assignment without touching the handshake-timing fix from 810c492 — and without duplicating Magic Garbage detection across two read-loop implementations.

## Test plan
- [x] Connect Android Auto over WiFi Direct via Wireless Helper, click Disconnect, confirm the AA screen closes cleanly instead of freezing
- [x] Confirm logcat shows the Magic Garbage detection followed by a clean quit (`ret < 0 (-2)`)
- [x] Spot-check that WiFi Direct/Hotspot/manual-IP connections still handshake normally (regression check for 810c492)
- [x] Spot-check USB still works (unaffected path, but touches the same Factory)

Tested on Issue https://github.com/andreknieriem/headunit-revived/issues/704

🤖 Generated with [Claude Code](https://claude.com/claude-code)