### PR TITLE
Cap negotiated video resolution to the physical panel (save bandwidth)

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/HeadUnitScreenConfig.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/HeadUnitScreenConfig.kt
@@ -185,6 +185,43 @@ object HeadUnitScreenConfig {
         }
     }
 
+    // Native standard resolution for a given panel size, mirroring the AUTO selection so the
+    // resolution cap never advertises more than the panel warrants (issue #650).
+    private fun autoResolutionForPanel(
+        w: Int,
+        h: Int,
+        portrait: Boolean,
+        canHevc: Boolean
+    ): Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType {
+        return if (portrait) {
+            if (w > 720 || h > 1280) {
+                Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._1080x1920
+            } else {
+                Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._720x1280
+            }
+        } else {
+            when {
+                w <= 800 && h <= 480 -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._800x480
+                (w >= 3840 || h >= 2160) && VideoDecoder.isHevcSupported() && Build.VERSION.SDK_INT >= 24 ->
+                    Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._3840x2160
+                (w >= 2560 || h >= 1440) && canHevc && Build.VERSION.SDK_INT >= 24 ->
+                    Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._2560x1440
+                w > 1280 || h > 720 -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._1920x1080
+                else -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._1280x720
+            }
+        }
+    }
+
+    private fun pixelsOf(type: Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType): Long {
+        val s = type.toString().replace("_", "")
+        return try {
+            val parts = s.split("x")
+            parts[0].toLong() * parts[1].toLong()
+        } catch (e: Exception) {
+            0L
+        }
+    }
+
     private fun recalculate() {
         // Calculate USABLE area
         screenWidthPx = realScreenWidthPx - systemInsetLeft - systemInsetRight
@@ -246,6 +283,23 @@ object HeadUnitScreenConfig {
                 codec
             }
         }
+
+        // Cap the negotiated resolution to what the physical panel warrants, so we never ask the
+        // phone for more pixels than the screen can show. Downscaling e.g. 1080p to a 600p panel
+        // every frame overloads the display scaler (MediaTek MDP) and stalls video (issue #650).
+        // min(current, panelCeiling): only ever lowers, so explicit lower choices and HEVC-gated
+        // 1440p/4K are never raised.
+        val preCapResolution = negotiatedResolutionType
+        val panelCeiling = autoResolutionForPanel(realScreenWidthPx, realScreenHeightPx, isPortraitDisplay, canNegotiateHevc)
+        if (pixelsOf(negotiatedResolutionType) > pixelsOf(panelCeiling)) {
+            negotiatedResolutionType = panelCeiling
+        }
+        AppLog.i(
+            "[RES_CAP] resolutionId=${currentSettings.resolutionId} " +
+                "realScreen=${realScreenWidthPx}x${realScreenHeightPx} usable=${screenWidthPx}x${screenHeightPx} " +
+                "portrait=$isPortraitDisplay locked=$isResolutionLocked chosen=$preCapResolution " +
+                "capped=$negotiatedResolutionType changed=${preCapResolution != negotiatedResolutionType}"
+        )
 
         // 2. Perform scaling calculations (now safe because negotiatedResolutionType is set)
         AppLog.i("[UI_DEBUG] CarScreen: usable area ${screenWidthPx}x${screenHeightPx}, using $negotiatedResolutionType")

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/SystemOptimizer.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/SystemOptimizer.kt
@@ -55,8 +55,11 @@ class SystemOptimizer(private val context: Context) {
         
         // 1. Resolution Recommendation
         val recResId = when {
-            width >= 2560 && hasH265 -> 4 
-            width >= 1080 || densityDpi >= 320 || aspectRatio > 2.0f -> 3
+            width >= 2560 && hasH265 -> 4
+            // Only recommend 1080p for genuinely >=1920-wide panels. The old rule also fired on
+            // densityDpi >= 320, which mis-set 1080p on small high-DPI head units and made them
+            // downscale every frame (issue #650). Small panels now default to 720p.
+            width >= 1920 -> 3
             else -> 2
         }
 


### PR DESCRIPTION
## What

Cap the video resolution the head unit negotiates with the phone to what the physical panel can actually display. A 1024x600 panel now requests 720p instead of 1080p; panels that are genuinely 1080p or higher are unchanged.

## Why

The app advertised the negotiated resolution to the phone without ever bounding it to the physical panel. On small panels this means the phone encodes and streams a much larger frame than the screen can show (for example 1920x1080 to a 1024x600 panel, more than double the pixels), which is:

- wasted bandwidth over the USB/WiFi link, for no visible gain,
- extra decode work on the head unit, and
- an unnecessary per-frame downscale in the display pipeline.

Capping to the panel removes that waste. The principle is simple: never ask the phone for more pixels than the screen has.

Note on origin: this came out of investigating #650 (video stall). On-device testing there confirmed the stall's main cause was the GLES rendering path, which is addressed separately (the setup wizard now recommends SurfaceView for those devices). So this resolution cap is a general efficiency improvement rather than the #650 fix, but it is worth having on its own.

## Change

- Cap the negotiated resolution to the native resolution the panel warrants, reusing the existing AUTO selection against the physical panel size. It only ever lowers, never raises, so explicit lower choices and HEVC-gated 1440p/4K are untouched. Result: 1024x600 to 720p; 1280x720 to 720p; a real 1920x1080 panel stays 1080p; 1440p/4K unchanged.
- Stop the setup wizard from recommending 1080p on small high-DPI panels (it keyed off densityDpi); base the recommendation on actual pixel width.
- Log the resolution decision ([RES_CAP]) for diagnostics.

## Testing

Builds clean on the github debug flavor. Reason-checked: 1024x600 to 720p, no change for real 1080p/1440p/4K panels, portrait handled.
