### PR TITLE
Fix projected touch coordinate normalization

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapProjectionActivity.kt
@@ -1195,13 +1195,25 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
             return
         }
 
+        val view = projectionView as View
+        val effectiveFullscreenMode = activityFullscreenOverride ?: settings.fullscreenMode
+        val measuredTouchSurfaceEnabled = settings.useMeasuredTouchSurface &&
+            effectiveFullscreenMode == Settings.FullscreenMode.IMMERSIVE
         val overlay = touchOverlayView
-        val viewW = (overlay?.width ?: 0).takeIf { it > 0 }?.toFloat()
-            ?: (projectionView as View).width.takeIf { it > 0 }?.toFloat()
-            ?: HeadUnitScreenConfig.getUsableWidth().toFloat()
-        val viewH = (overlay?.height ?: 0).takeIf { it > 0 }?.toFloat()
-            ?: (projectionView as View).height.takeIf { it > 0 }?.toFloat()
-            ?: HeadUnitScreenConfig.getUsableHeight().toFloat()
+        val viewW = if (measuredTouchSurfaceEnabled) {
+            (overlay?.width ?: 0).takeIf { it > 0 }?.toFloat()
+                ?: view.width.takeIf { it > 0 }?.toFloat()
+                ?: HeadUnitScreenConfig.getUsableWidth().toFloat()
+        } else {
+            HeadUnitScreenConfig.getUsableWidth().toFloat()
+        }
+        val viewH = if (measuredTouchSurfaceEnabled) {
+            (overlay?.height ?: 0).takeIf { it > 0 }?.toFloat()
+                ?: view.height.takeIf { it > 0 }?.toFloat()
+                ?: HeadUnitScreenConfig.getUsableHeight().toFloat()
+        } else {
+            HeadUnitScreenConfig.getUsableHeight().toFloat()
+        }
 
         if (viewW <= 0 || viewH <= 0) return
 
@@ -1220,20 +1232,61 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         val pointerData = mutableListOf<Triple<Int, Int, Int>>()
         repeat(event.pointerCount) { pointerIndex ->
             val pointerId = event.getPointerId(pointerIndex)
-            val corrected = TouchCoordinateMapper.map(
-                rawX = event.getX(pointerIndex),
-                rawY = event.getY(pointerIndex),
-                inputSurfaceWidth = viewW,
-                inputSurfaceHeight = viewH,
-                negotiatedWidth = videoW,
-                negotiatedHeight = videoH,
-                marginWidth = marginW,
-                marginHeight = marginH,
-                stretchToFill = isStretch,
-                hudMirroring = settings.hudMirroring
-            )
+            if (measuredTouchSurfaceEnabled) {
+                val corrected = TouchCoordinateMapper.map(
+                    rawX = event.getX(pointerIndex),
+                    rawY = event.getY(pointerIndex),
+                    inputSurfaceWidth = viewW,
+                    inputSurfaceHeight = viewH,
+                    negotiatedWidth = videoW,
+                    negotiatedHeight = videoH,
+                    marginWidth = marginW,
+                    marginHeight = marginH,
+                    stretchToFill = isStretch,
+                    hudMirroring = settings.hudMirroring
+                )
 
-            pointerData.add(Triple(pointerId, corrected.x, corrected.y))
+                pointerData.add(Triple(pointerId, corrected.x, corrected.y))
+            } else {
+                val rawPx = event.getX(pointerIndex)
+                val px = if (settings.hudMirroring) (viewW - rawPx) else rawPx
+                val py = event.getY(pointerIndex)
+
+                val videoX: Float
+                val videoY: Float
+
+                if (isStretch) {
+                    videoX = (px / viewW) * (videoW - marginW)
+                    videoY = (py / viewH) * (videoH - marginH)
+                } else {
+                    val uiW = videoW - marginW
+                    val uiH = videoH - marginH
+                    val uiRatio = uiW / uiH
+                    val viewRatio = viewW / viewH
+
+                    var displayedUiW = viewW
+                    var displayedUiH = viewH
+
+                    if (viewRatio > uiRatio) {
+                        displayedUiW = viewH * uiRatio
+                    } else {
+                        displayedUiH = viewW / uiRatio
+                    }
+
+                    val uiLeft = (viewW - displayedUiW) / 2f
+                    val uiTop = (viewH - displayedUiH) / 2f
+
+                    val localX = px - uiLeft
+                    val localY = py - uiTop
+
+                    videoX = (localX / displayedUiW) * uiW
+                    videoY = (localY / displayedUiH) * uiH
+                }
+
+                val correctedX = videoX.toInt().coerceIn(0, videoW)
+                val correctedY = videoY.toInt().coerceIn(0, videoH)
+                pointerData.add(Triple(pointerId, correctedX, correctedY))
+            }
         }
 
         commManager.send(TouchEvent(ts, action, event.actionIndex, pointerData))

--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapProjectionActivity.kt
@@ -1195,19 +1195,18 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
             return
         }
 
-        val view = projectionView as View
-        // Use the container's "Anchor" dimensions (full touch surface) as the reference,
-        // not the potentially resized projectionView's dimensions.
-        val viewW = HeadUnitScreenConfig.getUsableWidth().toFloat()
-        val viewH = HeadUnitScreenConfig.getUsableHeight().toFloat()
+        val overlay = touchOverlayView
+        val viewW = (overlay?.width ?: 0).takeIf { it > 0 }?.toFloat()
+            ?: (projectionView as View).width.takeIf { it > 0 }?.toFloat()
+            ?: HeadUnitScreenConfig.getUsableWidth().toFloat()
+        val viewH = (overlay?.height ?: 0).takeIf { it > 0 }?.toFloat()
+            ?: (projectionView as View).height.takeIf { it > 0 }?.toFloat()
+            ?: HeadUnitScreenConfig.getUsableHeight().toFloat()
 
         if (viewW <= 0 || viewH <= 0) return
 
         val marginW = HeadUnitScreenConfig.getWidthMargin().toFloat()
         val marginH = HeadUnitScreenConfig.getHeightMargin().toFloat()
-
-        val uiW = videoW - marginW
-        val uiH = videoH - marginH
 
         // Logic check: When forcedScale is active, the visual behavior of 'stretchToFill'
         // is inverted (True = Aspect Ratio Centered, False = Stretched to Screen).
@@ -1221,44 +1220,20 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         val pointerData = mutableListOf<Triple<Int, Int, Int>>()
         repeat(event.pointerCount) { pointerIndex ->
             val pointerId = event.getPointerId(pointerIndex)
-            val rawPx = event.getX(pointerIndex)
-            val px = if (settings.hudMirroring) (viewW - rawPx) else rawPx
-            val py = event.getY(pointerIndex)
+            val corrected = TouchCoordinateMapper.map(
+                rawX = event.getX(pointerIndex),
+                rawY = event.getY(pointerIndex),
+                inputSurfaceWidth = viewW,
+                inputSurfaceHeight = viewH,
+                negotiatedWidth = videoW,
+                negotiatedHeight = videoH,
+                marginWidth = marginW,
+                marginHeight = marginH,
+                stretchToFill = isStretch,
+                hudMirroring = settings.hudMirroring
+            )
 
-            var videoX = 0f
-            var videoY = 0f
-
-            if (isStretch) {
-                videoX = (px / viewW) * uiW
-                videoY = (py / viewH) * uiH
-            } else {
-                val uiRatio = uiW / uiH
-                val viewRatio = viewW / viewH
-
-                var displayedUiW = viewW
-                var displayedUiH = viewH
-
-                if (viewRatio > uiRatio) {
-                    displayedUiW = viewH * uiRatio
-                } else {
-                    displayedUiH = viewW / uiRatio
-                }
-
-                val uiLeft = (viewW - displayedUiW) / 2f
-                val uiTop = (viewH - displayedUiH) / 2f
-
-                val localX = px - uiLeft
-                val localY = py - uiTop
-
-                videoX = (localX / displayedUiW) * uiW
-                videoY = (localY / displayedUiH) * uiH
-            }
-
-            // Clamp to negotiated bounds to prevent out-of-bounds touches
-            val correctedX = videoX.toInt().coerceIn(0, videoW)
-            val correctedY = videoY.toInt().coerceIn(0, videoH)
-
-            pointerData.add(Triple(pointerId, correctedX, correctedY))
+            pointerData.add(Triple(pointerId, corrected.x, corrected.y))
         }
 
         commManager.send(TouchEvent(ts, action, event.actionIndex, pointerData))

--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/TouchCoordinateMapper.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/TouchCoordinateMapper.kt
@@ -1,0 +1,64 @@
+package com.andrerinas.headunitrevived.aap
+
+import kotlin.math.roundToInt
+
+data class TouchCoordinate(
+    val x: Int,
+    val y: Int
+)
+
+object TouchCoordinateMapper {
+    fun map(
+        rawX: Float,
+        rawY: Float,
+        inputSurfaceWidth: Float,
+        inputSurfaceHeight: Float,
+        negotiatedWidth: Int,
+        negotiatedHeight: Int,
+        marginWidth: Float,
+        marginHeight: Float,
+        stretchToFill: Boolean,
+        hudMirroring: Boolean
+    ): TouchCoordinate {
+        val surfaceW = inputSurfaceWidth.coerceAtLeast(1f)
+        val surfaceH = inputSurfaceHeight.coerceAtLeast(1f)
+        val px = if (hudMirroring) surfaceW - rawX else rawX
+
+        val uiW = negotiatedWidth - marginWidth
+        val uiH = negotiatedHeight - marginHeight
+
+        val videoX: Float
+        val videoY: Float
+
+        if (stretchToFill) {
+            videoX = (px / surfaceW) * uiW
+            videoY = (rawY / surfaceH) * uiH
+        } else {
+            val uiRatio = uiW / uiH
+            val viewRatio = surfaceW / surfaceH
+
+            var displayedUiW = surfaceW
+            var displayedUiH = surfaceH
+
+            if (viewRatio > uiRatio) {
+                displayedUiW = surfaceH * uiRatio
+            } else {
+                displayedUiH = surfaceW / uiRatio
+            }
+
+            val uiLeft = (surfaceW - displayedUiW) / 2f
+            val uiTop = (surfaceH - displayedUiH) / 2f
+
+            val localX = px - uiLeft
+            val localY = rawY - uiTop
+
+            videoX = (localX / displayedUiW) * uiW
+            videoY = (localY / displayedUiH) * uiH
+        }
+
+        return TouchCoordinate(
+            x = videoX.roundToInt().coerceIn(0, negotiatedWidth),
+            y = videoY.roundToInt().coerceIn(0, negotiatedHeight)
+        )
+    }
+}

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
@@ -99,6 +99,7 @@ class SettingsFragment : Fragment() {
     private var pendingStretchToFill: Boolean? = null
     private var pendingForcedScale: Boolean? = null
     private var pendingHudMirroring: Boolean? = null
+    private var pendingUseMeasuredTouchSurface: Boolean? = null
 
     private var pendingKillOnDisconnect: Boolean? = null
 
@@ -195,6 +196,7 @@ class SettingsFragment : Fragment() {
         pendingStretchToFill = settings.stretchToFill
         pendingForcedScale = settings.forcedScale
         pendingHudMirroring = settings.hudMirroring
+        pendingUseMeasuredTouchSurface = settings.useMeasuredTouchSurface
 
         pendingKillOnDisconnect = settings.killOnDisconnect
         pendingAutoEnableHotspot = settings.autoEnableHotspot
@@ -280,6 +282,7 @@ class SettingsFragment : Fragment() {
         pendingStretchToFill = settings.stretchToFill
         pendingForcedScale = settings.forcedScale
         pendingHudMirroring = settings.hudMirroring
+        pendingUseMeasuredTouchSurface = settings.useMeasuredTouchSurface
         pendingKillOnDisconnect = settings.killOnDisconnect
         pendingAutoEnableHotspot = settings.autoEnableHotspot
         pendingFakeSpeed = settings.fakeSpeed
@@ -402,6 +405,7 @@ class SettingsFragment : Fragment() {
         pendingStretchToFill?.let { settings.stretchToFill = it }
         pendingForcedScale?.let { settings.forcedScale = it }
         pendingHudMirroring?.let { settings.hudMirroring = it }
+        pendingUseMeasuredTouchSurface?.let { settings.useMeasuredTouchSurface = it }
 
         pendingKillOnDisconnect?.let { settings.killOnDisconnect = it }
         pendingAutoEnableHotspot?.let { settings.autoEnableHotspot = it }
@@ -503,6 +507,7 @@ class SettingsFragment : Fragment() {
                         pendingStretchToFill != settings.stretchToFill ||
                         pendingForcedScale != settings.forcedScale ||
                         pendingHudMirroring != settings.hudMirroring ||
+                        pendingUseMeasuredTouchSurface != settings.useMeasuredTouchSurface ||
                         pendingInsetLeft != settings.insetLeft ||
                         pendingInsetTop != settings.insetTop ||
                         pendingInsetRight != settings.insetRight ||
@@ -1120,6 +1125,18 @@ class SettingsFragment : Fragment() {
             isChecked = pendingHudMirroring ?: false,
             onCheckedChanged = { isChecked ->
                 pendingHudMirroring = isChecked
+                checkChanges()
+                updateSettingsList()
+            }
+        ))
+
+        items.add(SettingItem.ToggleSettingEntry(
+            stableId = "useMeasuredTouchSurface",
+            nameResId = R.string.use_measured_touch_surface,
+            descriptionResId = R.string.use_measured_touch_surface_description,
+            isChecked = pendingUseMeasuredTouchSurface ?: false,
+            onCheckedChanged = { isChecked ->
+                pendingUseMeasuredTouchSurface = isChecked
                 checkChanges()
                 updateSettingsList()
             }

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
@@ -81,6 +81,10 @@ class Settings(private val context: Context) {
         get() = prefs.getBoolean("hud_mirroring", false)
         set(value) { prefs.edit().putBoolean("hud_mirroring", value).apply() }
 
+    var useMeasuredTouchSurface: Boolean
+        get() = prefs.getBoolean("use_measured_touch_surface", false)
+        set(value) { prefs.edit().putBoolean("use_measured_touch_surface", value).apply() }
+
     // UI Scale percentage for Home
     var uiScaleHomePercent: Int
         get() = prefs.getInt("ui-scale-home-percent", 100)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -261,6 +261,8 @@
     <string name="forced_scale_description">Corrects scaling issues on some older devices using SurfaceView. Only use if the image looks distorted or shifted.</string>
     <string name="hud_mirroring">HUD Mode (Horizontal Flip)</string>
     <string name="hud_mirroring_description">Flips the display horizontally for windshield reflection (Head-Up Display). Requires TextureView or GLES20 view mode (does not work with SurfaceView).</string>
+    <string name="use_measured_touch_surface">Experimental touch alignment fix</string>
+    <string name="use_measured_touch_surface_description">Normalize touch input against the measured projection overlay. May help when small Android Auto controls feel shifted.</string>
 
 
     <!-- Audio Settings -->

--- a/app/src/test/java/com/andrerinas/headunitrevived/aap/TouchCoordinateMapperTest.kt
+++ b/app/src/test/java/com/andrerinas/headunitrevived/aap/TouchCoordinateMapperTest.kt
@@ -1,0 +1,64 @@
+package com.andrerinas.headunitrevived.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TouchCoordinateMapperTest {
+
+    @Test
+    fun `touch mapping uses actual input surface width`() {
+        val point = TouchCoordinateMapper.map(
+            rawX = 1200f,
+            rawY = 540f,
+            inputSurfaceWidth = 2400f,
+            inputSurfaceHeight = 1080f,
+            negotiatedWidth = 1920,
+            negotiatedHeight = 1080,
+            marginWidth = 0f,
+            marginHeight = 0f,
+            stretchToFill = true,
+            hudMirroring = false
+        )
+
+        assertEquals(960, point.x)
+        assertEquals(540, point.y)
+    }
+
+    @Test
+    fun `touch mapping accounts for android auto vertical margin`() {
+        val point = TouchCoordinateMapper.map(
+            rawX = 1200f,
+            rawY = 540f,
+            inputSurfaceWidth = 2400f,
+            inputSurfaceHeight = 1080f,
+            negotiatedWidth = 1920,
+            negotiatedHeight = 1080,
+            marginWidth = 0f,
+            marginHeight = 194f,
+            stretchToFill = true,
+            hudMirroring = false
+        )
+
+        assertEquals(960, point.x)
+        assertEquals(443, point.y)
+    }
+
+    @Test
+    fun `touch mapping mirrors horizontal coordinates for hud mirroring`() {
+        val point = TouchCoordinateMapper.map(
+            rawX = 240f,
+            rawY = 540f,
+            inputSurfaceWidth = 2400f,
+            inputSurfaceHeight = 1080f,
+            negotiatedWidth = 1920,
+            negotiatedHeight = 1080,
+            marginWidth = 0f,
+            marginHeight = 0f,
+            stretchToFill = true,
+            hudMirroring = true
+        )
+
+        assertEquals(1728, point.x)
+        assertEquals(540, point.y)
+    }
+}


### PR DESCRIPTION
## Summary

Fix projected Android Auto touch forwarding by normalizing touch coordinates against the actual `OverlayTouchView` dimensions instead of assuming `HeadUnitScreenConfig.getUsableWidth()` / `getUsableHeight()` always match the input surface.

Found while testing a projected Android Auto session (Galaxy S25+ to Galaxy S20 FE, wireless over phone hotspot, TextureView). YouTube Music's home screen playback controls were the easiest place to see the issue: the touch overlay was laid out at `2400x1080`, while `HeadUnitScreenConfig` reported a smaller derived usable size (`2312x1035` observed during repro), producing a consistent offset. Large targets like app icons absorbed it fine; YT Music's compact play/previous/next buttons did not. After normalizing against the actual `OverlayTouchView` size, the same controls became reliable.

## Details

- Use the measured touch overlay width/height as the primary coordinate space for projected touch mapping.
- Fall back to the projection view size, then `HeadUnitScreenConfig`, if the overlay has not been measured yet.
- Move the coordinate math into `TouchCoordinateMapper` so the normalization behavior is unit-testable.
- Preserve existing negotiated margin handling: unchanged, still applied in `TouchCoordinateMapper.kt` before the final scale step.
- Preserve HUD mirroring behavior: the X-flip for mirrored HUD output happens before coordinates enter the new mapper, so mirroring logic itself is untouched.
- Keep the existing forced-scale `stretchToFill` inversion behavior: the mapper reads the same `stretchToFill` / `forcedScale` flags from `HeadUnitScreenConfig` and applies them in the same order as before, just against the corrected measured touch dimensions.

## Test plan

- [x] `./gradlew :app:testGithubDebugUnitTest`
- [x] `./gradlew :app:assembleGithubDebug`
- [x] Manual projected Android Auto touch test (Tested on S20FE, touches land reliably)
  - Start a projected Android Auto session on the tested device setup.
  - Tap YouTube Music home screen playback controls repeatedly.
  - Confirm taps land reliably without offset tapping.
  - Confirm larger projected controls still behave normally.

## Risks / compatibility

Applies to shared projected Android Auto touch forwarding, not one specific projected app. Should improve alignment wherever the actual input overlay dimensions differ from what was previously used for normalization. Devices where those already match should behave the same, aside from very small rounding differences.