### PR TITLE
Fix WiFi Direct not auto-connecting when reusing an existing group (#719)

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
@@ -529,7 +529,24 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 createNewGroup(0)
                 return@requestGroupInfo
             } else {
-                AppLog.i("Existing P2P group found, skip createGroup")
+                // The group already exists (reused), so no WIFI_P2P_CONNECTION_CHANGED
+                // broadcast fires to trigger onGroupInfoAvailable. Resolve the device info
+                // and request the group info ourselves so the SSID, passphrase, IP and BSSID
+                // are delivered to the phone via onCredentialsReady, exactly like the freshly
+                // created group path does. Without this the phone never receives the
+                // credentials and cannot auto-join the reused group, so it has to be
+                // connected by hand through the Wireless Helper.
+                AppLog.i("Existing P2P group found, delivering its credentials")
+                isGroupOwner = group.isGroupOwner
+                WifiDirectCompat.requestDeviceInfo(manager, channel) { address ->
+                    AppLog.i("WifiDirectManager: Updated localDeviceAddress via requestDeviceInfo: $address")
+                    localDeviceAddress = address
+                    manager?.requestGroupInfo(channel, this@WifiDirectManager)
+                }
+                // Fallback: if requestDeviceInfo is not supported (< API 29), call directly
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                    manager?.requestGroupInfo(channel, this)
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #719.

When an existing P2P group is present, WifiDirectManager.checkGroupAndCreate() took a branch that only logged and returned, so onGroupInfoAvailable never ran and the group credentials (SSID, passphrase, IP, BSSID) were never delivered to the phone through onCredentialsReady. Since the group is now reused instead of being removed and recreated (PR #695), the phone stopped receiving the credentials and could no longer auto-join, so the Wireless Helper had to be opened by hand and the quick auto-reconnect was lost.

The reuse branch now resolves and delivers the credentials for the existing group, the same way the fresh-group path does: it sets the group-owner flag and runs the device-info then group-info request so onGroupInfoAvailable runs. The BSSID resolution from PR #699 still applies, since it lives inside onGroupInfoAvailable.

I cannot reproduce or test this myself, since I use a wireless USB adapter and not WiFi. A test build and a request to confirm are on #719.
