### PR TITLE
Fix Native AA Bluetooth handshake reliability

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
@@ -1708,6 +1708,24 @@ class AapService : Service(), UsbReceiver.Listener {
                     nativeAaHandshakeManager?.manualPoke(mac)
                 }
             }
+            ACTION_BT_AUTO_START          -> {
+                // AutoStartReceiver fires this on ACL_CONNECTED from a trusted device. If the
+                // service process was already alive (e.g. survived a prior disconnect/exit in
+                // this same session), onCreate()'s initWifiMode() never re-runs, so a Native AA
+                // mode that was stopped after a user exit (nativeAaHandshakeManager.stop() at
+                // disconnect) would otherwise stay dead forever despite the phone reconnecting.
+                // Only force a re-init when it's actually stopped — on a genuine cold start,
+                // onCreate() already armed everything moments ago and re-running would tear
+                // down and recreate the P2P group (new random SSID/passphrase) right as it's
+                // being delivered to the phone.
+                val settings = App.provide(this).settings
+                if (settings.wifiConnectionMode == 3 && nativeAaHandshakeManager?.isActive() != true) {
+                    AppLog.i("AapService: Bluetooth auto-start — Native AA handshake manager was stopped, re-arming.")
+                    userExitedAA = false
+                    userExitCooldownUntil = 0L
+                    initWifiMode(force = true)
+                }
+            }
             ACTION_NEARBY_CONNECT         -> {
                 val endpointId = intent?.getStringExtra(EXTRA_ENDPOINT_ID)
                 if (endpointId != null) {
@@ -2628,6 +2646,7 @@ class AapService : Service(), UsbReceiver.Listener {
         // Service action strings used with startService() and sendBroadcast()
         const val ACTION_START_SELF_MODE           = "com.andrerinas.headunitrevived.ACTION_START_SELF_MODE"
         const val ACTION_START_WIRELESS            = "com.andrerinas.headunitrevived.ACTION_START_WIRELESS"
+        const val ACTION_BT_AUTO_START              = "com.andrerinas.headunitrevived.ACTION_BT_AUTO_START"
         const val ACTION_START_WIRELESS_SCAN       = "com.andrerinas.headunitrevived.ACTION_START_WIRELESS_SCAN"
         const val ACTION_STOP_WIRELESS             = "com.andrerinas.headunitrevived.ACTION_STOP_WIRELESS"
         const val ACTION_NATIVE_AA_POKE            = "com.andrerinas.headunitrevived.ACTION_NATIVE_AA_POKE"

--- a/app/src/main/java/com/andrerinas/headunitrevived/app/AutoStartReceiver.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/app/AutoStartReceiver.kt
@@ -43,8 +43,10 @@ class AutoStartReceiver : BroadcastReceiver() {
             if (device != null && targetMacs.contains(device.address)) {
                 AppLog.i("MATCH! Starting AapService via Bluetooth Auto-start...")
 
-                // Start the service to make the app alive
-                val serviceIntent = Intent(context, AapService::class.java)
+                // Start the service to make the app alive. Explicit action so onStartCommand
+                // re-arms wireless mode even if the service process was already running from
+                // an earlier session (onCreate's init only runs once) — see ACTION_BT_AUTO_START.
+                val serviceIntent = Intent(context, AapService::class.java).setAction(AapService.ACTION_BT_AUTO_START)
                 try {
                     androidx.core.content.ContextCompat.startForegroundService(context, serviceIntent)
                 } catch (e: Exception) {

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
@@ -78,6 +78,8 @@ class NativeAaHandshakeManager(
         currentBssid = bssid
     }
 
+    fun isActive(): Boolean = isRunning
+
     @SuppressLint("MissingPermission")
     fun start() {
         if (isRunning) return
@@ -90,13 +92,16 @@ class NativeAaHandshakeManager(
             }
         }
 
-        isRunning = true
         val adapter = BluetoothHelper.getBluetoothAdapter(context)
         if (adapter == null || !adapter.isEnabled) {
+            // Leave isRunning false — isActive() callers (e.g. AapService's BT auto-start
+            // re-arm check) need to see this as genuinely stopped so they retry later,
+            // instead of believing the listener sockets are up when nothing was ever opened.
             AppLog.e("NativeAA: Bluetooth adapter not available or disabled")
             return
         }
 
+        isRunning = true
         AppLog.i("NativeAA: Starting Bluetooth Handshake Servers...")
 
         // Start AA RFCOMM Server

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
@@ -31,6 +31,7 @@ class NativeAaHandshakeManager(
         private val AA_UUID = UUID.fromString("4de17a00-52cb-11e6-bdf4-0800200c9a66")
         private val HFP_UUID = UUID.fromString("0000111e-0000-1000-8000-00805f9b34fb")
         private val A2DP_SOURCE_UUID = UUID.fromString("00001112-0000-1000-8000-00805f9b34fb")
+        private const val HANDSHAKE_RESPONSE_TIMEOUT_MS = 15_000L
 
         fun checkCompatibility(context: Context): Boolean {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -369,7 +370,17 @@ class NativeAaHandshakeManager(
             sendWifiStartRequest(output, ip, 5288)
 
             AppLog.i("NativeAA: Waiting for response from phone...")
-            val response = readProtobuf(input)
+            // No BluetoothSocket.setSoTimeout(); force-close via watchdog to unblock readFully() on timeout.
+            val watchdog = scope.launch(Dispatchers.IO) {
+                delay(HANDSHAKE_RESPONSE_TIMEOUT_MS)
+                AppLog.e("NativeAA: Handshake failed - No response from phone within ${HANDSHAKE_RESPONSE_TIMEOUT_MS / 1000}s of sending WifiStartRequest. Closing socket.")
+                try { socket.close() } catch (e: Exception) {}
+            }
+            val response = try {
+                readProtobuf(input)
+            } finally {
+                watchdog.cancel()
+            }
             AppLog.i("NativeAA: [RX] Received Type ${response.type} (Payload size: ${response.payload.size})")
 
             if (response.type == 2) {


### PR DESCRIPTION
## Summary

- Adds a 15s watchdog to the Native AA (Android Auto Wireless) Bluetooth handshake: after sending `WifiStartRequest`, `NativeAaHandshakeManager` called `DataInputStream.readFully()` with no timeout, so a phone that never replied left the handshake blocked forever with no error and no retry. `BluetoothSocket` has no `setSoTimeout()`, so a watchdog now force-closes the socket after 15s if no response arrives, turning a silent hang into a diagnosable failure.
- Fixes a latent bug in `NativeAaHandshakeManager.start()`: the "listener running" flag was set `true` before checking whether the Bluetooth adapter was actually ready. If that check ever failed once (e.g. at boot, before the head unit's BT stack finished initializing), the flag got stuck `true` forever, and the AA RFCOMM listener was never actually opened — every later start attempt (including manual pokes) silently no-opped instead of retrying.
- Fixes `AutoStartReceiver` starting `AapService` with a bare intent on a trusted-device Bluetooth reconnect. If the service process was already alive from an earlier session, `onCreate()`'s init never re-runs, so a Native AA handshake manager that had been stopped (e.g. after a user exit) stayed dead despite the phone reconnecting. The receiver now sends an explicit action so `onStartCommand` re-arms wireless mode only when the handshake manager isn't already active.

## Root cause context

Root-caused from user report #706, where a phone connected over Bluetooth, received `WifiStartRequest`, and never sent a response. Digging into a fresh log from the same reporter, the actual issue traced further back: no `"ACTIVELY LISTENING on Android Auto UUID"` or `"Connection accepted from"` line ever appeared in the whole session, despite two manual poke attempts that each successfully woke the phone — meaning HUR's own Bluetooth listener was never actually open. The `isRunning` flag bug above explains that exactly: a single early failure (adapter not ready yet) permanently defeats every subsequent start/retry attempt for the life of the process. The reporter tested with two different phones and got the identical result both times, pointing at HUR rather than phone-side power management.

## What this does NOT fix

This does not address why the Bluetooth adapter check might fail in the first place on a given unit (e.g. boot-order timing on some head unit chipsets). It makes that failure mode recoverable instead of a permanent, silent dead end.

## Test plan

- [x] Real hardware regression test: Unisoc-based head unit + Motorola phone — BT handshake, WiFi Direct join, SSL handshake, AA protocol negotiation, first video frame, clean disconnect.
- [x] Verified reconnect works after an in-session disconnect/exit without killing the app process (previously required a full app restart to recover).
- [ ] Awaiting confirmation from the #706 reporter.