### PR TITLE
Restore the WiFi Launcher wake so the Wireless Helper auto-launches again (#719)

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
@@ -2133,8 +2133,10 @@ class AapService : Service(), UsbReceiver.Listener {
                         }
                     }
                     5289 -> {
-                        // WiFi Launcher detected — no connection needed, just log
-                        AppLog.i("Triggered Wifi Launcher at $ip:$port.")
+                        // WiFi Launcher detected. The wake (holding the probe socket open) already
+                        // happened in NetworkDiscovery; here we just wait for the helper to launch
+                        // and connect back to our WirelessServer on 5288.
+                        AppLog.i("AapService: WiFi Launcher detected at $ip:$port; awaiting inbound helper connection on 5288")
                     }
                 }
             }

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NetworkDiscovery.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NetworkDiscovery.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.net.Inet4Address
@@ -146,10 +147,17 @@ class NetworkDiscovery(private val context: Context, private val listener: Liste
         // Check Port 5289 (Wifi Launcher) - prioritizing this
         val launcherSocket = checkPort(ip, 5289, timeout = 300)
         if (launcherSocket != null) {
-            AppLog.i("NetworkDiscovery: Found Wifi Launcher on $ip:5289")
+            // The phone-side Wireless Helper watches for this inbound probe to auto-launch
+            // itself. Hold the socket open briefly before closing so it has time to react;
+            // closing it instantly (as the consolidated scan did) stopped waking the helper,
+            // so the user had to open it by hand.
+            val holdMs = 500L
+            AppLog.i("NetworkDiscovery: Found Wifi Launcher on $ip:5289, holding probe ${holdMs}ms to wake the helper")
             reportedIps.add(ip)
+            try { delay(holdMs) } catch (e: Exception) {}
             withContext(Dispatchers.Main) {
                 try { launcherSocket.close() } catch (e: Exception) {}
+                AppLog.i("NetworkDiscovery: Wifi Launcher probe released; awaiting inbound helper connection on 5288")
                 listener.onServiceFound(ip, 5289)
             }
             return true
@@ -176,6 +184,9 @@ class NetworkDiscovery(private val context: Context, private val listener: Liste
             socket.connect(InetSocketAddress(ip, port), timeout)
             socket
         } catch (e: Exception) {
+            // Surface a failed Wifi Launcher probe so logs can tell "helper not listening"
+            // apart from "the scan never ran".
+            if (port == 5289) AppLog.d("NetworkDiscovery: $ip:5289 probe failed (${e.javaClass.simpleName}); Wifi Launcher not listening")
             null
         }
     }


### PR DESCRIPTION
Part of #719.

This is a second, separate cause behind #719, in a different code path from PR #722 (which fixes the WiFi Direct group reuse). This one is the WiFi Helper / WiFi Launcher path, used when the phone is the WiFi host (phone hotspot).

In Helper mode the head unit wakes the phone's Wireless Helper by opening a short TCP probe to port 5289 and holding it open for a moment, so the helper notices the inbound socket and launches itself. When the two NetworkDiscovery files were consolidated into one, that brief hold was dropped, and the probe socket is now closed instantly. As a result the helper is no longer woken when it is not already running, so the user has to open the Wireless Helper by hand. Once the helper is already open the connection still works, which matches the reports.

The 5289 probe is held open for about 500 ms again before closing, restoring the wake. I also added logging around it (probe held, probe released, and a failed probe line) so a connection log clearly shows whether the wake fired.

I cannot reproduce or test this myself, since I use a wireless USB adapter and not WiFi, so this is the first time I am touching the WiFi code and I am working on assumptions. A test build and a request to confirm are on #719.
