### PR TITLE
Unify wizard + wireless fixes (mine + @o-jcardenass #725) into one testable branch

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
@@ -1708,6 +1708,24 @@ class AapService : Service(), UsbReceiver.Listener {
                     nativeAaHandshakeManager?.manualPoke(mac)
                 }
             }
+            ACTION_BT_AUTO_START          -> {
+                // AutoStartReceiver fires this on ACL_CONNECTED from a trusted device. If the
+                // service process was already alive (e.g. survived a prior disconnect/exit in
+                // this same session), onCreate()'s initWifiMode() never re-runs, so a Native AA
+                // mode that was stopped after a user exit (nativeAaHandshakeManager.stop() at
+                // disconnect) would otherwise stay dead forever despite the phone reconnecting.
+                // Only force a re-init when it's actually stopped — on a genuine cold start,
+                // onCreate() already armed everything moments ago and re-running would tear
+                // down and recreate the P2P group (new random SSID/passphrase) right as it's
+                // being delivered to the phone.
+                val settings = App.provide(this).settings
+                if (settings.wifiConnectionMode == 3 && nativeAaHandshakeManager?.isActive() != true) {
+                    AppLog.i("AapService: Bluetooth auto-start — Native AA handshake manager was stopped, re-arming.")
+                    userExitedAA = false
+                    userExitCooldownUntil = 0L
+                    initWifiMode(force = true)
+                }
+            }
             ACTION_NEARBY_CONNECT         -> {
                 val endpointId = intent?.getStringExtra(EXTRA_ENDPOINT_ID)
                 if (endpointId != null) {
@@ -2630,6 +2648,7 @@ class AapService : Service(), UsbReceiver.Listener {
         // Service action strings used with startService() and sendBroadcast()
         const val ACTION_START_SELF_MODE           = "com.andrerinas.headunitrevived.ACTION_START_SELF_MODE"
         const val ACTION_START_WIRELESS            = "com.andrerinas.headunitrevived.ACTION_START_WIRELESS"
+        const val ACTION_BT_AUTO_START              = "com.andrerinas.headunitrevived.ACTION_BT_AUTO_START"
         const val ACTION_START_WIRELESS_SCAN       = "com.andrerinas.headunitrevived.ACTION_START_WIRELESS_SCAN"
         const val ACTION_STOP_WIRELESS             = "com.andrerinas.headunitrevived.ACTION_STOP_WIRELESS"
         const val ACTION_NATIVE_AA_POKE            = "com.andrerinas.headunitrevived.ACTION_NATIVE_AA_POKE"

--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
@@ -2133,8 +2133,10 @@ class AapService : Service(), UsbReceiver.Listener {
                         }
                     }
                     5289 -> {
-                        // WiFi Launcher detected — no connection needed, just log
-                        AppLog.i("Triggered Wifi Launcher at $ip:$port.")
+                        // WiFi Launcher detected. The wake (holding the probe socket open) already
+                        // happened in NetworkDiscovery; here we just wait for the helper to launch
+                        // and connect back to our WirelessServer on 5288.
+                        AppLog.i("AapService: WiFi Launcher detected at $ip:$port; awaiting inbound helper connection on 5288")
                     }
                 }
             }

--- a/app/src/main/java/com/andrerinas/headunitrevived/app/AutoStartReceiver.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/app/AutoStartReceiver.kt
@@ -43,8 +43,10 @@ class AutoStartReceiver : BroadcastReceiver() {
             if (device != null && targetMacs.contains(device.address)) {
                 AppLog.i("MATCH! Starting AapService via Bluetooth Auto-start...")
 
-                // Start the service to make the app alive
-                val serviceIntent = Intent(context, AapService::class.java)
+                // Start the service to make the app alive. Explicit action so onStartCommand
+                // re-arms wireless mode even if the service process was already running from
+                // an earlier session (onCreate's init only runs once) — see ACTION_BT_AUTO_START.
+                val serviceIntent = Intent(context, AapService::class.java).setAction(AapService.ACTION_BT_AUTO_START)
                 try {
                     androidx.core.content.ContextCompat.startForegroundService(context, serviceIntent)
                 } catch (e: Exception) {

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
@@ -78,6 +78,8 @@ class NativeAaHandshakeManager(
         currentBssid = bssid
     }
 
+    fun isActive(): Boolean = isRunning
+
     @SuppressLint("MissingPermission")
     fun start() {
         if (isRunning) return
@@ -90,13 +92,16 @@ class NativeAaHandshakeManager(
             }
         }
 
-        isRunning = true
         val adapter = BluetoothHelper.getBluetoothAdapter(context)
         if (adapter == null || !adapter.isEnabled) {
+            // Leave isRunning false — isActive() callers (e.g. AapService's BT auto-start
+            // re-arm check) need to see this as genuinely stopped so they retry later,
+            // instead of believing the listener sockets are up when nothing was ever opened.
             AppLog.e("NativeAA: Bluetooth adapter not available or disabled")
             return
         }
 
+        isRunning = true
         AppLog.i("NativeAA: Starting Bluetooth Handshake Servers...")
 
         // Start AA RFCOMM Server

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
@@ -31,6 +31,7 @@ class NativeAaHandshakeManager(
         private val AA_UUID = UUID.fromString("4de17a00-52cb-11e6-bdf4-0800200c9a66")
         private val HFP_UUID = UUID.fromString("0000111e-0000-1000-8000-00805f9b34fb")
         private val A2DP_SOURCE_UUID = UUID.fromString("00001112-0000-1000-8000-00805f9b34fb")
+        private const val HANDSHAKE_RESPONSE_TIMEOUT_MS = 15_000L
 
         fun checkCompatibility(context: Context): Boolean {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -369,7 +370,17 @@ class NativeAaHandshakeManager(
             sendWifiStartRequest(output, ip, 5288)
 
             AppLog.i("NativeAA: Waiting for response from phone...")
-            val response = readProtobuf(input)
+            // No BluetoothSocket.setSoTimeout(); force-close via watchdog to unblock readFully() on timeout.
+            val watchdog = scope.launch(Dispatchers.IO) {
+                delay(HANDSHAKE_RESPONSE_TIMEOUT_MS)
+                AppLog.e("NativeAA: Handshake failed - No response from phone within ${HANDSHAKE_RESPONSE_TIMEOUT_MS / 1000}s of sending WifiStartRequest. Closing socket.")
+                try { socket.close() } catch (e: Exception) {}
+            }
+            val response = try {
+                readProtobuf(input)
+            } finally {
+                watchdog.cancel()
+            }
             AppLog.i("NativeAA: [RX] Received Type ${response.type} (Payload size: ${response.payload.size})")
 
             if (response.type == 2) {

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
@@ -59,6 +59,8 @@ class NativeAaHandshakeManager(
     private val commManager = com.andrerinas.headunitrevived.App.provide(context).commManager
     private var aaServerSocket: BluetoothServerSocket? = null
     private var hfpServerSocket: BluetoothServerSocket? = null
+    // Extra RFCOMM listeners opened on secondary Bluetooth radios (dual-Bluetooth head units).
+    private val extraServerSockets = java.util.Collections.synchronizedList(mutableListOf<BluetoothServerSocket>())
     private var isRunning = false
 
     private var currentSsid: String? = null
@@ -147,6 +149,71 @@ class NativeAaHandshakeManager(
                 } else {
                     AppLog.d("NativeAA: HFP Server socket closed cleanly.")
                 }
+            }
+        }
+
+        // Experimental: some head units have two Bluetooth radios (e.g. "K706" and "CAR8032").
+        // The phone may be bonded to the one that is not the default, so it never reaches the
+        // listener above. Also open listeners on any other radio with a real, different address.
+        // Strict no-op on the usual single-radio device, and skipped when the address is masked
+        // (API 31+), so it cannot disturb the primary listener.
+        val primaryAddr = try { adapter.address } catch (e: Exception) { null }
+        if (primaryAddr != null && primaryAddr != "02:00:00:00:00:00") {
+            val secondaries = try {
+                BluetoothHelper.getAllBluetoothAdapters(context).filter {
+                    val a = try { it.address } catch (e: Exception) { null }
+                    a != null && a != "02:00:00:00:00:00" && a != primaryAddr
+                }
+            } catch (e: Exception) { emptyList() }
+            if (secondaries.isNotEmpty()) {
+                AppLog.i("NativeAA: Opening AA listeners on ${secondaries.size} secondary Bluetooth radio(s) for dual-radio head units")
+                secondaries.forEach { launchExtraServers(it) }
+            }
+        }
+    }
+
+    /**
+     * Open supplementary AA + HFP RFCOMM listeners on a secondary Bluetooth radio, so a phone
+     * bonded to that radio (dual-Bluetooth head units) can still reach us. Experimental, and
+     * fully guarded so a bad radio cannot affect the primary listener.
+     */
+    private fun launchExtraServers(extra: BluetoothAdapter) {
+        val addr = try { extra.address } catch (e: Exception) { "?" }
+        scope.launch(Dispatchers.IO + CoroutineName("NativeAa-RfcommServer-2")) {
+            try {
+                val server = extra.listenUsingRfcommWithServiceRecord("AA BT Listener", AA_UUID)
+                extraServerSockets.add(server)
+                AppLog.i("NativeAA: ACTIVELY LISTENING on Android Auto UUID on secondary radio [$addr]")
+                while (isRunning && isActive) {
+                    val socket = server.accept()
+                    if (socket != null) {
+                        AppLog.i("NativeAA: Connection accepted (secondary radio) from ${socket.remoteDevice.name}")
+                        scope.launch(Dispatchers.IO + CoroutineName("NativeAa-Handshake-${socket.remoteDevice.address}")) {
+                            handleHandshake(socket)
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                if (isRunning) AppLog.e("NativeAA: Secondary AA server error [$addr]: ${e.message}", e)
+                else AppLog.d("NativeAA: Secondary AA server closed cleanly [$addr].")
+            }
+        }
+        scope.launch(Dispatchers.IO + CoroutineName("NativeAa-HfpServer-2")) {
+            try {
+                val server = extra.listenUsingRfcommWithServiceRecord("Hands-Free Unit", HFP_UUID)
+                extraServerSockets.add(server)
+                while (isRunning && isActive) {
+                    val socket = server.accept()
+                    if (socket != null) {
+                        AppLog.i("NativeAA: HFP connection accepted (secondary radio) from ${socket.remoteDevice.name}.")
+                        scope.launch(Dispatchers.IO + CoroutineName("NativeAa-HfpResponder-${socket.remoteDevice.address}")) {
+                            handleHfp(socket)
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                if (isRunning) AppLog.e("NativeAA: Secondary HFP server error [$addr]: ${e.message}", e)
+                else AppLog.d("NativeAA: Secondary HFP server closed cleanly [$addr].")
             }
         }
     }
@@ -463,6 +530,10 @@ class NativeAaHandshakeManager(
         isRunning = false
         try { aaServerSocket?.close() } catch (e: Exception) {}
         try { hfpServerSocket?.close() } catch (e: Exception) {}
+        synchronized(extraServerSockets) {
+            extraServerSockets.forEach { try { it.close() } catch (e: Exception) {} }
+            extraServerSockets.clear()
+        }
         aaServerSocket = null
         hfpServerSocket = null
         currentSsid = null

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NetworkDiscovery.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NetworkDiscovery.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.net.Inet4Address
@@ -146,10 +147,17 @@ class NetworkDiscovery(private val context: Context, private val listener: Liste
         // Check Port 5289 (Wifi Launcher) - prioritizing this
         val launcherSocket = checkPort(ip, 5289, timeout = 300)
         if (launcherSocket != null) {
-            AppLog.i("NetworkDiscovery: Found Wifi Launcher on $ip:5289")
+            // The phone-side Wireless Helper watches for this inbound probe to auto-launch
+            // itself. Hold the socket open briefly before closing so it has time to react;
+            // closing it instantly (as the consolidated scan did) stopped waking the helper,
+            // so the user had to open it by hand.
+            val holdMs = 500L
+            AppLog.i("NetworkDiscovery: Found Wifi Launcher on $ip:5289, holding probe ${holdMs}ms to wake the helper")
             reportedIps.add(ip)
+            try { delay(holdMs) } catch (e: Exception) {}
             withContext(Dispatchers.Main) {
                 try { launcherSocket.close() } catch (e: Exception) {}
+                AppLog.i("NetworkDiscovery: Wifi Launcher probe released; awaiting inbound helper connection on 5288")
                 listener.onServiceFound(ip, 5289)
             }
             return true
@@ -176,6 +184,9 @@ class NetworkDiscovery(private val context: Context, private val listener: Liste
             socket.connect(InetSocketAddress(ip, port), timeout)
             socket
         } catch (e: Exception) {
+            // Surface a failed Wifi Launcher probe so logs can tell "helper not listening"
+            // apart from "the scan never ran".
+            if (port == 5289) AppLog.d("NetworkDiscovery: $ip:5289 probe failed (${e.javaClass.simpleName}); Wifi Launcher not listening")
             null
         }
     }

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
@@ -529,7 +529,24 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 createNewGroup(0)
                 return@requestGroupInfo
             } else {
-                AppLog.i("Existing P2P group found, skip createGroup")
+                // The group already exists (reused), so no WIFI_P2P_CONNECTION_CHANGED
+                // broadcast fires to trigger onGroupInfoAvailable. Resolve the device info
+                // and request the group info ourselves so the SSID, passphrase, IP and BSSID
+                // are delivered to the phone via onCredentialsReady, exactly like the freshly
+                // created group path does. Without this the phone never receives the
+                // credentials and cannot auto-join the reused group, so it has to be
+                // connected by hand through the Wireless Helper.
+                AppLog.i("Existing P2P group found, delivering its credentials")
+                isGroupOwner = group.isGroupOwner
+                WifiDirectCompat.requestDeviceInfo(manager, channel) { address ->
+                    AppLog.i("WifiDirectManager: Updated localDeviceAddress via requestDeviceInfo: $address")
+                    localDeviceAddress = address
+                    manager?.requestGroupInfo(channel, this@WifiDirectManager)
+                }
+                // Fallback: if requestDeviceInfo is not supported (< API 29), call directly
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                    manager?.requestGroupInfo(channel, this)
+                }
             }
         }
     }

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
@@ -41,6 +41,10 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     @Volatile private var manager: WifiP2pManager? = context.getSystemService(Context.WIFI_P2P_SERVICE) as? WifiP2pManager
     private var channel: WifiP2pManager.Channel? = null
     private var isGroupOwner = false
+    // True once we have created a P2P group in this session. A pre-existing group that we did
+    // NOT create this session is a stale persistent group (survives reboots) and is recreated
+    // fresh instead of reused, to stop the phone re-prompting to accept it (issue #719 / #703).
+    @Volatile private var groupCreatedThisSession = false
     private var isConnected = false
     @Volatile private var isGroupCreatingOrCreated = false
     private val handler = Handler(Looper.getMainLooper())
@@ -85,6 +89,8 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                     } else {
                         isGroupCreatingOrCreated = false
                         isConnected = false
+                        // P2P turned off tears down our active group; next time start fresh.
+                        groupCreatedThisSession = false
                     }
                 }
 
@@ -528,6 +534,26 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 AppLog.i("No existing P2P group, creating new one")
                 createNewGroup(0)
                 return@requestGroupInfo
+            } else if (!groupCreatedThisSession) {
+                // A P2P group exists but we did not create it this session, so it is a stale
+                // persistent group left over from a previous session or a reboot. Reusing it
+                // makes the phone re-prompt to accept a group it no longer trusts (the repeated
+                // accept prompts, and "works once then fails after reboot" on #719 / #703).
+                // Remove it and create a fresh one, the way it behaved before groups were reused.
+                AppLog.w("WifiDirectManager: Existing P2P group is stale (ssid=${group.networkName}, not created this session); removing and recreating a fresh one")
+                lastKnownBssid = null
+                isGroupOwner = false
+                manager?.removeGroup(channel, object : WifiP2pManager.ActionListener {
+                    override fun onSuccess() {
+                        AppLog.i("WifiDirectManager: Stale group removed, creating a fresh one")
+                        createNewGroup(0)
+                    }
+                    override fun onFailure(reason: Int) {
+                        AppLog.w("WifiDirectManager: removeGroup of stale group failed ($reason); creating a fresh one anyway")
+                        createNewGroup(0)
+                    }
+                })
+                return@requestGroupInfo
             } else {
                 // The group already exists (reused), so no WIFI_P2P_CONNECTION_CHANGED
                 // broadcast fires to trigger onGroupInfoAvailable. Resolve the device info
@@ -536,7 +562,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 // created group path does. Without this the phone never receives the
                 // credentials and cannot auto-join the reused group, so it has to be
                 // connected by hand through the Wireless Helper.
-                AppLog.i("Existing P2P group found, delivering its credentials")
+                AppLog.i("Existing P2P group found (created this session), delivering its credentials")
                 isGroupOwner = group.isGroupOwner
                 WifiDirectCompat.requestDeviceInfo(manager, channel) { address ->
                     AppLog.i("WifiDirectManager: Updated localDeviceAddress via requestDeviceInfo: $address")
@@ -565,9 +591,9 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
 
         mgr.createGroup(ch, object : WifiP2pManager.ActionListener {
             override fun onSuccess() {
-                AppLog.i("WifiDirectManager: P2P Group created.")
+                AppLog.i("WifiDirectManager: P2P Group created (fresh this session).")
                 isGroupOwner = true
-
+                groupCreatedThisSession = true
             }
             override fun onFailure(reason: Int) {
                 if (reason == 2 && retryCount < 3) { // 2 = BUSY
@@ -951,5 +977,6 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
 
         isGroupOwner = false
         isConnected = false
+        groupCreatedThisSession = false
     }
 }

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/DarkModeFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/DarkModeFragment.kt
@@ -369,6 +369,24 @@ class DarkModeFragment : Fragment(), SensorEventListener {
         }
     }
 
+    /**
+     * Persists the Auto/sunrise mode(s) and the fixed-point source immediately, so the mode
+     * is not deselected when the fragment is recreated on returning from the map (issue #647).
+     * [applyAppTheme] should be false right before navigating away, to avoid an activity
+     * recreate in the middle of the navigation.
+     */
+    private fun commitSunriseMode(applyAppTheme: Boolean) {
+        pendingUseFixedSunriseLocation = true
+        settings.useFixedSunriseLocation = true
+        pendingAppTheme?.let { settings.appTheme = it }
+        pendingNightMode?.let { settings.nightMode = it }
+        // Ask the service to re-send the Android Auto night mode (safe, no activity recreate).
+        requireContext().sendBroadcast(
+            Intent(AapService.ACTION_REQUEST_NIGHT_MODE_UPDATE).setPackage(requireContext().packageName)
+        )
+        if (applyAppTheme) App.appThemeManager?.forceRefresh()
+    }
+
     /** Sub-options for "Location (by area)" mode: outside-places appearance + manage places. */
     /**
      * Dedicated "Location" group, shown whenever either selector is set to Location. Its
@@ -511,10 +529,9 @@ class DarkModeFragment : Fragment(), SensorEventListener {
                 if (lat != null && lon != null && lat in -90.0..90.0 && lon in -180.0..180.0) {
                     settings.fixedSunriseLatitude = lat
                     settings.fixedSunriseLongitude = lon
-                    // Entering coordinates turns on the fixed point so it is not lost if the
-                    // settings screen is left without saving.
-                    settings.useFixedSunriseLocation = true
-                    pendingUseFixedSunriseLocation = true
+                    // Entering coordinates commits the Auto/sunrise mode and the fixed source
+                    // so they are not lost if the settings screen is left without saving.
+                    commitSunriseMode(applyAppTheme = true)
                     checkChanges()
                     updateSettingsList()
                 } else {
@@ -522,6 +539,9 @@ class DarkModeFragment : Fragment(), SensorEventListener {
                 }
             }
             .setNeutralButton(R.string.geofence_pick_on_map) { _, _ ->
+                // Commit the Auto/sunrise mode and the fixed source before leaving, so the mode
+                // is not deselected when the fragment is recreated on return (issue #647).
+                commitSunriseMode(applyAppTheme = false)
                 findNavController().navigate(
                     R.id.action_darkModeFragment_to_mapPickerFragment,
                     androidx.core.os.bundleOf(MapPickerFragment.ARG_MODE to MapPickerFragment.MODE_POINT)

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/MainActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/MainActivity.kt
@@ -31,6 +31,7 @@ import com.andrerinas.headunitrevived.aap.AapService
 import com.andrerinas.headunitrevived.app.BaseActivity
 import com.andrerinas.headunitrevived.connection.CommManager
 import com.andrerinas.headunitrevived.utils.AppLog
+import com.andrerinas.headunitrevived.utils.AppPermissions
 import android.content.res.Configuration
 import com.andrerinas.headunitrevived.utils.Settings
 import android.os.SystemClock
@@ -198,7 +199,8 @@ class MainActivity : BaseActivity() {
             findViewById<View>(R.id.splash_overlay)?.visibility = View.GONE
         }
 
-        requestPermissions()
+        // Runtime permissions are requested by the setup wizard's permissions step on fresh
+        // installs; for users who already finished onboarding we request them from checkSetupFlow().
         viewModel.register()
         handleLaunchIntent(intent)
         setupWifiDirectInfo()
@@ -809,27 +811,8 @@ class MainActivity : BaseActivity() {
     }
 
     private fun requestPermissions() {
-        val requiredPermissions = mutableListOf(
-            Manifest.permission.RECORD_AUDIO,
-            Manifest.permission.ACCESS_FINE_LOCATION,
-            Manifest.permission.ACCESS_COARSE_LOCATION
-        )
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            requiredPermissions.add(Manifest.permission.BLUETOOTH_ADVERTISE)
-            requiredPermissions.add(Manifest.permission.BLUETOOTH_CONNECT)
-            requiredPermissions.add(Manifest.permission.BLUETOOTH_SCAN)
-        }
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            requiredPermissions.add(Manifest.permission.NEARBY_WIFI_DEVICES)
-            requiredPermissions.add(Manifest.permission.POST_NOTIFICATIONS)
-        }
-
-        // Filter out permissions that are already granted
-        val permissionsToRequest = requiredPermissions.filter {
-            ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED
-        }
+        // Single source of truth: the same registry the wizard/Settings permissions screen use.
+        val permissionsToRequest = AppPermissions.missingNormalPermissions(this)
 
         if (permissionsToRequest.isNotEmpty()) {
             AppLog.i("Requesting missing permissions: $permissionsToRequest")
@@ -882,10 +865,15 @@ class MainActivity : BaseActivity() {
         val appSettings = Settings(this)
         // Show the intelligent onboarding wizard once whenever the stored version is
         // older than the current one (covers fresh installs and upgraders alike).
-        if (appSettings.onboardingVersion < OnboardingActivity.CURRENT_ONBOARDING_VERSION &&
-            !OnboardingActivity.deferredThisSession) {
+        val wizardPending = appSettings.onboardingVersion < OnboardingActivity.CURRENT_ONBOARDING_VERSION
+        if (wizardPending && !OnboardingActivity.deferredThisSession) {
+            // The wizard's permissions step handles runtime permissions, so don't also prompt here.
             startActivity(Intent(this, OnboardingActivity::class.java))
+        } else if (!wizardPending) {
+            // Onboarding already completed (e.g. upgraders): request runtime permissions directly.
+            requestPermissions()
         }
+        // Wizard deferred this session ("Do it later"): wait until it runs on the next launch.
     }
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/OnboardingActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/OnboardingActivity.kt
@@ -1,6 +1,7 @@
 package com.andrerinas.headunitrevived.main
 
 import android.content.Context
+import android.content.Intent
 import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
@@ -16,10 +17,13 @@ import com.andrerinas.headunitrevived.App
 import com.andrerinas.headunitrevived.R
 import com.andrerinas.headunitrevived.app.BaseActivity
 import com.andrerinas.headunitrevived.decoder.VideoDecoder
+import com.andrerinas.headunitrevived.utils.AppPermissions
 import com.andrerinas.headunitrevived.utils.AppThemeManager
 import com.andrerinas.headunitrevived.utils.LocaleHelper
+import com.andrerinas.headunitrevived.utils.PermissionRowBinder
 import com.andrerinas.headunitrevived.utils.Settings
 import com.andrerinas.headunitrevived.utils.SystemOptimizer
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.view.ViewCompat
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.button.MaterialButtonToggleGroup
@@ -60,6 +64,15 @@ class OnboardingActivity : BaseActivity() {
     private var selectedPortrait = false
     private var dpiPicker: com.andrerinas.headunitrevived.view.DpiPickerView? = null
 
+    // Permissions step (registered here, before the activity is RESUMED).
+    private var permissionBinder: PermissionRowBinder? = null
+    private val permNormalLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissionBinder?.rebind() }
+    private val permSpecialLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { permissionBinder?.rebind() }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -89,6 +102,7 @@ class OnboardingActivity : BaseActivity() {
 
         buildStepperDots()
         bindSteps()
+        bindPermissionsStep()
 
         backBtn.setOnClickListener { if (step > 0) { step--; render() } }
         nextBtn.setOnClickListener { onNext() }
@@ -104,9 +118,11 @@ class OnboardingActivity : BaseActivity() {
 
     override fun onResume() {
         super.onResume()
-        // Reflect any changes made in deep-linked settings screens (theme, automation).
+        // Reflect any changes made in deep-linked settings screens (theme, automation) or after
+        // returning from a special-permission settings screen (overlay / modify system settings).
         updateThemeButtonText()
         updateNightButtonText()
+        permissionBinder?.rebind()
     }
 
     private fun buildStepperDots() {
@@ -347,7 +363,19 @@ class OnboardingActivity : BaseActivity() {
             findViewById<MaterialCheckBox>(R.id.onb_safety_accept).isChecked else true
         if (step == STEP_READY) findViewById<TextView>(R.id.onb_ready_summary).text = summaryText()
         if (step == STEP_AUTOMATION) applyAutomationVisibility()
+        if (step == STEP_PERMISSIONS) permissionBinder?.rebind()
         updateStepperDots()
+    }
+
+    /** Wire the permissions checklist. Rows are rendered from the AppPermissions registry, so a
+     * future permission only needs a registry entry, not changes here. */
+    private fun bindPermissionsStep() {
+        val container = findViewById<LinearLayout>(R.id.onb_perms_container)
+        permissionBinder = PermissionRowBinder(this, container, permNormalLauncher, permSpecialLauncher)
+        findViewById<MaterialButton>(R.id.onb_perms_enable_all).setOnClickListener {
+            permissionBinder?.requestAllMissing()
+        }
+        permissionBinder?.rebind()
     }
 
     /** Show only the auto-start toggles that match the chosen connection type. Self Mode
@@ -568,10 +596,15 @@ class OnboardingActivity : BaseActivity() {
             Settings.Resolution.fromId(settings.resolutionId)?.resName ?: getString(R.string.auto)
         )
         val base = getString(R.string.onb_ready_summary, conn, res, settings.videoCodec)
+        val perms = getString(
+            R.string.onb_summary_permissions_format,
+            AppPermissions.grantedCount(this), AppPermissions.visible().size
+        )
         val vehicle = settings.vehicleDisplayName.trim()
-        return if (vehicle.isNotEmpty())
+        val head = if (vehicle.isNotEmpty())
             getString(R.string.onb_summary_vehicle_format, vehicle) + "\n" + base
         else base
+        return head + "\n" + perms
     }
 
     private fun resolveAttrColor(attr: Int): Int {
@@ -587,12 +620,13 @@ class OnboardingActivity : BaseActivity() {
         @Volatile
         var deferredThisSession = false
         private const val KEY_STEP = "onb_step"
-        private const val STEP_COUNT = 10
+        private const val STEP_COUNT = 11
         private const val STEP_SAFETY = 1
         private const val STEP_DISPLAY = 3
         private const val STEP_DPI = 4
         private const val STEP_AUTOMATION = 6
         private const val STEP_VEHICLE = 8
-        private const val STEP_READY = 9
+        private const val STEP_PERMISSIONS = 9
+        private const val STEP_READY = 10
     }
 }

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/OnboardingActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/OnboardingActivity.kt
@@ -104,6 +104,11 @@ class OnboardingActivity : BaseActivity() {
         bindSteps()
         bindPermissionsStep()
 
+        // Ready step: offer to jump straight into the loading screen setup (finishes the wizard).
+        findViewById<MaterialButton>(R.id.onb_loading_screen_button).setOnClickListener {
+            finishOnboardingInto(R.id.loadingScreenFragment)
+        }
+
         backBtn.setOnClickListener { if (step > 0) { step--; render() } }
         nextBtn.setOnClickListener { onNext() }
         skipBtn.setOnClickListener { onDoItLater() }
@@ -215,12 +220,13 @@ class OnboardingActivity : BaseActivity() {
             selectedPortrait = id == R.id.onb_orient_port
         }
 
-        // Graphical DPI picker (slider + preview + Small/Medium/Large tabs, all synced),
-        // pre-set to the recommended DPI for the detected panel.
+        // Graphical DPI picker (slider + preview + Small/Medium/Large tabs, all synced).
+        // Seed from the user's saved DPI when they already set one, so re-running the wizard
+        // does not overwrite their choice; the recommended value is shown as a hint instead.
         dpiPicker = findViewById<com.andrerinas.headunitrevived.view.DpiPickerView>(R.id.onb_dpi_picker).apply {
             val m = realMetrics()
             setPanelResolution(m.widthPixels, m.heightPixels)
-            dpi = recommendedDpi()
+            dpi = settings.dpiPixelDensity.takeIf { it != 0 } ?: recommendedDpi()
         }
 
         // --- Appearance: full theme + night-mode pickers; more options live in Settings ---
@@ -364,6 +370,8 @@ class OnboardingActivity : BaseActivity() {
         if (step == STEP_READY) findViewById<TextView>(R.id.onb_ready_summary).text = summaryText()
         if (step == STEP_AUTOMATION) applyAutomationVisibility()
         if (step == STEP_PERMISSIONS) permissionBinder?.rebind()
+        if (step == STEP_DPI) findViewById<TextView>(R.id.onb_dpi_recommended).text =
+            getString(R.string.onb_dpi_recommended, recommendedDpi())
         updateStepperDots()
     }
 
@@ -439,6 +447,19 @@ class OnboardingActivity : BaseActivity() {
         settings.hasCompletedSetupWizard = true
         settings.onboardingVersion = CURRENT_ONBOARDING_VERSION
         settings.commit()
+        finish()
+    }
+
+    /** Complete the wizard and open a specific Settings sub-screen (e.g. the loading screen setup). */
+    private fun finishOnboardingInto(destinationId: Int) {
+        settings.hasAcceptedDisclaimer = true
+        settings.hasCompletedSetupWizard = true
+        settings.onboardingVersion = CURRENT_ONBOARDING_VERSION
+        settings.commit()
+        startActivity(
+            Intent(this, SettingsActivity::class.java)
+                .putExtra(SettingsActivity.EXTRA_DESTINATION, destinationId)
+        )
         finish()
     }
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/PermissionsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/PermissionsFragment.kt
@@ -1,0 +1,56 @@
+package com.andrerinas.headunitrevived.main
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.andrerinas.headunitrevived.R
+import com.andrerinas.headunitrevived.utils.PermissionRowBinder
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.button.MaterialButton
+
+/**
+ * Settings entry point mirroring the wizard's permissions step, so users who already finished
+ * onboarding can review and grant permissions later. Both surfaces share [PermissionRowBinder]
+ * and the [com.andrerinas.headunitrevived.utils.AppPermissions] registry.
+ */
+class PermissionsFragment : Fragment() {
+
+    private var binder: PermissionRowBinder? = null
+
+    private val normalLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { binder?.rebind() }
+    private val specialLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { binder?.rebind() }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View = inflater.inflate(R.layout.fragment_permissions, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        view.findViewById<MaterialToolbar>(R.id.toolbar).setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
+
+        val list = view.findViewById<LinearLayout>(R.id.permissions_container)
+        binder = PermissionRowBinder(requireActivity(), list, normalLauncher, specialLauncher)
+        view.findViewById<MaterialButton>(R.id.enable_all_button).setOnClickListener {
+            binder?.requestAllMissing()
+        }
+        binder?.rebind()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // Refresh after returning from a special-permission settings screen.
+        binder?.rebind()
+    }
+}

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
@@ -625,6 +625,20 @@ class SettingsFragment : Fragment() {
             }
         ))
 
+        // Permissions checklist (same list the setup wizard shows)
+        items.add(SettingItem.SettingEntry(
+            stableId = "permissions",
+            nameResId = R.string.permissions,
+            value = getString(R.string.permissions_desc),
+            onClick = { _ ->
+                try {
+                    findNavController().navigate(R.id.action_settingsFragment_to_permissionsFragment)
+                } catch (e: Exception) {
+                    // Failover
+                }
+            }
+        ))
+
         // Connection mode (Feature B): drives which options appear in the Basic tab.
         items.add(SettingItem.SettingEntry(
             stableId = "connectionMode",

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/AppPermissions.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/AppPermissions.kt
@@ -1,0 +1,153 @@
+package com.andrerinas.headunitrevived.utils
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.provider.Settings
+import androidx.core.content.ContextCompat
+import com.andrerinas.headunitrevived.R
+
+/**
+ * Central, declarative registry of the runtime and special permissions the app surfaces to the
+ * user (the setup wizard permissions step and the Settings > Permissions screen read from here).
+ *
+ * To support a future permission, add a single [Entry] to [ALL] plus its two strings (title +
+ * help). The UI renders it automatically, with the correct SDK gating and grant flow. No wizard
+ * or layout code needs to change.
+ */
+object AppPermissions {
+
+    enum class Kind {
+        /** Standard dangerous permission, granted via a system dialog. */
+        NORMAL,
+        /** "Display over other apps" special access, granted via a settings screen. */
+        OVERLAY,
+        /** "Modify system settings" special access, granted via a settings screen. */
+        WRITE_SETTINGS,
+    }
+
+    data class Entry(
+        val id: String,
+        val titleRes: Int,
+        val helpRes: Int,
+        val kind: Kind,
+        /** Manifest permissions covered by this row (NORMAL only). */
+        val permissions: List<String> = emptyList(),
+        /** Lowest SDK where this row is relevant. */
+        val minSdk: Int = 1,
+        /** Highest SDK where this row is relevant (e.g. legacy storage tops out at API 29). */
+        val maxSdk: Int = Int.MAX_VALUE,
+        /** Recommended rather than required; shown with an "(optional)" hint. */
+        val optional: Boolean = false,
+    ) {
+        /** True when this row is relevant on the current device. */
+        fun applies(): Boolean = Build.VERSION.SDK_INT in minSdk..maxSdk
+
+        /** Manifest permissions that actually exist to request on this API level. */
+        fun requestablePermissions(): List<String> =
+            permissions.filter { Build.VERSION.SDK_INT >= permissionMinSdk(it) }
+
+        fun isGranted(context: Context): Boolean = when (kind) {
+            Kind.NORMAL -> requestablePermissions().all {
+                ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
+            }
+            Kind.OVERLAY ->
+                Build.VERSION.SDK_INT < Build.VERSION_CODES.M || Settings.canDrawOverlays(context)
+            Kind.WRITE_SETTINGS ->
+                Build.VERSION.SDK_INT < Build.VERSION_CODES.M || Settings.System.canWrite(context)
+        }
+    }
+
+    val ALL: List<Entry> = listOf(
+        Entry(
+            id = "mic",
+            titleRes = R.string.perm_mic_title,
+            helpRes = R.string.perm_mic_help,
+            kind = Kind.NORMAL,
+            permissions = listOf(Manifest.permission.RECORD_AUDIO),
+        ),
+        Entry(
+            id = "location",
+            titleRes = R.string.perm_location_title,
+            helpRes = R.string.perm_location_help,
+            kind = Kind.NORMAL,
+            permissions = listOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+            ),
+        ),
+        Entry(
+            id = "nearby",
+            titleRes = R.string.perm_nearby_title,
+            helpRes = R.string.perm_nearby_help,
+            kind = Kind.NORMAL,
+            // BLUETOOTH_* are API 31+, NEARBY_WIFI_DEVICES is API 33+; requestablePermissions()
+            // filters each one out on lower levels.
+            permissions = listOf(
+                Manifest.permission.BLUETOOTH_CONNECT,
+                Manifest.permission.BLUETOOTH_SCAN,
+                Manifest.permission.BLUETOOTH_ADVERTISE,
+                Manifest.permission.NEARBY_WIFI_DEVICES,
+            ),
+            minSdk = Build.VERSION_CODES.S,
+        ),
+        Entry(
+            id = "notifications",
+            titleRes = R.string.perm_notifications_title,
+            helpRes = R.string.perm_notifications_help,
+            kind = Kind.NORMAL,
+            permissions = listOf(Manifest.permission.POST_NOTIFICATIONS),
+            minSdk = Build.VERSION_CODES.TIRAMISU,
+        ),
+        Entry(
+            id = "overlay",
+            titleRes = R.string.perm_overlay_title,
+            helpRes = R.string.perm_overlay_help,
+            kind = Kind.OVERLAY,
+        ),
+        Entry(
+            id = "write_settings",
+            titleRes = R.string.perm_write_settings_title,
+            helpRes = R.string.perm_write_settings_help,
+            kind = Kind.WRITE_SETTINGS,
+            optional = true,
+        ),
+        Entry(
+            id = "storage",
+            titleRes = R.string.perm_storage_title,
+            helpRes = R.string.perm_storage_help,
+            kind = Kind.NORMAL,
+            permissions = listOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
+            // Legacy storage is a no-op under scoped storage (API 30+); only show it where it matters.
+            maxSdk = Build.VERSION_CODES.Q,
+            optional = true,
+        ),
+    )
+
+    /** Registry entries relevant on the current device. */
+    fun visible(): List<Entry> = ALL.filter { it.applies() }
+
+    /**
+     * Every not-yet-granted normal permission across the visible entries, de-duplicated, so they
+     * can be requested together in a single system dialog ("Enable all").
+     */
+    fun missingNormalPermissions(context: Context): List<String> =
+        visible().filter { it.kind == Kind.NORMAL }
+            .flatMap { it.requestablePermissions() }
+            .distinct()
+            .filter { ContextCompat.checkSelfPermission(context, it) != PackageManager.PERMISSION_GRANTED }
+
+    /** Count of visible entries already granted (for the wizard summary). */
+    fun grantedCount(context: Context): Int = visible().count { it.isGranted(context) }
+
+    /** The API level at which a given manifest permission became requestable. */
+    private fun permissionMinSdk(permission: String): Int = when (permission) {
+        Manifest.permission.BLUETOOTH_CONNECT,
+        Manifest.permission.BLUETOOTH_SCAN,
+        Manifest.permission.BLUETOOTH_ADVERTISE -> Build.VERSION_CODES.S
+        Manifest.permission.NEARBY_WIFI_DEVICES,
+        Manifest.permission.POST_NOTIFICATIONS -> Build.VERSION_CODES.TIRAMISU
+        else -> 1
+    }
+}

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/BluetoothHelper.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/BluetoothHelper.kt
@@ -47,6 +47,41 @@ object BluetoothHelper {
         }
     }
 
+    /** Instantiate the BluetoothAdapter backed by a specific system bluetooth service (reflection). */
+    private fun adapterForService(context: Context, serviceName: String): BluetoothAdapter? {
+        if (serviceName.isEmpty() || serviceName == "bluetooth_manager") return getDefaultAdapter(context)
+        return try {
+            val serviceManagerClass = Class.forName("android.os.ServiceManager")
+            val getServiceMethod = serviceManagerClass.getMethod("getService", String::class.java)
+            val binder = getServiceMethod.invoke(null, serviceName) as? IBinder ?: return null
+            val iBluetoothManagerStubClass = Class.forName("android.bluetooth.IBluetoothManager\$Stub")
+            val asInterfaceMethod = iBluetoothManagerStubClass.getMethod("asInterface", IBinder::class.java)
+            val managerService = asInterfaceMethod.invoke(null, binder) ?: return null
+            val iBluetoothManagerClass = Class.forName("android.bluetooth.IBluetoothManager")
+            val ctor = BluetoothAdapter::class.java.getDeclaredConstructor(iBluetoothManagerClass)
+            ctor.isAccessible = true
+            ctor.newInstance(managerService) as? BluetoothAdapter
+        } catch (e: Exception) {
+            AppLog.e("BluetoothHelper: adapterForService($serviceName) failed: ${e.message}", e)
+            null
+        }
+    }
+
+    /**
+     * All distinct, enabled Bluetooth adapters exposed by the system. Usually just the default
+     * radio; some head units expose a second Bluetooth chip as an extra service. Best-effort:
+     * bogus/non-adapter services resolve to null and are skipped.
+     */
+    fun getAllBluetoothAdapters(context: Context): List<BluetoothAdapter> {
+        val result = mutableListOf<BluetoothAdapter>()
+        getDefaultAdapter(context)?.let { result.add(it) }
+        for (service in listBluetoothServices()) {
+            if (service == "bluetooth_manager") continue
+            adapterForService(context, service)?.let { result.add(it) }
+        }
+        return result.filter { try { it.isEnabled } catch (e: Exception) { false } }
+    }
+
     fun listBluetoothServices(): List<String> {
         val bluetoothServices = mutableListOf<String>()
         try {

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/HotspotManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/HotspotManager.kt
@@ -22,7 +22,7 @@ object HotspotManager {
     private var cachedCallbackClass: Class<*>? = null
 
     fun setHotspotEnabled(context: Context, enabled: Boolean): Boolean {
-        AppLog.i("HotspotManager: Setting hotspot enabled=$enabled (API ${Build.VERSION.SDK_INT})")
+        AppLog.i("HotspotManager: Setting hotspot enabled=$enabled (API ${Build.VERSION.SDK_INT}, canWriteSettings=${canWriteSystemSettings(context)})")
 
         // On Android 8+, WiFi must be disabled before tethering can start
         if (enabled) {
@@ -46,12 +46,24 @@ object HotspotManager {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             if (tryTetheringManager(context, enabled)) return true
         }
-        if (tryConnectivityManager(context, enabled)) return true
-        if (tryLegacyWifiManager(context, enabled)) return true
+        // The remaining reflection paths (startTethering / setWifiApEnabled) require the special
+        // "Modify system settings" access (WRITE_SETTINGS). Without it the framework throws a
+        // SecurityException, so check first and surface a clear, actionable message instead.
+        if (canWriteSystemSettings(context)) {
+            if (tryConnectivityManager(context, enabled)) return true
+            if (tryLegacyWifiManager(context, enabled)) return true
+        } else {
+            AppLog.w("HotspotManager: Cannot enable the hotspot without the \"Modify system settings\" permission (WRITE_SETTINGS). Grant it in the setup wizard or Settings > Permissions.")
+        }
 
         AppLog.w("HotspotManager: All hotspot attempts failed.")
         return false
     }
+
+    /** WRITE_SETTINGS is a special access; a manifest declaration alone never grants it. */
+    private fun canWriteSystemSettings(context: Context): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.M ||
+            android.provider.Settings.System.canWrite(context)
 
     private fun tryConnectivityManager(context: Context, enabled: Boolean): Boolean {
         try {

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/PermissionRowBinder.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/PermissionRowBinder.kt
@@ -1,0 +1,103 @@
+package com.andrerinas.headunitrevived.utils
+
+import android.app.Activity
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.Settings
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.activity.result.ActivityResultLauncher
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import com.andrerinas.headunitrevived.R
+import com.google.android.material.button.MaterialButton
+
+/**
+ * Renders the [AppPermissions] registry as a checklist of rows into [container], reused by both
+ * the setup wizard permissions step and the Settings > Permissions screen. Each row shows a title,
+ * a help line, and either a green check (already granted) or an "Allow" button. The host owns the
+ * two activity-result launchers and passes them in so results route back to the host.
+ */
+class PermissionRowBinder(
+    private val activity: Activity,
+    private val container: LinearLayout,
+    private val normalLauncher: ActivityResultLauncher<Array<String>>,
+    private val specialLauncher: ActivityResultLauncher<Intent>,
+) {
+    // Permissions we have already asked for this session; used to detect a permanent denial
+    // (a repeat request would show no dialog), where we deep-link to the app's settings instead.
+    private val attempted = mutableSetOf<String>()
+
+    /** Rebuild every row from the registry and its current granted state. */
+    fun rebind() {
+        val inflater = LayoutInflater.from(container.context)
+        container.removeAllViews()
+        for (entry in AppPermissions.visible()) {
+            val row = inflater.inflate(R.layout.layout_onboarding_permission_item, container, false)
+            val title = row.findViewById<TextView>(R.id.perm_title)
+            val help = row.findViewById<TextView>(R.id.perm_help)
+            val check = row.findViewById<ImageView>(R.id.perm_status_check)
+            val button = row.findViewById<MaterialButton>(R.id.perm_status_button)
+
+            val name = container.context.getString(entry.titleRes)
+            title.text = if (entry.optional)
+                container.context.getString(R.string.perm_optional_format, name) else name
+            help.text = container.context.getString(entry.helpRes)
+
+            val granted = entry.isGranted(container.context)
+            check.visibility = if (granted) View.VISIBLE else View.GONE
+            button.visibility = if (granted) View.GONE else View.VISIBLE
+            button.setOnClickListener { onGrantClicked(entry) }
+
+            container.addView(row)
+        }
+    }
+
+    /** Request every missing normal permission in one system dialog. Special ones stay per-row. */
+    fun requestAllMissing() {
+        val missing = AppPermissions.missingNormalPermissions(activity)
+        if (missing.isNotEmpty()) {
+            attempted.addAll(missing)
+            normalLauncher.launch(missing.toTypedArray())
+        }
+    }
+
+    private fun onGrantClicked(entry: AppPermissions.Entry) {
+        when (entry.kind) {
+            AppPermissions.Kind.NORMAL -> {
+                val missing = entry.requestablePermissions().filter {
+                    ContextCompat.checkSelfPermission(activity, it) != PackageManager.PERMISSION_GRANTED
+                }
+                if (missing.isEmpty()) return
+                // If we already asked and the system will no longer prompt, send the user to
+                // the app's settings page where they can toggle it manually.
+                val permanentlyDenied = missing.all {
+                    attempted.contains(it) &&
+                        !ActivityCompat.shouldShowRequestPermissionRationale(activity, it)
+                }
+                if (permanentlyDenied) {
+                    openAppSettings()
+                } else {
+                    attempted.addAll(missing)
+                    normalLauncher.launch(missing.toTypedArray())
+                }
+            }
+            AppPermissions.Kind.OVERLAY -> specialLauncher.launch(
+                Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION, packageUri())
+            )
+            AppPermissions.Kind.WRITE_SETTINGS -> specialLauncher.launch(
+                Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS, packageUri())
+            )
+        }
+    }
+
+    private fun openAppSettings() = specialLauncher.launch(
+        Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, packageUri())
+    )
+
+    private fun packageUri(): Uri = Uri.parse("package:${activity.packageName}")
+}

--- a/app/src/main/res/drawable/ic_check.xml
+++ b/app/src/main/res/drawable/ic_check.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/material_green_700">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z" />
+</vector>

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -717,6 +717,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp"
+                    android:gravity="center_horizontal"
                     android:text="@string/onb_ready_loading_intro"
                     android:textAppearance="?attr/textAppearanceBody2" />
                 <com.google.android.material.button.MaterialButton
@@ -724,6 +725,7 @@
                     style="@style/Widget.MaterialComponents.Button.OutlinedButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
                     android:layout_marginTop="8dp"
                     android:text="@string/onb_ready_loading_button" />
             </LinearLayout>

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -652,7 +652,42 @@
             </LinearLayout>
         </ScrollView>
 
-        <!-- Step 8: Ready -->
+        <!-- Step 9: Permissions -->
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/onb_permissions_title"
+                    android:textAppearance="?attr/textAppearanceHeadline5"
+                    android:textStyle="bold" />
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="@string/onb_permissions_help"
+                    android:textAppearance="?attr/textAppearanceBody2" />
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/onb_perms_enable_all"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:text="@string/onb_perms_enable_all" />
+                <LinearLayout
+                    android:id="@+id/onb_perms_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:orientation="vertical" />
+            </LinearLayout>
+        </ScrollView>
+
+        <!-- Step 10: Ready -->
         <ScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent">

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -299,6 +299,12 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="12dp" />
                 <TextView
+                    android:id="@+id/onb_dpi_recommended"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:textAppearance="?attr/textAppearanceCaption" />
+                <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="12dp"
@@ -707,6 +713,19 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="12dp"
                     android:textAppearance="?attr/textAppearanceBody1" />
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/onb_ready_loading_intro"
+                    android:textAppearance="?attr/textAppearanceBody2" />
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/onb_loading_screen_button"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="@string/onb_ready_loading_button" />
             </LinearLayout>
         </ScrollView>
 

--- a/app/src/main/res/layout/fragment_permissions.xml
+++ b/app/src/main/res/layout/fragment_permissions.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="?attr/colorSurface">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:elevation="0dp"
+        android:background="?attr/colorSurface">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:title="@string/permissions"
+            app:navigationIcon="@drawable/ic_arrow_back_white"
+            app:titleTextColor="?android:attr/textColorPrimary"
+            app:navigationIconTint="?android:attr/textColorPrimary" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/onb_permissions_help"
+                android:textAppearance="?attr/textAppearanceBody2" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/enable_all_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/onb_perms_enable_all" />
+
+            <LinearLayout
+                android:id="@+id/permissions_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:orientation="vertical" />
+
+        </LinearLayout>
+    </ScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/layout_onboarding_permission_item.xml
+++ b/app/src/main/res/layout/layout_onboarding_permission_item.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- One permission row: title + help on the left, a green check (granted) or Allow button. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:paddingTop="10dp"
+    android:paddingBottom="10dp">
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/perm_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBody1" />
+
+        <TextView
+            android:id="@+id/perm_help"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:alpha="0.7"
+            android:textAppearance="?attr/textAppearanceCaption" />
+    </LinearLayout>
+
+    <ImageView
+        android:id="@+id/perm_status_check"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginStart="12dp"
+        android:contentDescription="@string/perm_granted"
+        android:src="@drawable/ic_check"
+        android:visibility="gone" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/perm_status_button"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:minWidth="0dp"
+        android:minHeight="0dp"
+        android:paddingTop="6dp"
+        android:paddingBottom="6dp"
+        android:text="@string/perm_allow"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -92,6 +92,13 @@
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
             app:popExitAnim="@anim/slide_out_right" />
+        <action
+            android:id="@+id/action_settingsFragment_to_permissionsFragment"
+            app:destination="@id/permissionsFragment"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right" />
     </fragment>
 
 
@@ -100,6 +107,11 @@
         android:id="@+id/keymapFragment"
         android:name="com.andrerinas.headunitrevived.main.KeymapFragment"
         android:label="@string/keymap" />
+
+    <fragment
+        android:id="@+id/permissionsFragment"
+        android:name="com.andrerinas.headunitrevived.main.PermissionsFragment"
+        android:label="@string/permissions" />
 
     <fragment
         android:id="@+id/aboutFragment"

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -758,4 +758,7 @@
     <string name="perm_write_settings_help">Umožňuje aplikaci automaticky zapnout hotspot pro bezdrátová připojení.</string>
     <string name="perm_storage_title">Úložiště</string>
     <string name="perm_storage_help">Potřebné pro zálohování a obnovu nastavení a pro výběr vlastního obrázku načítání.</string>
+    <string name="onb_dpi_recommended">Doporučeno pro vaši obrazovku: %1$d dpi</string>
+    <string name="onb_ready_loading_intro">Ještě jedna věc: nyní můžete nastavit vlastní načítací obrazovku, která se zobrazí při připojování auta.</string>
+    <string name="onb_ready_loading_button">Nastavit načítací obrazovku</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -733,4 +733,29 @@
     <string name="onb_vehicle_help_advanced">Další podrobnosti o vozidle můžete upravit na kartě Pokročilé. Tato data nepoužíváme; odesílají se pouze do Android Auto, protože je vyžaduje.</string>
     <string name="onb_summary_vehicle_format">Vozidlo: %1$s</string>
     <string name="sunrise_reference_help">Referenční bod používaný pro výpočet východu a západu slunce. Vyberte svou polohu jednou; funguje to bez GPS.</string>
+
+    <!-- Permissions / Onboarding -->
+    <string name="onb_summary_permissions_format">Oprávnění: %1$d z %2$d uděleno</string>
+    <string name="onb_permissions_title">Povolit oprávnění</string>
+    <string name="onb_permissions_help">Zapněte oprávnění, která aplikace potřebuje, aby vše fungovalo bez nečekaných výzev později. Tato oprávnění můžete kdykoli změnit.</string>
+    <string name="onb_perms_enable_all">Povolit vše</string>
+    <string name="perm_allow">Povolit</string>
+    <string name="perm_granted">Uděleno</string>
+    <string name="perm_optional_format">%1$s (volitelné)</string>
+    <string name="permissions">Oprávnění</string>
+    <string name="permissions_desc">Zkontrolujte a udělte oprávnění, která aplikace potřebuje</string>
+    <string name="perm_mic_title">Mikrofon</string>
+    <string name="perm_mic_help">Umožňuje Android Auto používat hlasové příkazy, Google Assistant a telefonní hovory.</string>
+    <string name="perm_location_title">Poloha</string>
+    <string name="perm_location_help">Odesílá GPS do telefonu pro navigaci, vyhledává bezdrátová připojení a řídí noční režim na základě polohy.</string>
+    <string name="perm_nearby_title">Zařízení v okolí</string>
+    <string name="perm_nearby_help">Potřebné pro připojení přes Bluetooth a Wi-Fi, směrování zvuku Bluetooth a automatické spuštění na spárovaném zařízení.</string>
+    <string name="perm_notifications_title">Oznámení</string>
+    <string name="perm_notifications_help">Zobrazuje průběžné oznámení, když běží Android Auto.</string>
+    <string name="perm_overlay_title">Zobrazit přes jiné aplikace</string>
+    <string name="perm_overlay_help">Umožňuje aplikaci otevřít obrazovku autorádia přes jiné aplikace, včetně automatického spuštění.</string>
+    <string name="perm_write_settings_title">Změna systémových nastavení</string>
+    <string name="perm_write_settings_help">Umožňuje aplikaci automaticky zapnout hotspot pro bezdrátová připojení.</string>
+    <string name="perm_storage_title">Úložiště</string>
+    <string name="perm_storage_help">Potřebné pro zálohování a obnovu nastavení a pro výběr vlastního obrázku načítání.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -764,4 +764,7 @@
     <string name="perm_write_settings_help">Ermöglicht der App, den Hotspot für kabellose Verbindungen automatisch einzuschalten.</string>
     <string name="perm_storage_title">Speicher</string>
     <string name="perm_storage_help">Wird benötigt, um Ihre Einstellungen zu sichern und wiederherzustellen sowie ein benutzerdefiniertes Ladebild auszuwählen.</string>
+    <string name="onb_dpi_recommended">Empfohlen für Ihren Bildschirm: %1$d dpi</string>
+    <string name="onb_ready_loading_intro">Noch eine Sache: Sie können jetzt einen benutzerdefinierten Ladebildschirm festlegen, der angezeigt wird, während das Auto eine Verbindung herstellt.</string>
+    <string name="onb_ready_loading_button">Ladebildschirm einrichten</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -739,4 +739,29 @@
     <string name="onb_vehicle_help_advanced">Weitere Fahrzeugdetails kannst du im Tab Erweitert anpassen. Wir verwenden diese Daten nicht, sie werden nur an Android Auto gesendet, weil es sie benötigt.</string>
     <string name="onb_summary_vehicle_format">Fahrzeug: %1$s</string>
     <string name="sunrise_reference_help">Der Referenzpunkt zur Berechnung von Sonnenaufgang und Sonnenuntergang. Wähle deinen Standort einmal aus; es funktioniert ohne GPS.</string>
+
+    <!-- Permissions onboarding -->
+    <string name="onb_summary_permissions_format">Berechtigungen: %1$d von %2$d erteilt</string>
+    <string name="onb_permissions_title">Berechtigungen aktivieren</string>
+    <string name="onb_permissions_help">Aktivieren Sie die Berechtigungen, die die App benötigt, damit später keine unerwarteten Aufforderungen erscheinen. Sie können diese jederzeit ändern.</string>
+    <string name="onb_perms_enable_all">Alle aktivieren</string>
+    <string name="perm_allow">Erlauben</string>
+    <string name="perm_granted">Erteilt</string>
+    <string name="perm_optional_format">%1$s (optional)</string>
+    <string name="permissions">Berechtigungen</string>
+    <string name="permissions_desc">Berechtigungen der App prüfen und erteilen</string>
+    <string name="perm_mic_title">Mikrofon</string>
+    <string name="perm_mic_help">Ermöglicht Android Auto die Nutzung von Sprachbefehlen, dem Google Assistant und Telefonanrufen.</string>
+    <string name="perm_location_title">Standort</string>
+    <string name="perm_location_help">Sendet GPS an das Handy für die Navigation, sucht nach kabellosen Verbindungen und steuert den standortbasierten Nachtmodus.</string>
+    <string name="perm_nearby_title">Geräte in der Nähe</string>
+    <string name="perm_nearby_help">Wird benötigt, um über Bluetooth und Wi-Fi zu verbinden, Bluetooth-Audio weiterzuleiten und bei einem gekoppelten Gerät automatisch zu starten.</string>
+    <string name="perm_notifications_title">Benachrichtigungen</string>
+    <string name="perm_notifications_help">Zeigt die laufende Benachrichtigung an, solange Android Auto aktiv ist.</string>
+    <string name="perm_overlay_title">Über anderen Apps einblenden</string>
+    <string name="perm_overlay_help">Ermöglicht der App, den Autobildschirm über anderen Apps zu öffnen, einschließlich Autostart.</string>
+    <string name="perm_write_settings_title">Systemeinstellungen ändern</string>
+    <string name="perm_write_settings_help">Ermöglicht der App, den Hotspot für kabellose Verbindungen automatisch einzuschalten.</string>
+    <string name="perm_storage_title">Speicher</string>
+    <string name="perm_storage_help">Wird benötigt, um Ihre Einstellungen zu sichern und wiederherzustellen sowie ein benutzerdefiniertes Ladebild auszuwählen.</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -767,4 +767,7 @@
     <string name="perm_write_settings_help">Permite a la aplicación activar la zona Wi-Fi automáticamente para conexiones inalámbricas.</string>
     <string name="perm_storage_title">Almacenamiento</string>
     <string name="perm_storage_help">Necesario para hacer copia de seguridad y restaurar tus ajustes, y para elegir una imagen de carga personalizada.</string>
+    <string name="onb_dpi_recommended">Recomendado para tu pantalla: %1$d dpi</string>
+    <string name="onb_ready_loading_intro">Una cosa más: ahora puedes configurar una pantalla de carga personalizada, que se muestra mientras el coche se conecta.</string>
+    <string name="onb_ready_loading_button">Configurar una pantalla de carga</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -742,4 +742,29 @@
     <string name="onb_vehicle_help_advanced">Puedes ajustar más detalles de tu vehículo en la pestaña Avanzados. Nosotros no usamos estos datos; solo se los enviamos a Android Auto porque los requiere.</string>
     <string name="onb_summary_vehicle_format">Vehículo: %1$s</string>
     <string name="sunrise_reference_help">El punto de referencia utilizado para calcular el amanecer y el atardecer. Elige tu ubicación una vez; funciona sin GPS.</string>
+
+    <!-- Onboarding permissions -->
+    <string name="onb_summary_permissions_format">Permisos: %1$d de %2$d concedidos</string>
+    <string name="onb_permissions_title">Activar permisos</string>
+    <string name="onb_permissions_help">Activa los permisos que la aplicación necesita para que todo funcione sin solicitudes inesperadas más adelante. Puedes cambiarlos en cualquier momento.</string>
+    <string name="onb_perms_enable_all">Activar todos</string>
+    <string name="perm_allow">Permitir</string>
+    <string name="perm_granted">Concedido</string>
+    <string name="perm_optional_format">%1$s (opcional)</string>
+    <string name="permissions">Permisos</string>
+    <string name="permissions_desc">Revisa y concede los permisos que necesita la aplicación</string>
+    <string name="perm_mic_title">Micrófono</string>
+    <string name="perm_mic_help">Permite a Android Auto usar comandos de voz, el Google Assistant y llamadas telefónicas.</string>
+    <string name="perm_location_title">Ubicación</string>
+    <string name="perm_location_help">Envía el GPS al móvil para la navegación, busca conexiones inalámbricas y activa el modo noche basado en la ubicación.</string>
+    <string name="perm_nearby_title">Dispositivos cercanos</string>
+    <string name="perm_nearby_help">Necesario para conectar por Bluetooth y Wi-Fi, enrutar el audio Bluetooth e iniciar automáticamente con un dispositivo emparejado.</string>
+    <string name="perm_notifications_title">Notificaciones</string>
+    <string name="perm_notifications_help">Muestra la notificación persistente mientras Android Auto está en ejecución.</string>
+    <string name="perm_overlay_title">Mostrar sobre otras aplicaciones</string>
+    <string name="perm_overlay_help">Permite a la aplicación abrir la pantalla del coche sobre otras aplicaciones, incluido el inicio automático.</string>
+    <string name="perm_write_settings_title">Modificar ajustes del sistema</string>
+    <string name="perm_write_settings_help">Permite a la aplicación activar la zona Wi-Fi automáticamente para conexiones inalámbricas.</string>
+    <string name="perm_storage_title">Almacenamiento</string>
+    <string name="perm_storage_help">Necesario para hacer copia de seguridad y restaurar tus ajustes, y para elegir una imagen de carga personalizada.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -744,4 +744,28 @@
     <string name="onb_vehicle_help_advanced">Puedes ajustar más detalles de tu vehículo en la pestaña Avanzados. Nosotros no usamos estos datos; solo se los enviamos a Android Auto porque los requiere.</string>
     <string name="onb_summary_vehicle_format">Vehículo: %1$s</string>
     <string name="sunrise_reference_help">El punto de referencia usado para calcular el amanecer y el atardecer. Elige tu ubicación una vez; funciona sin GPS.</string>
+
+    <string name="onb_summary_permissions_format">Permisos: %1$d de %2$d otorgados</string>
+    <string name="onb_permissions_title">Activar permisos</string>
+    <string name="onb_permissions_help">Activa los permisos que necesita la app para que todo funcione sin interrupciones inesperadas. Puedes cambiarlos en cualquier momento.</string>
+    <string name="onb_perms_enable_all">Activar todos</string>
+    <string name="perm_allow">Permitir</string>
+    <string name="perm_granted">Otorgado</string>
+    <string name="perm_optional_format">%1$s (opcional)</string>
+    <string name="permissions">Permisos</string>
+    <string name="permissions_desc">Revisar y otorgar los permisos que necesita la app</string>
+    <string name="perm_mic_title">Micrófono</string>
+    <string name="perm_mic_help">Permite que Android Auto use comandos de voz, el Google Assistant y llamadas telefónicas.</string>
+    <string name="perm_location_title">Ubicación</string>
+    <string name="perm_location_help">Envía el GPS al teléfono para la navegación, busca conexiones inalámbricas y activa el modo noche según la ubicación.</string>
+    <string name="perm_nearby_title">Dispositivos cercanos</string>
+    <string name="perm_nearby_help">Necesario para conectarse por Bluetooth y Wi-Fi, enrutar audio Bluetooth e iniciar automáticamente con un dispositivo emparejado.</string>
+    <string name="perm_notifications_title">Notificaciones</string>
+    <string name="perm_notifications_help">Muestra la notificación persistente mientras Android Auto está en ejecución.</string>
+    <string name="perm_overlay_title">Mostrar sobre otras apps</string>
+    <string name="perm_overlay_help">Permite que la app abra la pantalla del auto encima de otras apps, incluyendo el inicio automático.</string>
+    <string name="perm_write_settings_title">Modificar ajustes del sistema</string>
+    <string name="perm_write_settings_help">Permite que la app active la zona Wi-Fi automáticamente para conexiones inalámbricas.</string>
+    <string name="perm_storage_title">Almacenamiento</string>
+    <string name="perm_storage_help">Necesario para hacer copia de seguridad y restaurar tu configuración, y para elegir una imagen de carga personalizada.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -768,4 +768,7 @@
     <string name="perm_write_settings_help">Permite que la app active la zona Wi-Fi automáticamente para conexiones inalámbricas.</string>
     <string name="perm_storage_title">Almacenamiento</string>
     <string name="perm_storage_help">Necesario para hacer copia de seguridad y restaurar tu configuración, y para elegir una imagen de carga personalizada.</string>
+    <string name="onb_dpi_recommended">Recomendado para tu pantalla: %1$d dpi</string>
+    <string name="onb_ready_loading_intro">Una cosa más: ahora puedes establecer una pantalla de carga personalizada, que se muestra mientras el auto se conecta.</string>
+    <string name="onb_ready_loading_button">Configurar una pantalla de carga</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -758,4 +758,7 @@
     <string name="perm_write_settings_help">Laat de app de hotspot automatisch inschakelen voor draadloze verbindingen.</string>
     <string name="perm_storage_title">Opslag</string>
     <string name="perm_storage_help">Nodig om je instellingen te back-uppen en te herstellen en om een aangepaste laadafbeelding te kiezen.</string>
+    <string name="onb_dpi_recommended">Aanbevolen voor je scherm: %1$d dpi</string>
+    <string name="onb_ready_loading_intro">Nog één ding: je kunt nu een aangepast laadscherm instellen, dat wordt getoond terwijl de auto verbinding maakt.</string>
+    <string name="onb_ready_loading_button">Een laadscherm instellen</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -733,4 +733,29 @@
     <string name="onb_vehicle_help_advanced">Je kunt meer voertuiggegevens aanpassen op het tabblad Geavanceerd. Wij gebruiken deze gegevens niet; ze worden alleen naar Android Auto gestuurd omdat het ze vereist.</string>
     <string name="onb_summary_vehicle_format">Voertuig: %1$s</string>
     <string name="sunrise_reference_help">Het referentiepunt dat wordt gebruikt om zonsopkomst en zonsondergang te berekenen. Kies één keer je locatie; het werkt zonder gps.</string>
+
+    <!-- Permissions & onboarding -->
+    <string name="onb_summary_permissions_format">Machtigingen: %1$d van %2$d verleend</string>
+    <string name="onb_permissions_title">Machtigingen inschakelen</string>
+    <string name="onb_permissions_help">Schakel de machtigingen in die de app nodig heeft, zodat alles werkt zonder onverwachte prompts. Je kunt deze altijd later wijzigen.</string>
+    <string name="onb_perms_enable_all">Alles inschakelen</string>
+    <string name="perm_allow">Toestaan</string>
+    <string name="perm_granted">Verleend</string>
+    <string name="perm_optional_format">%1$s (optioneel)</string>
+    <string name="permissions">Machtigingen</string>
+    <string name="permissions_desc">Bekijk en verleen de machtigingen die de app nodig heeft</string>
+    <string name="perm_mic_title">Microfoon</string>
+    <string name="perm_mic_help">Laat Android Auto spraakopdrachten, de Google Assistant en telefoongesprekken gebruiken.</string>
+    <string name="perm_location_title">Locatie</string>
+    <string name="perm_location_help">Stuurt GPS naar de telefoon voor navigatie, scant naar draadloze verbindingen en schakelt de locatiegebaseerde nachtmodus in.</string>
+    <string name="perm_nearby_title">Apparaten in de buurt</string>
+    <string name="perm_nearby_help">Nodig om verbinding te maken via Bluetooth en Wi-Fi, Bluetooth-audio te routeren en automatisch te starten op een gekoppeld apparaat.</string>
+    <string name="perm_notifications_title">Meldingen</string>
+    <string name="perm_notifications_help">Toont de permanente melding terwijl Android Auto actief is.</string>
+    <string name="perm_overlay_title">Weergeven over andere apps</string>
+    <string name="perm_overlay_help">Laat de app het autoscherm boven andere apps openen, inclusief automatisch starten.</string>
+    <string name="perm_write_settings_title">Systeeminstellingen wijzigen</string>
+    <string name="perm_write_settings_help">Laat de app de hotspot automatisch inschakelen voor draadloze verbindingen.</string>
+    <string name="perm_storage_title">Opslag</string>
+    <string name="perm_storage_help">Nodig om je instellingen te back-uppen en te herstellen en om een aangepaste laadafbeelding te kiezen.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -759,4 +759,7 @@
     <string name="perm_write_settings_help">Umożliwia aplikacji automatyczne włączanie hotspotu dla połączeń bezprzewodowych.</string>
     <string name="perm_storage_title">Pamięć masowa</string>
     <string name="perm_storage_help">Potrzebne do tworzenia i przywracania kopii zapasowej ustawień oraz do wybrania niestandardowego obrazu ładowania.</string>
+    <string name="onb_dpi_recommended">Zalecane dla Twojego ekranu: %1$d dpi</string>
+    <string name="onb_ready_loading_intro">Jeszcze jedno: możesz teraz ustawić niestandardowy ekran ładowania wyświetlany podczas łączenia samochodu.</string>
+    <string name="onb_ready_loading_button">Skonfiguruj ekran ładowania</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -734,4 +734,29 @@
     <string name="onb_vehicle_help_advanced">Więcej szczegółów pojazdu możesz dostosować w karcie Zaawansowane. Nie używamy tych danych; są wysyłane tylko do Android Auto, ponieważ ich wymaga.</string>
     <string name="onb_summary_vehicle_format">Pojazd: %1$s</string>
     <string name="sunrise_reference_help">Punkt odniesienia używany do obliczania wschodu i zachodu słońca. Wybierz swoją lokalizację raz; działa bez GPS.</string>
+
+    <!-- Permissions onboarding -->
+    <string name="onb_summary_permissions_format">Uprawnienia: %1$d z %2$d przyznanych</string>
+    <string name="onb_permissions_title">Włącz uprawnienia</string>
+    <string name="onb_permissions_help">Włącz uprawnienia potrzebne aplikacji, aby wszystko działało bez niespodziewanych monitów. Możesz je zmienić w dowolnym momencie.</string>
+    <string name="onb_perms_enable_all">Włącz wszystkie</string>
+    <string name="perm_allow">Zezwól</string>
+    <string name="perm_granted">Przyznano</string>
+    <string name="perm_optional_format">%1$s (opcjonalne)</string>
+    <string name="permissions">Uprawnienia</string>
+    <string name="permissions_desc">Przejrzyj i przyznaj uprawnienia potrzebne aplikacji</string>
+    <string name="perm_mic_title">Mikrofon</string>
+    <string name="perm_mic_help">Umożliwia Android Auto korzystanie z poleceń głosowych, Google Assistant i połączeń telefonicznych.</string>
+    <string name="perm_location_title">Lokalizacja</string>
+    <string name="perm_location_help">Wysyła GPS do telefonu do nawigacji, skanuje połączenia bezprzewodowe i obsługuje tryb nocny oparty na lokalizacji.</string>
+    <string name="perm_nearby_title">Urządzenia w pobliżu</string>
+    <string name="perm_nearby_help">Potrzebne do połączenia przez Bluetooth i Wi-Fi, routingu dźwięku Bluetooth i automatycznego uruchamiania po sparowanym urządzeniu.</string>
+    <string name="perm_notifications_title">Powiadomienia</string>
+    <string name="perm_notifications_help">Wyświetla trwające powiadomienie podczas działania Android Auto.</string>
+    <string name="perm_overlay_title">Wyświetlaj nad innymi aplikacjami</string>
+    <string name="perm_overlay_help">Umożliwia aplikacji otwarcie ekranu samochodowego nad innymi aplikacjami, w tym podczas automatycznego uruchamiania.</string>
+    <string name="perm_write_settings_title">Modyfikacja ustawień systemowych</string>
+    <string name="perm_write_settings_help">Umożliwia aplikacji automatyczne włączanie hotspotu dla połączeń bezprzewodowych.</string>
+    <string name="perm_storage_title">Pamięć masowa</string>
+    <string name="perm_storage_help">Potrzebne do tworzenia i przywracania kopii zapasowej ustawień oraz do wybrania niestandardowego obrazu ładowania.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -735,4 +735,29 @@
     <string name="onb_vehicle_help_advanced">Você pode ajustar mais detalhes do veículo na aba Avançado. Não usamos esses dados; eles são enviados apenas ao Android Auto porque ele os exige.</string>
     <string name="onb_summary_vehicle_format">Veículo: %1$s</string>
     <string name="sunrise_reference_help">O ponto de referência usado para calcular o nascer e o pôr do sol. Escolha sua localização uma vez; funciona sem GPS.</string>
+
+    <!-- Onboarding permissions -->
+    <string name="onb_summary_permissions_format">Permissões: %1$d de %2$d concedidas</string>
+    <string name="onb_permissions_title">Ativar permissões</string>
+    <string name="onb_permissions_help">Ative as permissões que o app precisa para que tudo funcione sem solicitações inesperadas depois. Você pode alterar isso a qualquer momento.</string>
+    <string name="onb_perms_enable_all">Ativar todas</string>
+    <string name="perm_allow">Permitir</string>
+    <string name="perm_granted">Concedida</string>
+    <string name="perm_optional_format">%1$s (opcional)</string>
+    <string name="permissions">Permissões</string>
+    <string name="permissions_desc">Revise e conceda as permissões necessárias ao app</string>
+    <string name="perm_mic_title">Microfone</string>
+    <string name="perm_mic_help">Permite que o Android Auto use comandos de voz, o Google Assistant e chamadas telefônicas.</string>
+    <string name="perm_location_title">Localização</string>
+    <string name="perm_location_help">Envia o GPS ao celular para navegação, escaneia conexões sem fio e aciona o modo noturno baseado em localização.</string>
+    <string name="perm_nearby_title">Dispositivos próximos</string>
+    <string name="perm_nearby_help">Necessário para conectar via Bluetooth e Wi-Fi, rotear áudio Bluetooth e iniciar automaticamente em um dispositivo pareado.</string>
+    <string name="perm_notifications_title">Notificações</string>
+    <string name="perm_notifications_help">Exibe a notificação persistente enquanto o Android Auto está em execução.</string>
+    <string name="perm_overlay_title">Exibir sobre outros apps</string>
+    <string name="perm_overlay_help">Permite que o app abra a tela do carro sobre outros aplicativos, incluindo o início automático.</string>
+    <string name="perm_write_settings_title">Modificar configurações do sistema</string>
+    <string name="perm_write_settings_help">Permite que o app ative o ponto de acesso automaticamente para conexões sem fio.</string>
+    <string name="perm_storage_title">Armazenamento</string>
+    <string name="perm_storage_help">Necessário para fazer backup e restaurar suas configurações e para escolher uma imagem de carregamento personalizada.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -760,4 +760,7 @@
     <string name="perm_write_settings_help">Permite que o app ative o ponto de acesso automaticamente para conexões sem fio.</string>
     <string name="perm_storage_title">Armazenamento</string>
     <string name="perm_storage_help">Necessário para fazer backup e restaurar suas configurações e para escolher uma imagem de carregamento personalizada.</string>
+    <string name="onb_dpi_recommended">Recomendado para sua tela: %1$d dpi</string>
+    <string name="onb_ready_loading_intro">Mais uma coisa: agora você pode definir uma tela de carregamento personalizada, exibida enquanto o carro se conecta.</string>
+    <string name="onb_ready_loading_button">Configurar uma tela de carregamento</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -733,4 +733,29 @@
     <string name="onb_vehicle_help_advanced">Дополнительные сведения об автомобиле можно настроить на вкладке Дополнительно. Мы не используем эти данные; они отправляются только в Android Auto, потому что он их запрашивает.</string>
     <string name="onb_summary_vehicle_format">Автомобиль: %1$s</string>
     <string name="sunrise_reference_help">Опорная точка для расчёта восхода и заката. Укажите своё местоположение один раз; работает без GPS.</string>
+
+    <!-- Onboarding permissions -->
+    <string name="onb_summary_permissions_format">Разрешения: %1$d из %2$d предоставлено</string>
+    <string name="onb_permissions_title">Предоставление разрешений</string>
+    <string name="onb_permissions_help">Включите разрешения, необходимые приложению, чтобы в дальнейшем всё работало без неожиданных запросов. Вы можете изменить их в любой момент.</string>
+    <string name="onb_perms_enable_all">Разрешить все</string>
+    <string name="perm_allow">Разрешить</string>
+    <string name="perm_granted">Предоставлено</string>
+    <string name="perm_optional_format">%1$s (необязательно)</string>
+    <string name="permissions">Разрешения</string>
+    <string name="permissions_desc">Просмотр и предоставление разрешений, необходимых приложению</string>
+    <string name="perm_mic_title">Микрофон</string>
+    <string name="perm_mic_help">Позволяет Android Auto использовать голосовые команды, Google Assistant и телефонные звонки.</string>
+    <string name="perm_location_title">Местоположение</string>
+    <string name="perm_location_help">Передаёт GPS на телефон для навигации, выполняет поиск беспроводных подключений и управляет ночным режимом по местоположению.</string>
+    <string name="perm_nearby_title">Устройства поблизости</string>
+    <string name="perm_nearby_help">Необходимо для подключения по Bluetooth и Wi-Fi, маршрутизации Bluetooth-аудио и автозапуска при подключении сопряжённого устройства.</string>
+    <string name="perm_notifications_title">Уведомления</string>
+    <string name="perm_notifications_help">Отображает постоянное уведомление во время работы Android Auto.</string>
+    <string name="perm_overlay_title">Отображение поверх других приложений</string>
+    <string name="perm_overlay_help">Позволяет приложению открывать экран автомобиля поверх других приложений, включая автозапуск.</string>
+    <string name="perm_write_settings_title">Изменение системных настроек</string>
+    <string name="perm_write_settings_help">Позволяет приложению автоматически включать точку доступа для беспроводных подключений.</string>
+    <string name="perm_storage_title">Хранилище</string>
+    <string name="perm_storage_help">Необходимо для резервного копирования и восстановления настроек, а также для выбора пользовательского экрана загрузки.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -758,4 +758,7 @@
     <string name="perm_write_settings_help">Позволяет приложению автоматически включать точку доступа для беспроводных подключений.</string>
     <string name="perm_storage_title">Хранилище</string>
     <string name="perm_storage_help">Необходимо для резервного копирования и восстановления настроек, а также для выбора пользовательского экрана загрузки.</string>
+    <string name="onb_dpi_recommended">Рекомендуется для вашего экрана: %1$d dpi</string>
+    <string name="onb_ready_loading_intro">Ещё кое-что: теперь вы можете задать пользовательский экран загрузки, который отображается во время подключения автомобиля.</string>
+    <string name="onb_ready_loading_button">Настроить экран загрузки</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -735,4 +735,28 @@
     <string name="onb_vehicle_help_advanced">Більше даних про автомобіль можна налаштувати на вкладці Додатково. Ми не використовуємо ці дані; вони надсилаються лише в Android Auto, бо він їх вимагає.</string>
     <string name="onb_summary_vehicle_format">Автомобіль: %1$s</string>
     <string name="sunrise_reference_help">Опорна точка для розрахунку сходу та заходу сонця. Укажіть своє місцезнаходження один раз; працює без GPS.</string>
+
+    <string name="onb_summary_permissions_format">Дозволи: %1$d з %2$d надано</string>
+    <string name="onb_permissions_title">Увімкнути дозволи</string>
+    <string name="onb_permissions_help">Увімкніть дозволи, необхідні для роботи застосунку, щоб пізніше не виникало несподіваних запитів. Ви можете змінити їх будь-коли.</string>
+    <string name="onb_perms_enable_all">Увімкнути всі</string>
+    <string name="perm_allow">Дозволити</string>
+    <string name="perm_granted">Надано</string>
+    <string name="perm_optional_format">%1$s (необов\'язково)</string>
+    <string name="permissions">Дозволи</string>
+    <string name="permissions_desc">Переглянути та надати дозволи, необхідні для роботи застосунку</string>
+    <string name="perm_mic_title">Мікрофон</string>
+    <string name="perm_mic_help">Дозволяє Android Auto використовувати голосові команди, Google Assistant і телефонні дзвінки.</string>
+    <string name="perm_location_title">Місцезнаходження</string>
+    <string name="perm_location_help">Надсилає GPS на телефон для навігації, сканує бездротові підключення та забезпечує нічний режим на основі місцезнаходження.</string>
+    <string name="perm_nearby_title">Пристрої поблизу</string>
+    <string name="perm_nearby_help">Необхідний для підключення через Bluetooth і Wi-Fi, маршрутизації аудіо Bluetooth та автозапуску на сполученому пристрої.</string>
+    <string name="perm_notifications_title">Сповіщення</string>
+    <string name="perm_notifications_help">Показує постійне сповіщення під час роботи Android Auto.</string>
+    <string name="perm_overlay_title">Відображення поверх інших додатків</string>
+    <string name="perm_overlay_help">Дозволяє застосунку відкривати екран автомобіля поверх інших додатків, включаючи автозапуск.</string>
+    <string name="perm_write_settings_title">Зміна системних налаштувань</string>
+    <string name="perm_write_settings_help">Дозволяє застосунку автоматично вмикати точку доступу для бездротових підключень.</string>
+    <string name="perm_storage_title">Сховище</string>
+    <string name="perm_storage_help">Необхідне для резервного копіювання та відновлення налаштувань, а також для вибору користувацького зображення завантаження.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -759,4 +759,7 @@
     <string name="perm_write_settings_help">Дозволяє застосунку автоматично вмикати точку доступу для бездротових підключень.</string>
     <string name="perm_storage_title">Сховище</string>
     <string name="perm_storage_help">Необхідне для резервного копіювання та відновлення налаштувань, а також для вибору користувацького зображення завантаження.</string>
+    <string name="onb_dpi_recommended">Рекомендовано для вашого екрана: %1$d dpi</string>
+    <string name="onb_ready_loading_intro">Ще одне: тепер ви можете встановити власний екран завантаження, який відображатиметься під час підключення автомобіля.</string>
+    <string name="onb_ready_loading_button">Налаштувати екран завантаження</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -732,4 +732,29 @@
     <string name="onb_vehicle_help_advanced">你可以在進階分頁中調整更多車輛細節。我們不會使用這些資料，只會傳送給 Android Auto，因為它需要這些資料。</string>
     <string name="onb_summary_vehicle_format">車輛：%1$s</string>
     <string name="sunrise_reference_help">用來計算日出和日落時間的參考點。只需選擇一次位置，無需 GPS 即可運作。</string>
+
+    <!-- Onboarding permissions -->
+    <string name="onb_summary_permissions_format">權限：已授予 %1$d / %2$d 項</string>
+    <string name="onb_permissions_title">啟用權限</string>
+    <string name="onb_permissions_help">開啟應用程式所需的權限，以免日後出現意外提示。您隨時可以更改這些設定。</string>
+    <string name="onb_perms_enable_all">全部啟用</string>
+    <string name="perm_allow">允許</string>
+    <string name="perm_granted">已授予</string>
+    <string name="perm_optional_format">%1$s（選用）</string>
+    <string name="permissions">權限</string>
+    <string name="permissions_desc">檢視並授予應用程式所需的權限</string>
+    <string name="perm_mic_title">麥克風</string>
+    <string name="perm_mic_help">讓 Android Auto 使用語音指令、Google Assistant 及通話功能。</string>
+    <string name="perm_location_title">位置</string>
+    <string name="perm_location_help">將 GPS 傳送至手機以供導航使用、掃描無線連線，並驅動依位置判斷的夜間模式。</string>
+    <string name="perm_nearby_title">附近裝置</string>
+    <string name="perm_nearby_help">透過 Bluetooth 和 Wi-Fi 連線、路由 Bluetooth 音訊，以及在已配對裝置上自動啟動所需的權限。</string>
+    <string name="perm_notifications_title">通知</string>
+    <string name="perm_notifications_help">在 Android Auto 執行期間顯示持續通知。</string>
+    <string name="perm_overlay_title">顯示在其他應用程式上層</string>
+    <string name="perm_overlay_help">讓應用程式在其他應用程式上層開啟車機畫面，包括自動啟動。</string>
+    <string name="perm_write_settings_title">修改系統設定</string>
+    <string name="perm_write_settings_help">讓應用程式自動開啟熱點以進行無線連線。</string>
+    <string name="perm_storage_title">儲存空間</string>
+    <string name="perm_storage_help">備份和還原設定，以及選擇自訂載入畫面圖片所需的權限。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -757,4 +757,7 @@
     <string name="perm_write_settings_help">讓應用程式自動開啟熱點以進行無線連線。</string>
     <string name="perm_storage_title">儲存空間</string>
     <string name="perm_storage_help">備份和還原設定，以及選擇自訂載入畫面圖片所需的權限。</string>
+    <string name="onb_dpi_recommended">您螢幕的建議值：%1$d dpi</string>
+    <string name="onb_ready_loading_intro">還有一件事：您現在可以設定自訂載入畫面，在汽車連線時顯示。</string>
+    <string name="onb_ready_loading_button">設定載入畫面</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,33 @@
     <!-- %1$s connection, %2$s resolution, %3$s codec -->
     <string name="onb_ready_summary">Connection: %1$s\nResolution: %2$s\nCodec: %3$s\n\nYou can fine tune everything in Settings.</string>
     <string name="onb_summary_vehicle_format">Vehicle: %1$s</string>
+    <!-- %1$d granted, %2$d total -->
+    <string name="onb_summary_permissions_format">Permissions: %1$d of %2$d granted</string>
+
+    <!-- Onboarding wizard: permissions step + Settings > Permissions -->
+    <string name="onb_permissions_title">Enable permissions</string>
+    <string name="onb_permissions_help">Turn on the permissions the app needs so everything works without surprise prompts later. You can change these any time.</string>
+    <string name="onb_perms_enable_all">Enable all</string>
+    <string name="perm_allow">Allow</string>
+    <string name="perm_granted">Granted</string>
+    <!-- %1$s permission name -->
+    <string name="perm_optional_format">%1$s (optional)</string>
+    <string name="permissions">Permissions</string>
+    <string name="permissions_desc">Review and grant the permissions the app needs</string>
+    <string name="perm_mic_title">Microphone</string>
+    <string name="perm_mic_help">Lets Android Auto use voice commands, the Google Assistant and phone calls.</string>
+    <string name="perm_location_title">Location</string>
+    <string name="perm_location_help">Sends GPS to the phone for navigation, scans for wireless connections and drives location based night mode.</string>
+    <string name="perm_nearby_title">Nearby devices</string>
+    <string name="perm_nearby_help">Needed to connect over Bluetooth and Wi-Fi, route Bluetooth audio and auto start on a paired device.</string>
+    <string name="perm_notifications_title">Notifications</string>
+    <string name="perm_notifications_help">Shows the ongoing notification while Android Auto is running.</string>
+    <string name="perm_overlay_title">Display over other apps</string>
+    <string name="perm_overlay_help">Lets the app open the car screen on top of other apps, including auto start.</string>
+    <string name="perm_write_settings_title">Modify system settings</string>
+    <string name="perm_write_settings_help">Lets the app turn the hotspot on automatically for wireless connections.</string>
+    <string name="perm_storage_title">Storage</string>
+    <string name="perm_storage_help">Needed to back up and restore your settings and to pick a custom loading image.</string>
 
     <!-- Onboarding wizard: car brand / vehicle identity -->
     <string name="onb_vehicle_title">Your car</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,8 @@
     <string name="onb_summary_vehicle_format">Vehicle: %1$s</string>
     <!-- %1$d granted, %2$d total -->
     <string name="onb_summary_permissions_format">Permissions: %1$d of %2$d granted</string>
+    <string name="onb_ready_loading_intro">One more thing: you can now set a custom loading screen, shown while the car connects.</string>
+    <string name="onb_ready_loading_button">Set up a loading screen</string>
 
     <!-- Onboarding wizard: permissions step + Settings > Permissions -->
     <string name="onb_permissions_title">Enable permissions</string>
@@ -152,6 +154,8 @@
     <string name="onb_appearance_more_hint">You can find more dark mode options in Settings.</string>
     <string name="onb_automation_more_hint">You can find more options in Auto-connect and Auto-start settings.</string>
     <string name="onb_dpi_help">A higher DPI makes Android Auto icons and text larger, so less fits on screen. A lower DPI makes them smaller, so more fits. It applies when you connect Android Auto.</string>
+    <!-- %1$d recommended DPI value -->
+    <string name="onb_dpi_recommended">Recommended for your screen: %1$d dpi</string>
     <string name="onb_change_later">You can change this later in Settings.</string>
     <string name="dpi_automatic">Automatic</string>
     <string name="dpi_automatic_desc">Use the device density</string>


### PR DESCRIPTION
This unifies my open pull requests into a single branch, and also includes @o-jcardenass's #725, so everything can be tested and merged together in one place instead of one PR at a time. Landing them separately would create merge conflicts across the wizard and the wireless connection code, and this branch resolves that.

Includes and closes my PRs (changes verified identical file by file):
- #721 sunrise/sunset Auto mode stays selected when opening the map (#647)
- #722 WiFi Direct group reuse delivers credentials, restoring wireless auto-connect (#719). Confirmed by @o-jcardenass.
- #724 setup wizard permissions step, DPI preservation, loading screen suggestion, WRITE_SETTINGS auto-hotspot guard
- #727 WiFi Launcher wake restored so the Wireless Helper auto-launches (#719)

Also includes, with full credit and original authorship preserved:
- #725 by @o-jcardenass: Native AA Bluetooth handshake reliability (a 15s handshake timeout, and re-arming Native AA on Bluetooth reconnect). Thank you for this work.

Relationship to #725: this branch already contains #725, so merging this one brings in @o-jcardenass's fix too (his commits, his authorship). #725 does not need to be merged separately if this is merged. That said, @o-jcardenass, if you would rather land #725 on its own, tell me and I will drop those two commits from here. Our changes are complementary and do not overlap in logic (the one shared file, AapService.kt, is edited in different places, so there is no real conflict).

I cannot test the wireless parts myself, since I use a wireless USB adapter and not WiFi. A single test build that bundles all of the above is linked on the issues. Please test and let me know.

---

Two additional experimental fixes are bundled so everything can be tried in one build. They are isolated and low blast radius, but I cannot test them, so they are marked experimental:
- Native AA on dual-Bluetooth head units (#706): also listen for the phone on a secondary Bluetooth radio (for example K706 vs CAR8032), so a phone bonded to the other radio is still detected. Strict no-op on single-radio devices. This is a different, complementary approach to @o-jcardenass's #725 (which fixes handshake reliability); together they cover both angles.
- WiFi Direct stale group (#719 / #703): a persistent P2P group left over from a previous session or a reboot is recreated fresh instead of reused, to stop the phone re-prompting to accept it. The confirmed intra-session reuse path is unchanged.

If either experimental part misbehaves on your hardware, tell me and I will drop that commit. The idea is to try everything together as one "final" build: if it works, great, and if not, we take another direction.