### PR TITLE
Fix Native AA connecting loop: give the quiet-host path #730's group protections (#706)

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
@@ -734,6 +734,8 @@ class AapService : Service(), UsbReceiver.Listener {
                 AppLog.d("AapService: WiFi credentials received, but not in Native AA mode. Skipping HandshakeManager update.")
             }
         }
+        wifiDirectManager?.setNativeHandshakeStateProvider { nativeAaHandshakeManager?.isHandshakeInFlight() == true }
+        wifiDirectManager?.setNativeGroupInvalidatedListener { nativeAaHandshakeManager?.invalidateCredentials() }
 
 
         checkAlreadyConnectedUsb()

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
@@ -118,20 +118,23 @@ class NativeAaHandshakeManager(
         }
 
         isRunning = true
-        AppLog.i("NativeAA: Starting Bluetooth Handshake Servers...")
+        // Local Bluetooth radio address; logged on every accept so a dual-radio head unit's logs
+        // show which radio the phone actually reached (compare with the HU MAC in the phone's log).
+        val localAddr = try { adapter.address } catch (e: Exception) { "?" }
+        AppLog.i("NativeAA: Starting Bluetooth Handshake Servers (primary radio [$localAddr])...")
 
         // Start AA RFCOMM Server
         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-RfcommServer")) {
             try {
                 aaServerSocket = adapter.listenUsingRfcommWithServiceRecord("AA BT Listener", AA_UUID)
-                AppLog.i("NativeAA: ACTIVELY LISTENING on Android Auto UUID ($AA_UUID)... Waiting for phone to connect back!")
+                AppLog.i("NativeAA: ACTIVELY LISTENING on Android Auto UUID ($AA_UUID) on radio [$localAddr]... Waiting for phone to connect back!")
                 while (isRunning && isActive) {
                     val socket = aaServerSocket?.accept()
                     if (socket != null) {
-                        AppLog.i("NativeAA: Connection accepted from ${socket.remoteDevice.name}")
+                        AppLog.i("NativeAA: Connection accepted from ${socket.remoteDevice.name} (${socket.remoteDevice.address}) on local radio [$localAddr]")
                         // [FIX] Launch handshake in a separate coroutine so the server can accept the next connection!
                         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-Handshake-${socket.remoteDevice.address}")) {
-                            handleHandshake(socket)
+                            handleHandshake(socket, localAddr)
                         }
                     }
                 }
@@ -201,9 +204,9 @@ class NativeAaHandshakeManager(
                 while (isRunning && isActive) {
                     val socket = server.accept()
                     if (socket != null) {
-                        AppLog.i("NativeAA: Connection accepted (secondary radio) from ${socket.remoteDevice.name}")
+                        AppLog.i("NativeAA: Connection accepted (secondary radio [$addr]) from ${socket.remoteDevice.name} (${socket.remoteDevice.address})")
                         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-Handshake-${socket.remoteDevice.address}")) {
-                            handleHandshake(socket)
+                            handleHandshake(socket, addr)
                         }
                     }
                 }
@@ -388,11 +391,11 @@ class NativeAaHandshakeManager(
         }
     }
 
-    private suspend fun handleHandshake(socket: BluetoothSocket) = withContext(Dispatchers.IO) {
+    private suspend fun handleHandshake(socket: BluetoothSocket, localRadio: String? = null) = withContext(Dispatchers.IO) {
         handshakeInFlight = true
         try {
             val device = socket.remoteDevice
-            AppLog.i("NativeAA: Handling handshake for ${device.name} (${device.address})")
+            AppLog.i("NativeAA: Handling handshake for ${device.name} (${device.address}) on local radio [${localRadio ?: "?"}]")
 
             if (commManager.isConnected ||
                 commManager.connectionState.value is CommManager.ConnectionState.Connecting) {
@@ -460,7 +463,7 @@ class NativeAaHandshakeManager(
             // No BluetoothSocket.setSoTimeout(); force-close via watchdog to unblock readFully() on timeout.
             val watchdog = scope.launch(Dispatchers.IO) {
                 delay(HANDSHAKE_RESPONSE_TIMEOUT_MS)
-                AppLog.e("NativeAA: Handshake failed - No response from phone within ${HANDSHAKE_RESPONSE_TIMEOUT_MS / 1000}s of sending WifiStartRequest. Closing socket.")
+                AppLog.e("NativeAA: Handshake failed - No response from phone ${device.name} (${device.address}) on radio [${localRadio ?: "?"}] within ${HANDSHAKE_RESPONSE_TIMEOUT_MS / 1000}s of sending WifiStartRequest. Closing socket.")
                 try { socket.close() } catch (e: Exception) {}
             }
             val response = try {

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
@@ -68,6 +68,9 @@ class NativeAaHandshakeManager(
     private var currentIp: String? = null
     private var currentBssid: String? = null
     private var pokeJob: Job? = null
+    // True while handleHandshake() runs; lets WifiDirectManager's join watchdog know a real
+    // exchange is in progress. Bounded by handleHandshake()'s own timeouts, so it can't stick true.
+    @Volatile private var handshakeInFlight = false
 
     /**
      * Updates the WiFi credentials that will be sent to the phone during the next handshake.
@@ -80,7 +83,18 @@ class NativeAaHandshakeManager(
         currentBssid = bssid
     }
 
+    /** Clears cached credentials so an in-progress wait doesn't hand out stale ones for a group
+     *  that's about to be torn down. */
+    fun invalidateCredentials() {
+        currentSsid = null
+        currentPsk = null
+        currentIp = null
+        currentBssid = null
+    }
+
     fun isActive(): Boolean = isRunning
+
+    fun isHandshakeInFlight(): Boolean = handshakeInFlight
 
     @SuppressLint("MissingPermission")
     fun start() {
@@ -375,6 +389,7 @@ class NativeAaHandshakeManager(
     }
 
     private suspend fun handleHandshake(socket: BluetoothSocket) = withContext(Dispatchers.IO) {
+        handshakeInFlight = true
         try {
             val device = socket.remoteDevice
             AppLog.i("NativeAA: Handling handshake for ${device.name} (${device.address})")
@@ -475,6 +490,7 @@ class NativeAaHandshakeManager(
         } catch (e: Exception) {
             AppLog.e("NativeAA: Handshake error: ${e.message}", e)
         } finally {
+            handshakeInFlight = false
             try { socket.close() } catch (e: Exception) {}
             AppLog.i("NativeAA: BT Handshake socket closed.")
         }

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
@@ -476,7 +476,12 @@ class NativeAaHandshakeManager(
                 delay(1000) // [FIX] Increased delay to give phone more processing time
                 sendWifiSecurityResponse(output, ssid, psk, bssid)
                 AppLog.i("NativeAA: Handshake completed successfully on Bluetooth side.")
-                
+                // The credential exchange is done; the join watchdog no longer needs to defer
+                // for this handshake. Without this, it stayed true for the entire lifetime of
+                // the "maintain session" loop below (observed on-device stuck for 15+ minutes),
+                // permanently blocking recovery if the phone never actually joins the P2P group.
+                handshakeInFlight = false
+
                 // Keep the socket open to maintain the handshake session
                 AppLog.i("NativeAA: Maintaining Bluetooth session...")
                 while (isRunning && isActive && socket.isConnected) {

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
@@ -37,6 +37,12 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         private const val NATIVE_GROUP_MODE_5GHZ_REQUESTED = "5GHz requested"
         private const val NATIVE_GROUP_MODE_STANDARD_FALLBACK = "standard fallback"
         private const val NATIVE_GROUP_MODE_STANDARD_LEGACY = "standard (no 5GHz API)"
+        // Native AA join recovery: if no phone joins the quiet-host group within this window,
+        // tear it down and recreate a fresh one (bounded), and after a couple of tries drop the
+        // forced 5GHz band in case the phone cannot join it.
+        private const val NATIVE_JOIN_TIMEOUT_MS = 30000L
+        private const val MAX_NATIVE_JOIN_RECREATES = 4
+        private const val NATIVE_FORCE_STANDARD_AFTER = 2
     }
 
     @Volatile private var manager: WifiP2pManager? = context.getSystemService(Context.WIFI_P2P_SERVICE) as? WifiP2pManager
@@ -80,6 +86,13 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     private var native5GhzBandMismatchRetries = 0
     private var lastNativeGroupStatusMessage: String? = null
 
+    // Native AA join recovery state. The watchdog fires if the phone never joins our quiet-host
+    // group; nativeRecreateCount bounds how many times we recreate before giving up.
+    private var nativeRecreateCount = 0
+    private val nativeJoinWatchdog = Runnable {
+        if (!isClientConnected) recoverNativeGroup("no phone joined within ${NATIVE_JOIN_TIMEOUT_MS / 1000}s")
+    }
+
     private var onCredentialsReady: ((ssid: String, psk: String, ip: String, bssid: String) -> Unit)? = null
 
     fun setCredentialsListener(callback: (String, String, String, String) -> Unit) {
@@ -114,6 +127,8 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                         isGroupCreatingOrCreated = false
                         isConnected = false
                         isClientConnected = false
+                        cancelNativeJoinWatchdog()
+                        nativeRecreateCount = 0
                     }
                 }
 
@@ -152,6 +167,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                         isClientConnected = false
                         lastNativeGroupStatusMessage = null
                         isGroupCreatingOrCreated = false
+                        cancelNativeJoinWatchdog()
                     }
                 }
             }
@@ -190,7 +206,9 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     @SuppressLint("MissingPermission")
     private fun checkStuckRetryBurst() {
         val appSettings = App.provide(context).settings
-        if (appSettings.wifiConnectionMode != 2 || appSettings.helperConnectionStrategy != 1 || !isGroupOwner) {
+        val isHelperP2p = appSettings.wifiConnectionMode == 2 && appSettings.helperConnectionStrategy == 1
+        val isNative = appSettings.wifiConnectionMode == 3
+        if ((!isHelperP2p && !isNative) || !isGroupOwner) {
             tightBurstCount = 0
             return
         }
@@ -204,6 +222,12 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         if (tightBurstCount >= burstTriggerCount) {
             AppLog.w("WifiDirectManager: Detected $tightBurstCount CONNECTION_CHANGED repeats <${burstGapMs}ms apart — stuck retry loop against an already-consumed group. Self-healing.")
             tightBurstCount = 0
+            if (isNative) {
+                // Native quiet-host has no discovery loop; recreate the group with a full
+                // persistent-profile purge (bounded), the same class of fix as the helper path.
+                recoverNativeGroup("stuck PROV-DISC retry loop")
+                return
+            }
             val mgr = manager
             val ch = channel
             if (mgr != null && ch != null) {
@@ -311,9 +335,15 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 val clients = group.clientList
                 val hadClient = isClientConnected
                 isClientConnected = clients != null && clients.isNotEmpty()
+                if (isClientConnected) {
+                    // A phone joined — stop the native join watchdog and reset its budget.
+                    cancelNativeJoinWatchdog()
+                    nativeRecreateCount = 0
+                }
                 if (hadClient && !isClientConnected) {
                     AppLog.i("WifiDirectManager: Client disconnected from P2P group. Restarting discovery loop.")
                     startDiscoveryLoop()
+                    if (isNativeAaMode()) armNativeJoinWatchdog()
                 }
             } else {
                 isClientConnected = true
@@ -442,6 +472,8 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                     return
                 }
                 notifyNativeGroupStarted(ssid, frequency, band)
+                // The group is up. If no phone joins within the window, recover (recreate fresh).
+                armNativeJoinWatchdog()
             }
 
             if (ssid.isNotEmpty()) {
@@ -826,23 +858,18 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             return
         }
 
-        AppLog.i("WifiDirectManager: startNativeAaQuietHost() requested. Removing old group if any...")
+        AppLog.i("WifiDirectManager: startNativeAaQuietHost() requested. Purging old/persistent group if any...")
         nativeGroupCreationMode = NATIVE_GROUP_MODE_UNKNOWN
         lastNativeGroupStatusMessage = null
-        // The next createGroup() call generates a brand-new GO interface with a new random
-        // MAC — a cached BSSID from the group we're tearing down is now stale and must never
-        // be delivered for the new one.
-        lastKnownBssid = null
-        mgr.removeGroup(ch, object : WifiP2pManager.ActionListener {
-            override fun onSuccess() {
-                AppLog.d("WifiDirectManager: removeGroup SUCCESS. Creating quiet group...")
-                delayedCreateQuietGroup(0)
-            }
-            override fun onFailure(reason: Int) {
-                AppLog.d("WifiDirectManager: removeGroup failed (reason=$reason). This is expected if no group existed. Creating quiet group anyway...")
-                delayedCreateQuietGroup(0)
-            }
-        })
+        native5GhzBandMismatchRetries = 0
+        nativeRecreateCount = 0
+        cancelNativeJoinWatchdog()
+        // A stale persistent P2P group left over from a previous session or reboot desyncs the
+        // phone's WPS/PBC registrar into an endless "connecting" loop. removeGroup() alone keeps
+        // the persistent profile (the recreated group comes back with the same netId/SSID), so
+        // purge the profile too before creating a fresh group — the same fix #730 applied to the
+        // Helper path, which the native quiet-host path never got.
+        purgeAndCreateNativeGroup(forceStandard = false)
     }
 
     private fun delayedCreateQuietGroup(retryCount: Int) {
@@ -987,6 +1014,95 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         })
     }
 
+    // ---- Native AA join recovery (the quiet-host equivalent of #730's helper-path fixes) ----
+
+    /** Delete a persistent P2P group profile by netId via the hidden deletePersistentGroup API
+     *  (reflection), then run [onDone] regardless of outcome. */
+    @SuppressLint("MissingPermission")
+    private fun deletePersistentGroupById(netId: Int, onDone: () -> Unit) {
+        val mgr = manager
+        val ch = channel
+        if (mgr == null || ch == null || netId < 0) { onDone(); return }
+        try {
+            val method = mgr.javaClass.getMethod(
+                "deletePersistentGroup",
+                WifiP2pManager.Channel::class.java,
+                Int::class.javaPrimitiveType,
+                WifiP2pManager.ActionListener::class.java
+            )
+            method.invoke(mgr, ch, netId, object : WifiP2pManager.ActionListener {
+                override fun onSuccess() {
+                    AppLog.i("WifiDirectManager: Native AA deletePersistentGroup(netId=$netId) succeeded")
+                    onDone()
+                }
+                override fun onFailure(reason: Int) {
+                    AppLog.w("WifiDirectManager: Native AA deletePersistentGroup(netId=$netId) failed: ${getP2pErrorString(reason)}")
+                    onDone()
+                }
+            })
+        } catch (e: Exception) {
+            AppLog.w("WifiDirectManager: Native AA deletePersistentGroup reflection unavailable: ${e.message}")
+            onDone()
+        }
+    }
+
+    /** Tear down any current P2P group (active group + persistent profile) and create a fresh
+     *  native quiet-host group. When [forceStandard] is true, skip the 5GHz attempt and create a
+     *  plain (2.4GHz-capable) group, for phones that cannot join a 5GHz group owner. */
+    @SuppressLint("MissingPermission")
+    private fun purgeAndCreateNativeGroup(forceStandard: Boolean) {
+        val mgr = manager ?: return
+        val ch = channel ?: return
+        lastKnownBssid = null
+        val createFresh = {
+            if (forceStandard) standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_FALLBACK)
+            else delayedCreateQuietGroup(0)
+        }
+        mgr.requestGroupInfo(ch) { group ->
+            if (group == null) {
+                createFresh()
+                return@requestGroupInfo
+            }
+            val netId = try { group.networkId } catch (e: Exception) { -1 }
+            AppLog.i("WifiDirectManager: Native AA — purging existing group (netId=$netId) before recreate${if (forceStandard) " (forcing 2.4GHz)" else ""}")
+            mgr.removeGroup(ch, object : WifiP2pManager.ActionListener {
+                override fun onSuccess() { deletePersistentGroupById(netId) { createFresh() } }
+                override fun onFailure(reason: Int) {
+                    AppLog.w("WifiDirectManager: Native AA removeGroup before recreate failed: ${getP2pErrorString(reason)}")
+                    deletePersistentGroupById(netId) { createFresh() }
+                }
+            })
+        }
+    }
+
+    /** Recover a native quiet-host group when the phone never joins: recreate a fresh one, and
+     *  after a couple of tries drop the forced 5GHz band. Bounded by [MAX_NATIVE_JOIN_RECREATES]. */
+    private fun recoverNativeGroup(reason: String) {
+        cancelNativeJoinWatchdog()
+        if (isClientConnected) return
+        if (nativeRecreateCount >= MAX_NATIVE_JOIN_RECREATES) {
+            AppLog.w("WifiDirectManager: Native AA — phone still not connected after $nativeRecreateCount recreations ($reason); giving up until the next start.")
+            return
+        }
+        nativeRecreateCount++
+        val forceStandard = nativeRecreateCount >= NATIVE_FORCE_STANDARD_AFTER
+        AppLog.w("WifiDirectManager: Native AA recovery ($reason): recreate attempt $nativeRecreateCount/$MAX_NATIVE_JOIN_RECREATES${if (forceStandard) ", forcing 2.4GHz" else ""}.")
+        purgeAndCreateNativeGroup(forceStandard)
+    }
+
+    /** (Re)arm the native join watchdog; no-op unless we are a native-mode group owner with no
+     *  client yet. */
+    private fun armNativeJoinWatchdog() {
+        handler.removeCallbacks(nativeJoinWatchdog)
+        if (isNativeAaMode() && isGroupOwner && !isClientConnected) {
+            handler.postDelayed(nativeJoinWatchdog, NATIVE_JOIN_TIMEOUT_MS)
+        }
+    }
+
+    private fun cancelNativeJoinWatchdog() {
+        handler.removeCallbacks(nativeJoinWatchdog)
+    }
+
     private fun notifyNativeGroupStarted(ssid: String, frequency: Int, band: String) {
         val frequencyText = if (frequency > 0) "$frequency MHz" else "frequency unknown"
         val message = "Native AA WiFi Direct: $band ($frequencyText), $nativeGroupCreationMode"
@@ -1100,6 +1216,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         isClientConnected = false
         nativeGroupCreationMode = NATIVE_GROUP_MODE_UNKNOWN
         native5GhzBandMismatchRetries = 0
+        nativeRecreateCount = 0
         lastNativeGroupStatusMessage = null
         AapService.scanningState.value = false
         try { context.unregisterReceiver(receiver) } catch (e: Exception) {}

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
@@ -38,9 +38,10 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         private const val NATIVE_GROUP_MODE_STANDARD_FALLBACK = "standard fallback"
         private const val NATIVE_GROUP_MODE_STANDARD_LEGACY = "standard (no 5GHz API)"
         // Native AA join recovery: if no phone joins the quiet-host group within this window,
-        // tear it down and recreate a fresh one (bounded), and after a couple of tries drop the
-        // forced 5GHz band in case the phone cannot join it.
-        private const val NATIVE_JOIN_TIMEOUT_MS = 30000L
+        // tear it down and recreate a fresh one (bounded), dropping the forced 5GHz band after
+        // a couple of tries. 60s not 30s — a live BT reconnect was observed taking ~35s even
+        // when working, so 30s left no margin.
+        private const val NATIVE_JOIN_TIMEOUT_MS = 60000L
         private const val MAX_NATIVE_JOIN_RECREATES = 4
         private const val NATIVE_FORCE_STANDARD_AFTER = 2
     }
@@ -90,13 +91,34 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     // group; nativeRecreateCount bounds how many times we recreate before giving up.
     private var nativeRecreateCount = 0
     private val nativeJoinWatchdog = Runnable {
-        if (!isClientConnected) recoverNativeGroup("no phone joined within ${NATIVE_JOIN_TIMEOUT_MS / 1000}s")
+        if (isClientConnected) return@Runnable
+        if (isNativeHandshakeInFlight?.invoke() == true) {
+            // A handshake is exchanging credentials right now; recreating here would hand out a new SSID mid-exchange.
+            AppLog.i("WifiDirectManager: Native AA join watchdog fired but a Bluetooth handshake is in flight — deferring recovery.")
+            armNativeJoinWatchdog()
+            return@Runnable
+        }
+        recoverNativeGroup("no phone joined within ${NATIVE_JOIN_TIMEOUT_MS / 1000}s")
     }
 
     private var onCredentialsReady: ((ssid: String, psk: String, ip: String, bssid: String) -> Unit)? = null
+    // Set by AapService: whether NativeAaHandshakeManager has a live handshake in progress, so
+    // the join watchdog/self-heal never tears the group down mid-exchange.
+    private var isNativeHandshakeInFlight: (() -> Boolean)? = null
+    // Set by AapService: called right before a native group is torn down, to invalidate any
+    // not-yet-captured credentials in NativeAaHandshakeManager.
+    private var onNativeGroupInvalidated: (() -> Unit)? = null
 
     fun setCredentialsListener(callback: (String, String, String, String) -> Unit) {
         this.onCredentialsReady = callback
+    }
+
+    fun setNativeHandshakeStateProvider(provider: () -> Boolean) {
+        this.isNativeHandshakeInFlight = provider
+    }
+
+    fun setNativeGroupInvalidatedListener(callback: () -> Unit) {
+        this.onNativeGroupInvalidated = callback
     }
 
 
@@ -223,8 +245,12 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             AppLog.w("WifiDirectManager: Detected $tightBurstCount CONNECTION_CHANGED repeats <${burstGapMs}ms apart — stuck retry loop against an already-consumed group. Self-healing.")
             tightBurstCount = 0
             if (isNative) {
-                // Native quiet-host has no discovery loop; recreate the group with a full
-                // persistent-profile purge (bounded), the same class of fix as the helper path.
+                if (isNativeHandshakeInFlight?.invoke() == true) {
+                    AppLog.i("WifiDirectManager: Native AA stuck-retry-burst detected but a Bluetooth handshake is in flight — skipping recovery.")
+                    return
+                }
+                // Native quiet-host has no discovery loop; recreate the group (bounded), the
+                // same class of self-heal as the helper path.
                 recoverNativeGroup("stuck PROV-DISC retry loop")
                 return
             }
@@ -654,59 +680,23 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             // PROV-DISC retry storm (confirmed via live-device bisection against `ebab63a8`,
             // whose only change was skipping this teardown on reuse) — tear down and recreate
             // on every reuse rather than trying to detect which ones are broken.
-            // removeGroup() alone isn't enough: the recreated group keeps the same
-            // networkId/SSID unless deletePersistentGroup() purges the profile first.
-            val netId = try { group.networkId } catch (e: Exception) { -1 }
-            AppLog.i("WifiDirectManager: Existing P2P group found (netId=$netId) — deleting persistent profile and recreating fresh for a clean WPS/PBC registrar")
+            // NOTE: this used to also call deletePersistentGroup() to purge the profile (so a
+            // plain createGroup() wouldn't reuse the same SSID/netId) — confirmed on-device that
+            // call is rejected outright for every netId, including the profile's own real one.
+            // Dropped; likely a permission this app doesn't hold.
+            AppLog.i("WifiDirectManager: Existing P2P group found — removing and recreating fresh for a clean WPS/PBC registrar")
             // The next createGroup() call generates a brand-new GO interface with a new random
             // MAC — a cached BSSID from the group we're tearing down is now stale and must never
             // be delivered for the new one.
             lastKnownBssid = null
             manager?.removeGroup(channel, object : WifiP2pManager.ActionListener {
-                override fun onSuccess() { deletePersistentGroupThenCreate(netId) }
+                override fun onSuccess() { checkGroupAndCreateInFlight = false; createNewGroup(0) }
                 override fun onFailure(reason: Int) {
                     AppLog.w("WifiDirectManager: removeGroup before recreate failed: ${getP2pErrorString(reason)}")
-                    deletePersistentGroupThenCreate(netId)
-                }
-            })
-        }
-    }
-
-    // deletePersistentGroup(Channel, int, ActionListener) isn't public SDK, so it's called via
-    // reflection like setDeviceName() elsewhere in this file. Falls through to createNewGroup()
-    // regardless of outcome since removeGroup() already deactivated the group either way.
-    @SuppressLint("MissingPermission")
-    private fun deletePersistentGroupThenCreate(netId: Int) {
-        val mgr = manager
-        val ch = channel
-        if (mgr == null || ch == null || netId < 0) {
-            checkGroupAndCreateInFlight = false
-            createNewGroup(0)
-            return
-        }
-        try {
-            val method = mgr.javaClass.getMethod(
-                "deletePersistentGroup",
-                WifiP2pManager.Channel::class.java,
-                Int::class.javaPrimitiveType,
-                WifiP2pManager.ActionListener::class.java
-            )
-            method.invoke(mgr, ch, netId, object : WifiP2pManager.ActionListener {
-                override fun onSuccess() {
-                    AppLog.i("WifiDirectManager: deletePersistentGroup(netId=$netId) succeeded")
-                    checkGroupAndCreateInFlight = false
-                    createNewGroup(0)
-                }
-                override fun onFailure(reason: Int) {
-                    AppLog.w("WifiDirectManager: deletePersistentGroup(netId=$netId) failed: ${getP2pErrorString(reason)}")
                     checkGroupAndCreateInFlight = false
                     createNewGroup(0)
                 }
             })
-        } catch (e: Exception) {
-            AppLog.w("WifiDirectManager: deletePersistentGroup reflection unavailable: ${e.message}")
-            checkGroupAndCreateInFlight = false
-            createNewGroup(0)
         }
     }
 
@@ -858,18 +848,13 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             return
         }
 
-        AppLog.i("WifiDirectManager: startNativeAaQuietHost() requested. Purging old/persistent group if any...")
+        AppLog.i("WifiDirectManager: startNativeAaQuietHost() requested. Removing old group if any...")
         nativeGroupCreationMode = NATIVE_GROUP_MODE_UNKNOWN
         lastNativeGroupStatusMessage = null
         native5GhzBandMismatchRetries = 0
         nativeRecreateCount = 0
         cancelNativeJoinWatchdog()
-        // A stale persistent P2P group left over from a previous session or reboot desyncs the
-        // phone's WPS/PBC registrar into an endless "connecting" loop. removeGroup() alone keeps
-        // the persistent profile (the recreated group comes back with the same netId/SSID), so
-        // purge the profile too before creating a fresh group — the same fix #730 applied to the
-        // Helper path, which the native quiet-host path never got.
-        purgeAndCreateNativeGroup(forceStandard = false)
+        recreateNativeGroup(forceStandard = false)
     }
 
     private fun delayedCreateQuietGroup(retryCount: Int) {
@@ -1014,65 +999,32 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         })
     }
 
-    // ---- Native AA join recovery (the quiet-host equivalent of #730's helper-path fixes) ----
-
-    /** Delete a persistent P2P group profile by netId via the hidden deletePersistentGroup API
-     *  (reflection), then run [onDone] regardless of outcome. */
+    /**
+     * Tear down any current P2P group and create a fresh native quiet-host group.
+     * [forceStandard] skips the 5GHz attempt, for phones that can't join a 5GHz group owner.
+     *
+     * Used to also call deletePersistentGroup() here, mirroring #730's Helper-mode fix, but
+     * that's rejected outright on-device for every netId — likely a permission this app lacks.
+     * Dropped.
+     */
     @SuppressLint("MissingPermission")
-    private fun deletePersistentGroupById(netId: Int, onDone: () -> Unit) {
-        val mgr = manager
-        val ch = channel
-        if (mgr == null || ch == null || netId < 0) { onDone(); return }
-        try {
-            val method = mgr.javaClass.getMethod(
-                "deletePersistentGroup",
-                WifiP2pManager.Channel::class.java,
-                Int::class.javaPrimitiveType,
-                WifiP2pManager.ActionListener::class.java
-            )
-            method.invoke(mgr, ch, netId, object : WifiP2pManager.ActionListener {
-                override fun onSuccess() {
-                    AppLog.i("WifiDirectManager: Native AA deletePersistentGroup(netId=$netId) succeeded")
-                    onDone()
-                }
-                override fun onFailure(reason: Int) {
-                    AppLog.w("WifiDirectManager: Native AA deletePersistentGroup(netId=$netId) failed: ${getP2pErrorString(reason)}")
-                    onDone()
-                }
-            })
-        } catch (e: Exception) {
-            AppLog.w("WifiDirectManager: Native AA deletePersistentGroup reflection unavailable: ${e.message}")
-            onDone()
-        }
-    }
-
-    /** Tear down any current P2P group (active group + persistent profile) and create a fresh
-     *  native quiet-host group. When [forceStandard] is true, skip the 5GHz attempt and create a
-     *  plain (2.4GHz-capable) group, for phones that cannot join a 5GHz group owner. */
-    @SuppressLint("MissingPermission")
-    private fun purgeAndCreateNativeGroup(forceStandard: Boolean) {
+    private fun recreateNativeGroup(forceStandard: Boolean) {
         val mgr = manager ?: return
         val ch = channel ?: return
         lastKnownBssid = null
+        // Let an in-progress credential wait pick up the fresh group's creds, not stale ones.
+        onNativeGroupInvalidated?.invoke()
         val createFresh = {
             if (forceStandard) standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_FALLBACK)
             else delayedCreateQuietGroup(0)
         }
-        mgr.requestGroupInfo(ch) { group ->
-            if (group == null) {
+        mgr.removeGroup(ch, object : WifiP2pManager.ActionListener {
+            override fun onSuccess() { createFresh() }
+            override fun onFailure(reason: Int) {
+                AppLog.d("WifiDirectManager: Native AA removeGroup before recreate failed (reason=${getP2pErrorString(reason)}); expected if no group existed")
                 createFresh()
-                return@requestGroupInfo
             }
-            val netId = try { group.networkId } catch (e: Exception) { -1 }
-            AppLog.i("WifiDirectManager: Native AA — purging existing group (netId=$netId) before recreate${if (forceStandard) " (forcing 2.4GHz)" else ""}")
-            mgr.removeGroup(ch, object : WifiP2pManager.ActionListener {
-                override fun onSuccess() { deletePersistentGroupById(netId) { createFresh() } }
-                override fun onFailure(reason: Int) {
-                    AppLog.w("WifiDirectManager: Native AA removeGroup before recreate failed: ${getP2pErrorString(reason)}")
-                    deletePersistentGroupById(netId) { createFresh() }
-                }
-            })
-        }
+        })
     }
 
     /** Recover a native quiet-host group when the phone never joins: recreate a fresh one, and
@@ -1087,7 +1039,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         nativeRecreateCount++
         val forceStandard = nativeRecreateCount >= NATIVE_FORCE_STANDARD_AFTER
         AppLog.w("WifiDirectManager: Native AA recovery ($reason): recreate attempt $nativeRecreateCount/$MAX_NATIVE_JOIN_RECREATES${if (forceStandard) ", forcing 2.4GHz" else ""}.")
-        purgeAndCreateNativeGroup(forceStandard)
+        recreateNativeGroup(forceStandard)
     }
 
     /** (Re)arm the native join watchdog; no-op unless we are a native-mode group owner with no


### PR DESCRIPTION
Fixes part of #706 (the Native AA "Android is connecting..." loop).

Native mode (wifiConnectionMode 3) creates its own WiFi Direct group through startNativeAaQuietHost(), which is a separate code path from the Helper mode checkGroupAndCreate() that @o-jcardenass's #730 fixed. The native path never got those protections: it only called removeGroup() before creating, never deletePersistentGroup(), and had no re-advertise or self-heal loop. So a stale persistent P2P group left over from a previous session or a reboot desyncs the phone's WPS/PBC registrar into the same endless connecting loop #730 documented for Helper mode, with nothing to recover it.

What this changes (native path only, the Helper path and #730 are left untouched):
- Purge the persistent group profile (deletePersistentGroup) before creating a fresh native group, not just removeGroup, so the recreated group does not come back with the same netId/SSID. Same idea as #730.
- The stuck PROV-DISC retry-burst self-heal now also covers native mode (it was gated to Helper only) and recreates the native group with a full purge.
- A bounded join watchdog: if no phone joins the quiet host within 30s, tear down and recreate a fresh group. After a couple of tries it drops the forced 5GHz band, for phones that cannot associate to a 5GHz group owner (a second, independent cause of a permanent connecting loop with no fallback today).
- The watchdog is cancelled and state reset on client join, disconnect, P2P off, and stop, and the recreate count is bounded so it gives up cleanly instead of looping forever.

I cannot reproduce or test this myself, since I use a wireless USB adapter and not WiFi, so this is derived from reading the code. @o-jcardenass, since it extends your #730 into the native path, your eyes would be very welcome. A test build and a request to confirm are on #706.
