### PR TITLE
Wizard and Settings UX: report-a-problem screen, quick shortcuts, live Quick Settings, animated DPI preview

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapProjectionActivity.kt
@@ -199,9 +199,13 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
             val needsViewRecreate = intent.getBooleanExtra(QuickSettingsFragment.EXTRA_NEEDS_VIEW_RECREATE, false)
             val needsAudioRestart = intent.getBooleanExtra(QuickSettingsFragment.EXTRA_NEEDS_AUDIO_RESTART, false)
             val sensorRefresh = intent.getBooleanExtra(QuickSettingsFragment.EXTRA_SENSOR_REFRESH, false)
+            val applyFullscreen = intent.getBooleanExtra(QuickSettingsFragment.EXTRA_APPLY_FULLSCREEN, false)
 
             if (needsViewRecreate) {
                 recreateProjectionView()
+            }
+            if (applyFullscreen) {
+                setFullscreen()
             }
             if (sensorRefresh) {
                 sendBroadcast(Intent(AapService.ACTION_REFRESH_SENSORS).apply {

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/AutoConnectFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/AutoConnectFragment.kt
@@ -65,7 +65,7 @@ class AutoConnectFragment : Fragment() {
         }.toMutableList()
 
         // Single-USB auto-connect only applies to USB connections; hide it otherwise.
-        hiddenMethodIds = if (settings.primaryConnection.hidesUsb())
+        hiddenMethodIds = if (!settings.showsUsb())
             listOf(Settings.AUTO_CONNECT_SINGLE_USB) else emptyList()
         val visibleMethods = methods.filterNot { it.id in hiddenMethodIds }.toMutableList()
         adapter = AutoConnectAdapter(visibleMethods) { checkChanges() }

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/AutoStartFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/AutoStartFragment.kt
@@ -361,14 +361,13 @@ class AutoStartFragment : Fragment() {
             }
         }
 
-        // Hide options that do not apply to the chosen connection type. Bluetooth bridges
+        // Hide options that do not apply to the chosen connection types. Bluetooth bridges
         // WiFi, so it is treated as WiFi scope.
-        val conn = settings.primaryConnection
         val usbIds = setOf("listenForUsbDevices", "autoStartUsb", "reopenOnReconnection")
         val wifiIds = setOf("autoStartBt", "autoStartWifiWarning", "autoStartWifi", "autoStartWifiSsid")
         val filtered = items.filterNot { item ->
-            (item.stableId in usbIds && conn.hidesUsb()) ||
-                (item.stableId in wifiIds && conn.hidesWifi())
+            (item.stableId in usbIds && !settings.showsUsb()) ||
+                (item.stableId in wifiIds && !settings.showsWifi())
         }
 
         settingsAdapter.submitList(filtered) {

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/DarkModeFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/DarkModeFragment.kt
@@ -387,6 +387,26 @@ class DarkModeFragment : Fragment(), SensorEventListener {
         if (applyAppTheme) App.appThemeManager?.forceRefresh()
     }
 
+    /**
+     * Persists the Location-based dark mode selection right away, so it is not lost when the
+     * fragment is recreated on returning from the places screen or the map. Every control in the
+     * Location group calls this, so setting up a location mode never needs the Save button (the
+     * rest of Dark Mode still does). [applyTheme] should be false right before navigating away,
+     * to avoid an activity recreate in the middle of the navigation.
+     */
+    private fun commitLocationMode(applyTheme: Boolean) {
+        pendingAppTheme?.let { settings.appTheme = it }
+        pendingNightMode?.let { settings.nightMode = it }
+        pendingLocationOutsideNight?.let { settings.locationOutsideNight = it }
+        // Re-send the Android Auto night mode (safe, no activity recreate).
+        requireContext().sendBroadcast(
+            Intent(AapService.ACTION_REQUEST_NIGHT_MODE_UPDATE).setPackage(requireContext().packageName)
+        )
+        if (applyTheme) App.appThemeManager?.forceRefresh()
+        // The selection is saved now, so it no longer counts as a pending change.
+        checkChanges()
+    }
+
     /** Sub-options for "Location (by area)" mode: outside-places appearance + manage places. */
     /**
      * Dedicated "Location" group, shown whenever either selector is set to Location. Its
@@ -431,7 +451,7 @@ class DarkModeFragment : Fragment(), SensorEventListener {
                     .setTitle(R.string.location_outside_label)
                     .setSingleChoiceItems(options, if (pendingLocationOutsideNight == true) 1 else 0) { dialog, which ->
                         pendingLocationOutsideNight = which == 1
-                        checkChanges()
+                        commitLocationMode(applyTheme = true)
                         dialog.dismiss()
                         updateSettingsList()
                     }
@@ -446,7 +466,12 @@ class DarkModeFragment : Fragment(), SensorEventListener {
                 val n = settings.geofenceLocations.size
                 if (n == 0) getString(R.string.geofence_none) else getString(R.string.geofence_count_summary, n)
             },
-            onClick = { _ -> findNavController().navigate(R.id.action_darkModeFragment_to_locationsFragment) }
+            onClick = { _ ->
+                // Persist the location mode before leaving, so it survives the fragment being
+                // recreated on return from the places screen.
+                commitLocationMode(applyTheme = false)
+                findNavController().navigate(R.id.action_darkModeFragment_to_locationsFragment)
+            }
         ))
     }
 
@@ -469,7 +494,8 @@ class DarkModeFragment : Fragment(), SensorEventListener {
                 pendingNightMode = Settings.NightMode.LOCATION
             }
         }
-        checkChanges()
+        // Persist the scope right away so it is not lost when opening the places screen or map.
+        commitLocationMode(applyTheme = true)
         updateSettingsList()
     }
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/DpiSettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/DpiSettingsFragment.kt
@@ -65,6 +65,7 @@ class DpiSettingsFragment : Fragment() {
 
         autoSwitch.setOnCheckedChangeListener { _, checked ->
             picker.visibility = if (checked) View.GONE else View.VISIBLE
+            if (checked) picker.stopDemo() else picker.startDemo()
             updateSaveButtonState()
         }
         picker.setOnDpiChanged { updateSaveButtonState() }
@@ -74,6 +75,19 @@ class DpiSettingsFragment : Fragment() {
         })
 
         updateSaveButtonState()
+
+        // Show the animated demo right away when the picker is visible (Automatic off).
+        if (!auto) picker.startDemo()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        if (::picker.isInitialized) picker.stopDemo()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (::picker.isInitialized && !autoSwitch.isChecked) picker.startDemo()
     }
 
     private fun setupToolbar() {

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/OnboardingActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/OnboardingActivity.kt
@@ -556,11 +556,14 @@ class OnboardingActivity : BaseActivity() {
 
     private fun realMetrics(): DisplayMetrics {
         val metrics = DisplayMetrics()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            display?.getRealMetrics(metrics)
-        } else {
-            @Suppress("DEPRECATION")
-            (getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay.getRealMetrics(metrics)
+        @Suppress("DEPRECATION")
+        when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> display?.getRealMetrics(metrics)
+            // getRealMetrics is API 17; on API 16 it does not exist, so fall back to getMetrics.
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 ->
+                (getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay.getRealMetrics(metrics)
+            else ->
+                (getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay.getMetrics(metrics)
         }
         return metrics
     }

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/OnboardingActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/OnboardingActivity.kt
@@ -116,7 +116,7 @@ class OnboardingActivity : BaseActivity() {
             finishOnboardingInto(R.id.micSettingsFragment)
         }
 
-        backBtn.setOnClickListener { if (step > 0) { step--; render() } }
+        backBtn.setOnClickListener { if (step > 0) goBack() }
         nextBtn.setOnClickListener { onNext() }
         skipBtn.setOnClickListener { onDoItLater() }
 
@@ -143,9 +143,37 @@ class OnboardingActivity : BaseActivity() {
         dpiPicker?.stopDemo()
     }
 
+    /**
+     * A wizard step that does not apply to the chosen setup and is skipped entirely. The GPS source
+     * choice (this device vs the connected phone) makes no sense in Self Mode, where there is no
+     * separate phone, so it is hidden there.
+     */
+    private fun isStepHidden(s: Int): Boolean =
+        s == STEP_GPS && settings.primaryConnection == Settings.ConnectionKind.SELF_MODE
+
+    /** The steps actually shown, in order, after removing the ones that do not apply. */
+    private fun visibleSteps(): List<Int> = (0 until STEP_COUNT).filter { !isStepHidden(it) }
+
+    /** Move forward to the next visible step, or finish on the last one. */
+    private fun goForward() {
+        var s = step + 1
+        while (s < STEP_COUNT && isStepHidden(s)) s++
+        if (s >= STEP_COUNT) { finishOnboarding(); return }
+        step = s
+        render()
+    }
+
+    /** Move back to the previous visible step. */
+    private fun goBack() {
+        var s = step - 1
+        while (s > 0 && isStepHidden(s)) s--
+        step = s.coerceAtLeast(0)
+        render()
+    }
+
     private fun buildStepperDots() {
         stepper.removeAllViews()
-        for (i in 0 until STEP_COUNT) {
+        repeat(visibleSteps().size) {
             val dot = View(this)
             val h = (5 * resources.displayMetrics.density).toInt()
             val lp = LinearLayout.LayoutParams(h, h)
@@ -156,17 +184,21 @@ class OnboardingActivity : BaseActivity() {
     }
 
     private fun updateStepperDots() {
+        val steps = visibleSteps()
+        // Rebuild if the visible-step count changed (e.g. Self Mode just hid the GPS step).
+        if (stepper.childCount != steps.size) buildStepperDots()
         val density = resources.displayMetrics.density
         val active = resolveAttrColor(com.google.android.material.R.attr.colorPrimary)
         val inactive = 0x33808080
-        for (i in 0 until STEP_COUNT) {
+        val currentPos = steps.indexOf(step).coerceAtLeast(0)
+        for (i in steps.indices) {
             val dot = stepper.getChildAt(i) ?: continue
             val lp = dot.layoutParams as LinearLayout.LayoutParams
-            lp.width = ((if (i == step) 26 else 8) * density).toInt()
+            lp.width = ((if (i == currentPos) 26 else 8) * density).toInt()
             dot.layoutParams = lp
             val bg = android.graphics.drawable.GradientDrawable()
             bg.cornerRadius = 5 * density
-            bg.setColor(if (i <= step) active else inactive)
+            bg.setColor(if (i <= currentPos) active else inactive)
             dot.background = bg
         }
     }
@@ -436,7 +468,7 @@ class OnboardingActivity : BaseActivity() {
                 settings.headUnitMake = brand
             }
         }
-        if (step == STEP_COUNT - 1) finishOnboarding() else { step++; render() }
+        if (step == STEP_COUNT - 1) finishOnboarding() else goForward()
     }
 
     /**
@@ -457,7 +489,7 @@ class OnboardingActivity : BaseActivity() {
 
     override fun onBackPressed() {
         // Back walks the steps; from the first step it behaves like "Do it later".
-        if (step > 0) { step--; render() } else onDoItLater()
+        if (step > 0) goBack() else onDoItLater()
     }
 
     private fun finishOnboarding() {
@@ -664,6 +696,7 @@ class OnboardingActivity : BaseActivity() {
         private const val STEP_DISPLAY = 3
         private const val STEP_DPI = 4
         private const val STEP_AUTOMATION = 6
+        private const val STEP_GPS = 7
         private const val STEP_VEHICLE = 8
         private const val STEP_PERMISSIONS = 9
         private const val STEP_READY = 10

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/OnboardingActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/OnboardingActivity.kt
@@ -135,6 +135,12 @@ class OnboardingActivity : BaseActivity() {
         updateThemeButtonText()
         updateNightButtonText()
         permissionBinder?.rebind()
+        if (step == STEP_DPI) dpiPicker?.startDemo()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        dpiPicker?.stopDemo()
     }
 
     private fun buildStepperDots() {
@@ -377,8 +383,13 @@ class OnboardingActivity : BaseActivity() {
         if (step == STEP_READY) findViewById<TextView>(R.id.onb_ready_summary).text = summaryText()
         if (step == STEP_AUTOMATION) applyAutomationVisibility()
         if (step == STEP_PERMISSIONS) permissionBinder?.rebind()
-        if (step == STEP_DPI) findViewById<TextView>(R.id.onb_dpi_recommended).text =
-            getString(R.string.onb_dpi_recommended, recommendedDpi())
+        if (step == STEP_DPI) {
+            findViewById<TextView>(R.id.onb_dpi_recommended).text =
+                getString(R.string.onb_dpi_recommended, recommendedDpi())
+            dpiPicker?.startDemo()
+        } else {
+            dpiPicker?.stopDemo()
+        }
         updateStepperDots()
     }
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/OnboardingActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/OnboardingActivity.kt
@@ -149,7 +149,7 @@ class OnboardingActivity : BaseActivity() {
      * separate phone, so it is hidden there.
      */
     private fun isStepHidden(s: Int): Boolean =
-        s == STEP_GPS && settings.primaryConnection == Settings.ConnectionKind.SELF_MODE
+        s == STEP_GPS && !settings.showsExternalGps()
 
     /** The steps actually shown, in order, after removing the ones that do not apply. */
     private fun visibleSteps(): List<Int> = (0 until STEP_COUNT).filter { !isStepHidden(it) }
@@ -222,27 +222,27 @@ class OnboardingActivity : BaseActivity() {
             }
         }
 
-        // --- Connection: USB (cable or USB adapter) / WiFi / Self Mode ---
+        // --- Connection: multi-select of USB / WiFi / Self Mode ---
         val connGroup = findViewById<MaterialButtonToggleGroup>(R.id.onb_conn_group)
         isBinding = true
-        when (settings.primaryConnection) {
-            Settings.ConnectionKind.WIFI, Settings.ConnectionKind.NATIVE_AA -> connGroup.check(R.id.onb_conn_wifi)
-            Settings.ConnectionKind.SELF_MODE -> connGroup.check(R.id.onb_conn_self)
-            Settings.ConnectionKind.ALL -> connGroup.check(R.id.onb_conn_all)
-            Settings.ConnectionKind.USB_CABLE, Settings.ConnectionKind.USB_WIRELESS_ADAPTER -> connGroup.check(R.id.onb_conn_usb)
-            else -> {}
-        }
+        val modes = settings.connectionModes
+        if (Settings.ConnectionMode.USB in modes) connGroup.check(R.id.onb_conn_usb)
+        if (Settings.ConnectionMode.WIFI in modes) connGroup.check(R.id.onb_conn_wifi)
+        if (Settings.ConnectionMode.SELF in modes) connGroup.check(R.id.onb_conn_self)
         isBinding = false
         updateConnectionDetail()
-        connGroup.addOnButtonCheckedListener { _, checkedId, isChecked ->
-            if (!isChecked || isBinding) return@addOnButtonCheckedListener
-            settings.primaryConnection = when (checkedId) {
-                R.id.onb_conn_wifi -> Settings.ConnectionKind.WIFI
-                R.id.onb_conn_self -> Settings.ConnectionKind.SELF_MODE
-                R.id.onb_conn_all -> Settings.ConnectionKind.ALL
-                else -> Settings.ConnectionKind.USB_CABLE
+        connGroup.addOnButtonCheckedListener { group, _, _ ->
+            if (isBinding) return@addOnButtonCheckedListener
+            val checked = group.checkedButtonIds
+            val selected = buildSet {
+                if (R.id.onb_conn_usb in checked) add(Settings.ConnectionMode.USB)
+                if (R.id.onb_conn_wifi in checked) add(Settings.ConnectionMode.WIFI)
+                if (R.id.onb_conn_self in checked) add(Settings.ConnectionMode.SELF)
             }
+            settings.connectionModes = selected
             updateConnectionDetail()
+            // At least one is required; keep Next in sync while on this step.
+            if (step == STEP_CONNECTION) nextBtn.isEnabled = selected.isNotEmpty()
         }
 
         // --- Display: detected panel + size/orientation, pre-selected from detection ---
@@ -410,8 +410,11 @@ class OnboardingActivity : BaseActivity() {
         // GONE (not INVISIBLE) so its dedicated row collapses on the final step.
         skipBtn.visibility = if (step == STEP_COUNT - 1) View.GONE else View.VISIBLE
         nextBtn.text = getString(if (step == STEP_COUNT - 1) R.string.onb_ready_finish else R.string.onb_next)
-        nextBtn.isEnabled = if (step == STEP_SAFETY)
-            findViewById<MaterialCheckBox>(R.id.onb_safety_accept).isChecked else true
+        nextBtn.isEnabled = when (step) {
+            STEP_SAFETY -> findViewById<MaterialCheckBox>(R.id.onb_safety_accept).isChecked
+            STEP_CONNECTION -> settings.connectionModes.isNotEmpty()
+            else -> true
+        }
         if (step == STEP_READY) findViewById<TextView>(R.id.onb_ready_summary).text = summaryText()
         if (step == STEP_AUTOMATION) applyAutomationVisibility()
         if (step == STEP_PERMISSIONS) permissionBinder?.rebind()
@@ -439,17 +442,13 @@ class OnboardingActivity : BaseActivity() {
     /** Show only the auto-start toggles that match the chosen connection type. Self Mode
      * connects without USB or WiFi, so both groups are hidden. */
     private fun applyAutomationVisibility() {
-        val conn = settings.primaryConnection
-        val isWifi = conn == Settings.ConnectionKind.WIFI || conn == Settings.ConnectionKind.NATIVE_AA
-        val isSelf = conn == Settings.ConnectionKind.SELF_MODE
-        val isAll = conn == Settings.ConnectionKind.ALL
-        val usbVis = if (isAll || (!isWifi && !isSelf)) View.VISIBLE else View.GONE
+        val usbVis = if (settings.showsUsb()) View.VISIBLE else View.GONE
         findViewById<View>(R.id.onb_ac_single_row).visibility = usbVis
         findViewById<View>(R.id.onb_as_usb_row).visibility = usbVis
         findViewById<View>(R.id.onb_reopen_row).visibility = usbVis
         // Auto-start on WiFi is a legacy path that only applies up to Android 12L (API 32).
         findViewById<View>(R.id.onb_as_wifi_row).visibility =
-            if ((isWifi || isAll) && Build.VERSION.SDK_INT <= 32) View.VISIBLE else View.GONE
+            if (settings.showsWifi() && Build.VERSION.SDK_INT <= 32) View.VISIBLE else View.GONE
     }
 
     private fun onNext() {
@@ -543,13 +542,18 @@ class OnboardingActivity : BaseActivity() {
 
     private fun updateConnectionDetail() {
         val detail = findViewById<TextView>(R.id.onb_conn_detail)
-        detail.text = when (settings.primaryConnection) {
-            Settings.ConnectionKind.WIFI, Settings.ConnectionKind.NATIVE_AA -> getString(R.string.onb_connection_wifi_detail)
-            Settings.ConnectionKind.SELF_MODE -> getString(R.string.onb_connection_self_detail)
-            Settings.ConnectionKind.ALL -> getString(R.string.onb_connection_all_detail)
-            Settings.ConnectionKind.USB_CABLE, Settings.ConnectionKind.USB_WIRELESS_ADAPTER -> getString(R.string.onb_connection_usb_detail)
-            else -> ""
-        }
+        detail.text = if (settings.connectionModes.isEmpty()) "" else connectionModesLabel()
+    }
+
+    /** The chosen connection types as a readable label, e.g. "USB, WiFi". */
+    private fun connectionModesLabel(): String {
+        val modes = settings.connectionModes
+        if (modes.isEmpty()) return getString(R.string.connection_kind_unset)
+        val parts = mutableListOf<String>()
+        if (Settings.ConnectionMode.USB in modes) parts.add(getString(R.string.connection_kind_usb))
+        if (Settings.ConnectionMode.WIFI in modes) parts.add(getString(R.string.connection_kind_wifi))
+        if (Settings.ConnectionMode.SELF in modes) parts.add(getString(R.string.self_mode))
+        return parts.joinToString(", ")
     }
 
     // --- Display scan ---
@@ -658,13 +662,7 @@ class OnboardingActivity : BaseActivity() {
     // --- Ready ---
 
     private fun summaryText(): String {
-        val conn = when (settings.primaryConnection) {
-            Settings.ConnectionKind.WIFI, Settings.ConnectionKind.NATIVE_AA -> getString(R.string.connection_kind_wifi)
-            Settings.ConnectionKind.SELF_MODE -> getString(R.string.self_mode)
-            Settings.ConnectionKind.ALL -> getString(R.string.connection_kind_all)
-            Settings.ConnectionKind.USB_CABLE, Settings.ConnectionKind.USB_WIRELESS_ADAPTER -> getString(R.string.connection_kind_usb)
-            else -> getString(R.string.connection_kind_unset)
-        }
+        val conn = connectionModesLabel()
         val res = getString(
             R.string.resolution_recommended_format,
             Settings.Resolution.fromId(settings.resolutionId)?.resName ?: getString(R.string.auto)
@@ -696,6 +694,7 @@ class OnboardingActivity : BaseActivity() {
         private const val KEY_STEP = "onb_step"
         private const val STEP_COUNT = 11
         private const val STEP_SAFETY = 1
+        private const val STEP_CONNECTION = 2
         private const val STEP_DISPLAY = 3
         private const val STEP_DPI = 4
         private const val STEP_AUTOMATION = 6

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/OnboardingActivity.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/OnboardingActivity.kt
@@ -104,9 +104,16 @@ class OnboardingActivity : BaseActivity() {
         bindSteps()
         bindPermissionsStep()
 
-        // Ready step: offer to jump straight into the loading screen setup (finishes the wizard).
-        findViewById<MaterialButton>(R.id.onb_loading_screen_button).setOnClickListener {
+        // Ready step: optional-extras card. Each row finishes the wizard and jumps straight into
+        // that Settings sub-screen (things the wizard does not already walk you through).
+        findViewById<View>(R.id.onb_extra_loading).setOnClickListener {
             finishOnboardingInto(R.id.loadingScreenFragment)
+        }
+        findViewById<View>(R.id.onb_extra_keymap).setOnClickListener {
+            finishOnboardingInto(R.id.keymapFragment)
+        }
+        findViewById<View>(R.id.onb_extra_mic).setOnClickListener {
+            finishOnboardingInto(R.id.micSettingsFragment)
         }
 
         backBtn.setOnClickListener { if (step > 0) { step--; render() } }

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/QuickSettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/QuickSettingsFragment.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.andrerinas.headunitrevived.App
 import com.andrerinas.headunitrevived.R
+import com.andrerinas.headunitrevived.aap.AapService
 import com.andrerinas.headunitrevived.main.settings.SettingItem
 import com.andrerinas.headunitrevived.main.settings.SettingsAdapter
 import com.andrerinas.headunitrevived.utils.Settings
@@ -27,6 +28,7 @@ class QuickSettingsFragment : DialogFragment() {
         const val EXTRA_NEEDS_VIEW_RECREATE = "needs_view_recreate"
         const val EXTRA_NEEDS_AUDIO_RESTART = "needs_audio_restart"
         const val EXTRA_SENSOR_REFRESH = "sensor_refresh"
+        const val EXTRA_APPLY_FULLSCREEN = "apply_fullscreen"
     }
 
     private lateinit var settings: Settings
@@ -102,6 +104,22 @@ class QuickSettingsFragment : DialogFragment() {
             nameResId = R.string.night_mode,
             value = nightModeTitles[settings.nightMode.value],
             onClick = { showNightModeDialog() }
+        ))
+
+        // Screen rotation: a common "pulled over because it came up sideways" fix. Applied live.
+        items.add(SettingItem.SettingEntry(
+            stableId = "screenOrientation",
+            nameResId = R.string.screen_orientation,
+            value = resources.getStringArray(R.array.screen_orientation)[settings.screenOrientation.value],
+            onClick = { showOrientationDialog() }
+        ))
+
+        // System bars handling: fix a nav/status bar covering the projection, without a restart.
+        items.add(SettingItem.SettingEntry(
+            stableId = "fullscreenMode",
+            nameResId = R.string.start_in_fullscreen_mode,
+            value = fullscreenModeLabels()[settings.fullscreenMode.value],
+            onClick = { showFullscreenDialog() }
         ))
 
         items.add(SettingItem.ToggleSettingEntry(
@@ -194,13 +212,53 @@ class QuickSettingsFragment : DialogFragment() {
         settingsAdapter.submitList(items)
     }
 
-    private fun notifyChange(needsViewRecreate: Boolean = false, needsAudioRestart: Boolean = false, sensorRefresh: Boolean = false) {
+    private fun notifyChange(needsViewRecreate: Boolean = false, needsAudioRestart: Boolean = false, sensorRefresh: Boolean = false, applyFullscreen: Boolean = false) {
         val intent = Intent(ACTION_SETTINGS_CHANGED).apply {
             putExtra(EXTRA_NEEDS_VIEW_RECREATE, needsViewRecreate)
             putExtra(EXTRA_NEEDS_AUDIO_RESTART, needsAudioRestart)
             putExtra(EXTRA_SENSOR_REFRESH, sensorRefresh)
+            putExtra(EXTRA_APPLY_FULLSCREEN, applyFullscreen)
         }
         LocalBroadcastManager.getInstance(requireContext()).sendBroadcast(intent)
+    }
+
+    private fun fullscreenModeLabels() = arrayOf(
+        getString(R.string.fullscreen_none),
+        getString(R.string.fullscreen_immersive),
+        getString(R.string.fullscreen_status_only),
+        getString(R.string.fullscreen_immersive_avoid_notch)
+    )
+
+    private fun showOrientationDialog() {
+        val options = resources.getStringArray(R.array.screen_orientation)
+        MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
+            .setTitle(R.string.change_screen_orientation)
+            .setSingleChoiceItems(options, settings.screenOrientation.value) { dialog, which ->
+                val newOrientation = Settings.ScreenOrientation.fromInt(which) ?: Settings.ScreenOrientation.SYSTEM
+                settings.screenOrientation = newOrientation
+                settings.commit()
+                // Applied live: the projection activity re-reads the orientation on this broadcast.
+                requireContext().sendBroadcast(Intent(AapService.ACTION_ORIENTATION_CHANGED).apply {
+                    setPackage(requireContext().packageName)
+                })
+                dialog.dismiss()
+                updateSettingsList()
+            }
+            .show()
+    }
+
+    private fun showFullscreenDialog() {
+        MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
+            .setTitle(R.string.start_in_fullscreen_mode)
+            .setSingleChoiceItems(fullscreenModeLabels(), settings.fullscreenMode.value) { dialog, which ->
+                val newMode = Settings.FullscreenMode.fromInt(which) ?: Settings.FullscreenMode.NONE
+                settings.fullscreenMode = newMode
+                settings.commit()
+                notifyChange(applyFullscreen = true)
+                dialog.dismiss()
+                updateSettingsList()
+            }
+            .show()
     }
 
     private fun showAudioOffsetsDialog() {

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
@@ -992,17 +992,21 @@ class SettingsFragment : Fragment() {
         // --- Navigation Settings ---
         items.add(SettingItem.CategoryHeader("navigation", R.string.category_navigation))
 
-        items.add(SettingItem.ToggleSettingEntry(
-            stableId = "gpsNavigation",
-            nameResId = R.string.gps_for_navigation,
-            descriptionResId = R.string.gps_for_navigation_description,
-            isChecked = pendingUseGps!!,
-            onCheckedChanged = { isChecked ->
-                pendingUseGps = isChecked
-                checkChanges()
-                updateSettingsList()
-            }
-        ))
+        // The GPS source choice (this device vs the connected phone) is meaningless in Self Mode,
+        // where there is no separate phone, so hide it for those users.
+        if (settings.primaryConnection != Settings.ConnectionKind.SELF_MODE) {
+            items.add(SettingItem.ToggleSettingEntry(
+                stableId = "gpsNavigation",
+                nameResId = R.string.gps_for_navigation,
+                descriptionResId = R.string.gps_for_navigation_description,
+                isChecked = pendingUseGps!!,
+                onCheckedChanged = { isChecked ->
+                    pendingUseGps = isChecked
+                    checkChanges()
+                    updateSettingsList()
+                }
+            ))
+        }
 
         items.add(SettingItem.ToggleSettingEntry(
             stableId = "showNavigationNotifications",

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
@@ -70,7 +70,7 @@ class SettingsFragment : Fragment() {
     private val basicSettingIds = setOf(
         // General
         "autoOptimize", "connectionMode", "appLanguage", "uiScale",
-        // Wireless (shown in Basic only when primaryConnection is wireless)
+        // Wireless (shown in Basic only when WiFi is among the selected connection modes)
         "wifiConnectionMode",
         // Dark mode
         "darkModeSettings",
@@ -643,7 +643,7 @@ class SettingsFragment : Fragment() {
         items.add(SettingItem.SettingEntry(
             stableId = "connectionMode",
             nameResId = R.string.connection_mode,
-            value = connectionKindLabel(settings.primaryConnection),
+            value = connectionModesLabel(),
             onClick = { showConnectionModeDialog() }
         ))
 
@@ -992,9 +992,9 @@ class SettingsFragment : Fragment() {
         // --- Navigation Settings ---
         items.add(SettingItem.CategoryHeader("navigation", R.string.category_navigation))
 
-        // The GPS source choice (this device vs the connected phone) is meaningless in Self Mode,
-        // where there is no separate phone, so hide it for those users.
-        if (settings.primaryConnection != Settings.ConnectionKind.SELF_MODE) {
+        // The GPS source choice (this device vs the connected phone) only applies when a phone is
+        // connected. With Self Mode as the only connection there is no phone, so hide it.
+        if (settings.showsExternalGps()) {
             items.add(SettingItem.ToggleSettingEntry(
                 stableId = "gpsNavigation",
                 nameResId = R.string.gps_for_navigation,
@@ -1826,9 +1826,8 @@ class SettingsFragment : Fragment() {
     private val HIGH_BANDWIDTH_WIDTH = 2560
 
     private fun isHiddenByConnection(item: SettingItem, categoryId: String?): Boolean {
-        val conn = settings.primaryConnection
-        if (categoryId == "wirelessConnection") return conn.hidesWifi()
-        if (item.stableId in usbScopedIds) return conn.hidesUsb()
+        if (categoryId == "wirelessConnection") return !settings.showsWifi()
+        if (item.stableId in usbScopedIds) return !settings.showsUsb()
         return false
     }
 
@@ -1850,15 +1849,15 @@ class SettingsFragment : Fragment() {
         is SettingItem.CategoryHeader -> getString(item.titleResId)
     }
 
-    private fun connectionKindLabel(kind: Settings.ConnectionKind): String = when (kind) {
-        // USB (direct cable or USB wireless adapter) is presented as a single "USB" option.
-        Settings.ConnectionKind.USB_CABLE,
-        Settings.ConnectionKind.USB_WIRELESS_ADAPTER -> getString(R.string.connection_kind_usb)
-        Settings.ConnectionKind.WIFI,
-        Settings.ConnectionKind.NATIVE_AA -> getString(R.string.connection_kind_wifi)
-        Settings.ConnectionKind.SELF_MODE -> getString(R.string.self_mode)
-        Settings.ConnectionKind.ALL -> getString(R.string.connection_kind_all)
-        Settings.ConnectionKind.UNSET -> getString(R.string.connection_kind_unset)
+    /** The chosen connection types as a readable label ("USB, WiFi"); empty shows all. */
+    private fun connectionModesLabel(): String {
+        val modes = settings.connectionModes
+        if (modes.isEmpty()) return getString(R.string.connection_kind_all)
+        val parts = mutableListOf<String>()
+        if (Settings.ConnectionMode.USB in modes) parts.add(getString(R.string.connection_kind_usb))
+        if (Settings.ConnectionMode.WIFI in modes) parts.add(getString(R.string.connection_kind_wifi))
+        if (Settings.ConnectionMode.SELF in modes) parts.add(getString(R.string.self_mode))
+        return parts.joinToString(", ")
     }
 
     private fun showResolutionDialog() {
@@ -1929,25 +1928,23 @@ class SettingsFragment : Fragment() {
     }
 
     private fun showConnectionModeDialog() {
-        val kinds = listOf(
-            Settings.ConnectionKind.USB_CABLE,
-            Settings.ConnectionKind.WIFI,
-            Settings.ConnectionKind.SELF_MODE,
-            Settings.ConnectionKind.ALL
+        val order = listOf(
+            Settings.ConnectionMode.USB,
+            Settings.ConnectionMode.WIFI,
+            Settings.ConnectionMode.SELF
         )
-        val labels = kinds.map { connectionKindLabel(it) }.toTypedArray()
-        // Map any stored USB variant to the single USB option, WiFi/native to WiFi.
-        val current = when (settings.primaryConnection) {
-            Settings.ConnectionKind.USB_CABLE, Settings.ConnectionKind.USB_WIRELESS_ADAPTER -> 0
-            Settings.ConnectionKind.WIFI, Settings.ConnectionKind.NATIVE_AA -> 1
-            Settings.ConnectionKind.SELF_MODE -> 2
-            Settings.ConnectionKind.ALL -> 3
-            else -> -1
-        }
+        val labels = arrayOf(
+            getString(R.string.connection_kind_usb),
+            getString(R.string.connection_kind_wifi),
+            getString(R.string.self_mode)
+        )
+        val current = settings.connectionModes
+        val checked = BooleanArray(order.size) { order[it] in current }
         MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
             .setTitle(R.string.connection_mode)
-            .setSingleChoiceItems(labels, current) { dialog, which ->
-                settings.primaryConnection = kinds[which]
+            .setMultiChoiceItems(labels, checked) { _, which, isChecked -> checked[which] = isChecked }
+            .setPositiveButton(android.R.string.ok) { dialog, _ ->
+                settings.connectionModes = order.filterIndexed { i, _ -> checked[i] }.toSet()
                 dialog.dismiss()
                 updateSettingsList()
             }

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SettingsFragment.kt
@@ -79,7 +79,7 @@ class SettingsFragment : Fragment() {
         // Navigation
         "gpsNavigation",
         // Graphic
-        "resolution", "dpiPixelDensity", "viewMode", "screenOrientation", "startInFullscreenMode",
+        "resolution", "dpiPixelDensity", "viewMode", "screenOrientation", "startInFullscreenMode", "loadingScreen",
         // Video
         "videoCodec", "fpsLimit",
         // Input
@@ -87,7 +87,7 @@ class SettingsFragment : Fragment() {
         // Audio
         "enableAudioSink", "micSettings", "audioVolumeOffsets",
         // Info
-        "version", "about"
+        "version", "about", "support"
     )
 
     // Local state to hold changes before saving
@@ -1682,6 +1682,19 @@ class SettingsFragment : Fragment() {
             nameResId = R.string.version,
             value = BuildConfig.VERSION_NAME,
             onClick = { /* Read only */ }
+        ))
+
+        items.add(SettingItem.SettingEntry(
+            stableId = "support",
+            nameResId = R.string.support,
+            value = getString(R.string.support_description),
+            onClick = {
+                try {
+                    findNavController().navigate(R.id.action_settingsFragment_to_supportFragment)
+                } catch (e: Exception) {
+                    // Failover
+                }
+            }
         ))
 
         items.add(SettingItem.SettingEntry(

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SupportFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SupportFragment.kt
@@ -1,0 +1,64 @@
+package com.andrerinas.headunitrevived.main
+
+import android.os.Build
+import android.os.Bundle
+import android.text.Html
+import android.text.Spanned
+import android.text.method.LinkMovementMethod
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.andrerinas.headunitrevived.R
+import com.andrerinas.headunitrevived.utils.QrCodeGenerator
+import com.google.android.material.appbar.MaterialToolbar
+
+/**
+ * Dedicated support screen: a clickable link to the project's GitHub issues, a QR code of that
+ * same URL (so a head unit without internet can be scanned from a phone), a short how-to, and a
+ * note that opening an issue needs a GitHub account.
+ */
+class SupportFragment : Fragment() {
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return inflater.inflate(R.layout.fragment_support, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        view.findViewById<MaterialToolbar>(R.id.toolbar).setNavigationOnClickListener {
+            findNavController().popBackStack()
+        }
+
+        val url = getString(R.string.github_issues_url)
+
+        // Clickable link that opens the system browser if the head unit has one.
+        val link = view.findViewById<TextView>(R.id.support_link)
+        link.text = fromHtml("<a href=\"$url\">${getString(R.string.support_open_issues)}</a>")
+        link.movementMethod = LinkMovementMethod.getInstance()
+
+        // QR of the same URL. Generated offline, so it works without internet on the head unit.
+        val qr = view.findViewById<ImageView>(R.id.support_qr)
+        val bitmap = QrCodeGenerator.generateQrCode(url, 500)
+        if (bitmap != null) {
+            qr.setImageBitmap(bitmap)
+        } else {
+            // Generation failed: hide the QR block so we do not show an empty white box.
+            view.findViewById<View>(R.id.support_qr_container).visibility = View.GONE
+            view.findViewById<View>(R.id.support_qr_caption).visibility = View.GONE
+        }
+    }
+
+    private fun fromHtml(html: String): Spanned {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            Html.fromHtml(html, Html.FROM_HTML_MODE_LEGACY)
+        } else {
+            @Suppress("DEPRECATION")
+            Html.fromHtml(html)
+        }
+    }
+}

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SupportFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SupportFragment.kt
@@ -59,29 +59,48 @@ class SupportFragment : Fragment() {
         }
     }
 
-    /** Modal with the basic rules for opening a good, actionable issue. */
+    /** Modal with the rules for opening a good, actionable issue, split into required vs optional. */
     private fun showRulesDialog() {
-        val rules = listOf(
-            R.string.support_rules_english_title to R.string.support_rules_english_desc,
+        val dialogView = layoutInflater.inflate(R.layout.dialog_reporting_rules, null)
+        dialogView.findViewById<TextView>(R.id.rules_intro).text = getString(R.string.support_rules_intro)
+        dialogView.findViewById<TextView>(R.id.rules_required_header).text =
+            getString(R.string.support_rules_section_required)
+        dialogView.findViewById<TextView>(R.id.rules_recommend_header).text =
+            getString(R.string.support_rules_section_recommend)
+
+        // Required: English (title shown red + bold on purpose) and no duplicates.
+        val required = listOf(
+            Triple(R.string.support_rules_english_title, R.string.support_rules_english_desc, true),
+            Triple(R.string.support_rules_search_title, R.string.support_rules_search_desc, false)
+        )
+        // Recommendations: optional, but they speed up a fix.
+        val recommend = listOf(
             R.string.support_rules_device_title to R.string.support_rules_device_desc,
             R.string.support_rules_connection_title to R.string.support_rules_connection_desc,
             R.string.support_rules_appversion_title to R.string.support_rules_appversion_desc,
             R.string.support_rules_logs_title to R.string.support_rules_logs_desc,
-            R.string.support_rules_search_title to R.string.support_rules_search_desc,
             R.string.support_rules_phone_title to R.string.support_rules_phone_desc,
             R.string.support_rules_describe_title to R.string.support_rules_describe_desc,
             R.string.support_rules_oneissue_title to R.string.support_rules_oneissue_desc
         )
-        // The first rule (English-only) is highlighted red and bold; the rest are just bold.
+
         // <font color> and <b> are legacy HTML tags that Html.fromHtml renders on every API level.
-        val html = rules.mapIndexed { index, (title, desc) ->
-            val t = getString(title)
-            val titleHtml = if (index == 0) "<b><font color=\"#E53935\">$t</font></b>" else "<b>$t</b>"
-            "$titleHtml<br>${getString(desc)}"
-        }.joinToString("<br><br>")
+        dialogView.findViewById<TextView>(R.id.rules_required).text = fromHtml(
+            required.joinToString("<br><br>") { (title, desc, red) ->
+                val t = getString(title)
+                val titleHtml = if (red) "<b><font color=\"#E53935\">$t</font></b>" else "<b>$t</b>"
+                "$titleHtml<br>${getString(desc)}"
+            }
+        )
+        dialogView.findViewById<TextView>(R.id.rules_recommend).text = fromHtml(
+            recommend.joinToString("<br><br>") { (title, desc) ->
+                "<b>${getString(title)}</b><br>${getString(desc)}"
+            }
+        )
+
         MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.support_rules_button)
-            .setMessage(fromHtml(html))
+            .setView(dialogView)
             .setPositiveButton(R.string.close, null)
             .show()
     }

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/SupportFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/SupportFragment.kt
@@ -15,6 +15,8 @@ import androidx.navigation.fragment.findNavController
 import com.andrerinas.headunitrevived.R
 import com.andrerinas.headunitrevived.utils.QrCodeGenerator
 import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 /**
  * Dedicated support screen: a clickable link to the project's GitHub issues, a QR code of that
@@ -41,6 +43,10 @@ class SupportFragment : Fragment() {
         link.text = fromHtml("<a href=\"$url\">${getString(R.string.support_open_issues)}</a>")
         link.movementMethod = LinkMovementMethod.getInstance()
 
+        view.findViewById<MaterialButton>(R.id.support_rules_button).setOnClickListener {
+            showRulesDialog()
+        }
+
         // QR of the same URL. Generated offline, so it works without internet on the head unit.
         val qr = view.findViewById<ImageView>(R.id.support_qr)
         val bitmap = QrCodeGenerator.generateQrCode(url, 500)
@@ -51,6 +57,33 @@ class SupportFragment : Fragment() {
             view.findViewById<View>(R.id.support_qr_container).visibility = View.GONE
             view.findViewById<View>(R.id.support_qr_caption).visibility = View.GONE
         }
+    }
+
+    /** Modal with the basic rules for opening a good, actionable issue. */
+    private fun showRulesDialog() {
+        val rules = listOf(
+            R.string.support_rules_english_title to R.string.support_rules_english_desc,
+            R.string.support_rules_device_title to R.string.support_rules_device_desc,
+            R.string.support_rules_connection_title to R.string.support_rules_connection_desc,
+            R.string.support_rules_appversion_title to R.string.support_rules_appversion_desc,
+            R.string.support_rules_logs_title to R.string.support_rules_logs_desc,
+            R.string.support_rules_search_title to R.string.support_rules_search_desc,
+            R.string.support_rules_phone_title to R.string.support_rules_phone_desc,
+            R.string.support_rules_describe_title to R.string.support_rules_describe_desc,
+            R.string.support_rules_oneissue_title to R.string.support_rules_oneissue_desc
+        )
+        // The first rule (English-only) is highlighted red and bold; the rest are just bold.
+        // <font color> and <b> are legacy HTML tags that Html.fromHtml renders on every API level.
+        val html = rules.mapIndexed { index, (title, desc) ->
+            val t = getString(title)
+            val titleHtml = if (index == 0) "<b><font color=\"#E53935\">$t</font></b>" else "<b>$t</b>"
+            "$titleHtml<br>${getString(desc)}"
+        }.joinToString("<br><br>")
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.support_rules_button)
+            .setMessage(fromHtml(html))
+            .setPositiveButton(R.string.close, null)
+            .show()
     }
 
     private fun fromHtml(html: String): Spanned {

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
@@ -384,6 +384,38 @@ class Settings(private val context: Context) {
         get() = ConnectionKind.fromInt(prefs.getInt("primary-connection", ConnectionKind.UNSET.value))
         set(value) { prefs.edit().putInt("primary-connection", value.value).apply() }
 
+    /**
+     * The connection types the user actually uses (multi-select). Drives which settings are shown.
+     * Empty = nothing chosen yet, so everything is shown. Migrated once from the legacy
+     * single-choice [primaryConnection].
+     */
+    var connectionModes: Set<ConnectionMode>
+        get() {
+            val stored = prefs.getStringSet("connection-modes", null)
+            if (stored != null) return stored.mapNotNull { ConnectionMode.fromKey(it) }.toSet()
+            val migrated = migrateLegacyConnectionModes()
+            connectionModes = migrated
+            return migrated
+        }
+        set(value) {
+            prefs.edit().putStringSet("connection-modes", value.map { it.key }.toSet()).apply()
+        }
+
+    private fun migrateLegacyConnectionModes(): Set<ConnectionMode> = when (primaryConnection) {
+        ConnectionKind.USB_CABLE, ConnectionKind.USB_WIRELESS_ADAPTER -> setOf(ConnectionMode.USB)
+        ConnectionKind.WIFI, ConnectionKind.NATIVE_AA -> setOf(ConnectionMode.WIFI)
+        ConnectionKind.SELF_MODE -> setOf(ConnectionMode.SELF)
+        ConnectionKind.ALL -> setOf(ConnectionMode.USB, ConnectionMode.WIFI)
+        ConnectionKind.UNSET -> emptySet()
+    }
+
+    /** Whether USB-related settings should be shown (empty selection shows everything). */
+    fun showsUsb(): Boolean = connectionModes.isEmpty() || ConnectionMode.USB in connectionModes
+    /** Whether WiFi/wireless settings should be shown (empty selection shows everything). */
+    fun showsWifi(): Boolean = connectionModes.isEmpty() || ConnectionMode.WIFI in connectionModes
+    /** The external-GPS choice only applies when a phone is connected; false only for Self-only. */
+    fun showsExternalGps(): Boolean = showsUsb() || showsWifi()
+
     var autoConnectLastSession: Boolean
         get() = prefs.getBoolean("auto-connect-last-session", false)
         set(value) { prefs.edit().putBoolean("auto-connect-last-session", value).apply() }
@@ -662,6 +694,15 @@ class Settings(private val context: Context) {
         companion object {
             private val map = values().associateBy(ConnectionKind::value)
             fun fromInt(value: Int) = map[value] ?: UNSET
+        }
+    }
+
+    /** A connection type the user can pick in the multi-select (USB, WiFi or Self Mode). */
+    enum class ConnectionMode(val key: String) {
+        USB("usb"), WIFI("wifi"), SELF("self");
+
+        companion object {
+            fun fromKey(k: String) = values().firstOrNull { it.key == k }
         }
     }
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/SystemOptimizer.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/SystemOptimizer.kt
@@ -37,12 +37,14 @@ class SystemOptimizer(private val context: Context) {
     ): OptimizationResult {
         val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
         val metrics = DisplayMetrics()
-        
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            context.display?.getRealMetrics(metrics)
-        } else {
-            @Suppress("DEPRECATION")
-            windowManager.defaultDisplay.getRealMetrics(metrics)
+
+        @Suppress("DEPRECATION")
+        when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> context.display?.getRealMetrics(metrics)
+            // getRealMetrics is API 17; on API 16 it does not exist, so fall back to getMetrics.
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 ->
+                windowManager.defaultDisplay.getRealMetrics(metrics)
+            else -> windowManager.defaultDisplay.getMetrics(metrics)
         }
 
         val width = metrics.widthPixels.toFloat()

--- a/app/src/main/java/com/andrerinas/headunitrevived/view/DpiPickerView.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/view/DpiPickerView.kt
@@ -1,8 +1,12 @@
 package com.andrerinas.headunitrevived.view
 
+import android.animation.ValueAnimator
+import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.animation.AccelerateDecelerateInterpolator
 import android.view.inputmethod.EditorInfo
 import android.widget.LinearLayout
 import com.andrerinas.headunitrevived.R
@@ -20,6 +24,7 @@ import kotlin.math.roundToInt
  * values like 440 DPI are reachable. The text field lets the user type any exact value; the
  * tabs are handy presets and only light up when the current value matches one.
  */
+@SuppressLint("ClickableViewAccessibility")
 class DpiPickerView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -34,6 +39,15 @@ class DpiPickerView @JvmOverloads constructor(
     private var isBinding = false
     private var onDpiChanged: ((Int) -> Unit)? = null
 
+    // Self-running demo that sweeps only the preview illustration (not the slider or the number), so
+    // the user sees what DPI does before touching anything. It stops for good the moment the user
+    // interacts with the DPI controls.
+    private var demoAnimator: ValueAnimator? = null
+    private var userInteracted = false
+    // The "real" value (from init or a user action). The demo only animates the illustration and
+    // never touches this, so [dpi] keeps returning the intended value even mid-sweep.
+    private var committedDpi = MIN
+
     init {
         orientation = VERTICAL
         LayoutInflater.from(context).inflate(R.layout.view_dpi_picker, this, true)
@@ -43,10 +57,17 @@ class DpiPickerView @JvmOverloads constructor(
         tabs = findViewById(R.id.dpi_tabs)
 
         slider.addOnChangeListener { _, value, _ ->
-            if (!isBinding) applyDpi(value.toInt(), fromSlider = true)
+            if (!isBinding) { stopDemo(userDriven = true); applyDpi(value.toInt(), fromSlider = true) }
+        }
+        // ACTION_DOWN also covers tapping the thumb on its current value (no value change), so the
+        // demo still stops even when the touch does not move the slider.
+        slider.setOnTouchListener { _, event ->
+            if (event.actionMasked == MotionEvent.ACTION_DOWN) stopDemo(userDriven = true)
+            false
         }
         tabs.addOnButtonCheckedListener { _, checkedId, checked ->
             if (checked && !isBinding) {
+                stopDemo(userDriven = true)
                 val rep = when (checkedId) {
                     R.id.dpi_tab_small -> SMALL_REP
                     R.id.dpi_tab_large -> LARGE_REP
@@ -59,25 +80,69 @@ class DpiPickerView @JvmOverloads constructor(
         input.setOnEditorActionListener { _, actionId, _ ->
             if (actionId == EditorInfo.IME_ACTION_DONE) { commitInput(); true } else false
         }
-        input.setOnFocusChangeListener { _, hasFocus -> if (!hasFocus) commitInput() }
+        input.setOnFocusChangeListener { _, hasFocus ->
+            if (hasFocus) stopDemo(userDriven = true) else commitInput()
+        }
 
         // Initialise the field/preview/tab from the slider's default value.
         applyDpi(slider.value.toInt(), fromSlider = true, silent = true)
     }
 
     var dpi: Int
-        get() = slider.value.toInt()
+        // While the demo sweeps, report the intended value, not the animated frame.
+        get() = if (demoAnimator != null) committedDpi else slider.value.toInt()
         set(value) = applyDpi(value, fromSlider = false, silent = true)
 
     fun setOnDpiChanged(cb: (Int) -> Unit) { onDpiChanged = cb }
 
     fun setPanelResolution(widthPx: Int, heightPx: Int) = preview.setPanelResolution(widthPx, heightPx)
 
+    /**
+     * Starts a gentle looping demo that sweeps only the preview illustration through the DPI range,
+     * so the graphic shows what DPI does while the slider and number stay put. No-op once the user
+     * has interacted, or if the picker is disabled. Safe to call repeatedly (e.g. each time the
+     * step/screen becomes visible).
+     */
+    fun startDemo() {
+        if (userInteracted || demoAnimator != null || !slider.isEnabled) return
+        demoAnimator = ValueAnimator.ofFloat(DEMO_LOW.toFloat(), DEMO_HIGH.toFloat()).apply {
+            duration = DEMO_SWEEP_MS
+            startDelay = DEMO_START_DELAY_MS
+            repeatMode = ValueAnimator.REVERSE
+            repeatCount = ValueAnimator.INFINITE
+            interpolator = AccelerateDecelerateInterpolator()
+            addUpdateListener { anim ->
+                // Only the illustration animates; the slider and the DPI number stay at the real value.
+                preview.setDpi((anim.animatedValue as Float).toInt())
+            }
+            start()
+        }
+    }
+
+    /** Stops the demo (if running) without counting as user interaction, e.g. when the screen is
+     * hidden; the illustration is restored to the intended value. */
+    fun stopDemo() = stopDemo(userDriven = false)
+
+    private fun stopDemo(userDriven: Boolean) {
+        if (userDriven) userInteracted = true
+        val anim = demoAnimator ?: return
+        demoAnimator = null
+        anim.cancel()
+        // Resync the illustration to the real DPI (the slider and number never moved during the demo).
+        preview.setDpi(committedDpi)
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        stopDemo(userDriven = false)
+    }
+
     fun setPickerEnabled(enabled: Boolean) {
         slider.isEnabled = enabled
         input.isEnabled = enabled
         for (i in 0 until tabs.childCount) tabs.getChildAt(i).isEnabled = enabled
         alpha = if (enabled) 1f else 0.5f
+        if (!enabled) stopDemo(userDriven = false)
     }
 
     /** Parse the typed value, clamp it into range and apply; restore on invalid input. */
@@ -95,6 +160,7 @@ class DpiPickerView @JvmOverloads constructor(
 
     private fun applyDpi(raw: Int, fromSlider: Boolean, silent: Boolean = false) {
         val v = snap(raw)
+        committedDpi = v
         isBinding = true
         if (!fromSlider) slider.value = v.toFloat()
         tabs.check(tabFor(v))
@@ -134,5 +200,13 @@ class DpiPickerView @JvmOverloads constructor(
         private const val SMALL_MEDIUM_MAX = (SMALL_REP + MEDIUM_REP) / 2   // 153
         private const val MEDIUM_LARGE_MAX = (MEDIUM_REP + LARGE_REP) / 2   // 196
         private const val LARGE_HUGE_MAX = (LARGE_REP + HUGE_REP) / 2       // 269
+
+        // Demo sweep range and timing: the illustration alone sweeps the full 160..640 DPI range so
+        // the effect on how much content fits is clearly visible.
+        private const val DEMO_LOW = 160
+        private const val DEMO_HIGH = 640
+        private const val DEMO_SWEEP_MS = 3200L
+        // No wait: the illustration should start sweeping as soon as the step is shown.
+        private const val DEMO_START_DELAY_MS = 0L
     }
 }

--- a/app/src/main/res/drawable/ic_chevron_right.xml
+++ b/app/src/main/res/drawable/ic_chevron_right.xml
@@ -1,0 +1,4 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#000000" android:pathData="M10,6L8.59,7.41 13.17,12l-4.58,4.59L10,18l6,-6z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_image.xml
+++ b/app/src/main/res/drawable/ic_image.xml
@@ -1,0 +1,4 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#000000" android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_keyboard.xml
+++ b/app/src/main/res/drawable/ic_keyboard.xml
@@ -1,0 +1,4 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#000000" android:pathData="M20,5H4c-1.1,0 -1.99,0.9 -1.99,2L2,17c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V7c0,-1.1 -0.9,-2 -2,-2zM11,8h2v2h-2V8zM11,11h2v2h-2v-2zM8,8h2v2H8V8zM8,11h2v2H8v-2zM7,13H5v-2h2v2zM7,10H5V8h2v2zM16,17H8v-2h8v2zM16,13h-2v-2h2v2zM16,10h-2V8h2v2zM19,13h-2v-2h2v2zM19,10h-2V8h2v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_mic.xml
+++ b/app/src/main/res/drawable/ic_mic.xml
@@ -1,0 +1,4 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#000000" android:pathData="M12,14c1.66,0 2.99,-1.34 2.99,-3L15,5c0,-1.66 -1.34,-3 -3,-3S9,3.34 9,5v6c0,1.66 1.34,3 3,3zM17.3,11c0,3 -2.54,5.1 -5.3,5.1S6.7,14 6.7,11L5,11c0,3.41 2.72,6.23 6,6.72V21h2v-3.28c3.28,-0.48 6,-3.3 6,-6.72h-1.7z"/>
+</vector>

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -717,16 +717,187 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp"
-                    android:gravity="center_horizontal"
-                    android:text="@string/onb_ready_loading_intro"
-                    android:textAppearance="?attr/textAppearanceBody2" />
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/onb_loading_screen_button"
-                    android:layout_width="wrap_content"
+                    android:text="@string/onb_ready_extras_title"
+                    android:textAppearance="?attr/textAppearanceTitleSmall"
+                    android:textColor="?attr/colorOnSurfaceVariant" />
+
+                <com.google.android.material.card.MaterialCardView
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
                     android:layout_marginTop="8dp"
-                    android:text="@string/onb_ready_loading_button" />
+                    app:cardBackgroundColor="?attr/colorSurfaceVariant"
+                    app:cardCornerRadius="12dp"
+                    app:cardElevation="1dp"
+                    app:strokeWidth="0dp">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
+
+                        <!-- Loading screen -->
+                        <LinearLayout
+                            android:id="@+id/onb_extra_loading"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:background="?attr/selectableItemBackground"
+                            android:clickable="true"
+                            android:focusable="true"
+                            android:gravity="center_vertical"
+                            android:orientation="horizontal"
+                            android:paddingStart="16dp"
+                            android:paddingTop="14dp"
+                            android:paddingEnd="16dp"
+                            android:paddingBottom="14dp">
+                            <ImageView
+                                android:layout_width="24dp"
+                                android:layout_height="24dp"
+                                android:contentDescription="@string/loading_screen"
+                                android:src="@drawable/ic_image"
+                                app:tint="?attr/colorOnSurfaceVariant" />
+                            <LinearLayout
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="16dp"
+                                android:layout_marginEnd="12dp"
+                                android:layout_weight="1"
+                                android:orientation="vertical">
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/loading_screen"
+                                    android:textAppearance="?attr/textAppearanceBodyLarge"
+                                    android:textColor="?attr/colorOnSurface" />
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="2dp"
+                                    android:text="@string/onb_extra_loading_desc"
+                                    android:textAppearance="?attr/textAppearanceBodySmall"
+                                    android:textColor="?attr/colorOnSurfaceVariant" />
+                            </LinearLayout>
+                            <ImageView
+                                android:layout_width="20dp"
+                                android:layout_height="20dp"
+                                android:importantForAccessibility="no"
+                                android:src="@drawable/ic_chevron_right"
+                                app:tint="?attr/colorOnSurfaceVariant" />
+                        </LinearLayout>
+
+                        <View
+                            android:layout_width="match_parent"
+                            android:layout_height="1dp"
+                            android:layout_marginStart="56dp"
+                            android:alpha="0.12"
+                            android:background="?attr/colorOnSurface" />
+
+                        <!-- Keymap -->
+                        <LinearLayout
+                            android:id="@+id/onb_extra_keymap"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:background="?attr/selectableItemBackground"
+                            android:clickable="true"
+                            android:focusable="true"
+                            android:gravity="center_vertical"
+                            android:orientation="horizontal"
+                            android:paddingStart="16dp"
+                            android:paddingTop="14dp"
+                            android:paddingEnd="16dp"
+                            android:paddingBottom="14dp">
+                            <ImageView
+                                android:layout_width="24dp"
+                                android:layout_height="24dp"
+                                android:contentDescription="@string/keymap"
+                                android:src="@drawable/ic_keyboard"
+                                app:tint="?attr/colorOnSurfaceVariant" />
+                            <LinearLayout
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="16dp"
+                                android:layout_marginEnd="12dp"
+                                android:layout_weight="1"
+                                android:orientation="vertical">
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/keymap"
+                                    android:textAppearance="?attr/textAppearanceBodyLarge"
+                                    android:textColor="?attr/colorOnSurface" />
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="2dp"
+                                    android:text="@string/keymap_description"
+                                    android:textAppearance="?attr/textAppearanceBodySmall"
+                                    android:textColor="?attr/colorOnSurfaceVariant" />
+                            </LinearLayout>
+                            <ImageView
+                                android:layout_width="20dp"
+                                android:layout_height="20dp"
+                                android:importantForAccessibility="no"
+                                android:src="@drawable/ic_chevron_right"
+                                app:tint="?attr/colorOnSurfaceVariant" />
+                        </LinearLayout>
+
+                        <View
+                            android:layout_width="match_parent"
+                            android:layout_height="1dp"
+                            android:layout_marginStart="56dp"
+                            android:alpha="0.12"
+                            android:background="?attr/colorOnSurface" />
+
+                        <!-- Microphone -->
+                        <LinearLayout
+                            android:id="@+id/onb_extra_mic"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:background="?attr/selectableItemBackground"
+                            android:clickable="true"
+                            android:focusable="true"
+                            android:gravity="center_vertical"
+                            android:orientation="horizontal"
+                            android:paddingStart="16dp"
+                            android:paddingTop="14dp"
+                            android:paddingEnd="16dp"
+                            android:paddingBottom="14dp">
+                            <ImageView
+                                android:layout_width="24dp"
+                                android:layout_height="24dp"
+                                android:contentDescription="@string/microphone_settings"
+                                android:src="@drawable/ic_mic"
+                                app:tint="?attr/colorOnSurfaceVariant" />
+                            <LinearLayout
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="16dp"
+                                android:layout_marginEnd="12dp"
+                                android:layout_weight="1"
+                                android:orientation="vertical">
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/microphone_settings"
+                                    android:textAppearance="?attr/textAppearanceBodyLarge"
+                                    android:textColor="?attr/colorOnSurface" />
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="2dp"
+                                    android:text="@string/microphone_settings_description"
+                                    android:textAppearance="?attr/textAppearanceBodySmall"
+                                    android:textColor="?attr/colorOnSurfaceVariant" />
+                            </LinearLayout>
+                            <ImageView
+                                android:layout_width="20dp"
+                                android:layout_height="20dp"
+                                android:importantForAccessibility="no"
+                                android:src="@drawable/ic_chevron_right"
+                                app:tint="?attr/colorOnSurfaceVariant" />
+                        </LinearLayout>
+
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
             </LinearLayout>
         </ScrollView>
 

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -722,7 +722,6 @@
                     android:textAppearance="?attr/textAppearanceBody2" />
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/onb_loading_screen_button"
-                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal"

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -121,7 +121,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
                     android:orientation="vertical"
-                    app:singleSelection="true">
+                    app:singleSelection="false">
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/onb_conn_usb"
                         style="@style/Widget.MaterialComponents.Button.OutlinedButton"
@@ -146,14 +146,6 @@
                         app:icon="@drawable/ic_directions_car"
                         app:iconGravity="textStart"
                         android:text="@string/self_mode" />
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/onb_conn_all"
-                        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        app:icon="@drawable/ic_apps"
-                        app:iconGravity="textStart"
-                        android:text="@string/connection_kind_all" />
                 </com.google.android.material.button.MaterialButtonToggleGroup>
                 <TextView
                     android:id="@+id/onb_conn_detail"

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -575,7 +575,7 @@
                         android:layout_height="match_parent"
                         android:contentDescription="@string/onb_vehicle_title"
                         android:scaleType="fitCenter"
-                        android:src="@drawable/illus_car_dashboard" />
+                        app:srcCompat="@drawable/illus_car_dashboard" />
                     <TextView
                         android:id="@+id/onb_vehicle_screen_name"
                         android:layout_width="wrap_content"
@@ -753,7 +753,7 @@
                                 android:layout_width="24dp"
                                 android:layout_height="24dp"
                                 android:contentDescription="@string/loading_screen"
-                                android:src="@drawable/ic_image"
+                                app:srcCompat="@drawable/ic_image"
                                 app:tint="?attr/colorOnSurfaceVariant" />
                             <LinearLayout
                                 android:layout_width="0dp"
@@ -780,7 +780,7 @@
                                 android:layout_width="20dp"
                                 android:layout_height="20dp"
                                 android:importantForAccessibility="no"
-                                android:src="@drawable/ic_chevron_right"
+                                app:srcCompat="@drawable/ic_chevron_right"
                                 app:tint="?attr/colorOnSurfaceVariant" />
                         </LinearLayout>
 
@@ -809,7 +809,7 @@
                                 android:layout_width="24dp"
                                 android:layout_height="24dp"
                                 android:contentDescription="@string/keymap"
-                                android:src="@drawable/ic_keyboard"
+                                app:srcCompat="@drawable/ic_keyboard"
                                 app:tint="?attr/colorOnSurfaceVariant" />
                             <LinearLayout
                                 android:layout_width="0dp"
@@ -836,7 +836,7 @@
                                 android:layout_width="20dp"
                                 android:layout_height="20dp"
                                 android:importantForAccessibility="no"
-                                android:src="@drawable/ic_chevron_right"
+                                app:srcCompat="@drawable/ic_chevron_right"
                                 app:tint="?attr/colorOnSurfaceVariant" />
                         </LinearLayout>
 
@@ -865,7 +865,7 @@
                                 android:layout_width="24dp"
                                 android:layout_height="24dp"
                                 android:contentDescription="@string/microphone_settings"
-                                android:src="@drawable/ic_mic"
+                                app:srcCompat="@drawable/ic_mic"
                                 app:tint="?attr/colorOnSurfaceVariant" />
                             <LinearLayout
                                 android:layout_width="0dp"
@@ -892,7 +892,7 @@
                                 android:layout_width="20dp"
                                 android:layout_height="20dp"
                                 android:importantForAccessibility="no"
-                                android:src="@drawable/ic_chevron_right"
+                                app:srcCompat="@drawable/ic_chevron_right"
                                 app:tint="?attr/colorOnSurfaceVariant" />
                         </LinearLayout>
 

--- a/app/src/main/res/layout/dialog_reporting_rules.xml
+++ b/app/src/main/res/layout/dialog_reporting_rules.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp">
+
+        <TextView
+            android:id="@+id/rules_intro"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+
+        <TextView
+            android:id="@+id/rules_required_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:textAppearance="?attr/textAppearanceTitleSmall"
+            android:textColor="?attr/colorPrimary"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/rules_required"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textColor="?attr/colorOnSurface" />
+
+        <com.google.android.material.divider.MaterialDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp" />
+
+        <TextView
+            android:id="@+id/rules_recommend_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:textAppearance="?attr/textAppearanceTitleSmall"
+            android:textColor="?attr/colorPrimary"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/rules_recommend"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textColor="?attr/colorOnSurface" />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_support.xml
+++ b/app/src/main/res/layout/fragment_support.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="?attr/colorSurface">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorSurface"
+        app:elevation="0dp">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:title="@string/support"
+            app:navigationIcon="@drawable/ic_arrow_back_white"
+            app:titleTextColor="?attr/colorOnSurface"
+            app:navigationIconTint="?attr/colorOnSurface"
+            style="@style/Widget.Material3.Toolbar.Surface" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:cardCornerRadius="12dp"
+                app:strokeWidth="0dp"
+                app:cardElevation="2dp"
+                app:cardBackgroundColor="?attr/colorSurfaceVariant">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/support_title"
+                        android:textAppearance="?attr/textAppearanceTitleMedium"
+                        android:textColor="?attr/colorOnSurface"
+                        android:layout_marginBottom="8dp" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/support_help"
+                        android:textAppearance="?attr/textAppearanceBodyMedium"
+                        android:textColor="?attr/colorOnSurfaceVariant" />
+
+                    <!-- Clickable issues link (HTML + LinkMovementMethod set in code). -->
+                    <TextView
+                        android:id="@+id/support_link"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:textAppearance="?attr/textAppearanceBodyLarge"
+                        android:textColor="?attr/colorOnSurfaceVariant"
+                        android:textColorLink="?attr/colorPrimary" />
+
+                    <!-- QR on a fixed white background with a quiet zone, so it scans well in
+                         both light and dark theme. -->
+                    <FrameLayout
+                        android:id="@+id/support_qr_container"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal"
+                        android:layout_marginTop="20dp"
+                        android:background="@android:color/white"
+                        android:padding="12dp">
+
+                        <ImageView
+                            android:id="@+id/support_qr"
+                            android:layout_width="220dp"
+                            android:layout_height="220dp"
+                            android:contentDescription="@string/support_scan_qr"
+                            android:scaleType="fitCenter" />
+                    </FrameLayout>
+
+                    <TextView
+                        android:id="@+id/support_qr_caption"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:gravity="center_horizontal"
+                        android:text="@string/support_scan_qr"
+                        android:textAppearance="?attr/textAppearanceBodySmall"
+                        android:textColor="?attr/colorOnSurfaceVariant" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="20dp"
+                        android:text="@string/support_github_account_warning"
+                        android:textAppearance="?attr/textAppearanceBodyMedium"
+                        android:textColor="?attr/colorError"
+                        android:textStyle="bold" />
+
+                </LinearLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_support.xml
+++ b/app/src/main/res/layout/fragment_support.xml
@@ -102,6 +102,15 @@
                         android:textAppearance="?attr/textAppearanceBodySmall"
                         android:textColor="?attr/colorOnSurfaceVariant" />
 
+                    <!-- Opens a modal with the basic rules for opening a good issue. -->
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/support_rules_button"
+                        style="@style/Widget.Material3.Button.TonalButton"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:text="@string/support_rules_button" />
+
                     <TextView
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_support.xml
+++ b/app/src/main/res/layout/fragment_support.xml
@@ -102,10 +102,10 @@
                         android:textAppearance="?attr/textAppearanceBodySmall"
                         android:textColor="?attr/colorOnSurfaceVariant" />
 
-                    <!-- Opens a modal with the basic rules for opening a good issue. -->
+                    <!-- Opens a modal with the basic rules for opening a good issue. Filled
+                         (colorPrimary) so it stands out from the card background. -->
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/support_rules_button"
-                        style="@style/Widget.Material3.Button.TonalButton"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="16dp"

--- a/app/src/main/res/layout/layout_onboarding_permission_item.xml
+++ b/app/src/main/res/layout/layout_onboarding_permission_item.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- One permission row: title + help on the left, a green check (granted) or Allow button. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
@@ -35,7 +36,7 @@
         android:layout_height="24dp"
         android:layout_marginStart="12dp"
         android:contentDescription="@string/perm_granted"
-        android:src="@drawable/ic_check"
+        app:srcCompat="@drawable/ic_check"
         android:visibility="gone" />
 
     <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout/list_item_nearby.xml
+++ b/app/src/main/res/layout/list_item_nearby.xml
@@ -15,7 +15,7 @@
         android:layout_height="32dp"
         app:srcCompat="@drawable/ic_phone"
         android:layout_marginEnd="16dp"
-        android:tint="?android:attr/textColorPrimary" />
+        app:tint="?android:attr/textColorPrimary" />
 
     <TextView
         android:id="@+id/deviceName"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -43,6 +43,13 @@
             app:popEnterAnim="@anim/slide_in_left"
             app:popExitAnim="@anim/slide_out_right" />
         <action
+            android:id="@+id/action_settingsFragment_to_supportFragment"
+            app:destination="@id/supportFragment"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right" />
+        <action
             android:id="@+id/action_settingsFragment_to_autoConnectFragment"
             app:destination="@id/autoConnectFragment"
             app:enterAnim="@anim/slide_in_right"
@@ -117,6 +124,11 @@
         android:id="@+id/aboutFragment"
         android:name="com.andrerinas.headunitrevived.main.AboutFragment"
         android:label="@string/about" />
+
+    <fragment
+        android:id="@+id/supportFragment"
+        android:name="com.andrerinas.headunitrevived.main.SupportFragment"
+        android:label="@string/support" />
 
     <fragment
         android:id="@+id/autoConnectFragment"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -745,4 +745,23 @@
     <string name="support_github_account_warning">ملاحظة: تحتاج إلى حساب GitHub مجاني لفتح مشكلة جديدة.</string>
     <string name="onb_ready_extras_title">قبل أن تنهي، يمكنك أيضًا إعداد:</string>
     <string name="onb_extra_loading_desc">صورة مخصصة تظهر أثناء اتصال السيارة</string>
+
+    <string name="support_rules_button">قواعد الإبلاغ</string>
+    <string name="support_rules_english_desc">يرجى دائمًا كتابة مشكلتك باللغة الإنجليزية. القائم على المشروع ومعظم المساهمين يقرؤون الإنجليزية، والموضوع الذي يخلط لغات كثيرة يتحول سريعًا إلى برج بابل لا يفهم فيه أحد الآخر. لست واثقًا من الإنجليزية؟ مترجم مثل Google Translate أو DeepL مقبول تمامًا.</string>
+    <string name="support_rules_device_title">اذكر الجهاز الذي يشغّل التطبيق</string>
+    <string name="support_rules_device_desc">إصدار Android للجهاز الذي يعرض Android Auto (وحدة الوسائط أو الشاشة)، وماركته وطرازه إن عرفتهما.</string>
+    <string name="support_rules_connection_title">اذكر طريقة الاتصال</string>
+    <string name="support_rules_connection_desc">كابل USB، أو محول USB لاسلكي، أو WiFi Direct، أو WiFi (خادم وحدة الرأس)، أو Self Mode. إن كان الاتصال لاسلكيًا، أضف طراز المحول أو الدونغل.</string>
+    <string name="support_rules_appversion_title">أرفق إصدار التطبيق</string>
+    <string name="support_rules_appversion_desc">إصدار Headunit Revived، المعروض في شاشة حول.</string>
+    <string name="support_rules_logs_title">أرفق السجلات فور حدوث المشكلة</string>
+    <string name="support_rules_logs_desc">انتقل إلى الإعدادات وافتح تبويب متقدم، ثم فعّل وضع التصحيح في قسم تصحيح الأخطاء، وأعد إنتاج المشكلة، ثم اضغط تصدير السجلات مباشرة بعدها حتى يغطي السجل لحظة الخلل لا مجرد بداية التشغيل. أرفق الملف بمشكلتك.</string>
+    <string name="support_rules_search_title">ابحث أولاً</string>
+    <string name="support_rules_search_desc">قد تكون مشكلتك مُبلَّغًا عنها من قبل. ابحث في المشكلات الموجودة وأضف تعليقك هناك بدلًا من فتح نسخة مكررة.</string>
+    <string name="support_rules_phone_title">هاتفك مهم أيضًا</string>
+    <string name="support_rules_phone_desc">طراز هاتفك وإصدار Android عليه وإصدار تطبيق Android Auto المثبَّت فيه. بعض المشكلات تنشأ من إصدار بعينه من Android Auto.</string>
+    <string name="support_rules_describe_title">صف المشكلة بوضوح</string>
+    <string name="support_rules_describe_desc">ما الذي فعلته، وما الذي توقعت حدوثه، وما الذي حدث فعلًا. لقطة شاشة أو مقطع فيديو قصير تساعد كثيرًا في المشكلات المرئية.</string>
+    <string name="support_rules_oneissue_title">مشكلة واحدة لكل تقرير</string>
+    <string name="support_rules_oneissue_desc">خصص كل تقرير لمشكلة واحدة حتى يمكن تتبعها وإصلاحها. افتح تقارير منفصلة للمشكلات غير المرتبطة ببعضها.</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -746,8 +746,11 @@
     <string name="onb_ready_extras_title">قبل أن تنهي، يمكنك أيضًا إعداد:</string>
     <string name="onb_extra_loading_desc">صورة مخصصة تظهر أثناء اتصال السيارة</string>
 
+    <string name="support_rules_intro">شرطان فقط مطلوبان. ما عداهما اختياري، لكنه يساعد على حل مشكلتك بشكل أسرع.</string>
+    <string name="support_rules_section_required">مطلوب</string>
+    <string name="support_rules_section_recommend">توصيات (اختيارية)</string>
     <string name="support_rules_button">قواعد الإبلاغ</string>
-    <string name="support_rules_english_desc">يرجى دائمًا كتابة مشكلتك باللغة الإنجليزية. القائم على المشروع ومعظم المساهمين يقرؤون الإنجليزية، والموضوع الذي يخلط لغات كثيرة يتحول سريعًا إلى برج بابل لا يفهم فيه أحد الآخر. لست واثقًا من الإنجليزية؟ مترجم مثل Google Translate أو DeepL مقبول تمامًا.</string>
+    <string name="support_rules_english_desc">يرجى دائمًا كتابة مشكلتك باللغة الإنجليزية. إنها اللغة التي يشترك فيها القائم على المشروع ومعظم المساهمين، والموضوع الذي يخلط لغات كثيرة يتحول سريعًا إلى برج بابل لا يستطيع فيه أحد مساعدة الآخر. لا أحد يحكم عليك أو على مستواك في الإنجليزية أو على أسلوبك في الكتابة، فلا تقلق من الأخطاء. إن أعانك على ذلك، يمكن لمترجم مثل Google Translate أو DeepL، أو لذكاء اصطناعي مثل ChatGPT أو Claude، أن يكتب رسالتك ويصوّغها بالإنجليزية نيابةً عنك.</string>
     <string name="support_rules_device_title">اذكر الجهاز الذي يشغّل التطبيق</string>
     <string name="support_rules_device_desc">إصدار Android للجهاز الذي يعرض Android Auto (وحدة الوسائط أو الشاشة)، وماركته وطرازه إن عرفتهما.</string>
     <string name="support_rules_connection_title">اذكر طريقة الاتصال</string>
@@ -756,8 +759,8 @@
     <string name="support_rules_appversion_desc">إصدار Headunit Revived، المعروض في شاشة حول.</string>
     <string name="support_rules_logs_title">أرفق السجلات فور حدوث المشكلة</string>
     <string name="support_rules_logs_desc">انتقل إلى الإعدادات وافتح تبويب متقدم، ثم فعّل وضع التصحيح في قسم تصحيح الأخطاء، وأعد إنتاج المشكلة، ثم اضغط تصدير السجلات مباشرة بعدها حتى يغطي السجل لحظة الخلل لا مجرد بداية التشغيل. أرفق الملف بمشكلتك.</string>
-    <string name="support_rules_search_title">ابحث أولاً</string>
-    <string name="support_rules_search_desc">قد تكون مشكلتك مُبلَّغًا عنها من قبل. ابحث في المشكلات الموجودة وأضف تعليقك هناك بدلًا من فتح نسخة مكررة.</string>
+    <string name="support_rules_search_title">لا تكرار</string>
+    <string name="support_rules_search_desc">ابحث في المشكلات الموجودة أولاً. إن كانت هناك مشكلة مفتوحة تصف ما تواجهه، أضف تفاصيلك كتعليق عليها بدلاً من فتح مشكلة جديدة. لا تفتح مشكلة جديدة إلا إذا لم يكن ثمة مشكلة مطابقة.</string>
     <string name="support_rules_phone_title">هاتفك مهم أيضًا</string>
     <string name="support_rules_phone_desc">طراز هاتفك وإصدار Android عليه وإصدار تطبيق Android Auto المثبَّت فيه. بعض المشكلات تنشأ من إصدار بعينه من Android Auto.</string>
     <string name="support_rules_describe_title">صف المشكلة بوضوح</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -735,4 +735,12 @@
     <string name="onb_vehicle_help_advanced">يمكنك ضبط المزيد من تفاصيل مركبتك في علامة التبويب المتقدمة. نحن لا نستخدم هذه البيانات؛ تُرسَل فقط إلى Android Auto لأنه يطلبها.</string>
     <string name="onb_summary_vehicle_format">المركبة: %1$s</string>
     <string name="sunrise_reference_help">النقطة المرجعية المستخدمة لحساب وقت الشروق والغروب. اختر موقعك مرة واحدة؛ يعمل بدون نظام تحديد المواقع.</string>
+
+    <string name="support">الإبلاغ عن مشكلة</string>
+    <string name="support_description">البحث عن الأخطاء أو الإبلاغ عنها على GitHub</string>
+    <string name="support_title">الإبلاغ عن مشكلة</string>
+    <string name="support_help">إذا واجهت خطأً أو مشكلة، يرجى البحث عنها أولاً في قائمة المشكلات على GitHub. إذا لم يُبلِّغ عنها أحد بعد، افتح مشكلة جديدة وصف فيها ما يحدث، ووحدة الرأس الخاصة بك، والخطوات اللازمة لإعادة إنتاج المشكلة.</string>
+    <string name="support_open_issues">فتح صفحة المشكلات على GitHub</string>
+    <string name="support_scan_qr">أو امسح رمز QR هذا لفتح قائمة المشكلات على جهاز آخر.</string>
+    <string name="support_github_account_warning">ملاحظة: تحتاج إلى حساب GitHub مجاني لإنشاء مشكلة.</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -737,10 +737,10 @@
     <string name="sunrise_reference_help">النقطة المرجعية المستخدمة لحساب وقت الشروق والغروب. اختر موقعك مرة واحدة؛ يعمل بدون نظام تحديد المواقع.</string>
 
     <string name="support">الإبلاغ عن مشكلة</string>
-    <string name="support_description">البحث عن الأخطاء أو الإبلاغ عنها على GitHub</string>
+    <string name="support_description">ابحث عن الأخطاء أو أبلغ عنها على GitHub</string>
     <string name="support_title">الإبلاغ عن مشكلة</string>
-    <string name="support_help">إذا واجهت خطأً أو مشكلة، يرجى البحث عنها أولاً في قائمة المشكلات على GitHub. إذا لم يُبلِّغ عنها أحد بعد، افتح مشكلة جديدة وصف فيها ما يحدث، ووحدة الرأس الخاصة بك، والخطوات اللازمة لإعادة إنتاج المشكلة.</string>
+    <string name="support_help">إذا صادفت خطأً أو مشكلة، ابحث عنها أولاً في قائمة المشكلات على GitHub. إن لم يُبلِّغ عنها أحد بعد، افتح مشكلة جديدة واذكر فيها ما الذي يحدث، وطراز شاشة سيارتك، والخطوات اللازمة لإعادة تكرار المشكلة.</string>
     <string name="support_open_issues">فتح صفحة المشكلات على GitHub</string>
     <string name="support_scan_qr">أو امسح رمز QR هذا لفتح قائمة المشكلات على جهاز آخر.</string>
-    <string name="support_github_account_warning">ملاحظة: تحتاج إلى حساب GitHub مجاني لإنشاء مشكلة.</string>
+    <string name="support_github_account_warning">ملاحظة: تحتاج إلى حساب GitHub مجاني لفتح مشكلة جديدة.</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -743,4 +743,6 @@
     <string name="support_open_issues">فتح صفحة المشكلات على GitHub</string>
     <string name="support_scan_qr">أو امسح رمز QR هذا لفتح قائمة المشكلات على جهاز آخر.</string>
     <string name="support_github_account_warning">ملاحظة: تحتاج إلى حساب GitHub مجاني لفتح مشكلة جديدة.</string>
+    <string name="onb_ready_extras_title">قبل أن تنهي، يمكنك أيضًا إعداد:</string>
+    <string name="onb_extra_loading_desc">صورة مخصصة تظهر أثناء اتصال السيارة</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -774,7 +774,7 @@
 
     <!-- Support / reporting rules -->
     <string name="support_rules_button">Pravidla hlášení</string>
-    <string name="support_rules_english_desc">Prosím, pište vždy v angličtině. Správce a většina lidí, kteří zde pomáhají, čtou anglicky, a vlákno, kde se mísí více jazyků, se rychle proměňuje v malou babylonskou věž, kde si nikdo nerozumí. Angličtina vám nejde? Překladač jako Google Translate nebo DeepL je naprosto v pořádku.</string>
+    <string name="support_rules_english_desc">Pište prosím vždy anglicky. Angličtina je jediný jazyk, který správce a většina lidí, kteří zde pomáhají, sdílejí, a vlákno v mnoha jazycích se rychle promění v malou babylonskou věž, kde si nikdo nemůže pomoci. Nikdo vás nesoudí — ani vaši angličtinu, ani způsob, jakým píšete, takže si nedělejte starosti s chybami. Pokud to pomůže, překladač jako Google Translate nebo DeepL, nebo AI jako ChatGPT nebo Claude, za vás zprávu v angličtině napíše a upraví.</string>
     <string name="support_rules_device_title">Řekněte, na čem aplikaci spouštíte</string>
     <string name="support_rules_device_desc">Verze Androidu zařízení, které promítá Android Auto (vaše autorádio nebo obrazovka), a jeho značka a model, pokud je znáte.</string>
     <string name="support_rules_connection_title">Řekněte, jak se připojujete</string>
@@ -783,12 +783,16 @@
     <string name="support_rules_appversion_desc">Verzi Headunit Revived najdete na obrazovce O aplikaci a podpora.</string>
     <string name="support_rules_logs_title">Přiložte protokoly, hned po tom, co se to stane</string>
     <string name="support_rules_logs_desc">V Nastavení přejděte na záložku Pokročilé, v sekci Ladění zapněte Režim ladění, zopakujte problém a hned poté klepněte na Exportovat protokoly, aby protokol zachytil okamžik selhání, a ne jen start. Přiložte tento soubor k hlášení.</string>
-    <string name="support_rules_search_title">Nejprve hledejte</string>
-    <string name="support_rules_search_desc">Váš problém už možná byl nahlášen. Prohledejte existující hlášení a přispějte do stávajícího místo vytváření duplikátu.</string>
+    <string name="support_rules_search_title">Žádné duplicity</string>
+    <string name="support_rules_search_desc">Nejprve prohledejte existující hlášení. Pokud už otevřené hlášení váš problém popisuje, přidejte své podrobnosti jako komentář tam, místo abyste otevírali nové. Nové hlášení otevřete, jen pokud žádné neodpovídá.</string>
     <string name="support_rules_phone_title">Záleží i na vašem telefonu</string>
     <string name="support_rules_phone_desc">Model vašeho telefonu, jeho verze Androidu a verze aplikace Android Auto v telefonu. Některé problémy jsou způsobeny konkrétní verzí Android Auto.</string>
     <string name="support_rules_describe_title">Popište to jasně</string>
     <string name="support_rules_describe_desc">Co jste udělali, co jste očekávali a co se skutečně stalo. Screenshot nebo krátké video velmi pomáhá u vizuálních problémů.</string>
     <string name="support_rules_oneissue_title">Jeden problém na jedno hlášení</string>
     <string name="support_rules_oneissue_desc">Každé hlášení nechte pro jediný problém, aby bylo možné ho sledovat a opravit. Pro nesouvisející problémy otevřete samostatná hlášení.</string>
+
+    <string name="support_rules_intro">Jsou vyžadovány jen dvě věci. Vše ostatní je volitelné, ale pomůže to váš problém vyřešit mnohem rychleji.</string>
+    <string name="support_rules_section_required">Povinné</string>
+    <string name="support_rules_section_recommend">Doporučení (volitelné)</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -769,4 +769,6 @@
     <string name="support_open_issues">Otevřít hlášení na GitHubu</string>
     <string name="support_scan_qr">Nebo naskenujte tento QR kód a otevřete seznam hlášení na jiném zařízení.</string>
     <string name="support_github_account_warning">Poznámka: k vytvoření hlášení potřebujete bezplatný účet na GitHubu.</string>
+    <string name="onb_ready_extras_title">Než dokončíte, můžete také nastavit:</string>
+    <string name="onb_extra_loading_desc">Vlastní obrázek zobrazený při připojování auta</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -771,4 +771,24 @@
     <string name="support_github_account_warning">Poznámka: k vytvoření hlášení potřebujete bezplatný účet na GitHubu.</string>
     <string name="onb_ready_extras_title">Než dokončíte, můžete také nastavit:</string>
     <string name="onb_extra_loading_desc">Vlastní obrázek zobrazený při připojování auta</string>
+
+    <!-- Support / reporting rules -->
+    <string name="support_rules_button">Pravidla hlášení</string>
+    <string name="support_rules_english_desc">Prosím, pište vždy v angličtině. Správce a většina lidí, kteří zde pomáhají, čtou anglicky, a vlákno, kde se mísí více jazyků, se rychle proměňuje v malou babylonskou věž, kde si nikdo nerozumí. Angličtina vám nejde? Překladač jako Google Translate nebo DeepL je naprosto v pořádku.</string>
+    <string name="support_rules_device_title">Řekněte, na čem aplikaci spouštíte</string>
+    <string name="support_rules_device_desc">Verze Androidu zařízení, které promítá Android Auto (vaše autorádio nebo obrazovka), a jeho značka a model, pokud je znáte.</string>
+    <string name="support_rules_connection_title">Řekněte, jak se připojujete</string>
+    <string name="support_rules_connection_desc">USB kabel, bezdrátový USB adaptér, WiFi Direct, WiFi (headunit server) nebo Self Mode. Pokud jde o bezdrátové připojení, uveďte model adaptéru nebo donglu.</string>
+    <string name="support_rules_appversion_title">Uveďte verzi aplikace</string>
+    <string name="support_rules_appversion_desc">Verzi Headunit Revived najdete na obrazovce O aplikaci a podpora.</string>
+    <string name="support_rules_logs_title">Přiložte protokoly, hned po tom, co se to stane</string>
+    <string name="support_rules_logs_desc">V Nastavení přejděte na záložku Pokročilé, v sekci Ladění zapněte Režim ladění, zopakujte problém a hned poté klepněte na Exportovat protokoly, aby protokol zachytil okamžik selhání, a ne jen start. Přiložte tento soubor k hlášení.</string>
+    <string name="support_rules_search_title">Nejprve hledejte</string>
+    <string name="support_rules_search_desc">Váš problém už možná byl nahlášen. Prohledejte existující hlášení a přispějte do stávajícího místo vytváření duplikátu.</string>
+    <string name="support_rules_phone_title">Záleží i na vašem telefonu</string>
+    <string name="support_rules_phone_desc">Model vašeho telefonu, jeho verze Androidu a verze aplikace Android Auto v telefonu. Některé problémy jsou způsobeny konkrétní verzí Android Auto.</string>
+    <string name="support_rules_describe_title">Popište to jasně</string>
+    <string name="support_rules_describe_desc">Co jste udělali, co jste očekávali a co se skutečně stalo. Screenshot nebo krátké video velmi pomáhá u vizuálních problémů.</string>
+    <string name="support_rules_oneissue_title">Jeden problém na jedno hlášení</string>
+    <string name="support_rules_oneissue_desc">Každé hlášení nechte pro jediný problém, aby bylo možné ho sledovat a opravit. Pro nesouvisející problémy otevřete samostatná hlášení.</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -762,11 +762,11 @@
     <string name="onb_ready_loading_intro">Ještě jedna věc: nyní můžete nastavit vlastní načítací obrazovku, která se zobrazí při připojování auta.</string>
     <string name="onb_ready_loading_button">Nastavit načítací obrazovku</string>
 
-    <string name="support">Nahlásit problém</string>
-    <string name="support_description">Hledat nebo nahlašovat chyby na GitHubu</string>
-    <string name="support_title">Nahlásit problém</string>
-    <string name="support_help">Pokud narazíte na chybu nebo problém, nejprve ho vyhledejte v seznamu problémů na GitHubu. Pokud ho ještě nikdo nenahlásil, otevřete nový problém a popište, co se děje, vaši hlavní jednotku a kroky k reprodukci.</string>
-    <string name="support_open_issues">Otevřít stránku problémů na GitHubu</string>
-    <string name="support_scan_qr">Nebo naskenujte tento QR kód pro otevření seznamu problémů na jiném zařízení.</string>
-    <string name="support_github_account_warning">Poznámka: pro vytvoření problému potřebujete bezplatný účet GitHub.</string>
+    <string name="support">Nahlásit chybu</string>
+    <string name="support_description">Hledejte nebo nahlašujte chyby na GitHubu</string>
+    <string name="support_title">Nahlásit chybu</string>
+    <string name="support_help">Pokud narazíte na chybu nebo problém, nejprve ho vyhledejte v seznamu hlášení na GitHubu. Pokud ho ještě nikdo nenahlásil, vytvořte nové hlášení a popište, co se stalo, vaše autorádio a postup, jak chybu zopakovat.</string>
+    <string name="support_open_issues">Otevřít hlášení na GitHubu</string>
+    <string name="support_scan_qr">Nebo naskenujte tento QR kód a otevřete seznam hlášení na jiném zařízení.</string>
+    <string name="support_github_account_warning">Poznámka: k vytvoření hlášení potřebujete bezplatný účet na GitHubu.</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -761,4 +761,12 @@
     <string name="onb_dpi_recommended">Doporučeno pro vaši obrazovku: %1$d dpi</string>
     <string name="onb_ready_loading_intro">Ještě jedna věc: nyní můžete nastavit vlastní načítací obrazovku, která se zobrazí při připojování auta.</string>
     <string name="onb_ready_loading_button">Nastavit načítací obrazovku</string>
+
+    <string name="support">Nahlásit problém</string>
+    <string name="support_description">Hledat nebo nahlašovat chyby na GitHubu</string>
+    <string name="support_title">Nahlásit problém</string>
+    <string name="support_help">Pokud narazíte na chybu nebo problém, nejprve ho vyhledejte v seznamu problémů na GitHubu. Pokud ho ještě nikdo nenahlásil, otevřete nový problém a popište, co se děje, vaši hlavní jednotku a kroky k reprodukci.</string>
+    <string name="support_open_issues">Otevřít stránku problémů na GitHubu</string>
+    <string name="support_scan_qr">Nebo naskenujte tento QR kód pro otevření seznamu problémů na jiném zařízení.</string>
+    <string name="support_github_account_warning">Poznámka: pro vytvoření problému potřebujete bezplatný účet GitHub.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -780,7 +780,7 @@
 
     <!-- Support / issue reporting rules -->
     <string name="support_rules_button">Melderegeln</string>
-    <string name="support_rules_english_desc">Bitte schreibe dein Problem immer auf Englisch. Der Maintainer und die meisten Helfer hier lesen Englisch, und ein Thread in vielen verschiedenen Sprachen wird schnell zum kleinen Babylonischen Sprachgewirr, bei dem niemand den anderen versteht. Kein gutes Englisch? Ein Übersetzer wie Google Translate oder DeepL ist völlig in Ordnung.</string>
+    <string name="support_rules_english_desc">Bitte schreibe dein Problem immer auf Englisch. Es ist die einzige Sprache, die der Maintainer und die meisten Helfer hier teilen, und ein Thread in vielen Sprachen wird schnell zum kleinen Turm zu Babel, bei dem niemand niemandem helfen kann. Niemand bewertet dich, dein Englisch oder wie du schreibst, also mach dir keine Sorgen wegen Fehlern. Wenn es hilft, kann ein Übersetzer wie Google Translate oder DeepL, oder eine KI wie ChatGPT oder Claude, deine Nachricht auf Englisch formulieren und aufpolieren.</string>
     <string name="support_rules_device_title">Sag, was die App ausführt</string>
     <string name="support_rules_device_desc">Die Android-Version des Geräts, das Android Auto projiziert (dein Autoradio oder Bildschirm), sowie Marke und Modell, falls bekannt.</string>
     <string name="support_rules_connection_title">Sag, wie du dich verbindest</string>
@@ -789,12 +789,15 @@
     <string name="support_rules_appversion_desc">Die Headunit Revived Version, die auf dem Bildschirm „Über Headunit Revived" angezeigt wird.</string>
     <string name="support_rules_logs_title">Logs anhängen, direkt nach dem Problem</string>
     <string name="support_rules_logs_desc">Wechsle in den Einstellungen zum Tab „Erweitert", aktiviere im Abschnitt „Debug" den Debug Modus, reproduziere das Problem und tippe danach sofort auf „Logs exportieren", damit das Log den Moment des Fehlers und nicht nur den Start enthält. Hänge diese Datei an dein Issue an.</string>
-    <string name="support_rules_search_title">Zuerst suchen</string>
-    <string name="support_rules_search_desc">Dein Problem wurde vielleicht schon gemeldet. Durchsuche die vorhandenen Issues und ergänze dort, anstatt ein Duplikat zu öffnen.</string>
+    <string name="support_rules_search_title">Keine Duplikate</string>
+    <string name="support_rules_search_desc">Durchsuche zuerst die vorhandenen Issues. Wenn ein offenes Issue dein Problem bereits beschreibt, füge deine Details dort als Kommentar hinzu, anstatt ein neues zu öffnen. Öffne nur dann ein neues Issue, wenn keines passt.</string>
     <string name="support_rules_phone_title">Dein Handy ist auch wichtig</string>
     <string name="support_rules_phone_desc">Dein Handymodell, seine Android-Version und die Android Auto App-Version auf dem Handy. Manche Probleme kommen von einem bestimmten Android Auto-Release.</string>
     <string name="support_rules_describe_title">Klar beschreiben</string>
     <string name="support_rules_describe_desc">Was du gemacht hast, was du erwartet hast und was tatsächlich passiert ist. Ein Screenshot oder ein kurzes Video hilft bei visuellen Problemen sehr.</string>
     <string name="support_rules_oneissue_title">Ein Problem pro Issue</string>
     <string name="support_rules_oneissue_desc">Halte jedes Issue auf ein einzelnes Problem beschränkt, damit es verfolgt und behoben werden kann. Öffne separate Issues für unzusammenhängende Probleme.</string>
+    <string name="support_rules_intro">Nur zwei Dinge sind erforderlich. Alles andere ist optional, hilft aber dabei, dein Problem viel schneller zu lösen.</string>
+    <string name="support_rules_section_required">Erforderlich</string>
+    <string name="support_rules_section_recommend">Empfehlungen (optional)</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -767,4 +767,12 @@
     <string name="onb_dpi_recommended">Empfohlen für Ihren Bildschirm: %1$d dpi</string>
     <string name="onb_ready_loading_intro">Noch eine Sache: Sie können jetzt einen benutzerdefinierten Ladebildschirm festlegen, der angezeigt wird, während das Auto eine Verbindung herstellt.</string>
     <string name="onb_ready_loading_button">Ladebildschirm einrichten</string>
+
+    <string name="support">Problem melden</string>
+    <string name="support_description">Fehler auf GitHub suchen oder melden</string>
+    <string name="support_title">Problem melden</string>
+    <string name="support_help">Wenn Sie auf einen Fehler oder ein Problem stoßen, suchen Sie bitte zuerst in der GitHub-Problemliste danach. Falls es noch niemand gemeldet hat, öffnen Sie ein neues Issue und beschreiben Sie, was passiert, Ihr Autoradio und die Schritte zur Reproduktion.</string>
+    <string name="support_open_issues">GitHub-Problemseite öffnen</string>
+    <string name="support_scan_qr">Oder scannen Sie diesen QR-Code, um die Problemliste auf einem anderen Gerät zu öffnen.</string>
+    <string name="support_github_account_warning">Hinweis: Sie benötigen ein kostenloses GitHub-Konto, um ein Issue zu erstellen.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -775,4 +775,6 @@
     <string name="support_open_issues">GitHub-Problemseite öffnen</string>
     <string name="support_scan_qr">Oder scannen Sie diesen QR-Code, um die Problemliste auf einem anderen Gerät zu öffnen.</string>
     <string name="support_github_account_warning">Hinweis: Sie benötigen ein kostenloses GitHub-Konto, um ein Issue zu erstellen.</string>
+    <string name="onb_ready_extras_title">Bevor Sie fertig sind, können Sie auch einrichten:</string>
+    <string name="onb_extra_loading_desc">Ein benutzerdefiniertes Bild, das während der Verbindung des Fahrzeugs angezeigt wird</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -777,4 +777,24 @@
     <string name="support_github_account_warning">Hinweis: Sie benötigen ein kostenloses GitHub-Konto, um ein Issue zu erstellen.</string>
     <string name="onb_ready_extras_title">Bevor Sie fertig sind, können Sie auch einrichten:</string>
     <string name="onb_extra_loading_desc">Ein benutzerdefiniertes Bild, das während der Verbindung des Fahrzeugs angezeigt wird</string>
+
+    <!-- Support / issue reporting rules -->
+    <string name="support_rules_button">Melderegeln</string>
+    <string name="support_rules_english_desc">Bitte schreibe dein Problem immer auf Englisch. Der Maintainer und die meisten Helfer hier lesen Englisch, und ein Thread in vielen verschiedenen Sprachen wird schnell zum kleinen Babylonischen Sprachgewirr, bei dem niemand den anderen versteht. Kein gutes Englisch? Ein Übersetzer wie Google Translate oder DeepL ist völlig in Ordnung.</string>
+    <string name="support_rules_device_title">Sag, was die App ausführt</string>
+    <string name="support_rules_device_desc">Die Android-Version des Geräts, das Android Auto projiziert (dein Autoradio oder Bildschirm), sowie Marke und Modell, falls bekannt.</string>
+    <string name="support_rules_connection_title">Sag, wie du dich verbindest</string>
+    <string name="support_rules_connection_desc">USB-Kabel, kabelloser USB-Adapter, WiFi Direct, WiFi (Headunit-Server) oder Self Mode. Bei kabelloser Verbindung bitte das Adapter- oder Dongle-Modell angeben.</string>
+    <string name="support_rules_appversion_title">App-Version angeben</string>
+    <string name="support_rules_appversion_desc">Die Headunit Revived Version, die auf dem Bildschirm „Über Headunit Revived" angezeigt wird.</string>
+    <string name="support_rules_logs_title">Logs anhängen, direkt nach dem Problem</string>
+    <string name="support_rules_logs_desc">Wechsle in den Einstellungen zum Tab „Erweitert", aktiviere im Abschnitt „Debug" den Debug Modus, reproduziere das Problem und tippe danach sofort auf „Logs exportieren", damit das Log den Moment des Fehlers und nicht nur den Start enthält. Hänge diese Datei an dein Issue an.</string>
+    <string name="support_rules_search_title">Zuerst suchen</string>
+    <string name="support_rules_search_desc">Dein Problem wurde vielleicht schon gemeldet. Durchsuche die vorhandenen Issues und ergänze dort, anstatt ein Duplikat zu öffnen.</string>
+    <string name="support_rules_phone_title">Dein Handy ist auch wichtig</string>
+    <string name="support_rules_phone_desc">Dein Handymodell, seine Android-Version und die Android Auto App-Version auf dem Handy. Manche Probleme kommen von einem bestimmten Android Auto-Release.</string>
+    <string name="support_rules_describe_title">Klar beschreiben</string>
+    <string name="support_rules_describe_desc">Was du gemacht hast, was du erwartet hast und was tatsächlich passiert ist. Ein Screenshot oder ein kurzes Video hilft bei visuellen Problemen sehr.</string>
+    <string name="support_rules_oneissue_title">Ein Problem pro Issue</string>
+    <string name="support_rules_oneissue_desc">Halte jedes Issue auf ein einzelnes Problem beschränkt, damit es verfolgt und behoben werden kann. Öffne separate Issues für unzusammenhängende Probleme.</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -784,7 +784,7 @@
 
     <!-- Support rules -->
     <string name="support_rules_button">Normas para reportar</string>
-    <string name="support_rules_english_desc">Por favor, escribe siempre tu incidencia en inglés. El mantenedor y la mayoría de personas que ayudan aquí leen inglés, y un hilo que mezcla muchos idiomas se convierte rápidamente en una pequeña torre de Babel donde nadie entiende a nadie. ¿No te sientes seguro con el inglés? Un traductor como Google Translate o DeepL va perfectamente.</string>
+    <string name="support_rules_english_desc">Por favor, escribe siempre tu incidencia en inglés. Es el idioma que el mantenedor y la mayoría de las personas que ayudan aquí tienen en común, y un hilo con muchos idiomas se convierte rápidamente en una pequeña torre de Babel donde nadie puede ayudar a nadie. Nadie te juzga por tu nivel de inglés ni por cómo escribes, así que no te preocupes por los errores. Si te ayuda, un traductor como Google Translate o DeepL, o una IA como ChatGPT o Claude, puede escribir y ordenar tu mensaje en inglés por ti.</string>
     <string name="support_rules_device_title">Di qué ejecuta la app</string>
     <string name="support_rules_device_desc">La versión de Android del dispositivo que proyecta Android Auto (tu radio o pantalla), y la marca y el modelo si los conoces.</string>
     <string name="support_rules_connection_title">Di cómo te conectas</string>
@@ -793,12 +793,15 @@
     <string name="support_rules_appversion_desc">La versión de Headunit Revived, que aparece en la pantalla Acerca de.</string>
     <string name="support_rules_logs_title">Adjunta los registros justo cuando ocurra</string>
     <string name="support_rules_logs_desc">Ve a Ajustes, abre la pestaña Avanzado, activa el Modo depuración en la sección Depuración, reproduce el problema y toca Exportar registros enseguida para que el registro cubra el momento del fallo y no solo el arranque. Adjunta ese archivo a tu incidencia.</string>
-    <string name="support_rules_search_title">Busca primero</string>
-    <string name="support_rules_search_desc">Es posible que tu problema ya esté reportado. Busca en las incidencias existentes y añade un comentario en esa en lugar de abrir un duplicado.</string>
+    <string name="support_rules_search_title">Sin duplicados</string>
+    <string name="support_rules_search_desc">Busca primero entre las incidencias existentes. Si ya hay una abierta que describe tu problema, añade tus detalles como comentario en vez de abrir una nueva. Solo abre una incidencia nueva si ninguna coincide.</string>
     <string name="support_rules_phone_title">Tu móvil también importa</string>
     <string name="support_rules_phone_desc">El modelo de tu móvil, su versión de Android y la versión de la app Android Auto instalada en el móvil. Algunos problemas vienen de una versión concreta de Android Auto.</string>
     <string name="support_rules_describe_title">Descríbelo con claridad</string>
     <string name="support_rules_describe_desc">Qué hiciste, qué esperabas que pasara y qué pasó realmente. Una captura de pantalla o un vídeo corto ayuda mucho en problemas visuales.</string>
     <string name="support_rules_oneissue_title">Un problema por incidencia</string>
     <string name="support_rules_oneissue_desc">Limita cada incidencia a un solo problema para poder rastrearlo y resolverlo. Abre incidencias separadas para problemas distintos.</string>
+    <string name="support_rules_intro">Solo se requieren dos cosas. Todo lo demás es opcional, aunque ayuda a resolver tu problema mucho más rápido.</string>
+    <string name="support_rules_section_required">Obligatorio</string>
+    <string name="support_rules_section_recommend">Recomendaciones (opcional)</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -770,4 +770,13 @@
     <string name="onb_dpi_recommended">Recomendado para tu pantalla: %1$d dpi</string>
     <string name="onb_ready_loading_intro">Una cosa más: ahora puedes configurar una pantalla de carga personalizada, que se muestra mientras el coche se conecta.</string>
     <string name="onb_ready_loading_button">Configurar una pantalla de carga</string>
+
+    <!-- Support / bug reporting -->
+    <string name="support">Informar de un problema</string>
+    <string name="support_description">Buscar o informar errores en GitHub</string>
+    <string name="support_title">Informar de un problema</string>
+    <string name="support_help">Si encuentras un error o un problema, busca primero si alguien lo ha reportado en la lista de issues de GitHub. Si nadie lo ha reportado aún, abre un nuevo issue y describe qué ocurre, tu radio y los pasos para reproducirlo.</string>
+    <string name="support_open_issues">Abrir la página de issues de GitHub</string>
+    <string name="support_scan_qr">O escanea este código QR para abrir la lista de issues en otro dispositivo.</string>
+    <string name="support_github_account_warning">Nota: necesitas una cuenta gratuita de GitHub para crear un issue.</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -779,4 +779,6 @@
     <string name="support_open_issues">Abrir la página de issues de GitHub</string>
     <string name="support_scan_qr">O escanea este código QR para abrir la lista de issues en otro dispositivo.</string>
     <string name="support_github_account_warning">Nota: necesitas una cuenta gratuita de GitHub para crear un issue.</string>
+    <string name="onb_ready_extras_title">Antes de terminar, también puedes configurar:</string>
+    <string name="onb_extra_loading_desc">Una imagen personalizada que se muestra mientras el coche se conecta</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -781,4 +781,24 @@
     <string name="support_github_account_warning">Nota: necesitas una cuenta gratuita de GitHub para crear un issue.</string>
     <string name="onb_ready_extras_title">Antes de terminar, también puedes configurar:</string>
     <string name="onb_extra_loading_desc">Una imagen personalizada que se muestra mientras el coche se conecta</string>
+
+    <!-- Support rules -->
+    <string name="support_rules_button">Normas para reportar</string>
+    <string name="support_rules_english_desc">Por favor, escribe siempre tu incidencia en inglés. El mantenedor y la mayoría de personas que ayudan aquí leen inglés, y un hilo que mezcla muchos idiomas se convierte rápidamente en una pequeña torre de Babel donde nadie entiende a nadie. ¿No te sientes seguro con el inglés? Un traductor como Google Translate o DeepL va perfectamente.</string>
+    <string name="support_rules_device_title">Di qué ejecuta la app</string>
+    <string name="support_rules_device_desc">La versión de Android del dispositivo que proyecta Android Auto (tu radio o pantalla), y la marca y el modelo si los conoces.</string>
+    <string name="support_rules_connection_title">Di cómo te conectas</string>
+    <string name="support_rules_connection_desc">Cable USB, adaptador inalámbrico USB, WiFi Direct, WiFi (headunit server) o Self Mode. Si es inalámbrico, añade el modelo del adaptador o dongle.</string>
+    <string name="support_rules_appversion_title">Incluye la versión de la app</string>
+    <string name="support_rules_appversion_desc">La versión de Headunit Revived, que aparece en la pantalla Acerca de.</string>
+    <string name="support_rules_logs_title">Adjunta los registros justo cuando ocurra</string>
+    <string name="support_rules_logs_desc">Ve a Ajustes, abre la pestaña Avanzado, activa el Modo depuración en la sección Depuración, reproduce el problema y toca Exportar registros enseguida para que el registro cubra el momento del fallo y no solo el arranque. Adjunta ese archivo a tu incidencia.</string>
+    <string name="support_rules_search_title">Busca primero</string>
+    <string name="support_rules_search_desc">Es posible que tu problema ya esté reportado. Busca en las incidencias existentes y añade un comentario en esa en lugar de abrir un duplicado.</string>
+    <string name="support_rules_phone_title">Tu móvil también importa</string>
+    <string name="support_rules_phone_desc">El modelo de tu móvil, su versión de Android y la versión de la app Android Auto instalada en el móvil. Algunos problemas vienen de una versión concreta de Android Auto.</string>
+    <string name="support_rules_describe_title">Descríbelo con claridad</string>
+    <string name="support_rules_describe_desc">Qué hiciste, qué esperabas que pasara y qué pasó realmente. Una captura de pantalla o un vídeo corto ayuda mucho en problemas visuales.</string>
+    <string name="support_rules_oneissue_title">Un problema por incidencia</string>
+    <string name="support_rules_oneissue_desc">Limita cada incidencia a un solo problema para poder rastrearlo y resolverlo. Abre incidencias separadas para problemas distintos.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -771,4 +771,11 @@
     <string name="onb_dpi_recommended">Recomendado para tu pantalla: %1$d dpi</string>
     <string name="onb_ready_loading_intro">Una cosa más: ahora puedes establecer una pantalla de carga personalizada, que se muestra mientras el auto se conecta.</string>
     <string name="onb_ready_loading_button">Configurar una pantalla de carga</string>
+    <string name="support">Reportar un problema</string>
+    <string name="support_description">Busca o reporta errores en GitHub</string>
+    <string name="support_title">Reportar un problema</string>
+    <string name="support_help">Si encuentras un error o un problema, por favor búscalo primero en la lista de issues de GitHub. Si nadie lo ha reportado aún, abre un nuevo issue y describe qué ocurre, tu unidad de cabeza, y los pasos para reproducirlo.</string>
+    <string name="support_open_issues">Abrir la página de issues de GitHub</string>
+    <string name="support_scan_qr">O escanea este código QR para abrir la lista de issues en otro dispositivo.</string>
+    <string name="support_github_account_warning">Nota: necesitas una cuenta gratuita de GitHub para crear un issue.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -780,4 +780,24 @@
     <string name="support_github_account_warning">Nota: necesitas una cuenta gratuita de GitHub para crear un issue.</string>
     <string name="onb_ready_extras_title">Antes de terminar, también puedes configurar:</string>
     <string name="onb_extra_loading_desc">Una imagen personalizada que se muestra mientras el auto se conecta</string>
+
+    <!-- Support rules -->
+    <string name="support_rules_button">Reglas para reportar</string>
+    <string name="support_rules_english_desc">Por favor, escribe siempre tu reporte en inglés. El mantenedor y la mayoría de quienes ayudan aquí leen inglés, y un hilo que mezcla varios idiomas se convierte rápidamente en una torre de Babel donde nadie entiende a nadie. ¿No te sientes seguro con el inglés? Un traductor como Google Translate o DeepL está perfectamente bien.</string>
+    <string name="support_rules_device_title">Di qué ejecuta la app</string>
+    <string name="support_rules_device_desc">La versión de Android del dispositivo que proyecta Android Auto (tu radio o pantalla), y su marca y modelo si los conoces.</string>
+    <string name="support_rules_connection_title">Di cómo te conectas</string>
+    <string name="support_rules_connection_desc">Cable USB, adaptador inalámbrico USB, WiFi Direct, WiFi (headunit server) o Self Mode. Si es inalámbrico, agrega el modelo del adaptador o dongle.</string>
+    <string name="support_rules_appversion_title">Incluye la versión de la app</string>
+    <string name="support_rules_appversion_desc">La versión de Headunit Revived, que se muestra en la pantalla de Acerca de.</string>
+    <string name="support_rules_logs_title">Adjunta registros, justo después de que ocurra</string>
+    <string name="support_rules_logs_desc">Ve a Ajustes, abre la pestaña Avanzado, activa el Modo de depuración en la sección Depuración, reproduce el problema y luego toca Exportar registros de inmediato para que el registro cubra el momento exacto del fallo y no solo el inicio. Adjunta ese archivo a tu reporte.</string>
+    <string name="support_rules_search_title">Busca primero</string>
+    <string name="support_rules_search_desc">Es posible que tu problema ya haya sido reportado. Busca en los issues existentes y añade tu comentario ahí en lugar de abrir un duplicado.</string>
+    <string name="support_rules_phone_title">Tu teléfono también importa</string>
+    <string name="support_rules_phone_desc">El modelo de tu teléfono, su versión de Android y la versión de la app Android Auto en el teléfono. Algunos problemas vienen de una versión específica de Android Auto.</string>
+    <string name="support_rules_describe_title">Descríbelo claramente</string>
+    <string name="support_rules_describe_desc">Qué hiciste, qué esperabas y qué pasó en realidad. Una captura de pantalla o un video corto ayuda mucho para problemas visuales.</string>
+    <string name="support_rules_oneissue_title">Un problema por issue</string>
+    <string name="support_rules_oneissue_desc">Mantén cada issue enfocado en un solo problema para que pueda rastrearse y corregirse. Abre issues separados para problemas distintos.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -778,4 +778,6 @@
     <string name="support_open_issues">Abrir la página de issues de GitHub</string>
     <string name="support_scan_qr">O escanea este código QR para abrir la lista de issues en otro dispositivo.</string>
     <string name="support_github_account_warning">Nota: necesitas una cuenta gratuita de GitHub para crear un issue.</string>
+    <string name="onb_ready_extras_title">Antes de terminar, también puedes configurar:</string>
+    <string name="onb_extra_loading_desc">Una imagen personalizada que se muestra mientras el auto se conecta</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -783,7 +783,7 @@
 
     <!-- Support rules -->
     <string name="support_rules_button">Reglas para reportar</string>
-    <string name="support_rules_english_desc">Por favor, escribe siempre tu reporte en inglés. El mantenedor y la mayoría de quienes ayudan aquí leen inglés, y un hilo que mezcla varios idiomas se convierte rápidamente en una torre de Babel donde nadie entiende a nadie. ¿No te sientes seguro con el inglés? Un traductor como Google Translate o DeepL está perfectamente bien.</string>
+    <string name="support_rules_english_desc">Por favor, escribe siempre tu reporte en inglés. Es el único idioma que el mantenedor y la mayoría de quienes ayudan aquí tienen en común, y un hilo en varios idiomas se convierte rápidamente en una torre de Babel donde nadie puede ayudar a nadie. Nadie te juzga, ni tu nivel de inglés ni cómo escribes, así que no te preocupes por los errores. Si te ayuda, un traductor como Google Translate o DeepL, o una IA como ChatGPT o Claude, puede escribir y ordenar tu mensaje en inglés por ti.</string>
     <string name="support_rules_device_title">Di qué ejecuta la app</string>
     <string name="support_rules_device_desc">La versión de Android del dispositivo que proyecta Android Auto (tu radio o pantalla), y su marca y modelo si los conoces.</string>
     <string name="support_rules_connection_title">Di cómo te conectas</string>
@@ -792,12 +792,15 @@
     <string name="support_rules_appversion_desc">La versión de Headunit Revived, que se muestra en la pantalla de Acerca de.</string>
     <string name="support_rules_logs_title">Adjunta registros, justo después de que ocurra</string>
     <string name="support_rules_logs_desc">Ve a Ajustes, abre la pestaña Avanzado, activa el Modo de depuración en la sección Depuración, reproduce el problema y luego toca Exportar registros de inmediato para que el registro cubra el momento exacto del fallo y no solo el inicio. Adjunta ese archivo a tu reporte.</string>
-    <string name="support_rules_search_title">Busca primero</string>
-    <string name="support_rules_search_desc">Es posible que tu problema ya haya sido reportado. Busca en los issues existentes y añade tu comentario ahí en lugar de abrir un duplicado.</string>
+    <string name="support_rules_search_title">Sin duplicados</string>
+    <string name="support_rules_search_desc">Busca primero en los issues existentes. Si ya hay uno abierto que describe tu problema, añade ahí tus detalles como comentario en lugar de abrir uno nuevo. Solo abre un issue nuevo si ninguno coincide.</string>
     <string name="support_rules_phone_title">Tu teléfono también importa</string>
     <string name="support_rules_phone_desc">El modelo de tu teléfono, su versión de Android y la versión de la app Android Auto en el teléfono. Algunos problemas vienen de una versión específica de Android Auto.</string>
     <string name="support_rules_describe_title">Descríbelo claramente</string>
     <string name="support_rules_describe_desc">Qué hiciste, qué esperabas y qué pasó en realidad. Una captura de pantalla o un video corto ayuda mucho para problemas visuales.</string>
     <string name="support_rules_oneissue_title">Un problema por issue</string>
     <string name="support_rules_oneissue_desc">Mantén cada issue enfocado en un solo problema para que pueda rastrearse y corregirse. Abre issues separados para problemas distintos.</string>
+    <string name="support_rules_intro">Solo se necesitan dos cosas. Todo lo demás es opcional, pero ayuda a resolver tu problema mucho más rápido.</string>
+    <string name="support_rules_section_required">Requerido</string>
+    <string name="support_rules_section_recommend">Recomendaciones (opcional)</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -774,7 +774,7 @@
     <string name="support">Reportar un problema</string>
     <string name="support_description">Busca o reporta errores en GitHub</string>
     <string name="support_title">Reportar un problema</string>
-    <string name="support_help">Si encuentras un error o un problema, por favor búscalo primero en la lista de issues de GitHub. Si nadie lo ha reportado aún, abre un nuevo issue y describe qué ocurre, tu unidad de cabeza, y los pasos para reproducirlo.</string>
+    <string name="support_help">Si encuentras un error o un problema, búscalo primero en la lista de issues de GitHub. Si nadie lo ha reportado aún, abre un nuevo issue y describe qué ocurre, tu radio y los pasos para reproducirlo.</string>
     <string name="support_open_issues">Abrir la página de issues de GitHub</string>
     <string name="support_scan_qr">O escanea este código QR para abrir la lista de issues en otro dispositivo.</string>
     <string name="support_github_account_warning">Nota: necesitas una cuenta gratuita de GitHub para crear un issue.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -740,4 +740,6 @@
     <string name="support_open_issues">GitHub hibajelentések megnyitása</string>
     <string name="support_scan_qr">Vagy olvasd be ezt a QR-kódot, ha egy másik eszközön szeretnéd megnyitni a hibajelentések listáját.</string>
     <string name="support_github_account_warning">Megjegyzés: hibajegy létrehozásához ingyenes GitHub-fiókra van szükség.</string>
+    <string name="onb_ready_extras_title">Mielőtt befejeznéd, ezeket is beállíthatod:</string>
+    <string name="onb_extra_loading_desc">Egyéni kép, amely az autó csatlakozása közben jelenik meg</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -732,4 +732,12 @@
     <string name="onb_vehicle_help_advanced">További járműadatokat a Speciális lapon állíthatsz be. Ezeket az adatokat nem használjuk; csak azért küldjük az Android Autónak, mert megköveteli.</string>
     <string name="onb_summary_vehicle_format">Jármű: %1$s</string>
     <string name="sunrise_reference_help">A napkelte és napnyugta kiszámításához használt referenciapont. Válassza ki egyszer a helyét; GPS nélkül is működik.</string>
+
+    <string name="support">Probléma bejelentése</string>
+    <string name="support_description">Hibák keresése vagy bejelentése GitHub-on</string>
+    <string name="support_title">Probléma bejelentése</string>
+    <string name="support_help">Ha hibát vagy problémát tapasztalsz, kérjük, először keresd meg a GitHub hibalistájában. Ha még senki nem jelentette, nyiss egy új hibajegyet, és írd le, mi történt, milyen fejegységet használsz, és hogyan lehet reprodukálni a problémát.</string>
+    <string name="support_open_issues">GitHub hibák listájának megnyitása</string>
+    <string name="support_scan_qr">Vagy szkenneld be ezt a QR-kódot a hibák listájának egy másik eszközön való megnyitásához.</string>
+    <string name="support_github_account_warning">Megjegyzés: egy ingyenes GitHub fiókra van szükséged hibajegy létrehozásához.</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -734,10 +734,10 @@
     <string name="sunrise_reference_help">A napkelte és napnyugta kiszámításához használt referenciapont. Válassza ki egyszer a helyét; GPS nélkül is működik.</string>
 
     <string name="support">Probléma bejelentése</string>
-    <string name="support_description">Hibák keresése vagy bejelentése GitHub-on</string>
+    <string name="support_description">Keress vagy jelents hibákat GitHub-on</string>
     <string name="support_title">Probléma bejelentése</string>
-    <string name="support_help">Ha hibát vagy problémát tapasztalsz, kérjük, először keresd meg a GitHub hibalistájában. Ha még senki nem jelentette, nyiss egy új hibajegyet, és írd le, mi történt, milyen fejegységet használsz, és hogyan lehet reprodukálni a problémát.</string>
-    <string name="support_open_issues">GitHub hibák listájának megnyitása</string>
-    <string name="support_scan_qr">Vagy szkenneld be ezt a QR-kódot a hibák listájának egy másik eszközön való megnyitásához.</string>
-    <string name="support_github_account_warning">Megjegyzés: egy ingyenes GitHub fiókra van szükséged hibajegy létrehozásához.</string>
+    <string name="support_help">Ha hibát vagy problémát tapasztalsz, először keresd meg a GitHub-os hibajelentések között. Ha még senki nem jelentette, nyiss egy új hibajegyet, és írd le, mi történt, milyen fejegységet használsz, és hogyan lehet reprodukálni a hibát.</string>
+    <string name="support_open_issues">GitHub hibajelentések megnyitása</string>
+    <string name="support_scan_qr">Vagy olvasd be ezt a QR-kódot, ha egy másik eszközön szeretnéd megnyitni a hibajelentések listáját.</string>
+    <string name="support_github_account_warning">Megjegyzés: hibajegy létrehozásához ingyenes GitHub-fiókra van szükség.</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -745,7 +745,10 @@
 
     <!-- Support / issue reporting rules -->
     <string name="support_rules_button">Hibajelentési szabályok</string>
-    <string name="support_rules_english_desc">Kérjük, mindig angolul írd le a problémádat. A karbantartó és a legtöbb segítő angolul olvas, egy vegyes nyelvű szál pedig hamar olyan Bábel tornyává válik, ahol senki sem érti a másikat. Nem megy biztosan az angol? Egy fordítóprogram, mint a Google Translate vagy a DeepL, teljesen megfelel.</string>
+    <string name="support_rules_intro">Csak két dolog kötelező. Minden más nem szükséges, de sokat segít a probléma gyorsabb megoldásában.</string>
+    <string name="support_rules_section_required">Kötelező</string>
+    <string name="support_rules_section_recommend">Javaslatok (nem kötelező)</string>
+    <string name="support_rules_english_desc">Kérjük, mindig angolul írd le a problémádat. Ez az egyetlen nyelv, amelyet a karbantartó és a legtöbb segítő közösen ért, és egy sok nyelvű szál hamar olyan Bábel tornyává válik, ahol senki sem tud senkinek segíteni. Senki sem ítél meg az angolod szintje vagy az írásod módja miatt, szóval ne aggódj a hibák miatt. Ha segít, egy fordítóprogram, mint a Google Translate vagy a DeepL, vagy egy mesterséges intelligencia, mint a ChatGPT vagy a Claude, megírja és rendbe teszi az üzeneted angolul.</string>
     <string name="support_rules_device_title">Mondd el, min fut az alkalmazás</string>
     <string name="support_rules_device_desc">Az Android Auto-t megjelenítő eszköz (a fejegységed vagy a képernyőd) Android-verziója, és ha tudod, a gyártója és modellje.</string>
     <string name="support_rules_connection_title">Mondd el, hogyan csatlakozol</string>
@@ -754,8 +757,8 @@
     <string name="support_rules_appversion_desc">A Headunit Revived verziószámát a Rólunk képernyőn találod.</string>
     <string name="support_rules_logs_title">Csatold a naplókat, rögtön a hiba után</string>
     <string name="support_rules_logs_desc">Menj a Beállítások Speciális fülére, kapcsold be a Hibakeresési módot a Hibakeresés részben, idézd elő a problémát, majd közvetlenül utána koppints a Naplók exportálása gombra, hogy a napló tartalmazza a hibás pillanatot, ne csak az indítást. Ezt a fájlt csatold a hibajegyedhez.</string>
-    <string name="support_rules_search_title">Előbb keress</string>
-    <string name="support_rules_search_desc">Lehet, hogy a hibát már valaki bejelentette. Keresd meg a meglévő hibajegyek között, és inkább ahhoz szólj hozzá, ne nyiss másolatot.</string>
+    <string name="support_rules_search_title">Nincs kettőzés</string>
+    <string name="support_rules_search_desc">Először keresd meg a meglévő hibajegyeket. Ha egy nyitott hibajegy már leírja a problémádat, inkább ahhoz fűzz hozzászólást, ne nyiss újat. Csak akkor nyiss új hibajegyet, ha egyik sem egyezik.</string>
     <string name="support_rules_phone_title">A telefonod is számít</string>
     <string name="support_rules_phone_desc">A telefon modellje, Android-verziója és az Android Auto alkalmazás verziója a telefonon. Néhány hiba egy adott Android Auto kiadáshoz köthető.</string>
     <string name="support_rules_describe_title">Írd le érthetően</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -742,4 +742,24 @@
     <string name="support_github_account_warning">Megjegyzés: hibajegy létrehozásához ingyenes GitHub-fiókra van szükség.</string>
     <string name="onb_ready_extras_title">Mielőtt befejeznéd, ezeket is beállíthatod:</string>
     <string name="onb_extra_loading_desc">Egyéni kép, amely az autó csatlakozása közben jelenik meg</string>
+
+    <!-- Support / issue reporting rules -->
+    <string name="support_rules_button">Hibajelentési szabályok</string>
+    <string name="support_rules_english_desc">Kérjük, mindig angolul írd le a problémádat. A karbantartó és a legtöbb segítő angolul olvas, egy vegyes nyelvű szál pedig hamar olyan Bábel tornyává válik, ahol senki sem érti a másikat. Nem megy biztosan az angol? Egy fordítóprogram, mint a Google Translate vagy a DeepL, teljesen megfelel.</string>
+    <string name="support_rules_device_title">Mondd el, min fut az alkalmazás</string>
+    <string name="support_rules_device_desc">Az Android Auto-t megjelenítő eszköz (a fejegységed vagy a képernyőd) Android-verziója, és ha tudod, a gyártója és modellje.</string>
+    <string name="support_rules_connection_title">Mondd el, hogyan csatlakozol</string>
+    <string name="support_rules_connection_desc">USB-kábellel, USB-s vezeték nélküli adapterrel, WiFi Direct-tel, WiFi-n (fejegység szerver) vagy Self Mode-ban. Ha vezeték nélküli, add meg az adapter vagy dongle modelljét is.</string>
+    <string name="support_rules_appversion_title">Add meg az alkalmazás verzióját</string>
+    <string name="support_rules_appversion_desc">A Headunit Revived verziószámát a Rólunk képernyőn találod.</string>
+    <string name="support_rules_logs_title">Csatold a naplókat, rögtön a hiba után</string>
+    <string name="support_rules_logs_desc">Menj a Beállítások Speciális fülére, kapcsold be a Hibakeresési módot a Hibakeresés részben, idézd elő a problémát, majd közvetlenül utána koppints a Naplók exportálása gombra, hogy a napló tartalmazza a hibás pillanatot, ne csak az indítást. Ezt a fájlt csatold a hibajegyedhez.</string>
+    <string name="support_rules_search_title">Előbb keress</string>
+    <string name="support_rules_search_desc">Lehet, hogy a hibát már valaki bejelentette. Keresd meg a meglévő hibajegyek között, és inkább ahhoz szólj hozzá, ne nyiss másolatot.</string>
+    <string name="support_rules_phone_title">A telefonod is számít</string>
+    <string name="support_rules_phone_desc">A telefon modellje, Android-verziója és az Android Auto alkalmazás verziója a telefonon. Néhány hiba egy adott Android Auto kiadáshoz köthető.</string>
+    <string name="support_rules_describe_title">Írd le érthetően</string>
+    <string name="support_rules_describe_desc">Mit csináltál, mit vártál, és mi történt valójában. Vizuális problémáknál egy képernyőfotó vagy rövid videó sokat segít.</string>
+    <string name="support_rules_oneissue_title">Egy hibajegy, egy probléma</string>
+    <string name="support_rules_oneissue_desc">Minden hibajegy egyetlen problémáról szóljon, hogy könnyen nyomon követhető és javítható legyen. Egymással össze nem függő problémákhoz nyiss külön hibajegyeket.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -749,4 +749,24 @@
     <string name="support_github_account_warning">Nota: è necessario un account GitHub gratuito per creare una segnalazione.</string>
     <string name="onb_ready_extras_title">Prima di finire, puoi anche configurare:</string>
     <string name="onb_extra_loading_desc">Un\'immagine personalizzata mostrata mentre l\'auto si connette</string>
+
+    <!-- Support rules -->
+    <string name="support_rules_button">Regole per le segnalazioni</string>
+    <string name="support_rules_english_desc">Scrivi sempre in inglese. Il maintainer e la maggior parte di chi aiuta legge l\'inglese, e un thread con tante lingue diventa in fretta una piccola torre di Babele in cui nessuno capisce nessuno. Non te la cavi con l\'inglese? Un traduttore come Google Translate o DeepL va benissimo.</string>
+    <string name="support_rules_device_title">Di\' cosa fa girare l\'app</string>
+    <string name="support_rules_device_desc">La versione Android del dispositivo che proietta Android Auto (la tua autoradio o schermo), e la marca e il modello se li conosci.</string>
+    <string name="support_rules_connection_title">Di\' come ti connetti</string>
+    <string name="support_rules_connection_desc">Cavo USB, adattatore wireless USB, WiFi Direct, WiFi (headunit server) o Self Mode. Se è wireless, aggiungi il modello dell\'adattatore o dongle.</string>
+    <string name="support_rules_appversion_title">Includi la versione dell\'app</string>
+    <string name="support_rules_appversion_desc">La versione di Headunit Revived, mostrata nella schermata Informazioni e Supporto.</string>
+    <string name="support_rules_logs_title">Allega i log, subito dopo che accade</string>
+    <string name="support_rules_logs_desc">Vai nella scheda Avanzate delle Impostazioni, attiva la Modalità Debug nella sezione Debug, riproduci il problema, poi tocca Esporta Log subito dopo, in modo che il log copra il momento in cui si è rotto e non solo l\'avvio. Allega quel file alla segnalazione.</string>
+    <string name="support_rules_search_title">Cerca prima</string>
+    <string name="support_rules_search_desc">Il tuo problema potrebbe essere già stato segnalato. Cerca tra le segnalazioni esistenti e aggiungi lì il tuo commento invece di aprire un duplicato.</string>
+    <string name="support_rules_phone_title">Anche il tuo telefono conta</string>
+    <string name="support_rules_phone_desc">Il modello del tuo telefono, la versione Android e la versione dell\'app Android Auto sul telefono. Alcuni problemi vengono da una versione specifica di Android Auto.</string>
+    <string name="support_rules_describe_title">Descrivi chiaramente</string>
+    <string name="support_rules_describe_desc">Cosa hai fatto, cosa ti aspettavi e cosa è successo davvero. Uno screenshot o un breve video aiuta molto per i problemi visivi.</string>
+    <string name="support_rules_oneissue_title">Un problema per segnalazione</string>
+    <string name="support_rules_oneissue_desc">Tieni ogni segnalazione a un singolo problema, così è più facile tracciarlo e risolverlo. Apri segnalazioni separate per problemi non correlati.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -752,7 +752,7 @@
 
     <!-- Support rules -->
     <string name="support_rules_button">Regole per le segnalazioni</string>
-    <string name="support_rules_english_desc">Scrivi sempre in inglese. Il maintainer e la maggior parte di chi aiuta legge l\'inglese, e un thread con tante lingue diventa in fretta una piccola torre di Babele in cui nessuno capisce nessuno. Non te la cavi con l\'inglese? Un traduttore come Google Translate o DeepL va benissimo.</string>
+    <string name="support_rules_english_desc">Scrivi sempre la segnalazione in inglese. È la lingua che il maintainer e la maggior parte di chi aiuta qui ha in comune, e un thread in molte lingue diventa rapidamente una piccola torre di Babele in cui nessuno riesce ad aiutare nessuno. Nessuno ti giudica per il tuo livello di inglese o per come scrivi, quindi non preoccuparti degli errori. Se può aiutare, un traduttore come Google Translate o DeepL, oppure un\'AI come ChatGPT o Claude, può scrivere e sistemare il tuo messaggio in inglese al posto tuo.</string>
     <string name="support_rules_device_title">Di\' cosa fa girare l\'app</string>
     <string name="support_rules_device_desc">La versione Android del dispositivo che proietta Android Auto (la tua autoradio o schermo), e la marca e il modello se li conosci.</string>
     <string name="support_rules_connection_title">Di\' come ti connetti</string>
@@ -761,12 +761,15 @@
     <string name="support_rules_appversion_desc">La versione di Headunit Revived, mostrata nella schermata Informazioni e Supporto.</string>
     <string name="support_rules_logs_title">Allega i log, subito dopo che accade</string>
     <string name="support_rules_logs_desc">Vai nella scheda Avanzate delle Impostazioni, attiva la Modalità Debug nella sezione Debug, riproduci il problema, poi tocca Esporta Log subito dopo, in modo che il log copra il momento in cui si è rotto e non solo l\'avvio. Allega quel file alla segnalazione.</string>
-    <string name="support_rules_search_title">Cerca prima</string>
-    <string name="support_rules_search_desc">Il tuo problema potrebbe essere già stato segnalato. Cerca tra le segnalazioni esistenti e aggiungi lì il tuo commento invece di aprire un duplicato.</string>
+    <string name="support_rules_search_title">Nessun duplicato</string>
+    <string name="support_rules_search_desc">Cerca prima tra le segnalazioni esistenti. Se ce n\'è già una aperta che descrive il tuo problema, aggiungi lì i tuoi dettagli come commento invece di aprirne una nuova. Apri una nuova segnalazione solo se non ne esiste nessuna corrispondente.</string>
     <string name="support_rules_phone_title">Anche il tuo telefono conta</string>
     <string name="support_rules_phone_desc">Il modello del tuo telefono, la versione Android e la versione dell\'app Android Auto sul telefono. Alcuni problemi vengono da una versione specifica di Android Auto.</string>
     <string name="support_rules_describe_title">Descrivi chiaramente</string>
     <string name="support_rules_describe_desc">Cosa hai fatto, cosa ti aspettavi e cosa è successo davvero. Uno screenshot o un breve video aiuta molto per i problemi visivi.</string>
     <string name="support_rules_oneissue_title">Un problema per segnalazione</string>
     <string name="support_rules_oneissue_desc">Tieni ogni segnalazione a un singolo problema, così è più facile tracciarlo e risolverlo. Apri segnalazioni separate per problemi non correlati.</string>
+    <string name="support_rules_intro">Sono richieste solo due cose. Tutto il resto è facoltativo, ma aiuta a risolvere il problema molto più in fretta.</string>
+    <string name="support_rules_section_required">Obbligatorio</string>
+    <string name="support_rules_section_recommend">Consigli (facoltativi)</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -747,4 +747,6 @@
     <string name="support_open_issues">Apri la pagina delle segnalazioni su GitHub</string>
     <string name="support_scan_qr">Oppure scansiona questo codice QR per aprire la lista delle segnalazioni su un altro dispositivo.</string>
     <string name="support_github_account_warning">Nota: è necessario un account GitHub gratuito per creare una segnalazione.</string>
+    <string name="onb_ready_extras_title">Prima di finire, puoi anche configurare:</string>
+    <string name="onb_extra_loading_desc">Un\'immagine personalizzata mostrata mentre l\'auto si connette</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -743,7 +743,7 @@
     <string name="support">Segnala un problema</string>
     <string name="support_description">Cerca o segnala bug su GitHub</string>
     <string name="support_title">Segnala un problema</string>
-    <string name="support_help">Se riscontri un bug o un problema, cerca prima nella lista delle segnalazioni su GitHub. Se nessuno lo ha ancora riportato, apri una nuova segnalazione e descrivi cosa succede, la tua unità di bordo e i passaggi per riprodurlo.</string>
+    <string name="support_help">Se riscontri un bug o un problema, cerca prima nella lista delle segnalazioni su GitHub. Se nessuno lo ha ancora riportato, apri una nuova segnalazione e descrivi cosa succede, la tua autoradio e i passaggi per riprodurlo.</string>
     <string name="support_open_issues">Apri la pagina delle segnalazioni su GitHub</string>
     <string name="support_scan_qr">Oppure scansiona questo codice QR per aprire la lista delle segnalazioni su un altro dispositivo.</string>
     <string name="support_github_account_warning">Nota: è necessario un account GitHub gratuito per creare una segnalazione.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -740,4 +740,11 @@
     <string name="onb_vehicle_help_advanced">Puoi regolare altri dettagli del veicolo nella scheda Avanzate. Non usiamo questi dati; vengono inviati solo ad Android Auto perché li richiede.</string>
     <string name="onb_summary_vehicle_format">Veicolo: %1$s</string>
     <string name="sunrise_reference_help">Il punto di riferimento usato per calcolare l\'alba e il tramonto. Scegli la tua posizione una volta; funziona senza GPS.</string>
+    <string name="support">Segnala un problema</string>
+    <string name="support_description">Cerca o segnala bug su GitHub</string>
+    <string name="support_title">Segnala un problema</string>
+    <string name="support_help">Se riscontri un bug o un problema, cerca prima nella lista delle segnalazioni su GitHub. Se nessuno lo ha ancora riportato, apri una nuova segnalazione e descrivi cosa succede, la tua unità di bordo e i passaggi per riprodurlo.</string>
+    <string name="support_open_issues">Apri la pagina delle segnalazioni su GitHub</string>
+    <string name="support_scan_qr">Oppure scansiona questo codice QR per aprire la lista delle segnalazioni su un altro dispositivo.</string>
+    <string name="support_github_account_warning">Nota: è necessario un account GitHub gratuito per creare una segnalazione.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -753,7 +753,10 @@
 
     <!-- Support rules -->
     <string name="support_rules_button">報告のルール</string>
-    <string name="support_rules_english_desc">issueは必ず英語で書いてください。メンテナーやサポートしてくれる方々は英語を読んでいます。多言語が混在するスレッドはバベルの塔のようになり、誰も理解できなくなります。英語に自信がなければ、Google TranslateやDeepLなどの翻訳ツールを使っても大丈夫です。</string>
+    <string name="support_rules_intro">必須項目は2つだけです。それ以外は任意ですが、あると問題をより早く解決できます。</string>
+    <string name="support_rules_section_required">必須</string>
+    <string name="support_rules_section_recommend">推奨（任意）</string>
+    <string name="support_rules_english_desc">issueは必ず英語で書いてください。メンテナーとほとんどのサポートメンバーが共有できる言語は英語だけです。多言語が混在するスレッドはバベルの塔のようになり、誰も助けられなくなります。英語のレベルや文章の書き方は誰も気にしません。安心して書いてください。Google TranslateやDeepL、あるいはChatGPTやClaudeのようなAIが、英語で文章を書いたり整えたりするのを手伝ってくれます。</string>
     <string name="support_rules_device_title">アプリを動かしているデバイスを書いてください</string>
     <string name="support_rules_device_desc">Android Autoを投影しているデバイス（車載機または画面）のAndroidバージョンと、分かればブランドおよびモデル名。</string>
     <string name="support_rules_connection_title">接続方法を書いてください</string>
@@ -762,8 +765,8 @@
     <string name="support_rules_appversion_desc">Headunit Revivedのバージョンは、アプリとサポート画面に表示されています。</string>
     <string name="support_rules_logs_title">発生直後にログを添付してください</string>
     <string name="support_rules_logs_desc">設定の「詳細」タブを開き、「デバッグ」セクションで「デバッグモード」をオンにして問題を再現した後、すぐに「ログをエクスポート」をタップしてください。問題が発生した瞬間を含むログが取得できます。そのファイルをissueに添付してください。</string>
-    <string name="support_rules_search_title">先に検索してください</string>
-    <string name="support_rules_search_desc">同じ問題がすでに報告されているかもしれません。既存のissueを検索し、重複を開く代わりにそのissueにコメントを追加してください。</string>
+    <string name="support_rules_search_title">重複なし</string>
+    <string name="support_rules_search_desc">まず既存のissueを検索してください。同じ問題がすでに報告されていれば、新しいissueを作らずにそのissueにコメントを追加してください。一致するものがない場合にのみ、新しいissueを作成してください。</string>
     <string name="support_rules_phone_title">スマートフォンの情報も重要です</string>
     <string name="support_rules_phone_desc">スマートフォンのモデル、Androidバージョン、およびスマートフォン上のAndroid Autoアプリのバージョン。特定のAndroid Autoリリースに起因する問題もあります。</string>
     <string name="support_rules_describe_title">問題を明確に説明してください</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -742,10 +742,10 @@
     <string name="sunrise_reference_help">日の出と日の入りを計算するための基準点です。場所を一度選択すれば、GPS なしで機能します。</string>
 
     <string name="support">問題を報告する</string>
-    <string name="support_description">GitHubでバグを検索または報告する</string>
+    <string name="support_description">GitHubでバグを検索・報告する</string>
     <string name="support_title">問題を報告する</string>
-    <string name="support_help">バグや問題が発生した場合は、まずGitHubのissueリストで検索してください。まだ誰も報告していない場合は、新しいissueを作成し、発生した内容、お使いの車載機、再現手順を記載してください。</string>
+    <string name="support_help">バグや不具合が発生した場合は、まずGitHubのissueリストで同様の報告がないか確認してください。まだ誰も報告していない場合は、新しいissueを作成し、症状・お使いの車載機・再現手順を詳しく記載してください。</string>
     <string name="support_open_issues">GitHubのissueページを開く</string>
-    <string name="support_scan_qr">または、このQRコードをスキャンして別のデバイスでissueリストを開いてください。</string>
-    <string name="support_github_account_warning">注意：issueを作成するには、無料のGitHubアカウントが必要です。</string>
+    <string name="support_scan_qr">このQRコードをスキャンして、別のデバイスでissueリストを開くこともできます。</string>
+    <string name="support_github_account_warning">ご注意：issueを作成するには、無料のGitHubアカウントが必要です。</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -750,4 +750,24 @@
     <string name="support_github_account_warning">ご注意：issueを作成するには、無料のGitHubアカウントが必要です。</string>
     <string name="onb_ready_extras_title">完了する前に、以下もセットアップできます：</string>
     <string name="onb_extra_loading_desc">車が接続中に表示されるカスタム画像</string>
+
+    <!-- Support rules -->
+    <string name="support_rules_button">報告のルール</string>
+    <string name="support_rules_english_desc">issueは必ず英語で書いてください。メンテナーやサポートしてくれる方々は英語を読んでいます。多言語が混在するスレッドはバベルの塔のようになり、誰も理解できなくなります。英語に自信がなければ、Google TranslateやDeepLなどの翻訳ツールを使っても大丈夫です。</string>
+    <string name="support_rules_device_title">アプリを動かしているデバイスを書いてください</string>
+    <string name="support_rules_device_desc">Android Autoを投影しているデバイス（車載機または画面）のAndroidバージョンと、分かればブランドおよびモデル名。</string>
+    <string name="support_rules_connection_title">接続方法を書いてください</string>
+    <string name="support_rules_connection_desc">USBケーブル、USBワイヤレスアダプター、WiFi Direct、WiFi（headunit server）、またはSelf Mode。ワイヤレスの場合はアダプターやドングルのモデルも書いてください。</string>
+    <string name="support_rules_appversion_title">アプリのバージョンを記載してください</string>
+    <string name="support_rules_appversion_desc">Headunit Revivedのバージョンは、アプリとサポート画面に表示されています。</string>
+    <string name="support_rules_logs_title">発生直後にログを添付してください</string>
+    <string name="support_rules_logs_desc">設定の「詳細」タブを開き、「デバッグ」セクションで「デバッグモード」をオンにして問題を再現した後、すぐに「ログをエクスポート」をタップしてください。問題が発生した瞬間を含むログが取得できます。そのファイルをissueに添付してください。</string>
+    <string name="support_rules_search_title">先に検索してください</string>
+    <string name="support_rules_search_desc">同じ問題がすでに報告されているかもしれません。既存のissueを検索し、重複を開く代わりにそのissueにコメントを追加してください。</string>
+    <string name="support_rules_phone_title">スマートフォンの情報も重要です</string>
+    <string name="support_rules_phone_desc">スマートフォンのモデル、Androidバージョン、およびスマートフォン上のAndroid Autoアプリのバージョン。特定のAndroid Autoリリースに起因する問題もあります。</string>
+    <string name="support_rules_describe_title">問題を明確に説明してください</string>
+    <string name="support_rules_describe_desc">何をしたか、何を期待していたか、実際に何が起きたかを書いてください。見た目の問題はスクリーンショットや短い動画があると非常に助かります。</string>
+    <string name="support_rules_oneissue_title">1件のissueにつき1つの問題</string>
+    <string name="support_rules_oneissue_desc">追跡・修正しやすくするために、issueは1件につき1つの問題に絞ってください。関係のない問題は別のissueを作成してください。</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -740,4 +740,12 @@
     <string name="onb_vehicle_help_advanced">車両の詳細は詳細設定タブで調整できます。このデータは当方では使用せず、Android Auto が必要とするため送信するだけです。</string>
     <string name="onb_summary_vehicle_format">車両: %1$s</string>
     <string name="sunrise_reference_help">日の出と日の入りを計算するための基準点です。場所を一度選択すれば、GPS なしで機能します。</string>
+
+    <string name="support">問題を報告する</string>
+    <string name="support_description">GitHubでバグを検索または報告する</string>
+    <string name="support_title">問題を報告する</string>
+    <string name="support_help">バグや問題が発生した場合は、まずGitHubのissueリストで検索してください。まだ誰も報告していない場合は、新しいissueを作成し、発生した内容、お使いの車載機、再現手順を記載してください。</string>
+    <string name="support_open_issues">GitHubのissueページを開く</string>
+    <string name="support_scan_qr">または、このQRコードをスキャンして別のデバイスでissueリストを開いてください。</string>
+    <string name="support_github_account_warning">注意：issueを作成するには、無料のGitHubアカウントが必要です。</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -748,4 +748,6 @@
     <string name="support_open_issues">GitHubのissueページを開く</string>
     <string name="support_scan_qr">このQRコードをスキャンして、別のデバイスでissueリストを開くこともできます。</string>
     <string name="support_github_account_warning">ご注意：issueを作成するには、無料のGitHubアカウントが必要です。</string>
+    <string name="onb_ready_extras_title">完了する前に、以下もセットアップできます：</string>
+    <string name="onb_extra_loading_desc">車が接続中に表示されるカスタム画像</string>
 </resources>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -665,4 +665,12 @@
     <string name="onb_vehicle_help_aa">ეს სახელი იგზავნება Android Auto-ში. ის ჩანს ტელეფონის კავშირების ისტორიაში და Android Auto-ს მისალმების ეკრანზე.</string>
     <string name="onb_vehicle_help_advanced">მანქანის დამატებითი დეტალები შეგიძლიათ დააკონფიგუროთ ჩანართში დამატებითი. ჩვენ არ ვიყენებთ ამ მონაცემებს; ისინი იგზავნება მხოლოდ Android Auto-ში, რადგან ის ამას მოითხოვს.</string>
     <string name="onb_summary_vehicle_format">მანქანა: %1$s</string>
+
+    <string name="support">პრობლემის შეტყობინება</string>
+    <string name="support_description">GitHub-ზე ხარვეზების ძებნა ან შეტყობინება</string>
+    <string name="support_title">პრობლემის შეტყობინება</string>
+    <string name="support_help">თუ წააწყდებით ხარვეზს ან პრობლემას, გთხოვთ, ჯერ მოძებნოთ იგი GitHub-ის პრობლემების სიაში. თუ არავის შეუტყობინებია, გახსენით ახალი საკითხი და აღწერეთ რა ხდება, თქვენი მონიტორი და პრობლემის გამეორების ნაბიჯები.</string>
+    <string name="support_open_issues">GitHub-ის პრობლემების გვერდის გახსნა</string>
+    <string name="support_scan_qr">ან დაასკანირეთ ეს QR კოდი სხვა მოწყობილობაზე პრობლემების სიის გასახსნელად.</string>
+    <string name="support_github_account_warning">შენიშვნა: საკითხის შესაქმნელად საჭიროა უფასო GitHub ანგარიში.</string>
 </resources>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -673,4 +673,6 @@
     <string name="support_open_issues">GitHub-ის საკითხების გვერდის გახსნა</string>
     <string name="support_scan_qr">ან დაასკანირეთ ეს QR კოდი, რათა გახსნათ საკითხების სია სხვა მოწყობილობაზე.</string>
     <string name="support_github_account_warning">შენიშვნა: საკითხის შესაქმნელად საჭიროა უფასო GitHub ანგარიში.</string>
+    <string name="onb_ready_extras_title">დასრულებამდე შეგიძლიათ ასევე გამართოთ:</string>
+    <string name="onb_extra_loading_desc">სახეობრივი სურათი, რომელიც ჩანს მანქანის დაკავშირების დროს</string>
 </resources>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -677,7 +677,7 @@
     <string name="onb_extra_loading_desc">სახეობრივი სურათი, რომელიც ჩანს მანქანის დაკავშირების დროს</string>
 
     <string name="support_rules_button">შეტყობინების წესები</string>
-    <string name="support_rules_english_desc">გთხოვთ, პრობლემა ყოველთვის ინგლისურად აღწეროთ. პროექტის შემქმნელი და დამხმარეთა უმეტესობა ინგლისურს კითხულობს, ხოლო ნაირენოვანი ძაფი სწრაფად გადაიქცევა ბაბილონის გოდოლად, სადაც ვერავინ ვერავის ვერ ხვდება. ინგლისური ენა თავს ცოტა ეუხერხულება? Google Translate ან DeepL სრულიად გამოდგება.</string>
+    <string name="support_rules_english_desc">გთხოვთ, პრობლემა ყოველთვის ინგლისურად აღწეროთ. ეს ის ერთი ენაა, რომელსაც პროექტის შემქმნელი და აქ მომხმარეთა უმეტესობა იზიარებს, ხოლო ნაირენოვანი ძაფი სწრაფად გადაიქცევა ბაბილონის გოდოლად, სადაც ვერავინ ვერ ეხმარება ვერავის. არავინ გასამართლებთ — არც თქვენს ინგლისურს, არც ჩაწერის სტილს, ამიტომ ნუ ინერვიულებთ შეცდომებზე. თუ გამოგადგებათ, მთარგმნელი, Google Translate ან DeepL, ან ხელოვნური ინტელექტი, ChatGPT ან Claude, დაგეხმარებათ ინგლისურად გამართულად ჩამოაყალიბოთ გზავნილი.</string>
     <string name="support_rules_device_title">აღწერეთ, რომელ მოწყობილობაზე მუშაობს აპი</string>
     <string name="support_rules_device_desc">Android Auto-ს გამომჩენი მოწყობილობის (თქვენი მონიტორის ან ეკრანის) Android ვერსია, ასევე მწარმოებელი და მოდელი, თუ იცით.</string>
     <string name="support_rules_connection_title">მიუთითეთ, როგორ უკავშირდებით</string>
@@ -686,12 +686,15 @@
     <string name="support_rules_appversion_desc">Headunit Revived-ის ვერსია, რომელიც ნაჩვენებია შესახებ ეკრანზე.</string>
     <string name="support_rules_logs_title">მიამაგრეთ ლოგი — პრობლემის შემდეგ დაუყოვნებლივ</string>
     <string name="support_rules_logs_desc">გახსენით პარამეტრები, გადადით დამატებითი ჩანართზე, ჩართეთ გამართვის რეჟიმი გამართვა განყოფილებაში, გაიმეორეთ პრობლემა, შემდეგ დაუყოვნებლივ შეეხეთ ლოგების ექსპორტი, რათა ლოგი მოიცავდეს შეცდომის მომენტს და არა მხოლოდ გაშვებას. მიამაგრეთ ეს ფაილი საკითხს.</string>
-    <string name="support_rules_search_title">ჯერ მოძებნეთ</string>
-    <string name="support_rules_search_desc">შესაძლოა, თქვენი პრობლემა უკვე შეტყობინებულია. მოძებნეთ არსებულ საკითხებში და დაამატეთ კომენტარი იქ, ახლის გახსნის ნაცვლად.</string>
+    <string name="support_rules_search_title">დუბლიკატები არ გახსნათ</string>
+    <string name="support_rules_search_desc">ჯერ მოძებნეთ არსებულ საკითხებში. თუ ღია საკითხი უკვე აღწერს თქვენს პრობლემას, კომენტარი დაამატეთ იქ ახლის გახსნის ნაცვლად. ახალი გახსენით მხოლოდ იმ შემთხვევაში, თუ არც ერთი არ ემთხვევა.</string>
     <string name="support_rules_phone_title">ტელეფონიც მნიშვნელოვანია</string>
     <string name="support_rules_phone_desc">თქვენი ტელეფონის მოდელი, მისი Android ვერსია და ტელეფონზე დაყენებული Android Auto-ს ვერსია. ზოგიერთი პრობლემა კონკრეტული Android Auto-ს გამოშვებით არის გამოწვეული.</string>
     <string name="support_rules_describe_title">ნათლად აღწერეთ პრობლემა</string>
     <string name="support_rules_describe_desc">რა გააკეთეთ, რას ელოდეთ და რეალურად რა მოხდა. ეკრანის სურათი ან მოკლე ვიდეო ძალიან გვეხმარება ვიზუალური პრობლემებისთვის.</string>
     <string name="support_rules_oneissue_title">ერთი საკითხი — ერთი პრობლემა</string>
     <string name="support_rules_oneissue_desc">ყოველ საკითხს ერთი პრობლემა ეძღვნება, რათა მისი თვალყურის დევნება და გამოსწორება მარტივი იყოს. დაუკავშირებელი პრობლემებისთვის გახსენით ცალკე საკითხები.</string>
+    <string name="support_rules_intro">მხოლოდ ორი რამ არის სავალდებულო. ყველა დანარჩენი სურვილისამებრ, მაგრამ ეს ძალიან აჩქარებს პრობლემის გადაჭრას.</string>
+    <string name="support_rules_section_required">სავალდებულო</string>
+    <string name="support_rules_section_recommend">რეკომენდაციები (სურვილისამებრ)</string>
 </resources>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -669,8 +669,8 @@
     <string name="support">პრობლემის შეტყობინება</string>
     <string name="support_description">GitHub-ზე ხარვეზების ძებნა ან შეტყობინება</string>
     <string name="support_title">პრობლემის შეტყობინება</string>
-    <string name="support_help">თუ წააწყდებით ხარვეზს ან პრობლემას, გთხოვთ, ჯერ მოძებნოთ იგი GitHub-ის პრობლემების სიაში. თუ არავის შეუტყობინებია, გახსენით ახალი საკითხი და აღწერეთ რა ხდება, თქვენი მონიტორი და პრობლემის გამეორების ნაბიჯები.</string>
-    <string name="support_open_issues">GitHub-ის პრობლემების გვერდის გახსნა</string>
-    <string name="support_scan_qr">ან დაასკანირეთ ეს QR კოდი სხვა მოწყობილობაზე პრობლემების სიის გასახსნელად.</string>
+    <string name="support_help">თუ წაიქეცით ხარვეზში ან პრობლემაში, გთხოვთ, ჯერ მოძებნოთ იგი GitHub-ის საკითხების სიაში. თუ ჯერ არავის შეუტყობინებია ამის შესახებ, გახსენით ახალი საკითხი და აღწერეთ: რა ხდება, რა მონიტორი გაქვთ და როგორ შეიძლება პრობლემის გამეორება.</string>
+    <string name="support_open_issues">GitHub-ის საკითხების გვერდის გახსნა</string>
+    <string name="support_scan_qr">ან დაასკანირეთ ეს QR კოდი, რათა გახსნათ საკითხების სია სხვა მოწყობილობაზე.</string>
     <string name="support_github_account_warning">შენიშვნა: საკითხის შესაქმნელად საჭიროა უფასო GitHub ანგარიში.</string>
 </resources>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -675,4 +675,23 @@
     <string name="support_github_account_warning">შენიშვნა: საკითხის შესაქმნელად საჭიროა უფასო GitHub ანგარიში.</string>
     <string name="onb_ready_extras_title">დასრულებამდე შეგიძლიათ ასევე გამართოთ:</string>
     <string name="onb_extra_loading_desc">სახეობრივი სურათი, რომელიც ჩანს მანქანის დაკავშირების დროს</string>
+
+    <string name="support_rules_button">შეტყობინების წესები</string>
+    <string name="support_rules_english_desc">გთხოვთ, პრობლემა ყოველთვის ინგლისურად აღწეროთ. პროექტის შემქმნელი და დამხმარეთა უმეტესობა ინგლისურს კითხულობს, ხოლო ნაირენოვანი ძაფი სწრაფად გადაიქცევა ბაბილონის გოდოლად, სადაც ვერავინ ვერავის ვერ ხვდება. ინგლისური ენა თავს ცოტა ეუხერხულება? Google Translate ან DeepL სრულიად გამოდგება.</string>
+    <string name="support_rules_device_title">აღწერეთ, რომელ მოწყობილობაზე მუშაობს აპი</string>
+    <string name="support_rules_device_desc">Android Auto-ს გამომჩენი მოწყობილობის (თქვენი მონიტორის ან ეკრანის) Android ვერსია, ასევე მწარმოებელი და მოდელი, თუ იცით.</string>
+    <string name="support_rules_connection_title">მიუთითეთ, როგორ უკავშირდებით</string>
+    <string name="support_rules_connection_desc">USB კაბელი, USB უსადენო ადაპტერი, WiFi Direct, WiFi (headunit server) ან Self Mode. თუ კავშირი უსადენოა, დაამატეთ ადაპტერის ან დონგლის მოდელი.</string>
+    <string name="support_rules_appversion_title">მიუთითეთ აპის ვერსია</string>
+    <string name="support_rules_appversion_desc">Headunit Revived-ის ვერსია, რომელიც ნაჩვენებია შესახებ ეკრანზე.</string>
+    <string name="support_rules_logs_title">მიამაგრეთ ლოგი — პრობლემის შემდეგ დაუყოვნებლივ</string>
+    <string name="support_rules_logs_desc">გახსენით პარამეტრები, გადადით დამატებითი ჩანართზე, ჩართეთ გამართვის რეჟიმი გამართვა განყოფილებაში, გაიმეორეთ პრობლემა, შემდეგ დაუყოვნებლივ შეეხეთ ლოგების ექსპორტი, რათა ლოგი მოიცავდეს შეცდომის მომენტს და არა მხოლოდ გაშვებას. მიამაგრეთ ეს ფაილი საკითხს.</string>
+    <string name="support_rules_search_title">ჯერ მოძებნეთ</string>
+    <string name="support_rules_search_desc">შესაძლოა, თქვენი პრობლემა უკვე შეტყობინებულია. მოძებნეთ არსებულ საკითხებში და დაამატეთ კომენტარი იქ, ახლის გახსნის ნაცვლად.</string>
+    <string name="support_rules_phone_title">ტელეფონიც მნიშვნელოვანია</string>
+    <string name="support_rules_phone_desc">თქვენი ტელეფონის მოდელი, მისი Android ვერსია და ტელეფონზე დაყენებული Android Auto-ს ვერსია. ზოგიერთი პრობლემა კონკრეტული Android Auto-ს გამოშვებით არის გამოწვეული.</string>
+    <string name="support_rules_describe_title">ნათლად აღწერეთ პრობლემა</string>
+    <string name="support_rules_describe_desc">რა გააკეთეთ, რას ელოდეთ და რეალურად რა მოხდა. ეკრანის სურათი ან მოკლე ვიდეო ძალიან გვეხმარება ვიზუალური პრობლემებისთვის.</string>
+    <string name="support_rules_oneissue_title">ერთი საკითხი — ერთი პრობლემა</string>
+    <string name="support_rules_oneissue_desc">ყოველ საკითხს ერთი პრობლემა ეძღვნება, რათა მისი თვალყურის დევნება და გამოსწორება მარტივი იყოს. დაუკავშირებელი პრობლემებისთვის გახსენით ცალკე საკითხები.</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -737,4 +737,11 @@
     <string name="onb_vehicle_help_advanced">고급 탭에서 차량 세부정보를 더 조정할 수 있습니다. 이 데이터는 저희가 사용하지 않으며, Android Auto가 요구하므로 전송만 합니다.</string>
     <string name="onb_summary_vehicle_format">차량: %1$s</string>
     <string name="sunrise_reference_help">일출과 일몰을 계산하는 데 사용되는 기준점입니다. 위치를 한 번만 선택하면 GPS 없이도 작동합니다.</string>
+    <string name="support">문제 신고</string>
+    <string name="support_description">GitHub에서 버그를 검색하거나 신고하세요</string>
+    <string name="support_title">문제 신고</string>
+    <string name="support_help">버그나 문제가 발생하면 먼저 GitHub 이슈 목록에서 해당 문제를 검색하세요. 아직 신고된 내용이 없다면 새 이슈를 열어 발생한 상황, 사용 중인 헤드유닛, 재현 단계를 설명해 주세요.</string>
+    <string name="support_open_issues">GitHub 이슈 페이지 열기</string>
+    <string name="support_scan_qr">또는 이 QR 코드를 스캔하면 다른 기기에서 이슈 목록을 열 수 있습니다.</string>
+    <string name="support_github_account_warning">참고: 이슈를 등록하려면 무료 GitHub 계정이 필요합니다.</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -740,8 +740,8 @@
     <string name="support">문제 신고</string>
     <string name="support_description">GitHub에서 버그를 검색하거나 신고하세요</string>
     <string name="support_title">문제 신고</string>
-    <string name="support_help">버그나 문제가 발생하면 먼저 GitHub 이슈 목록에서 해당 문제를 검색하세요. 아직 신고된 내용이 없다면 새 이슈를 열어 발생한 상황, 사용 중인 헤드유닛, 재현 단계를 설명해 주세요.</string>
+    <string name="support_help">버그나 문제가 발생하면 먼저 GitHub 이슈 목록에서 검색해 보세요. 아직 신고된 내용이 없다면 새 이슈를 열어 발생한 상황, 사용 중인 헤드유닛 기종, 재현 방법을 구체적으로 설명해 주세요.</string>
     <string name="support_open_issues">GitHub 이슈 페이지 열기</string>
-    <string name="support_scan_qr">또는 이 QR 코드를 스캔하면 다른 기기에서 이슈 목록을 열 수 있습니다.</string>
-    <string name="support_github_account_warning">참고: 이슈를 등록하려면 무료 GitHub 계정이 필요합니다.</string>
+    <string name="support_scan_qr">또는 이 QR 코드를 스캔하여 다른 기기에서 이슈 목록을 여세요.</string>
+    <string name="support_github_account_warning">참고: 이슈를 작성하려면 무료 GitHub 계정이 필요합니다.</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -746,4 +746,24 @@
     <string name="support_github_account_warning">참고: 이슈를 작성하려면 무료 GitHub 계정이 필요합니다.</string>
     <string name="onb_ready_extras_title">마무리하기 전에 추가로 설정할 수 있습니다:</string>
     <string name="onb_extra_loading_desc">차량 연결 중에 표시되는 사용자 지정 이미지</string>
+
+    <!-- Support / issue reporting rules -->
+    <string name="support_rules_button">신고 규칙</string>
+    <string name="support_rules_english_desc">이슈는 항상 영어로 작성해 주세요. 메인테이너와 도움을 주는 분들 대부분이 영어를 사용하며, 여러 언어가 섞인 스레드는 누구도 이해하기 어려운 바벨탑이 되어버립니다. 영어가 자신 없으시다면 Google Translate나 DeepL 같은 번역기를 충분히 활용하셔도 됩니다.</string>
+    <string name="support_rules_device_title">앱을 실행하는 기기를 알려주세요</string>
+    <string name="support_rules_device_desc">Android Auto를 투영하는 기기(헤드유닛 또는 화면)의 Android 버전과, 알고 계신다면 브랜드와 모델도 함께 알려주세요.</string>
+    <string name="support_rules_connection_title">연결 방식을 알려주세요</string>
+    <string name="support_rules_connection_desc">USB 케이블, USB 무선 어댑터, WiFi Direct, WiFi(헤드유닛 서버) 또는 Self Mode 중 하나를 알려주세요. 무선 연결이라면 어댑터나 동글 모델도 함께 기재해 주세요.</string>
+    <string name="support_rules_appversion_title">앱 버전을 포함해 주세요</string>
+    <string name="support_rules_appversion_desc">정보 및 지원 화면에 표시된 Headunit Revived 버전을 알려주세요.</string>
+    <string name="support_rules_logs_title">문제 발생 직후에 로그를 첨부해 주세요</string>
+    <string name="support_rules_logs_desc">설정의 고급 탭으로 이동해 디버그 섹션에서 디버그 모드를 켠 다음, 문제를 재현하고 바로 로그 내보내기를 탭하세요. 이렇게 해야 앱 시작 시점이 아닌 문제가 발생한 순간이 로그에 포함됩니다. 해당 파일을 이슈에 첨부해 주세요.</string>
+    <string name="support_rules_search_title">먼저 검색해 보세요</string>
+    <string name="support_rules_search_desc">이미 신고된 문제일 수 있습니다. 기존 이슈를 검색한 뒤, 같은 내용이 있다면 새 이슈를 열지 말고 그 이슈에 댓글을 달아주세요.</string>
+    <string name="support_rules_phone_title">휴대폰 정보도 중요합니다</string>
+    <string name="support_rules_phone_desc">휴대폰 모델, Android 버전, 그리고 휴대폰에 설치된 Android Auto 앱 버전도 알려주세요. 특정 Android Auto 버전에서만 발생하는 문제도 있습니다.</string>
+    <string name="support_rules_describe_title">증상을 명확하게 설명해 주세요</string>
+    <string name="support_rules_describe_desc">어떤 작업을 했는지, 어떤 결과를 예상했는지, 실제로는 어떻게 됐는지를 적어주세요. 화면 관련 문제라면 스크린샷이나 짧은 동영상이 큰 도움이 됩니다.</string>
+    <string name="support_rules_oneissue_title">이슈 하나에 문제 하나만</string>
+    <string name="support_rules_oneissue_desc">추적과 수정이 쉽도록 이슈 하나에는 문제 하나만 담아주세요. 관련 없는 문제는 별도의 이슈로 열어주세요.</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -744,4 +744,6 @@
     <string name="support_open_issues">GitHub 이슈 페이지 열기</string>
     <string name="support_scan_qr">또는 이 QR 코드를 스캔하여 다른 기기에서 이슈 목록을 여세요.</string>
     <string name="support_github_account_warning">참고: 이슈를 작성하려면 무료 GitHub 계정이 필요합니다.</string>
+    <string name="onb_ready_extras_title">마무리하기 전에 추가로 설정할 수 있습니다:</string>
+    <string name="onb_extra_loading_desc">차량 연결 중에 표시되는 사용자 지정 이미지</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -749,7 +749,7 @@
 
     <!-- Support / issue reporting rules -->
     <string name="support_rules_button">신고 규칙</string>
-    <string name="support_rules_english_desc">이슈는 항상 영어로 작성해 주세요. 메인테이너와 도움을 주는 분들 대부분이 영어를 사용하며, 여러 언어가 섞인 스레드는 누구도 이해하기 어려운 바벨탑이 되어버립니다. 영어가 자신 없으시다면 Google Translate나 DeepL 같은 번역기를 충분히 활용하셔도 됩니다.</string>
+    <string name="support_rules_english_desc">이슈는 항상 영어로 작성해 주세요. 메인테이너와 여기서 도움을 주는 분들 대부분이 영어를 공통으로 사용합니다. 여러 언어가 섞인 스레드는 아무도 서로 도울 수 없는 작은 바벨탑이 되어버립니다. 영어 실력을 평가하는 곳이 아니니 틀려도 괜찮습니다. 도움이 된다면 Google Translate나 DeepL 같은 번역기, 또는 ChatGPT나 Claude 같은 AI로 영어 메시지를 작성하거나 다듬어도 됩니다.</string>
     <string name="support_rules_device_title">앱을 실행하는 기기를 알려주세요</string>
     <string name="support_rules_device_desc">Android Auto를 투영하는 기기(헤드유닛 또는 화면)의 Android 버전과, 알고 계신다면 브랜드와 모델도 함께 알려주세요.</string>
     <string name="support_rules_connection_title">연결 방식을 알려주세요</string>
@@ -758,12 +758,15 @@
     <string name="support_rules_appversion_desc">정보 및 지원 화면에 표시된 Headunit Revived 버전을 알려주세요.</string>
     <string name="support_rules_logs_title">문제 발생 직후에 로그를 첨부해 주세요</string>
     <string name="support_rules_logs_desc">설정의 고급 탭으로 이동해 디버그 섹션에서 디버그 모드를 켠 다음, 문제를 재현하고 바로 로그 내보내기를 탭하세요. 이렇게 해야 앱 시작 시점이 아닌 문제가 발생한 순간이 로그에 포함됩니다. 해당 파일을 이슈에 첨부해 주세요.</string>
-    <string name="support_rules_search_title">먼저 검색해 보세요</string>
-    <string name="support_rules_search_desc">이미 신고된 문제일 수 있습니다. 기존 이슈를 검색한 뒤, 같은 내용이 있다면 새 이슈를 열지 말고 그 이슈에 댓글을 달아주세요.</string>
+    <string name="support_rules_search_title">중복 금지</string>
+    <string name="support_rules_search_desc">먼저 기존 이슈를 검색해 주세요. 같은 문제를 설명하는 열린 이슈가 있다면 새 이슈를 열지 말고 거기에 댓글로 내용을 추가해 주세요. 해당하는 이슈가 없을 때만 새 이슈를 열어주세요.</string>
     <string name="support_rules_phone_title">휴대폰 정보도 중요합니다</string>
     <string name="support_rules_phone_desc">휴대폰 모델, Android 버전, 그리고 휴대폰에 설치된 Android Auto 앱 버전도 알려주세요. 특정 Android Auto 버전에서만 발생하는 문제도 있습니다.</string>
     <string name="support_rules_describe_title">증상을 명확하게 설명해 주세요</string>
     <string name="support_rules_describe_desc">어떤 작업을 했는지, 어떤 결과를 예상했는지, 실제로는 어떻게 됐는지를 적어주세요. 화면 관련 문제라면 스크린샷이나 짧은 동영상이 큰 도움이 됩니다.</string>
     <string name="support_rules_oneissue_title">이슈 하나에 문제 하나만</string>
     <string name="support_rules_oneissue_desc">추적과 수정이 쉽도록 이슈 하나에는 문제 하나만 담아주세요. 관련 없는 문제는 별도의 이슈로 열어주세요.</string>
+    <string name="support_rules_intro">두 가지만 필요합니다. 나머지는 선택 사항이지만, 있을수록 훨씬 빠르게 해결할 수 있습니다.</string>
+    <string name="support_rules_section_required">필수</string>
+    <string name="support_rules_section_recommend">권장 사항 (선택)</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -775,7 +775,7 @@
 
     <!-- Support rules -->
     <string name="support_rules_button">Meldingsregels</string>
-    <string name="support_rules_english_desc">Schrijf je issue altijd in het Engels. De beheerder en de meeste mensen die hier helpen lezen Engels, en een discussie in veel verschillende talen wordt snel een kleine toren van Babel waar niemand de ander begrijpt. Niet zeker van je Engels? Een vertaler zoals Google Translate of DeepL is prima.</string>
+    <string name="support_rules_english_desc">Schrijf je issue altijd in het Engels. Het is de taal die de beheerder en de meeste mensen hier delen, en een discussie in allerlei talen wordt al snel een kleine toren van Babel waar niemand iemand kan helpen. Niemand beoordeelt je, je niveau van Engels of de manier waarop je schrijft, dus maak je geen zorgen over fouten. Als het helpt, kan een vertaler zoals Google Translate of DeepL, of een AI zoals ChatGPT of Claude, je bericht in het Engels schrijven en oppoetsen.</string>
     <string name="support_rules_device_title">Zeg wat de app draait</string>
     <string name="support_rules_device_desc">De Android-versie van het apparaat dat Android Auto projecteert (je autoradio of scherm), en het merk en model als je die weet.</string>
     <string name="support_rules_connection_title">Zeg hoe je verbindt</string>
@@ -784,12 +784,15 @@
     <string name="support_rules_appversion_desc">De versie van Headunit Revived, te zien op het scherm Over &amp; Support.</string>
     <string name="support_rules_logs_title">Voeg logs toe, direct nadat het gebeurt</string>
     <string name="support_rules_logs_desc">Ga naar het tabblad Geavanceerd in Instellingen, zet Debug Modus aan in het gedeelte Debug, reproduceer het probleem en tik daarna meteen op Logs exporteren zodat het logbestand het moment van de fout bevat en niet alleen de start. Voeg dat bestand toe aan je issue.</string>
-    <string name="support_rules_search_title">Zoek eerst</string>
-    <string name="support_rules_search_desc">Je probleem is mogelijk al gemeld. Zoek in de bestaande issues en voeg aan dat issue toe in plaats van een duplicaat te openen.</string>
+    <string name="support_rules_search_title">Geen duplicaten</string>
+    <string name="support_rules_search_desc">Zoek eerst in de bestaande issues. Als er al een open issue is dat je probleem beschrijft, voeg je je gegevens daar als reactie toe in plaats van een nieuw issue te openen. Open alleen een nieuw issue als er geen overeenkomst is.</string>
     <string name="support_rules_phone_title">Je telefoon telt ook mee</string>
     <string name="support_rules_phone_desc">Je telefoonmodel, de Android-versie en de versie van de Android Auto-app op de telefoon. Sommige problemen komen van een specifieke Android Auto-release.</string>
     <string name="support_rules_describe_title">Beschrijf het duidelijk</string>
     <string name="support_rules_describe_desc">Wat je hebt gedaan, wat je verwachtte en wat er daadwerkelijk gebeurde. Een screenshot of korte video helpt veel bij visuele problemen.</string>
     <string name="support_rules_oneissue_title">Één probleem per issue</string>
     <string name="support_rules_oneissue_desc">Houd elk issue beperkt tot één probleem zodat het gevolgd en opgelost kan worden. Open aparte issues voor niet-gerelateerde problemen.</string>
+    <string name="support_rules_intro">Er zijn maar twee dingen verplicht. De rest is optioneel, maar het helpt je probleem veel sneller op te lossen.</string>
+    <string name="support_rules_section_required">Verplicht</string>
+    <string name="support_rules_section_recommend">Aanbevelingen (optioneel)</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -761,4 +761,13 @@
     <string name="onb_dpi_recommended">Aanbevolen voor je scherm: %1$d dpi</string>
     <string name="onb_ready_loading_intro">Nog één ding: je kunt nu een aangepast laadscherm instellen, dat wordt getoond terwijl de auto verbinding maakt.</string>
     <string name="onb_ready_loading_button">Een laadscherm instellen</string>
+
+    <!-- Support / Bug report -->
+    <string name="support">Probleem melden</string>
+    <string name="support_description">Zoek of meld bugs op GitHub</string>
+    <string name="support_title">Probleem melden</string>
+    <string name="support_help">Als je een bug of probleem tegenkomt, kijk dan eerst in de lijst met GitHub-issues. Als niemand het al heeft gemeld, open dan een nieuw issue en beschrijf wat er gebeurt, je autoradio en de stappen om het te reproduceren.</string>
+    <string name="support_open_issues">Open de GitHub-issuespagina</string>
+    <string name="support_scan_qr">Of scan deze QR-code om de issueslijst op een ander apparaat te openen.</string>
+    <string name="support_github_account_warning">Let op: je hebt een gratis GitHub-account nodig om een issue aan te maken.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -770,4 +770,6 @@
     <string name="support_open_issues">Open de GitHub-issuespagina</string>
     <string name="support_scan_qr">Of scan deze QR-code om de issueslijst op een ander apparaat te openen.</string>
     <string name="support_github_account_warning">Let op: je hebt een gratis GitHub-account nodig om een issue aan te maken.</string>
+    <string name="onb_ready_extras_title">Voordat je klaar bent, kun je ook instellen:</string>
+    <string name="onb_extra_loading_desc">Een aangepaste afbeelding die wordt getoond terwijl de auto verbinding maakt</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -772,4 +772,24 @@
     <string name="support_github_account_warning">Let op: je hebt een gratis GitHub-account nodig om een issue aan te maken.</string>
     <string name="onb_ready_extras_title">Voordat je klaar bent, kun je ook instellen:</string>
     <string name="onb_extra_loading_desc">Een aangepaste afbeelding die wordt getoond terwijl de auto verbinding maakt</string>
+
+    <!-- Support rules -->
+    <string name="support_rules_button">Meldingsregels</string>
+    <string name="support_rules_english_desc">Schrijf je issue altijd in het Engels. De beheerder en de meeste mensen die hier helpen lezen Engels, en een discussie in veel verschillende talen wordt snel een kleine toren van Babel waar niemand de ander begrijpt. Niet zeker van je Engels? Een vertaler zoals Google Translate of DeepL is prima.</string>
+    <string name="support_rules_device_title">Zeg wat de app draait</string>
+    <string name="support_rules_device_desc">De Android-versie van het apparaat dat Android Auto projecteert (je autoradio of scherm), en het merk en model als je die weet.</string>
+    <string name="support_rules_connection_title">Zeg hoe je verbindt</string>
+    <string name="support_rules_connection_desc">USB-kabel, draadloze USB-adapter, WiFi Direct, WiFi (headunit server) of Self Mode. Als het draadloos is, voeg dan het model van de adapter of dongle toe.</string>
+    <string name="support_rules_appversion_title">Vermeld de app-versie</string>
+    <string name="support_rules_appversion_desc">De versie van Headunit Revived, te zien op het scherm Over &amp; Support.</string>
+    <string name="support_rules_logs_title">Voeg logs toe, direct nadat het gebeurt</string>
+    <string name="support_rules_logs_desc">Ga naar het tabblad Geavanceerd in Instellingen, zet Debug Modus aan in het gedeelte Debug, reproduceer het probleem en tik daarna meteen op Logs exporteren zodat het logbestand het moment van de fout bevat en niet alleen de start. Voeg dat bestand toe aan je issue.</string>
+    <string name="support_rules_search_title">Zoek eerst</string>
+    <string name="support_rules_search_desc">Je probleem is mogelijk al gemeld. Zoek in de bestaande issues en voeg aan dat issue toe in plaats van een duplicaat te openen.</string>
+    <string name="support_rules_phone_title">Je telefoon telt ook mee</string>
+    <string name="support_rules_phone_desc">Je telefoonmodel, de Android-versie en de versie van de Android Auto-app op de telefoon. Sommige problemen komen van een specifieke Android Auto-release.</string>
+    <string name="support_rules_describe_title">Beschrijf het duidelijk</string>
+    <string name="support_rules_describe_desc">Wat je hebt gedaan, wat je verwachtte en wat er daadwerkelijk gebeurde. Een screenshot of korte video helpt veel bij visuele problemen.</string>
+    <string name="support_rules_oneissue_title">Één probleem per issue</string>
+    <string name="support_rules_oneissue_desc">Houd elk issue beperkt tot één probleem zodat het gevolgd en opgelost kan worden. Open aparte issues voor niet-gerelateerde problemen.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -770,4 +770,6 @@
     <string name="support_open_issues">Otwórz stronę zgłoszeń GitHub</string>
     <string name="support_scan_qr">Lub zeskanuj ten kod QR, aby otworzyć listę zgłoszeń na innym urządzeniu.</string>
     <string name="support_github_account_warning">Uwaga: aby utworzyć zgłoszenie, potrzebujesz bezpłatnego konta GitHub.</string>
+    <string name="onb_ready_extras_title">Zanim skończysz, możesz też skonfigurować:</string>
+    <string name="onb_extra_loading_desc">Niestandardowy obraz wyświetlany podczas łączenia samochodu</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -766,7 +766,7 @@
     <string name="support">Zgłoś problem</string>
     <string name="support_description">Szukaj lub zgłaszaj błędy na GitHub</string>
     <string name="support_title">Zgłoś problem</string>
-    <string name="support_help">Jeśli napotkasz błąd lub problem, najpierw poszukaj go na liście zgłoszeń GitHub. Jeśli nikt jeszcze go nie zgłosił, otwórz nowe zgłoszenie i opisz, co się dzieje, jakie masz radio samochodowe i jak odtworzyć problem.</string>
+    <string name="support_help">Jeśli napotkasz błąd lub problem, najpierw poszukaj go na liście zgłoszeń GitHub. Jeśli nikt jeszcze go nie zgłosił, otwórz nowe zgłoszenie i opisz, co się dzieje, jakie masz radio samochodowe oraz podaj kroki potrzebne do odtworzenia błędu.</string>
     <string name="support_open_issues">Otwórz stronę zgłoszeń GitHub</string>
     <string name="support_scan_qr">Lub zeskanuj ten kod QR, aby otworzyć listę zgłoszeń na innym urządzeniu.</string>
     <string name="support_github_account_warning">Uwaga: aby utworzyć zgłoszenie, potrzebujesz bezpłatnego konta GitHub.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -762,4 +762,12 @@
     <string name="onb_dpi_recommended">Zalecane dla Twojego ekranu: %1$d dpi</string>
     <string name="onb_ready_loading_intro">Jeszcze jedno: możesz teraz ustawić niestandardowy ekran ładowania wyświetlany podczas łączenia samochodu.</string>
     <string name="onb_ready_loading_button">Skonfiguruj ekran ładowania</string>
+
+    <string name="support">Zgłoś problem</string>
+    <string name="support_description">Szukaj lub zgłaszaj błędy na GitHub</string>
+    <string name="support_title">Zgłoś problem</string>
+    <string name="support_help">Jeśli napotkasz błąd lub problem, najpierw poszukaj go na liście zgłoszeń GitHub. Jeśli nikt jeszcze go nie zgłosił, otwórz nowe zgłoszenie i opisz, co się dzieje, jakie masz radio samochodowe i jak odtworzyć problem.</string>
+    <string name="support_open_issues">Otwórz stronę zgłoszeń GitHub</string>
+    <string name="support_scan_qr">Lub zeskanuj ten kod QR, aby otworzyć listę zgłoszeń na innym urządzeniu.</string>
+    <string name="support_github_account_warning">Uwaga: aby utworzyć zgłoszenie, potrzebujesz bezpłatnego konta GitHub.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -774,7 +774,7 @@
     <string name="onb_extra_loading_desc">Niestandardowy obraz wyświetlany podczas łączenia samochodu</string>
 
     <string name="support_rules_button">Zasady zgłaszania</string>
-    <string name="support_rules_english_desc">Proszę zawsze pisać zgłoszenie po angielsku. Opiekun projektu i większość osób pomagających tutaj czyta po angielsku, a wątek mieszający wiele języków szybko zamienia się w małą wieżę Babel, gdzie nikt nikogo nie rozumie. Nie czujesz się pewnie po angielsku? Tłumacz taki jak Google Translate lub DeepL jest jak najbardziej w porządku.</string>
+    <string name="support_rules_english_desc">Prosimy zawsze pisać po angielsku. To jedyny język, który opiekun projektu i większość osób tu pomagających mają wspólny, a wątek w wielu językach zamienia się w małą wieżę Babel, gdzie nikt nikomu nie może pomóc. Nikt nie ocenia Twojego angielskiego ani tego, jak piszesz, więc nie martw się o błędy. Jeśli to pomoże, tłumacz taki jak Google Translate lub DeepL, albo AI jak ChatGPT lub Claude, może napisać i poprawić Twoją wiadomość po angielsku.</string>
     <string name="support_rules_device_title">Napisz, na czym działa aplikacja</string>
     <string name="support_rules_device_desc">Wersja Androida urządzenia wyświetlającego Android Auto (Twoje radio samochodowe lub ekran) oraz jego marka i model, jeśli je znasz.</string>
     <string name="support_rules_connection_title">Napisz, jak się łączysz</string>
@@ -783,12 +783,15 @@
     <string name="support_rules_appversion_desc">Wersja Headunit Revived widoczna na ekranie O aplikacji i Wsparcie.</string>
     <string name="support_rules_logs_title">Dołącz logi, zaraz po wystąpieniu problemu</string>
     <string name="support_rules_logs_desc">Przejdź do karty Zaawansowane w Ustawieniach, włącz Tryb debugowania w sekcji Debugowanie, odtwórz problem, a potem od razu naciśnij Eksportuj logi, żeby log obejmował moment awarii, a nie tylko start. Dołącz ten plik do zgłoszenia.</string>
-    <string name="support_rules_search_title">Najpierw poszukaj</string>
-    <string name="support_rules_search_desc">Twój problem może być już zgłoszony. Przejrzyj istniejące zgłoszenia i dodaj komentarz do tego samego, zamiast otwierać duplikat.</string>
+    <string name="support_rules_search_title">Bez duplikatów</string>
+    <string name="support_rules_search_desc">Najpierw przeszukaj istniejące zgłoszenia. Jeśli otwarte zgłoszenie już opisuje Twój problem, dodaj swoje szczegóły jako komentarz zamiast otwierać nowe. Otwieraj nowe zgłoszenie tylko wtedy, gdy żadne nie pasuje.</string>
     <string name="support_rules_phone_title">Twój telefon też ma znaczenie</string>
     <string name="support_rules_phone_desc">Model telefonu, jego wersja Androida i wersja aplikacji Android Auto na telefonie. Niektóre problemy wynikają z konkretnego wydania Android Auto.</string>
     <string name="support_rules_describe_title">Opisz problem wyraźnie</string>
     <string name="support_rules_describe_desc">Co zrobiłeś, czego oczekiwałeś i co faktycznie się stało. Zrzut ekranu lub krótkie wideo bardzo pomaga w przypadku problemów wizualnych.</string>
     <string name="support_rules_oneissue_title">Jeden problem na zgłoszenie</string>
     <string name="support_rules_oneissue_desc">Każde zgłoszenie powinno dotyczyć jednego problemu, żeby można go było śledzić i naprawić. Niezwiązane problemy zgłaszaj osobno.</string>
+    <string name="support_rules_intro">Wymagane są tylko dwie rzeczy. Wszystko inne jest opcjonalne, ale bardzo przyspiesza rozwiązanie problemu.</string>
+    <string name="support_rules_section_required">Wymagane</string>
+    <string name="support_rules_section_recommend">Zalecenia (opcjonalne)</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -772,4 +772,23 @@
     <string name="support_github_account_warning">Uwaga: aby utworzyć zgłoszenie, potrzebujesz bezpłatnego konta GitHub.</string>
     <string name="onb_ready_extras_title">Zanim skończysz, możesz też skonfigurować:</string>
     <string name="onb_extra_loading_desc">Niestandardowy obraz wyświetlany podczas łączenia samochodu</string>
+
+    <string name="support_rules_button">Zasady zgłaszania</string>
+    <string name="support_rules_english_desc">Proszę zawsze pisać zgłoszenie po angielsku. Opiekun projektu i większość osób pomagających tutaj czyta po angielsku, a wątek mieszający wiele języków szybko zamienia się w małą wieżę Babel, gdzie nikt nikogo nie rozumie. Nie czujesz się pewnie po angielsku? Tłumacz taki jak Google Translate lub DeepL jest jak najbardziej w porządku.</string>
+    <string name="support_rules_device_title">Napisz, na czym działa aplikacja</string>
+    <string name="support_rules_device_desc">Wersja Androida urządzenia wyświetlającego Android Auto (Twoje radio samochodowe lub ekran) oraz jego marka i model, jeśli je znasz.</string>
+    <string name="support_rules_connection_title">Napisz, jak się łączysz</string>
+    <string name="support_rules_connection_desc">Kabel USB, bezprzewodowy adapter USB, WiFi Direct, WiFi (headunit server) lub Self Mode. Jeśli połączenie jest bezprzewodowe, podaj model adaptera lub klucza.</string>
+    <string name="support_rules_appversion_title">Podaj wersję aplikacji</string>
+    <string name="support_rules_appversion_desc">Wersja Headunit Revived widoczna na ekranie O aplikacji i Wsparcie.</string>
+    <string name="support_rules_logs_title">Dołącz logi, zaraz po wystąpieniu problemu</string>
+    <string name="support_rules_logs_desc">Przejdź do karty Zaawansowane w Ustawieniach, włącz Tryb debugowania w sekcji Debugowanie, odtwórz problem, a potem od razu naciśnij Eksportuj logi, żeby log obejmował moment awarii, a nie tylko start. Dołącz ten plik do zgłoszenia.</string>
+    <string name="support_rules_search_title">Najpierw poszukaj</string>
+    <string name="support_rules_search_desc">Twój problem może być już zgłoszony. Przejrzyj istniejące zgłoszenia i dodaj komentarz do tego samego, zamiast otwierać duplikat.</string>
+    <string name="support_rules_phone_title">Twój telefon też ma znaczenie</string>
+    <string name="support_rules_phone_desc">Model telefonu, jego wersja Androida i wersja aplikacji Android Auto na telefonie. Niektóre problemy wynikają z konkretnego wydania Android Auto.</string>
+    <string name="support_rules_describe_title">Opisz problem wyraźnie</string>
+    <string name="support_rules_describe_desc">Co zrobiłeś, czego oczekiwałeś i co faktycznie się stało. Zrzut ekranu lub krótkie wideo bardzo pomaga w przypadku problemów wizualnych.</string>
+    <string name="support_rules_oneissue_title">Jeden problem na zgłoszenie</string>
+    <string name="support_rules_oneissue_desc">Każde zgłoszenie powinno dotyczyć jednego problemu, żeby można go było śledzić i naprawić. Niezwiązane problemy zgłaszaj osobno.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -763,4 +763,12 @@
     <string name="onb_dpi_recommended">Recomendado para sua tela: %1$d dpi</string>
     <string name="onb_ready_loading_intro">Mais uma coisa: agora você pode definir uma tela de carregamento personalizada, exibida enquanto o carro se conecta.</string>
     <string name="onb_ready_loading_button">Configurar uma tela de carregamento</string>
+
+    <string name="support">Reportar um problema</string>
+    <string name="support_description">Pesquise ou reporte bugs no GitHub</string>
+    <string name="support_title">Reportar um problema</string>
+    <string name="support_help">Se você encontrar um bug ou problema, primeiro procure-o na lista de issues do GitHub. Se ninguém tiver reportado ainda, abra uma nova issue e descreva o que acontece, sua central multimídia e os passos para reproduzir o problema.</string>
+    <string name="support_open_issues">Abrir a página de issues do GitHub</string>
+    <string name="support_scan_qr">Ou escaneie este código QR para abrir a lista de issues em outro dispositivo.</string>
+    <string name="support_github_account_warning">Nota: você precisa de uma conta gratuita no GitHub para criar uma issue.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -774,4 +774,23 @@
 
     <string name="onb_ready_extras_title">Antes de concluir, você também pode configurar:</string>
     <string name="onb_extra_loading_desc">Uma imagem personalizada exibida enquanto o carro se conecta</string>
+
+    <string name="support_rules_button">Regras para reportar</string>
+    <string name="support_rules_english_desc">Por favor, escreva sempre sua dúvida em inglês. O mantenedor e a maioria das pessoas que ajudam aqui leem inglês, e uma discussão misturando vários idiomas vira rapidinho uma torre de Babel onde ninguém entende ninguém. Não se sente seguro em inglês? Um tradutor como o Google Translate ou o DeepL funciona muito bem.</string>
+    <string name="support_rules_device_title">Diga o que executa o app</string>
+    <string name="support_rules_device_desc">A versão do Android do dispositivo que projeta o Android Auto (sua central multimídia ou tela) e a marca e o modelo, se você souber.</string>
+    <string name="support_rules_connection_title">Diga como você se conecta</string>
+    <string name="support_rules_connection_desc">Cabo USB, adaptador USB sem fio, WiFi Direct, WiFi (headunit server) ou Self Mode. Se for sem fio, informe o modelo do adaptador ou dongle.</string>
+    <string name="support_rules_appversion_title">Inclua a versão do app</string>
+    <string name="support_rules_appversion_desc">A versão do Headunit Revived, exibida na tela Sobre.</string>
+    <string name="support_rules_logs_title">Anexe os logs logo após o problema acontecer</string>
+    <string name="support_rules_logs_desc">Vá em Configurações, aba Avançado, ative o Modo de depuração na seção Depuração, reproduza o problema e toque em Exportar logs imediatamente depois, para que o log cubra o momento da falha e não só o início. Anexe esse arquivo à sua issue.</string>
+    <string name="support_rules_search_title">Pesquise antes</string>
+    <string name="support_rules_search_desc">Seu problema pode já ter sido reportado. Pesquise nas issues existentes e adicione seu comentário lá em vez de abrir uma duplicata.</string>
+    <string name="support_rules_phone_title">Seu celular também importa</string>
+    <string name="support_rules_phone_desc">O modelo do seu celular, a versão do Android nele e a versão do app Android Auto. Alguns problemas vêm de uma versão específica do Android Auto.</string>
+    <string name="support_rules_describe_title">Descreva com clareza</string>
+    <string name="support_rules_describe_desc">O que você fez, o que esperava que acontecesse e o que aconteceu de fato. Uma captura de tela ou um vídeo curto ajuda muito para problemas visuais.</string>
+    <string name="support_rules_oneissue_title">Um problema por issue</string>
+    <string name="support_rules_oneissue_desc">Mantenha cada issue focada em um único problema para que ele possa ser rastreado e corrigido. Abra issues separadas para problemas não relacionados.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -771,4 +771,7 @@
     <string name="support_open_issues">Abrir a página de issues do GitHub</string>
     <string name="support_scan_qr">Ou escaneie este código QR para abrir a lista de issues em outro dispositivo.</string>
     <string name="support_github_account_warning">Nota: você precisa de uma conta gratuita no GitHub para criar uma issue.</string>
+
+    <string name="onb_ready_extras_title">Antes de concluir, você também pode configurar:</string>
+    <string name="onb_extra_loading_desc">Uma imagem personalizada exibida enquanto o carro se conecta</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -776,7 +776,7 @@
     <string name="onb_extra_loading_desc">Uma imagem personalizada exibida enquanto o carro se conecta</string>
 
     <string name="support_rules_button">Regras para reportar</string>
-    <string name="support_rules_english_desc">Por favor, escreva sempre sua dúvida em inglês. O mantenedor e a maioria das pessoas que ajudam aqui leem inglês, e uma discussão misturando vários idiomas vira rapidinho uma torre de Babel onde ninguém entende ninguém. Não se sente seguro em inglês? Um tradutor como o Google Translate ou o DeepL funciona muito bem.</string>
+    <string name="support_rules_english_desc">Por favor, escreva sempre sua dúvida em inglês. É o idioma que o mantenedor e a maioria das pessoas que ajudam aqui compartilham, e uma discussão em vários idiomas vira uma torre de Babel onde ninguém consegue ajudar ninguém. Ninguém vai te julgar pelo seu inglês ou pela forma como você escreve, então não se preocupe com erros. Se precisar, um tradutor como o Google Translate ou o DeepL, ou uma IA como o ChatGPT ou o Claude, pode escrever e organizar sua mensagem em inglês para você.</string>
     <string name="support_rules_device_title">Diga o que executa o app</string>
     <string name="support_rules_device_desc">A versão do Android do dispositivo que projeta o Android Auto (sua central multimídia ou tela) e a marca e o modelo, se você souber.</string>
     <string name="support_rules_connection_title">Diga como você se conecta</string>
@@ -785,12 +785,15 @@
     <string name="support_rules_appversion_desc">A versão do Headunit Revived, exibida na tela Sobre.</string>
     <string name="support_rules_logs_title">Anexe os logs logo após o problema acontecer</string>
     <string name="support_rules_logs_desc">Vá em Configurações, aba Avançado, ative o Modo de depuração na seção Depuração, reproduza o problema e toque em Exportar logs imediatamente depois, para que o log cubra o momento da falha e não só o início. Anexe esse arquivo à sua issue.</string>
-    <string name="support_rules_search_title">Pesquise antes</string>
-    <string name="support_rules_search_desc">Seu problema pode já ter sido reportado. Pesquise nas issues existentes e adicione seu comentário lá em vez de abrir uma duplicata.</string>
+    <string name="support_rules_search_title">Sem duplicatas</string>
+    <string name="support_rules_search_desc">Primeiro pesquise nas issues existentes. Se já houver uma issue aberta descrevendo o seu problema, adicione seus detalhes como comentário lá, em vez de abrir uma nova. Só abra uma nova issue se nenhuma corresponder.</string>
     <string name="support_rules_phone_title">Seu celular também importa</string>
     <string name="support_rules_phone_desc">O modelo do seu celular, a versão do Android nele e a versão do app Android Auto. Alguns problemas vêm de uma versão específica do Android Auto.</string>
     <string name="support_rules_describe_title">Descreva com clareza</string>
     <string name="support_rules_describe_desc">O que você fez, o que esperava que acontecesse e o que aconteceu de fato. Uma captura de tela ou um vídeo curto ajuda muito para problemas visuais.</string>
     <string name="support_rules_oneissue_title">Um problema por issue</string>
     <string name="support_rules_oneissue_desc">Mantenha cada issue focada em um único problema para que ele possa ser rastreado e corrigido. Abra issues separadas para problemas não relacionados.</string>
+    <string name="support_rules_intro">Apenas duas coisas são obrigatórias. Todo o resto é opcional, mas ajuda a resolver seu problema muito mais rápido.</string>
+    <string name="support_rules_section_required">Obrigatório</string>
+    <string name="support_rules_section_recommend">Recomendações (opcional)</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -744,4 +744,23 @@
     <string name="support_github_account_warning">Notă: ai nevoie de un cont GitHub gratuit pentru a crea o problemă.</string>
     <string name="onb_ready_extras_title">Înainte să termini, poți configura și:</string>
     <string name="onb_extra_loading_desc">O imagine personalizată afișată cât timp mașina se conectează</string>
+
+    <string name="support_rules_button">Reguli de raportare</string>
+    <string name="support_rules_english_desc">Te rugăm să scrii întotdeauna problema ta în engleză. Cel care întreține proiectul și majoritatea celor care ajută aici citesc engleza, iar un fir de discuție care amestecă mai multe limbi se transformă rapid într-un mic turnul Babel în care nimeni nu înțelege pe nimeni. Nu ești sigur pe engleză? Un traducător precum Google Translate sau DeepL merge perfect.</string>
+    <string name="support_rules_device_title">Spune ce rulează aplicația</string>
+    <string name="support_rules_device_desc">Versiunea Android a dispozitivului care proiectează Android Auto (unitatea ta principală sau ecranul) și marca și modelul acestuia, dacă le știi.</string>
+    <string name="support_rules_connection_title">Spune cum te conectezi</string>
+    <string name="support_rules_connection_desc">Cablu USB, adaptor wireless USB, WiFi Direct, WiFi (headunit server) sau Self Mode. Dacă este wireless, adaugă modelul adaptorului sau dongle-ului.</string>
+    <string name="support_rules_appversion_title">Include versiunea aplicației</string>
+    <string name="support_rules_appversion_desc">Versiunea Headunit Revived, afișată pe ecranul Despre.</string>
+    <string name="support_rules_logs_title">Atașează logurile, imediat după ce se întâmplă</string>
+    <string name="support_rules_logs_desc">Mergi în Setări la fila Avansate, activează Mod depanare (Debug) în secțiunea Depanare, reproduci problema, apoi apasă Exportă logurile imediat după, ca logul să acopere momentul în care s-a produs eroarea, nu doar pornirea. Atașează acel fișier la problema ta.</string>
+    <string name="support_rules_search_title">Caută mai întâi</string>
+    <string name="support_rules_search_desc">Problema ta poate fi deja raportată. Caută în problemele existente și adaugă acolo, în loc să deschizi un duplicat.</string>
+    <string name="support_rules_phone_title">Telefonul tău contează și el</string>
+    <string name="support_rules_phone_desc">Modelul telefonului tău, versiunea Android a acestuia și versiunea aplicației Android Auto de pe telefon. Unele probleme vin dintr-o anumită versiune Android Auto.</string>
+    <string name="support_rules_describe_title">Descrie clar</string>
+    <string name="support_rules_describe_desc">Ce ai făcut, ce te-ai așteptat să se întâmple și ce s-a întâmplat de fapt. Un screenshot sau un scurt videoclip ajută mult pentru problemele vizuale.</string>
+    <string name="support_rules_oneissue_title">O problemă pe fir</string>
+    <string name="support_rules_oneissue_desc">Păstrează fiecare fir de discuție la o singură problemă, ca să poată fi urmărită și rezolvată. Deschide fire separate pentru probleme diferite.</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -746,7 +746,7 @@
     <string name="onb_extra_loading_desc">O imagine personalizată afișată cât timp mașina se conectează</string>
 
     <string name="support_rules_button">Reguli de raportare</string>
-    <string name="support_rules_english_desc">Te rugăm să scrii întotdeauna problema ta în engleză. Cel care întreține proiectul și majoritatea celor care ajută aici citesc engleza, iar un fir de discuție care amestecă mai multe limbi se transformă rapid într-un mic turnul Babel în care nimeni nu înțelege pe nimeni. Nu ești sigur pe engleză? Un traducător precum Google Translate sau DeepL merge perfect.</string>
+    <string name="support_rules_english_desc">Te rugăm să scrii întotdeauna problema ta în engleză. Este singura limbă pe care o înțelege cel care întreține proiectul și cei mai mulți dintre cei care ajută aici, iar un fir în mai multe limbi se transformă repede într-un mic turnul Babel în care nimeni nu poate ajuta pe nimeni. Nu te judecă nimeni — nici nivelul de engleză, nici felul în care scrii — deci nu-ți face griji pentru greșeli. Dacă te ajută, un traducător precum Google Translate sau DeepL, ori un AI precum ChatGPT sau Claude, poate să îți scrie și să îți pună în ordine mesajul în engleză.</string>
     <string name="support_rules_device_title">Spune ce rulează aplicația</string>
     <string name="support_rules_device_desc">Versiunea Android a dispozitivului care proiectează Android Auto (unitatea ta principală sau ecranul) și marca și modelul acestuia, dacă le știi.</string>
     <string name="support_rules_connection_title">Spune cum te conectezi</string>
@@ -755,12 +755,15 @@
     <string name="support_rules_appversion_desc">Versiunea Headunit Revived, afișată pe ecranul Despre.</string>
     <string name="support_rules_logs_title">Atașează logurile, imediat după ce se întâmplă</string>
     <string name="support_rules_logs_desc">Mergi în Setări la fila Avansate, activează Mod depanare (Debug) în secțiunea Depanare, reproduci problema, apoi apasă Exportă logurile imediat după, ca logul să acopere momentul în care s-a produs eroarea, nu doar pornirea. Atașează acel fișier la problema ta.</string>
-    <string name="support_rules_search_title">Caută mai întâi</string>
-    <string name="support_rules_search_desc">Problema ta poate fi deja raportată. Caută în problemele existente și adaugă acolo, în loc să deschizi un duplicat.</string>
+    <string name="support_rules_search_title">Fără duplicate</string>
+    <string name="support_rules_search_desc">Caută mai întâi în problemele existente. Dacă o problemă deschisă descrie deja situația ta, adaugă detaliile tale acolo ca un comentariu, în loc să deschizi una nouă. Deschide o problemă nouă doar dacă niciuna nu se potrivește.</string>
     <string name="support_rules_phone_title">Telefonul tău contează și el</string>
     <string name="support_rules_phone_desc">Modelul telefonului tău, versiunea Android a acestuia și versiunea aplicației Android Auto de pe telefon. Unele probleme vin dintr-o anumită versiune Android Auto.</string>
     <string name="support_rules_describe_title">Descrie clar</string>
     <string name="support_rules_describe_desc">Ce ai făcut, ce te-ai așteptat să se întâmple și ce s-a întâmplat de fapt. Un screenshot sau un scurt videoclip ajută mult pentru problemele vizuale.</string>
     <string name="support_rules_oneissue_title">O problemă pe fir</string>
     <string name="support_rules_oneissue_desc">Păstrează fiecare fir de discuție la o singură problemă, ca să poată fi urmărită și rezolvată. Deschide fire separate pentru probleme diferite.</string>
+    <string name="support_rules_intro">Sunt necesare doar două lucruri. Restul este opțional, dar te ajută să-ți rezolvăm problema mult mai repede.</string>
+    <string name="support_rules_section_required">Obligatoriu</string>
+    <string name="support_rules_section_recommend">Recomandări (opțional)</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -742,4 +742,6 @@
     <string name="support_open_issues">Deschide pagina de probleme GitHub</string>
     <string name="support_scan_qr">Sau scanează acest cod QR pentru a deschide lista de probleme pe un alt dispozitiv.</string>
     <string name="support_github_account_warning">Notă: ai nevoie de un cont GitHub gratuit pentru a crea o problemă.</string>
+    <string name="onb_ready_extras_title">Înainte să termini, poți configura și:</string>
+    <string name="onb_extra_loading_desc">O imagine personalizată afișată cât timp mașina se conectează</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -734,4 +734,12 @@
     <string name="onb_vehicle_help_advanced">Poți ajusta mai multe detalii despre vehicul în fila Avansat. Nu folosim aceste date; sunt trimise doar către Android Auto deoarece le solicită.</string>
     <string name="onb_summary_vehicle_format">Vehicul: %1$s</string>
     <string name="sunrise_reference_help">Punctul de referință folosit pentru a calcula răsăritul și apusul soarelui. Alege-ți locația o singură dată; funcționează fără GPS.</string>
+
+    <string name="support">Raportează o problemă</string>
+    <string name="support_description">Caută sau raportează erori pe GitHub</string>
+    <string name="support_title">Raportează o problemă</string>
+    <string name="support_help">Dacă întâmpini o eroare sau o problemă, caută mai întâi în lista de probleme de pe GitHub. Dacă nimeni nu a raportat-o încă, deschide o problemă nouă și descrie ce se întâmplă, unitatea ta principală și pașii pentru a o reproduce.</string>
+    <string name="support_open_issues">Deschide pagina de probleme GitHub</string>
+    <string name="support_scan_qr">Sau scanează acest cod QR pentru a deschide lista de probleme pe un alt dispozitiv.</string>
+    <string name="support_github_account_warning">Notă: ai nevoie de un cont GitHub gratuit pentru a crea o problemă.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -761,4 +761,12 @@
     <string name="onb_dpi_recommended">Рекомендуется для вашего экрана: %1$d dpi</string>
     <string name="onb_ready_loading_intro">Ещё кое-что: теперь вы можете задать пользовательский экран загрузки, который отображается во время подключения автомобиля.</string>
     <string name="onb_ready_loading_button">Настроить экран загрузки</string>
+
+    <string name="support">Сообщить о проблеме</string>
+    <string name="support_description">Найдите или сообщите об ошибках на GitHub</string>
+    <string name="support_title">Сообщить о проблеме</string>
+    <string name="support_help">Если вы столкнулись с ошибкой или проблемой, сначала найдите её в списке задач GitHub. Если о ней ещё никто не сообщал, создайте новую задачу и опишите, что происходит, ваше головное устройство и шаги для воспроизведения.</string>
+    <string name="support_open_issues">Открыть страницу задач GitHub</string>
+    <string name="support_scan_qr">Или отсканируйте этот QR-код, чтобы открыть список задач на другом устройстве.</string>
+    <string name="support_github_account_warning">Примечание: для создания задачи вам нужна бесплатная учётная запись GitHub.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -774,7 +774,7 @@
 
     <!-- Support rules -->
     <string name="support_rules_button">Правила отчётов</string>
-    <string name="support_rules_english_desc">Пожалуйста, всегда пишите вопрос на английском языке. Разработчик и большинство помощников читают по-английски, а ветка на нескольких языках быстро превращается в Вавилонскую башню, где никто никого не понимает. Не уверены в английском? Переводчик вроде Google Translate или DeepL подойдёт отлично.</string>
+    <string name="support_rules_english_desc">Пожалуйста, всегда пишите вопрос на английском языке. Это единственный язык, который объединяет разработчика и большинство тех, кто здесь помогает, а тред на нескольких языках быстро превращается в маленькую Вавилонскую башню, где никто никому не может помочь. Никто не осудит вас, ваш уровень английского или то, как вы пишете, — не переживайте из-за ошибок. Если нужна помощь, переводчик вроде Google Translate или DeepL, или ИИ вроде ChatGPT или Claude, напишет и оформит ваше сообщение на английском за вас.</string>
     <string name="support_rules_device_title">Укажите, на чём запущено приложение</string>
     <string name="support_rules_device_desc">Версию Android устройства, которое принимает Android Auto (ваше головное устройство или экран), а также марку и модель, если знаете.</string>
     <string name="support_rules_connection_title">Укажите способ подключения</string>
@@ -783,12 +783,15 @@
     <string name="support_rules_appversion_desc">Версию Headunit Revived, которая отображается на экране «Справка и поддержка».</string>
     <string name="support_rules_logs_title">Прикрепите логи сразу после проблемы</string>
     <string name="support_rules_logs_desc">Перейдите в настройки на вкладку «Расширенные», включите «Режим отладки» в разделе «Отладка», воспроизведите проблему, затем сразу нажмите «Выгрузка логов», чтобы лог охватил момент сбоя, а не только запуск. Прикрепите этот файл к обращению.</string>
-    <string name="support_rules_search_title">Сначала поищите</string>
-    <string name="support_rules_search_desc">Возможно, о вашей проблеме уже сообщали. Поищите в существующих обращениях и добавьте комментарий туда, вместо того чтобы создавать дублирующее.</string>
+    <string name="support_rules_search_title">Без дублей</string>
+    <string name="support_rules_search_desc">Сначала поищите среди существующих обращений. Если открытое обращение уже описывает вашу проблему, добавьте свои подробности туда в виде комментария, а не открывайте новое. Новое обращение стоит создавать только если ни одно не подходит.</string>
     <string name="support_rules_phone_title">Телефон тоже важен</string>
     <string name="support_rules_phone_desc">Укажите модель телефона, версию Android на нём и версию приложения Android Auto. Некоторые проблемы связаны с конкретным выпуском Android Auto.</string>
     <string name="support_rules_describe_title">Опишите проблему чётко</string>
     <string name="support_rules_describe_desc">Что вы сделали, что ожидали и что произошло на самом деле. Скриншот или короткое видео очень помогают при визуальных проблемах.</string>
     <string name="support_rules_oneissue_title">Одна проблема — одно обращение</string>
     <string name="support_rules_oneissue_desc">Держите каждое обращение посвящённым одной проблеме, чтобы её можно было отследить и исправить. Создавайте отдельные обращения для несвязанных проблем.</string>
+    <string name="support_rules_intro">Нужно только два условия. Всё остальное необязательно, но поможет решить проблему гораздо быстрее.</string>
+    <string name="support_rules_section_required">Обязательно</string>
+    <string name="support_rules_section_recommend">Рекомендации (необязательно)</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -771,4 +771,24 @@
     <string name="support_github_account_warning">Примечание: для создания обращения необходима бесплатная учётная запись GitHub.</string>
     <string name="onb_ready_extras_title">Перед завершением вы также можете настроить:</string>
     <string name="onb_extra_loading_desc">Пользовательское изображение, отображаемое пока автомобиль подключается</string>
+
+    <!-- Support rules -->
+    <string name="support_rules_button">Правила отчётов</string>
+    <string name="support_rules_english_desc">Пожалуйста, всегда пишите вопрос на английском языке. Разработчик и большинство помощников читают по-английски, а ветка на нескольких языках быстро превращается в Вавилонскую башню, где никто никого не понимает. Не уверены в английском? Переводчик вроде Google Translate или DeepL подойдёт отлично.</string>
+    <string name="support_rules_device_title">Укажите, на чём запущено приложение</string>
+    <string name="support_rules_device_desc">Версию Android устройства, которое принимает Android Auto (ваше головное устройство или экран), а также марку и модель, если знаете.</string>
+    <string name="support_rules_connection_title">Укажите способ подключения</string>
+    <string name="support_rules_connection_desc">USB-кабель, USB-беспроводной адаптер, WiFi Direct, WiFi (headunit server) или Self Mode. Если беспроводное — добавьте модель адаптера или донгла.</string>
+    <string name="support_rules_appversion_title">Укажите версию приложения</string>
+    <string name="support_rules_appversion_desc">Версию Headunit Revived, которая отображается на экране «Справка и поддержка».</string>
+    <string name="support_rules_logs_title">Прикрепите логи сразу после проблемы</string>
+    <string name="support_rules_logs_desc">Перейдите в настройки на вкладку «Расширенные», включите «Режим отладки» в разделе «Отладка», воспроизведите проблему, затем сразу нажмите «Выгрузка логов», чтобы лог охватил момент сбоя, а не только запуск. Прикрепите этот файл к обращению.</string>
+    <string name="support_rules_search_title">Сначала поищите</string>
+    <string name="support_rules_search_desc">Возможно, о вашей проблеме уже сообщали. Поищите в существующих обращениях и добавьте комментарий туда, вместо того чтобы создавать дублирующее.</string>
+    <string name="support_rules_phone_title">Телефон тоже важен</string>
+    <string name="support_rules_phone_desc">Укажите модель телефона, версию Android на нём и версию приложения Android Auto. Некоторые проблемы связаны с конкретным выпуском Android Auto.</string>
+    <string name="support_rules_describe_title">Опишите проблему чётко</string>
+    <string name="support_rules_describe_desc">Что вы сделали, что ожидали и что произошло на самом деле. Скриншот или короткое видео очень помогают при визуальных проблемах.</string>
+    <string name="support_rules_oneissue_title">Одна проблема — одно обращение</string>
+    <string name="support_rules_oneissue_desc">Держите каждое обращение посвящённым одной проблеме, чтобы её можно было отследить и исправить. Создавайте отдельные обращения для несвязанных проблем.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -762,11 +762,11 @@
     <string name="onb_ready_loading_intro">Ещё кое-что: теперь вы можете задать пользовательский экран загрузки, который отображается во время подключения автомобиля.</string>
     <string name="onb_ready_loading_button">Настроить экран загрузки</string>
 
-    <string name="support">Сообщить о проблеме</string>
+    <string name="support">Сообщить об ошибке</string>
     <string name="support_description">Найдите или сообщите об ошибках на GitHub</string>
-    <string name="support_title">Сообщить о проблеме</string>
-    <string name="support_help">Если вы столкнулись с ошибкой или проблемой, сначала найдите её в списке задач GitHub. Если о ней ещё никто не сообщал, создайте новую задачу и опишите, что происходит, ваше головное устройство и шаги для воспроизведения.</string>
-    <string name="support_open_issues">Открыть страницу задач GitHub</string>
-    <string name="support_scan_qr">Или отсканируйте этот QR-код, чтобы открыть список задач на другом устройстве.</string>
-    <string name="support_github_account_warning">Примечание: для создания задачи вам нужна бесплатная учётная запись GitHub.</string>
+    <string name="support_title">Сообщить об ошибке</string>
+    <string name="support_help">Если вы столкнулись с ошибкой или проблемой, сначала поищите её в списке обращений на GitHub. Если никто ещё не сообщал об этом, создайте новое обращение и опишите, что происходит, укажите модель вашего головного устройства и шаги для воспроизведения.</string>
+    <string name="support_open_issues">Открыть список обращений на GitHub</string>
+    <string name="support_scan_qr">Или отсканируйте этот QR-код, чтобы открыть список обращений на другом устройстве.</string>
+    <string name="support_github_account_warning">Примечание: для создания обращения необходима бесплатная учётная запись GitHub.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -769,4 +769,6 @@
     <string name="support_open_issues">Открыть список обращений на GitHub</string>
     <string name="support_scan_qr">Или отсканируйте этот QR-код, чтобы открыть список обращений на другом устройстве.</string>
     <string name="support_github_account_warning">Примечание: для создания обращения необходима бесплатная учётная запись GitHub.</string>
+    <string name="onb_ready_extras_title">Перед завершением вы также можете настроить:</string>
+    <string name="onb_extra_loading_desc">Пользовательское изображение, отображаемое пока автомобиль подключается</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -738,4 +738,7 @@
     <string name="support_open_issues">GitHub Issues sayfasını aç</string>
     <string name="support_scan_qr">Veya Issues listesini başka bir cihazda açmak için bu QR kodunu tarayın.</string>
     <string name="support_github_account_warning">Not: Konu oluşturmak için ücretsiz bir GitHub hesabına ihtiyacınız var.</string>
+
+    <string name="onb_ready_extras_title">Bitirmeden önce şunları da ayarlayabilirsiniz:</string>
+    <string name="onb_extra_loading_desc">Araç bağlanırken gösterilen özel bir görsel</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -743,8 +743,11 @@
     <string name="onb_extra_loading_desc">Araç bağlanırken gösterilen özel bir görsel</string>
 
     <!-- Support rules -->
+    <string name="support_rules_intro">Yalnızca iki şey zorunludur. Diğerleri isteğe bağlıdır, ancak sorununuzun çok daha hızlı çözülmesine yardımcı olur.</string>
+    <string name="support_rules_section_required">Zorunlu</string>
+    <string name="support_rules_section_recommend">Öneriler (isteğe bağlı)</string>
     <string name="support_rules_button">Bildirme kuralları</string>
-    <string name="support_rules_english_desc">Lütfen sorunuzu her zaman İngilizce yazın. Proje sorumlusu ve yardım eden kişilerin çoğu İngilizce okur; farklı dillerin karıştığı bir konu, kimsenin kimseyi anlamadığı küçük bir Babil Kulesi\'ne dönüşür. İngilizceye güvenmiyorsanız Google Translate veya DeepL gibi bir çevirmen tamamen geçerlidir.</string>
+    <string name="support_rules_english_desc">Lütfen sorunuzu her zaman İngilizce yazın. Proje sorumlusu ve yardım eden kişilerin çoğunun ortak dili İngilizce, birçok dilde yazılmış bir konu ise kimsenin kimseye yardım edemediği küçük bir Babil Kulesi\'ne dönüşür. Kimse İngilizcenizi, seviyenizi ya da yazış biçiminizi yargılamaz, hata yapmaktan çekinmeyin. İşe yararsa, Google Translate veya DeepL gibi bir çevirmen ya da ChatGPT veya Claude gibi bir yapay zeka mesajınızı sizin için İngilizce olarak yazıp düzenleyebilir.</string>
     <string name="support_rules_device_title">Uygulamayı neyin çalıştırdığını belirtin</string>
     <string name="support_rules_device_desc">Android Auto\'yu yansıtan cihazın (multimedya sisteminiz veya ekranınız) Android sürümünü ve biliyorsanız marka ile modelini yazın.</string>
     <string name="support_rules_connection_title">Nasıl bağlandığınızı belirtin</string>
@@ -753,8 +756,8 @@
     <string name="support_rules_appversion_desc">Hakkında ekranında gösterilen Headunit Revived sürümü.</string>
     <string name="support_rules_logs_title">Olduğu anda günlükleri ekleyin</string>
     <string name="support_rules_logs_desc">Ayarlar\'da Gelişmiş sekmesini açın, Hata Ayıklama bölümünde Hata Ayıklama Modu\'nu etkinleştirin, sorunu yeniden oluşturun ve hemen ardından Günlükleri Dışa Aktar\'a dokunun; böylece günlük yalnızca başlangıcı değil sorunun yaşandığı anı da kapsar. Bu dosyayı konunuza ekleyin.</string>
-    <string name="support_rules_search_title">Önce arayın</string>
-    <string name="support_rules_search_desc">Sorununuz daha önce bildirilmiş olabilir. Mevcut konuları arayın ve mükerrer konu açmak yerine o konuya ekleyin.</string>
+    <string name="support_rules_search_title">Mükerrer konu açmayın</string>
+    <string name="support_rules_search_desc">Önce mevcut konuları arayın. Sorununuzu zaten açıklayan açık bir konu varsa, yeni bir tane açmak yerine yorumunuzu oraya ekleyin. Yalnızca eşleşen konu yoksa yeni bir tane açın.</string>
     <string name="support_rules_phone_title">Telefonunuz da önemli</string>
     <string name="support_rules_phone_desc">Telefon modeliniz, Android sürümü ve telefondaki Android Auto uygulama sürümü. Bazı sorunlar belirli bir Android Auto sürümünden kaynaklanır.</string>
     <string name="support_rules_describe_title">Net bir şekilde açıklayın</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -730,4 +730,12 @@
     <string name="onb_vehicle_help_advanced">Gelişmiş sekmesinde daha fazla araç ayrıntısını düzenleyebilirsiniz. Bu verileri biz kullanmayız; yalnızca Android Auto gerektirdiği için gönderilir.</string>
     <string name="onb_summary_vehicle_format">Araç: %1$s</string>
     <string name="sunrise_reference_help">Gün doğumu ve gün batımını hesaplamak için kullanılan referans noktası. Konumunuzu bir kez seçin; GPS olmadan çalışır.</string>
+
+    <string name="support">Sorun bildir</string>
+    <string name="support_description">GitHub\'da hataları arayın veya bildirin</string>
+    <string name="support_title">Sorun bildir</string>
+    <string name="support_help">Bir hata veya sorunla karşılaşırsanız, lütfen önce GitHub sorunlar listesinde arayın. Henüz kimse bildirmediyse yeni bir sorun açın ve ne olduğunu, multimedya sisteminizi ve sorunu yeniden oluşturma adımlarını açıklayın.</string>
+    <string name="support_open_issues">GitHub sorunlar sayfasını aç</string>
+    <string name="support_scan_qr">Veya sorunlar listesini başka bir cihazda açmak için bu QR kodunu tarayın.</string>
+    <string name="support_github_account_warning">Not: Sorun oluşturmak için ücretsiz bir GitHub hesabına ihtiyacınız var.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -732,10 +732,10 @@
     <string name="sunrise_reference_help">Gün doğumu ve gün batımını hesaplamak için kullanılan referans noktası. Konumunuzu bir kez seçin; GPS olmadan çalışır.</string>
 
     <string name="support">Sorun bildir</string>
-    <string name="support_description">GitHub\'da hataları arayın veya bildirin</string>
+    <string name="support_description">GitHub\'da hata arayın veya bildirin</string>
     <string name="support_title">Sorun bildir</string>
-    <string name="support_help">Bir hata veya sorunla karşılaşırsanız, lütfen önce GitHub sorunlar listesinde arayın. Henüz kimse bildirmediyse yeni bir sorun açın ve ne olduğunu, multimedya sisteminizi ve sorunu yeniden oluşturma adımlarını açıklayın.</string>
-    <string name="support_open_issues">GitHub sorunlar sayfasını aç</string>
-    <string name="support_scan_qr">Veya sorunlar listesini başka bir cihazda açmak için bu QR kodunu tarayın.</string>
-    <string name="support_github_account_warning">Not: Sorun oluşturmak için ücretsiz bir GitHub hesabına ihtiyacınız var.</string>
+    <string name="support_help">Bir hata veya sorunla karşılaşırsanız lütfen önce GitHub Issues listesinde arayın. Henüz kimse bildirmediyse yeni bir konu açın ve ne olduğunu, multimedya sisteminizi ve sorunu yeniden oluşturma adımlarını açıklayın.</string>
+    <string name="support_open_issues">GitHub Issues sayfasını aç</string>
+    <string name="support_scan_qr">Veya Issues listesini başka bir cihazda açmak için bu QR kodunu tarayın.</string>
+    <string name="support_github_account_warning">Not: Konu oluşturmak için ücretsiz bir GitHub hesabına ihtiyacınız var.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -741,4 +741,24 @@
 
     <string name="onb_ready_extras_title">Bitirmeden önce şunları da ayarlayabilirsiniz:</string>
     <string name="onb_extra_loading_desc">Araç bağlanırken gösterilen özel bir görsel</string>
+
+    <!-- Support rules -->
+    <string name="support_rules_button">Bildirme kuralları</string>
+    <string name="support_rules_english_desc">Lütfen sorunuzu her zaman İngilizce yazın. Proje sorumlusu ve yardım eden kişilerin çoğu İngilizce okur; farklı dillerin karıştığı bir konu, kimsenin kimseyi anlamadığı küçük bir Babil Kulesi\'ne dönüşür. İngilizceye güvenmiyorsanız Google Translate veya DeepL gibi bir çevirmen tamamen geçerlidir.</string>
+    <string name="support_rules_device_title">Uygulamayı neyin çalıştırdığını belirtin</string>
+    <string name="support_rules_device_desc">Android Auto\'yu yansıtan cihazın (multimedya sisteminiz veya ekranınız) Android sürümünü ve biliyorsanız marka ile modelini yazın.</string>
+    <string name="support_rules_connection_title">Nasıl bağlandığınızı belirtin</string>
+    <string name="support_rules_connection_desc">USB kablo, USB kablosuz adaptör, WiFi Direct, WiFi (headunit sunucusu) veya Self Mode. Kablosuz bağlantı kullanıyorsanız adaptör veya dongle modelini de ekleyin.</string>
+    <string name="support_rules_appversion_title">Uygulama sürümünü ekleyin</string>
+    <string name="support_rules_appversion_desc">Hakkında ekranında gösterilen Headunit Revived sürümü.</string>
+    <string name="support_rules_logs_title">Olduğu anda günlükleri ekleyin</string>
+    <string name="support_rules_logs_desc">Ayarlar\'da Gelişmiş sekmesini açın, Hata Ayıklama bölümünde Hata Ayıklama Modu\'nu etkinleştirin, sorunu yeniden oluşturun ve hemen ardından Günlükleri Dışa Aktar\'a dokunun; böylece günlük yalnızca başlangıcı değil sorunun yaşandığı anı da kapsar. Bu dosyayı konunuza ekleyin.</string>
+    <string name="support_rules_search_title">Önce arayın</string>
+    <string name="support_rules_search_desc">Sorununuz daha önce bildirilmiş olabilir. Mevcut konuları arayın ve mükerrer konu açmak yerine o konuya ekleyin.</string>
+    <string name="support_rules_phone_title">Telefonunuz da önemli</string>
+    <string name="support_rules_phone_desc">Telefon modeliniz, Android sürümü ve telefondaki Android Auto uygulama sürümü. Bazı sorunlar belirli bir Android Auto sürümünden kaynaklanır.</string>
+    <string name="support_rules_describe_title">Net bir şekilde açıklayın</string>
+    <string name="support_rules_describe_desc">Ne yaptığınızı, ne beklediğinizi ve gerçekte ne olduğunu yazın. Görsel sorunlar için bir ekran görüntüsü veya kısa bir video çok işe yarar.</string>
+    <string name="support_rules_oneissue_title">Konu başına bir sorun</string>
+    <string name="support_rules_oneissue_desc">Her konuyu tek bir sorunla sınırlı tutun ki takip edilip düzeltilebilsin. İlgisiz sorunlar için ayrı konular açın.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -762,4 +762,13 @@
     <string name="onb_dpi_recommended">Рекомендовано для вашого екрана: %1$d dpi</string>
     <string name="onb_ready_loading_intro">Ще одне: тепер ви можете встановити власний екран завантаження, який відображатиметься під час підключення автомобіля.</string>
     <string name="onb_ready_loading_button">Налаштувати екран завантаження</string>
+
+    <!-- Support / bug reporting -->
+    <string name="support">Повідомити про проблему</string>
+    <string name="support_description">Шукайте або повідомляйте про помилки на GitHub</string>
+    <string name="support_title">Повідомити про проблему</string>
+    <string name="support_help">Якщо ви зіткнулися з помилкою або проблемою, спочатку знайдіть її у списку issues на GitHub. Якщо її ще ніхто не повідомляв, відкрийте нове issue та опишіть, що сталося, вашу магнітолу і кроки для відтворення.</string>
+    <string name="support_open_issues">Відкрити сторінку issues на GitHub</string>
+    <string name="support_scan_qr">Або відскануйте цей QR-код, щоб відкрити список issues на іншому пристрої.</string>
+    <string name="support_github_account_warning">Примітка: для створення issue потрібен безкоштовний обліковий запис GitHub.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -773,4 +773,24 @@
     <string name="support_github_account_warning">Примітка: для створення issue потрібен безкоштовний акаунт GitHub.</string>
     <string name="onb_ready_extras_title">Перед завершенням ви також можете налаштувати:</string>
     <string name="onb_extra_loading_desc">Власне зображення, що відображається під час підключення автомобіля</string>
+
+    <!-- Support rules -->
+    <string name="support_rules_button">Правила звернень</string>
+    <string name="support_rules_english_desc">Будь ласка, завжди пишіть своє повідомлення англійською мовою. Мейнтейнер та більшість людей, які тут допомагають, читають англійською, і тред, де змішано багато мов, швидко перетворюється на маленьку Вавилонську вежу, де ніхто нікого не розуміє. Не впевнені в англійській? Перекладач на кшталт Google Translate або DeepL — цілком прийнятне рішення.</string>
+    <string name="support_rules_device_title">Вкажіть, на чому запущено застосунок</string>
+    <string name="support_rules_device_desc">Версія Android пристрою, що транслює Android Auto (ваша магнітола або екран), а також його марка й модель, якщо відомі.</string>
+    <string name="support_rules_connection_title">Вкажіть спосіб підключення</string>
+    <string name="support_rules_connection_desc">USB-кабель, USB бездротовий адаптер, WiFi Direct, WiFi (headunit server) або Self Mode. Якщо бездротовий — вкажіть модель адаптера чи донгла.</string>
+    <string name="support_rules_appversion_title">Вкажіть версію застосунку</string>
+    <string name="support_rules_appversion_desc">Версію Headunit Revived, яку вказано на екрані «Про застосунок і підтримка».</string>
+    <string name="support_rules_logs_title">Додайте логи одразу після того, як сталася проблема</string>
+    <string name="support_rules_logs_desc">Перейдіть до Налаштувань на вкладку Додатково, увімкніть Режим налагодження в розділі Налагодження, відтворіть проблему, а потім одразу натисніть «Експортувати журнал подій» — щоб лог охопив саме той момент, а не лише запуск. Прикріпіть цей файл до свого звернення.</string>
+    <string name="support_rules_search_title">Спочатку пошукайте</string>
+    <string name="support_rules_search_desc">Можливо, про вашу проблему вже повідомляли. Перегляньте наявні issues і додайте коментар до існуючого, замість того щоб відкривати дублікат.</string>
+    <string name="support_rules_phone_title">Телефон теж має значення</string>
+    <string name="support_rules_phone_desc">Модель телефону, версія Android на ньому та версія застосунку Android Auto. Деякі проблеми пов\'язані з конкретним випуском Android Auto.</string>
+    <string name="support_rules_describe_title">Опишіть проблему чітко</string>
+    <string name="support_rules_describe_desc">Що ви зробили, чого очікували і що сталося насправді. Скріншот або короткий відеозапис дуже допомагають у випадку візуальних проблем.</string>
+    <string name="support_rules_oneissue_title">Одна проблема — одне звернення</string>
+    <string name="support_rules_oneissue_desc">Кожне звернення має стосуватися однієї проблеми, щоб її можна було відстежити й виправити. Для непов\'язаних проблем відкривайте окремі issues.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -771,4 +771,6 @@
     <string name="support_open_issues">Відкрити список issues на GitHub</string>
     <string name="support_scan_qr">Або відскануйте цей QR-код, щоб відкрити список issues на іншому пристрої.</string>
     <string name="support_github_account_warning">Примітка: для створення issue потрібен безкоштовний акаунт GitHub.</string>
+    <string name="onb_ready_extras_title">Перед завершенням ви також можете налаштувати:</string>
+    <string name="onb_extra_loading_desc">Власне зображення, що відображається під час підключення автомобіля</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -767,8 +767,8 @@
     <string name="support">Повідомити про проблему</string>
     <string name="support_description">Шукайте або повідомляйте про помилки на GitHub</string>
     <string name="support_title">Повідомити про проблему</string>
-    <string name="support_help">Якщо ви зіткнулися з помилкою або проблемою, спочатку знайдіть її у списку issues на GitHub. Якщо її ще ніхто не повідомляв, відкрийте нове issue та опишіть, що сталося, вашу магнітолу і кроки для відтворення.</string>
-    <string name="support_open_issues">Відкрити сторінку issues на GitHub</string>
+    <string name="support_help">Якщо ви зіткнулися з помилкою або проблемою, спочатку пошукайте її у списку issues на GitHub. Якщо ніхто ще не повідомляв про неї, відкрийте нове issue та опишіть, що сталося, вашу магнітолу і кроки для відтворення.</string>
+    <string name="support_open_issues">Відкрити список issues на GitHub</string>
     <string name="support_scan_qr">Або відскануйте цей QR-код, щоб відкрити список issues на іншому пристрої.</string>
-    <string name="support_github_account_warning">Примітка: для створення issue потрібен безкоштовний обліковий запис GitHub.</string>
+    <string name="support_github_account_warning">Примітка: для створення issue потрібен безкоштовний акаунт GitHub.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -776,7 +776,7 @@
 
     <!-- Support rules -->
     <string name="support_rules_button">Правила звернень</string>
-    <string name="support_rules_english_desc">Будь ласка, завжди пишіть своє повідомлення англійською мовою. Мейнтейнер та більшість людей, які тут допомагають, читають англійською, і тред, де змішано багато мов, швидко перетворюється на маленьку Вавилонську вежу, де ніхто нікого не розуміє. Не впевнені в англійській? Перекладач на кшталт Google Translate або DeepL — цілком прийнятне рішення.</string>
+    <string name="support_rules_english_desc">Будь ласка, завжди пишіть своє звернення англійською. Це єдина мова, яку мейнтейнер і більшість помічників розуміють, і тред, де змішано кілька мов, швидко перетворюється на маленьку Вавилонську вежу, де ніхто нікому не може допомогти. Ніхто вас не засуджуватиме — ні за рівень англійської, ні за помилки, тому не переживайте. Якщо це допоможе, перекладач на кшталт Google Translate або DeepL, чи ШІ типу ChatGPT або Claude, може написати й відредагувати ваше повідомлення англійською.</string>
     <string name="support_rules_device_title">Вкажіть, на чому запущено застосунок</string>
     <string name="support_rules_device_desc">Версія Android пристрою, що транслює Android Auto (ваша магнітола або екран), а також його марка й модель, якщо відомі.</string>
     <string name="support_rules_connection_title">Вкажіть спосіб підключення</string>
@@ -785,12 +785,15 @@
     <string name="support_rules_appversion_desc">Версію Headunit Revived, яку вказано на екрані «Про застосунок і підтримка».</string>
     <string name="support_rules_logs_title">Додайте логи одразу після того, як сталася проблема</string>
     <string name="support_rules_logs_desc">Перейдіть до Налаштувань на вкладку Додатково, увімкніть Режим налагодження в розділі Налагодження, відтворіть проблему, а потім одразу натисніть «Експортувати журнал подій» — щоб лог охопив саме той момент, а не лише запуск. Прикріпіть цей файл до свого звернення.</string>
-    <string name="support_rules_search_title">Спочатку пошукайте</string>
-    <string name="support_rules_search_desc">Можливо, про вашу проблему вже повідомляли. Перегляньте наявні issues і додайте коментар до існуючого, замість того щоб відкривати дублікат.</string>
+    <string name="support_rules_search_title">Без дублікатів</string>
+    <string name="support_rules_search_desc">Спочатку пошукайте серед наявних issues. Якщо відкрите issue вже описує вашу проблему, додайте свої деталі в коментар там, а не відкривайте нове. Відкривайте нове issue лише якщо жодне не підходить.</string>
     <string name="support_rules_phone_title">Телефон теж має значення</string>
     <string name="support_rules_phone_desc">Модель телефону, версія Android на ньому та версія застосунку Android Auto. Деякі проблеми пов\'язані з конкретним випуском Android Auto.</string>
     <string name="support_rules_describe_title">Опишіть проблему чітко</string>
     <string name="support_rules_describe_desc">Що ви зробили, чого очікували і що сталося насправді. Скріншот або короткий відеозапис дуже допомагають у випадку візуальних проблем.</string>
     <string name="support_rules_oneissue_title">Одна проблема — одне звернення</string>
     <string name="support_rules_oneissue_desc">Кожне звернення має стосуватися однієї проблеми, щоб її можна було відстежити й виправити. Для непов\'язаних проблем відкривайте окремі issues.</string>
+    <string name="support_rules_intro">Потрібні лише дві речі. Все інше необов\'язкове, але значно прискорює вирішення проблеми.</string>
+    <string name="support_rules_section_required">Обов\'язково</string>
+    <string name="support_rules_section_recommend">Рекомендації (необов\'язково)</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -739,4 +739,12 @@
     <string name="onb_vehicle_help_advanced">Bạn có thể tinh chỉnh thêm chi tiết xe trong tab Nâng cao. Chúng tôi không dùng dữ liệu này; nó chỉ được gửi đến Android Auto vì Android Auto yêu cầu.</string>
     <string name="onb_summary_vehicle_format">Xe: %1$s</string>
     <string name="sunrise_reference_help">Điểm tham chiếu được dùng để tính thời gian mặt trời mọc và lặn. Chọn vị trí của bạn một lần; hoạt động mà không cần GPS.</string>
+
+    <string name="support">Báo cáo sự cố</string>
+    <string name="support_description">Tìm kiếm hoặc báo lỗi trên GitHub</string>
+    <string name="support_title">Báo cáo sự cố</string>
+    <string name="support_help">Nếu bạn gặp lỗi hoặc sự cố, vui lòng tìm kiếm trong danh sách GitHub issues trước. Nếu chưa ai báo cáo, hãy mở issue mới và mô tả những gì xảy ra, thiết bị đầu phát của bạn và các bước tái hiện sự cố.</string>
+    <string name="support_open_issues">Mở trang GitHub issues</string>
+    <string name="support_scan_qr">Hoặc quét mã QR này để mở danh sách issues trên thiết bị khác.</string>
+    <string name="support_github_account_warning">Lưu ý: bạn cần tài khoản GitHub miễn phí để tạo issue.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -752,7 +752,7 @@
 
     <!-- Support rules -->
     <string name="support_rules_button">Quy tắc báo cáo</string>
-    <string name="support_rules_english_desc">Vui lòng luôn viết sự cố của bạn bằng tiếng Anh. Người duy trì dự án và hầu hết những người hỗ trợ đây đều đọc tiếng Anh, và một chủ đề pha trộn nhiều ngôn ngữ nhanh chóng trở thành tháp Babel nơi không ai hiểu ai. Không tự tin với tiếng Anh? Dùng công cụ dịch như Google Translate hoặc DeepL là hoàn toàn ổn.</string>
+    <string name="support_rules_english_desc">Vui lòng luôn viết sự cố của bạn bằng tiếng Anh. Đây là ngôn ngữ chung của người duy trì dự án và hầu hết những người hỗ trợ ở đây, và một chủ đề pha trộn nhiều ngôn ngữ sẽ nhanh chóng trở thành tháp Babel nơi không ai có thể giúp được ai. Không ai phán xét bạn, trình độ tiếng Anh hay cách bạn viết, vì vậy đừng lo lắng về lỗi. Nếu cần, các công cụ dịch như Google Translate hay DeepL, hoặc AI như ChatGPT hay Claude, có thể giúp bạn viết và chỉnh sửa tin nhắn bằng tiếng Anh.</string>
     <string name="support_rules_device_title">Cho biết máy nào đang chạy ứng dụng</string>
     <string name="support_rules_device_desc">Phiên bản Android của thiết bị đang chiếu Android Auto (màn hình ô tô của bạn), cùng hãng và mẫu máy nếu biết.</string>
     <string name="support_rules_connection_title">Cho biết bạn kết nối như thế nào</string>
@@ -761,12 +761,15 @@
     <string name="support_rules_appversion_desc">Phiên bản Headunit Revived, hiển thị trên màn hình Giới thiệu.</string>
     <string name="support_rules_logs_title">Đính kèm log, ngay sau khi xảy ra</string>
     <string name="support_rules_logs_desc">Vào Cài đặt, chọn tab Nâng cao, bật Chế độ gỡ lỗi trong phần Gỡ lỗi, tái hiện sự cố, rồi nhấn Xuất log ngay sau đó để log ghi lại đúng thời điểm xảy ra chứ không chỉ từ lúc khởi động. Đính kèm tệp đó vào issue.</string>
-    <string name="support_rules_search_title">Tìm kiếm trước</string>
-    <string name="support_rules_search_desc">Sự cố của bạn có thể đã được báo cáo. Hãy tìm trong các issue hiện có và bổ sung vào đó thay vì mở issue trùng lặp.</string>
+    <string name="support_rules_search_title">Không trùng lặp</string>
+    <string name="support_rules_search_desc">Trước tiên hãy tìm kiếm trong các issue hiện có. Nếu đã có issue mô tả đúng sự cố của bạn, hãy thêm thông tin của bạn làm bình luận ở đó thay vì mở issue mới. Chỉ mở issue mới nếu không có issue nào phù hợp.</string>
     <string name="support_rules_phone_title">Điện thoại của bạn cũng quan trọng</string>
     <string name="support_rules_phone_desc">Mẫu điện thoại, phiên bản Android và phiên bản ứng dụng Android Auto trên điện thoại. Một số sự cố xuất phát từ một phiên bản Android Auto cụ thể.</string>
     <string name="support_rules_describe_title">Mô tả rõ ràng</string>
     <string name="support_rules_describe_desc">Bạn đã làm gì, bạn mong đợi điều gì và điều gì thực sự xảy ra. Ảnh chụp màn hình hoặc video ngắn rất hữu ích cho các sự cố về hình ảnh.</string>
     <string name="support_rules_oneissue_title">Một sự cố mỗi issue</string>
     <string name="support_rules_oneissue_desc">Mỗi issue chỉ nên đề cập một sự cố để dễ theo dõi và xử lý. Hãy mở issue riêng cho các sự cố không liên quan.</string>
+    <string name="support_rules_intro">Chỉ cần hai điều bắt buộc. Phần còn lại là tuỳ chọn, nhưng sẽ giúp giải quyết vấn đề của bạn nhanh hơn nhiều.</string>
+    <string name="support_rules_section_required">Bắt buộc</string>
+    <string name="support_rules_section_recommend">Khuyến nghị (tuỳ chọn)</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -747,4 +747,6 @@
     <string name="support_open_issues">Mở trang issues trên GitHub</string>
     <string name="support_scan_qr">Hoặc quét mã QR này để mở danh sách issues trên thiết bị khác.</string>
     <string name="support_github_account_warning">Lưu ý: bạn cần có tài khoản GitHub miễn phí để tạo issue.</string>
+    <string name="onb_ready_extras_title">Trước khi hoàn tất, bạn cũng có thể thiết lập:</string>
+    <string name="onb_extra_loading_desc">Hình ảnh tuỳ chỉnh hiển thị khi xe đang kết nối</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -749,4 +749,24 @@
     <string name="support_github_account_warning">Lưu ý: bạn cần có tài khoản GitHub miễn phí để tạo issue.</string>
     <string name="onb_ready_extras_title">Trước khi hoàn tất, bạn cũng có thể thiết lập:</string>
     <string name="onb_extra_loading_desc">Hình ảnh tuỳ chỉnh hiển thị khi xe đang kết nối</string>
+
+    <!-- Support rules -->
+    <string name="support_rules_button">Quy tắc báo cáo</string>
+    <string name="support_rules_english_desc">Vui lòng luôn viết sự cố của bạn bằng tiếng Anh. Người duy trì dự án và hầu hết những người hỗ trợ đây đều đọc tiếng Anh, và một chủ đề pha trộn nhiều ngôn ngữ nhanh chóng trở thành tháp Babel nơi không ai hiểu ai. Không tự tin với tiếng Anh? Dùng công cụ dịch như Google Translate hoặc DeepL là hoàn toàn ổn.</string>
+    <string name="support_rules_device_title">Cho biết máy nào đang chạy ứng dụng</string>
+    <string name="support_rules_device_desc">Phiên bản Android của thiết bị đang chiếu Android Auto (màn hình ô tô của bạn), cùng hãng và mẫu máy nếu biết.</string>
+    <string name="support_rules_connection_title">Cho biết bạn kết nối như thế nào</string>
+    <string name="support_rules_connection_desc">Cáp USB, bộ chuyển không dây USB, WiFi Direct, WiFi (headunit server) hoặc Self Mode. Nếu là kết nối không dây, hãy thêm mẫu bộ chuyển hoặc dongle.</string>
+    <string name="support_rules_appversion_title">Ghi rõ phiên bản ứng dụng</string>
+    <string name="support_rules_appversion_desc">Phiên bản Headunit Revived, hiển thị trên màn hình Giới thiệu.</string>
+    <string name="support_rules_logs_title">Đính kèm log, ngay sau khi xảy ra</string>
+    <string name="support_rules_logs_desc">Vào Cài đặt, chọn tab Nâng cao, bật Chế độ gỡ lỗi trong phần Gỡ lỗi, tái hiện sự cố, rồi nhấn Xuất log ngay sau đó để log ghi lại đúng thời điểm xảy ra chứ không chỉ từ lúc khởi động. Đính kèm tệp đó vào issue.</string>
+    <string name="support_rules_search_title">Tìm kiếm trước</string>
+    <string name="support_rules_search_desc">Sự cố của bạn có thể đã được báo cáo. Hãy tìm trong các issue hiện có và bổ sung vào đó thay vì mở issue trùng lặp.</string>
+    <string name="support_rules_phone_title">Điện thoại của bạn cũng quan trọng</string>
+    <string name="support_rules_phone_desc">Mẫu điện thoại, phiên bản Android và phiên bản ứng dụng Android Auto trên điện thoại. Một số sự cố xuất phát từ một phiên bản Android Auto cụ thể.</string>
+    <string name="support_rules_describe_title">Mô tả rõ ràng</string>
+    <string name="support_rules_describe_desc">Bạn đã làm gì, bạn mong đợi điều gì và điều gì thực sự xảy ra. Ảnh chụp màn hình hoặc video ngắn rất hữu ích cho các sự cố về hình ảnh.</string>
+    <string name="support_rules_oneissue_title">Một sự cố mỗi issue</string>
+    <string name="support_rules_oneissue_desc">Mỗi issue chỉ nên đề cập một sự cố để dễ theo dõi và xử lý. Hãy mở issue riêng cho các sự cố không liên quan.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -741,10 +741,10 @@
     <string name="sunrise_reference_help">Điểm tham chiếu được dùng để tính thời gian mặt trời mọc và lặn. Chọn vị trí của bạn một lần; hoạt động mà không cần GPS.</string>
 
     <string name="support">Báo cáo sự cố</string>
-    <string name="support_description">Tìm kiếm hoặc báo lỗi trên GitHub</string>
+    <string name="support_description">Tìm kiếm hoặc báo cáo lỗi trên GitHub</string>
     <string name="support_title">Báo cáo sự cố</string>
-    <string name="support_help">Nếu bạn gặp lỗi hoặc sự cố, vui lòng tìm kiếm trong danh sách GitHub issues trước. Nếu chưa ai báo cáo, hãy mở issue mới và mô tả những gì xảy ra, thiết bị đầu phát của bạn và các bước tái hiện sự cố.</string>
-    <string name="support_open_issues">Mở trang GitHub issues</string>
+    <string name="support_help">Nếu bạn gặp lỗi hoặc sự cố, vui lòng tìm trước trong danh sách GitHub issues. Nếu chưa có ai báo cáo, hãy mở một issue mới và mô tả hiện tượng xảy ra, màn hình ô tô của bạn, và các bước để tái hiện sự cố.</string>
+    <string name="support_open_issues">Mở trang issues trên GitHub</string>
     <string name="support_scan_qr">Hoặc quét mã QR này để mở danh sách issues trên thiết bị khác.</string>
-    <string name="support_github_account_warning">Lưu ý: bạn cần tài khoản GitHub miễn phí để tạo issue.</string>
+    <string name="support_github_account_warning">Lưu ý: bạn cần có tài khoản GitHub miễn phí để tạo issue.</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -773,8 +773,11 @@
     <string name="onb_extra_loading_desc">汽車連線時顯示的自訂圖片</string>
 
     <!-- Support Rules -->
+    <string name="support_rules_intro">只有兩項是必填的，其餘都是選填，但填得越詳細，問題就越容易被解決。</string>
+    <string name="support_rules_section_required">必填</string>
+    <string name="support_rules_section_recommend">建議（選填）</string>
     <string name="support_rules_button">回報須知</string>
-    <string name="support_rules_english_desc">請務必以英文描述您的問題。維護者及大多數協助者使用英文，若討論串混雜多種語言，很快就會變成一座巴別塔，讓所有人都看不懂彼此在說什麼。英文不夠有信心？用 Google Translate 或 DeepL 翻譯完全沒問題。</string>
+    <string name="support_rules_english_desc">請務必以英文描述您的問題。英文是維護者與大多數協助者共同使用的語言，若討論串混雜多種語言，很快就會變成一座巴別塔，讓大家都無法互相幫忙。不必擔心英文程度或拼字，沒有人會在意。如果有需要，可以用 Google Translate 或 DeepL 這類翻譯工具，或是 ChatGPT 或 Claude 這類 AI，幫您把問題寫成英文或潤飾一下。</string>
     <string name="support_rules_device_title">說明執行應用程式的裝置</string>
     <string name="support_rules_device_desc">投射 Android Auto 的裝置（您的車機或螢幕）所使用的 Android 版本，以及品牌和型號（如果知道的話）。</string>
     <string name="support_rules_connection_title">說明連線方式</string>
@@ -783,8 +786,8 @@
     <string name="support_rules_appversion_desc">Headunit Revived 的版本號，可在關於畫面中查看。</string>
     <string name="support_rules_logs_title">在問題發生後立即附上日誌</string>
     <string name="support_rules_logs_desc">請進入設定，切換到進階分頁，在除錯區段開啟除錯模式，重現問題，然後立即點選匯出日誌，確保日誌涵蓋問題發生的當下而非僅有啟動時的紀錄。請將該檔案附至您的 Issue。</string>
-    <string name="support_rules_search_title">先搜尋看看</string>
-    <string name="support_rules_search_desc">您的問題可能已有人回報過。請先搜尋現有的 Issue，如果找到相同問題，請在那個 Issue 補充說明，而不是重新開一個重複的。</string>
+    <string name="support_rules_search_title">不要重複回報</string>
+    <string name="support_rules_search_desc">請先搜尋現有的 Issue。如果已有人回報相同問題，請在那個 Issue 補充您的情況，不要另開新的。只有在找不到相符的 Issue 時，才開一個新的。</string>
     <string name="support_rules_phone_title">手機資訊也很重要</string>
     <string name="support_rules_phone_desc">您的手機型號、Android 版本，以及手機上 Android Auto 應用程式的版本。有些問題只在特定版本的 Android Auto 上出現。</string>
     <string name="support_rules_describe_title">清楚描述問題</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -771,4 +771,24 @@
     <string name="support_github_account_warning">注意：建立 Issue 需要一個免費的 GitHub 帳號。</string>
     <string name="onb_ready_extras_title">完成前，您還可以設定：</string>
     <string name="onb_extra_loading_desc">汽車連線時顯示的自訂圖片</string>
+
+    <!-- Support Rules -->
+    <string name="support_rules_button">回報須知</string>
+    <string name="support_rules_english_desc">請務必以英文描述您的問題。維護者及大多數協助者使用英文，若討論串混雜多種語言，很快就會變成一座巴別塔，讓所有人都看不懂彼此在說什麼。英文不夠有信心？用 Google Translate 或 DeepL 翻譯完全沒問題。</string>
+    <string name="support_rules_device_title">說明執行應用程式的裝置</string>
+    <string name="support_rules_device_desc">投射 Android Auto 的裝置（您的車機或螢幕）所使用的 Android 版本，以及品牌和型號（如果知道的話）。</string>
+    <string name="support_rules_connection_title">說明連線方式</string>
+    <string name="support_rules_connection_desc">USB 線、USB 無線轉接器、WiFi Direct、WiFi（車機伺服器）或 Self Mode。若為無線連線，請附上轉接器或 Dongle 的型號。</string>
+    <string name="support_rules_appversion_title">附上應用程式版本</string>
+    <string name="support_rules_appversion_desc">Headunit Revived 的版本號，可在關於畫面中查看。</string>
+    <string name="support_rules_logs_title">在問題發生後立即附上日誌</string>
+    <string name="support_rules_logs_desc">請進入設定，切換到進階分頁，在除錯區段開啟除錯模式，重現問題，然後立即點選匯出日誌，確保日誌涵蓋問題發生的當下而非僅有啟動時的紀錄。請將該檔案附至您的 Issue。</string>
+    <string name="support_rules_search_title">先搜尋看看</string>
+    <string name="support_rules_search_desc">您的問題可能已有人回報過。請先搜尋現有的 Issue，如果找到相同問題，請在那個 Issue 補充說明，而不是重新開一個重複的。</string>
+    <string name="support_rules_phone_title">手機資訊也很重要</string>
+    <string name="support_rules_phone_desc">您的手機型號、Android 版本，以及手機上 Android Auto 應用程式的版本。有些問題只在特定版本的 Android Auto 上出現。</string>
+    <string name="support_rules_describe_title">清楚描述問題</string>
+    <string name="support_rules_describe_desc">您做了什麼、預期會發生什麼，以及實際發生了什麼。對於視覺問題，附上截圖或短片會非常有幫助。</string>
+    <string name="support_rules_oneissue_title">一個 Issue 只處理一個問題</string>
+    <string name="support_rules_oneissue_desc">每個 Issue 請聚焦於單一問題，方便追蹤和修復。不相關的問題請另開 Issue。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -769,4 +769,6 @@
     <string name="support_open_issues">前往 GitHub Issues 頁面</string>
     <string name="support_scan_qr">或掃描此 QR 碼，在其他裝置上開啟 Issues 清單。</string>
     <string name="support_github_account_warning">注意：建立 Issue 需要一個免費的 GitHub 帳號。</string>
+    <string name="onb_ready_extras_title">完成前，您還可以設定：</string>
+    <string name="onb_extra_loading_desc">汽車連線時顯示的自訂圖片</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -763,10 +763,10 @@
 
     <!-- Support / Bug Report -->
     <string name="support">回報問題</string>
-    <string name="support_description">在 GitHub 上搜尋或回報錯誤</string>
+    <string name="support_description">在 GitHub 上搜尋或回報 Bug</string>
     <string name="support_title">回報問題</string>
-    <string name="support_help">如果您遇到錯誤或問題，請先在 GitHub 問題列表中查找。如果尚無人回報，請開啟新問題並描述發生的情況、您的車機，以及重現步驟。</string>
-    <string name="support_open_issues">開啟 GitHub 問題頁面</string>
-    <string name="support_scan_qr">或掃描此 QR 碼，在其他裝置上開啟問題列表。</string>
-    <string name="support_github_account_warning">注意：您需要一個免費的 GitHub 帳號才能建立問題。</string>
+    <string name="support_help">若您遇到 Bug 或其他問題，請先在 GitHub 的 Issues 清單中搜尋，確認是否已有人回報過。若尚未有人提出，請開啟新的 Issue，說明發生的狀況、您使用的車機型號，以及重現問題的步驟。</string>
+    <string name="support_open_issues">前往 GitHub Issues 頁面</string>
+    <string name="support_scan_qr">或掃描此 QR 碼，在其他裝置上開啟 Issues 清單。</string>
+    <string name="support_github_account_warning">注意：建立 Issue 需要一個免費的 GitHub 帳號。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -760,4 +760,13 @@
     <string name="onb_dpi_recommended">您螢幕的建議值：%1$d dpi</string>
     <string name="onb_ready_loading_intro">還有一件事：您現在可以設定自訂載入畫面，在汽車連線時顯示。</string>
     <string name="onb_ready_loading_button">設定載入畫面</string>
+
+    <!-- Support / Bug Report -->
+    <string name="support">回報問題</string>
+    <string name="support_description">在 GitHub 上搜尋或回報錯誤</string>
+    <string name="support_title">回報問題</string>
+    <string name="support_help">如果您遇到錯誤或問題，請先在 GitHub 問題列表中查找。如果尚無人回報，請開啟新問題並描述發生的情況、您的車機，以及重現步驟。</string>
+    <string name="support_open_issues">開啟 GitHub 問題頁面</string>
+    <string name="support_scan_qr">或掃描此 QR 碼，在其他裝置上開啟問題列表。</string>
+    <string name="support_github_account_warning">注意：您需要一個免費的 GitHub 帳號才能建立問題。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,9 @@
     <string name="onb_summary_permissions_format">Permissions: %1$d of %2$d granted</string>
     <string name="onb_ready_loading_intro">One more thing: you can now set a custom loading screen, shown while the car connects.</string>
     <string name="onb_ready_loading_button">Set up a loading screen</string>
+    <!-- Ready step optional-extras card -->
+    <string name="onb_ready_extras_title">Before you finish, you can also set up:</string>
+    <string name="onb_extra_loading_desc">A custom image shown while the car connects</string>
 
     <!-- Onboarding wizard: permissions step + Settings > Permissions -->
     <string name="onb_permissions_title">Enable permissions</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -475,6 +475,28 @@
     <string name="support_scan_qr">Or scan this QR code to open the issues list on another device.</string>
     <string name="support_github_account_warning">Note: you need a free GitHub account to create an issue.</string>
     <string name="github_issues_url" translatable="false">https://github.com/andreknieriem/headunit-revived/issues</string>
+
+    <!-- Reporting rules modal (shown from a button under the QR on the Support screen) -->
+    <string name="support_rules_button">Reporting rules</string>
+    <!-- This title stays in English in every language on purpose. -->
+    <string name="support_rules_english_title" translatable="false">All posts in English</string>
+    <string name="support_rules_english_desc">Please always write your issue in English. The maintainer and most people who help here read English, and a thread mixing many languages quickly turns into a little Tower of Babel where nobody understands anyone. Not confident in English? A translator like Google Translate or DeepL is perfectly fine.</string>
+    <string name="support_rules_device_title">Say what runs the app</string>
+    <string name="support_rules_device_desc">The Android version of the device projecting Android Auto (your head unit or screen), and its brand and model if you know them.</string>
+    <string name="support_rules_connection_title">Say how you connect</string>
+    <string name="support_rules_connection_desc">USB cable, USB wireless adapter, WiFi Direct, WiFi (headunit server) or Self Mode. If it is wireless, add the adapter or dongle model.</string>
+    <string name="support_rules_appversion_title">Include the app version</string>
+    <string name="support_rules_appversion_desc">The Headunit Revived version, shown on the About screen.</string>
+    <string name="support_rules_logs_title">Attach logs, right after it happens</string>
+    <string name="support_rules_logs_desc">Switch Settings to the Advanced tab, turn on Debug Mode in the Debug section, reproduce the problem, then tap Export Logs right after so the log covers the moment it broke and not just the start. Attach that file to your issue.</string>
+    <string name="support_rules_search_title">Search first</string>
+    <string name="support_rules_search_desc">Your problem may already be reported. Search the existing issues and add to that one instead of opening a duplicate.</string>
+    <string name="support_rules_phone_title">Your phone matters too</string>
+    <string name="support_rules_phone_desc">Your phone model, its Android version and the Android Auto app version on the phone. Some problems come from a specific Android Auto release.</string>
+    <string name="support_rules_describe_title">Describe it clearly</string>
+    <string name="support_rules_describe_desc">What you did, what you expected and what actually happened. A screenshot or a short video helps a lot for visual problems.</string>
+    <string name="support_rules_oneissue_title">One problem per issue</string>
+    <string name="support_rules_oneissue_desc">Keep each issue to a single problem so it can be tracked and fixed. Open separate issues for unrelated problems.</string>
     <string name="version">Version</string>
     <string name="about_title">About Headunit Revived</string>
     <string name="copyright">© 2025-%d André Rinas</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -462,6 +462,16 @@
     <string name="category_info">Info</string>
     <string name="about">About &amp; Support</string>
     <string name="about_description">Get more information about Headunit Revived</string>
+
+    <!-- Support / report a problem screen -->
+    <string name="support">Report a problem</string>
+    <string name="support_description">Search or report bugs on GitHub</string>
+    <string name="support_title">Report a problem</string>
+    <string name="support_help">If you run into a bug or a problem, please first look for it in the GitHub issues list. If no one has reported it yet, open a new issue and describe what happens, your head unit, and the steps to reproduce it.</string>
+    <string name="support_open_issues">Open the GitHub issues page</string>
+    <string name="support_scan_qr">Or scan this QR code to open the issues list on another device.</string>
+    <string name="support_github_account_warning">Note: you need a free GitHub account to create an issue.</string>
+    <string name="github_issues_url" translatable="false">https://github.com/andreknieriem/headunit-revived/issues</string>
     <string name="version">Version</string>
     <string name="about_title">About Headunit Revived</string>
     <string name="copyright">© 2025-%d André Rinas</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -478,9 +478,12 @@
 
     <!-- Reporting rules modal (shown from a button under the QR on the Support screen) -->
     <string name="support_rules_button">Reporting rules</string>
+    <string name="support_rules_intro">Only two things are required. Everything else is optional, but it helps solve your problem much faster.</string>
+    <string name="support_rules_section_required">Required</string>
+    <string name="support_rules_section_recommend">Recommendations (optional)</string>
     <!-- This title stays in English in every language on purpose. -->
     <string name="support_rules_english_title" translatable="false">All posts in English</string>
-    <string name="support_rules_english_desc">Please always write your issue in English. The maintainer and most people who help here read English, and a thread mixing many languages quickly turns into a little Tower of Babel where nobody understands anyone. Not confident in English? A translator like Google Translate or DeepL is perfectly fine.</string>
+    <string name="support_rules_english_desc">Please always write your issue in English. It is the one language the maintainer and most people helping here share, and a thread in many languages just turns into a little Tower of Babel where nobody can help anyone. No one judges you, your level of English or the way you write, so do not worry about mistakes. If it helps, a translator like Google Translate or DeepL, or an AI like ChatGPT or Claude, can write and tidy up your message in English for you.</string>
     <string name="support_rules_device_title">Say what runs the app</string>
     <string name="support_rules_device_desc">The Android version of the device projecting Android Auto (your head unit or screen), and its brand and model if you know them.</string>
     <string name="support_rules_connection_title">Say how you connect</string>
@@ -489,8 +492,8 @@
     <string name="support_rules_appversion_desc">The Headunit Revived version, shown on the About screen.</string>
     <string name="support_rules_logs_title">Attach logs, right after it happens</string>
     <string name="support_rules_logs_desc">Switch Settings to the Advanced tab, turn on Debug Mode in the Debug section, reproduce the problem, then tap Export Logs right after so the log covers the moment it broke and not just the start. Attach that file to your issue.</string>
-    <string name="support_rules_search_title">Search first</string>
-    <string name="support_rules_search_desc">Your problem may already be reported. Search the existing issues and add to that one instead of opening a duplicate.</string>
+    <string name="support_rules_search_title">No duplicates</string>
+    <string name="support_rules_search_desc">First search the existing issues. If an open issue already describes your problem, add your details as a comment there instead of opening a new one. Only open a new issue if none matches.</string>
     <string name="support_rules_phone_title">Your phone matters too</string>
     <string name="support_rules_phone_desc">Your phone model, its Android version and the Android Auto app version on the phone. Some problems come from a specific Android Auto release.</string>
     <string name="support_rules_describe_title">Describe it clearly</string>


### PR DESCRIPTION
This builds on the Settings redesign and the first-run wizard with a set of UX improvements, a clearer way to report problems, a fix for a crash on old Android, and a multi-select for the connection type.

Old-Android crash fix
The setup wizard crashed on launch on Android below 5.0 (reported on #647 for Android 4.4.2). Several ImageViews loaded vector drawables through android:src, which the framework cannot inflate before API 21, so the whole onboarding layout failed to inflate. They now use app:srcCompat. This also guards Display.getRealMetrics (added in API 17), which threw on Android 4.1 during the display scan, and switches the nearby-device icon to app:tint so it stays themed on old devices.

Connection multi-select
The connection choice used to be single-select (USB, WiFi, Self Mode or All). It is now a multi-select, so someone who connects more than one way can pick several and see the settings for each. Only Self Mode hides the USB, wireless and external-GPS settings; only USB hides the wireless ones; only WiFi hides the USB ones; combinations show the union. The wizard uses checkable buttons (at least one required) and Settings a multi-choice dialog. Existing choices migrate automatically, and this only changes which settings are shown, not the connection logic.

Report a problem screen
A dedicated screen with a direct link to the GitHub issues page and a QR code, so someone on a head unit with no browser or no internet can scan it from their phone. It has a short help text (search first, then open a new one) and a note that opening an issue needs a GitHub account. It is aimed at users who get lost and do not know where or how to report a bug. It also lives in the Basic tab so it is easy to find.

Loading screen in Basic
The custom loading screen setting now shows up in the Basic tab, not only in Advanced.

Wizard finishing card
The last wizard step now has a small card with quick shortcuts to the things the wizard does not cover: the loading screen, the keymap and the microphone. Each one finishes setup and opens the matching screen.

Wizard button color
The loading-screen button on the last step is now a filled, colored button so it reads as an action.

Animated DPI preview
On the DPI step the illustration animates on its own as a short demo, sweeping the size range so people understand what it does. Only the illustration moves, the slider and the number stay at the real value, and it stops the moment the user starts setting their own DPI. Same behavior in the standalone DPI screen, and it never changes the saved value.

Quick Settings additions
Two settings that apply live during projection with no reconnect: screen orientation and screen mode (system bars). Anything that needs a reconnect stays out of the overlay on purpose.

Translations
All new user-facing strings are translated across the existing locales.

A debug build to verify the old-Android crash fix is linked from #647. The branch is up to date with main and has no conflicts.
