### PR TITLE
Fix Native AA connecting loop and Bluetooth handshake instability (#706)

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
@@ -734,6 +734,8 @@ class AapService : Service(), UsbReceiver.Listener {
                 AppLog.d("AapService: WiFi credentials received, but not in Native AA mode. Skipping HandshakeManager update.")
             }
         }
+        wifiDirectManager?.setNativeHandshakeStateProvider { nativeAaHandshakeManager?.isHandshakeInFlight() == true }
+        wifiDirectManager?.setNativeGroupInvalidatedListener { nativeAaHandshakeManager?.invalidateCredentials() }
 
 
         checkAlreadyConnectedUsb()

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
@@ -98,7 +98,13 @@ class NativeAaHandshakeManager(
         currentBssid = null
     }
 
-    fun isActive(): Boolean = isRunning
+    // isRunning alone isn't enough once closeAaListeners() can close the AA_UUID listener while
+    // leaving the manager otherwise running (HFP stays up) — callers like AutoStartReceiver's
+    // BT-reconnect re-arm need to know whether a connection can actually be accepted right now,
+    // not just whether the manager was start()ed. See the "Re-arm on Bluetooth reconnect" fix
+    // this restores the invariant for: isActive() must mean "genuinely able to accept," not
+    // "believed to be running."
+    fun isActive(): Boolean = isRunning && !aaListenersClosedForSession
 
     fun isHandshakeInFlight(): Boolean = handshakeInFlight
 

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
@@ -480,17 +480,18 @@ class NativeAaHandshakeManager(
                 sendWifiSecurityResponse(output, ssid, psk, bssid)
                 AppLog.i("NativeAA: Handshake completed successfully on Bluetooth side.")
                 // The credential exchange is done; the join watchdog no longer needs to defer
-                // for this handshake. Without this, it stayed true for the entire lifetime of
-                // the "maintain session" loop below (observed on-device stuck for 15+ minutes),
-                // permanently blocking recovery if the phone never actually joins the P2P group.
+                // for this handshake.
                 handshakeInFlight = false
 
-                // Keep the socket open to maintain the handshake session
-                AppLog.i("NativeAA: Maintaining Bluetooth session...")
-                while (isRunning && isActive && socket.isConnected) {
-                    delay(5000)
-                }
-                AppLog.i("NativeAA: Handshake session ending (isRunning=$isRunning, isConnected=${socket.isConnected})")
+                // Release the Bluetooth connection shortly after handoff instead of holding it
+                // indefinitely. The real Android Auto protocol closes Bluetooth right after the
+                // WiFi credential exchange — confirmed via a reference wireless-dongle
+                // implementation (nisargjhaveri/WirelessAndroidAutoDongle#17/#18), where holding
+                // it open caused the same "confusion, especially with phone calls" symptom this
+                // repo has seen reported. Short grace window for the phone to finish reading the
+                // response before we close.
+                delay(3000)
+                AppLog.i("NativeAA: Handshake session ending, releasing Bluetooth connection.")
             } else {
                 AppLog.w("NativeAA: Handshake failed - Unexpected response type ${response.type}. Expected Type 2.")
             }

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
@@ -118,20 +118,23 @@ class NativeAaHandshakeManager(
         }
 
         isRunning = true
-        AppLog.i("NativeAA: Starting Bluetooth Handshake Servers...")
+        // Local Bluetooth radio address; logged on every accept so a dual-radio head unit's logs
+        // show which radio the phone actually reached (compare with the HU MAC in the phone's log).
+        val localAddr = try { adapter.address } catch (e: Exception) { "?" }
+        AppLog.i("NativeAA: Starting Bluetooth Handshake Servers (primary radio [$localAddr])...")
 
         // Start AA RFCOMM Server
         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-RfcommServer")) {
             try {
                 aaServerSocket = adapter.listenUsingRfcommWithServiceRecord("AA BT Listener", AA_UUID)
-                AppLog.i("NativeAA: ACTIVELY LISTENING on Android Auto UUID ($AA_UUID)... Waiting for phone to connect back!")
+                AppLog.i("NativeAA: ACTIVELY LISTENING on Android Auto UUID ($AA_UUID) on radio [$localAddr]... Waiting for phone to connect back!")
                 while (isRunning && isActive) {
                     val socket = aaServerSocket?.accept()
                     if (socket != null) {
-                        AppLog.i("NativeAA: Connection accepted from ${socket.remoteDevice.name}")
+                        AppLog.i("NativeAA: Connection accepted from ${socket.remoteDevice.name} (${socket.remoteDevice.address}) on local radio [$localAddr]")
                         // [FIX] Launch handshake in a separate coroutine so the server can accept the next connection!
                         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-Handshake-${socket.remoteDevice.address}")) {
-                            handleHandshake(socket)
+                            handleHandshake(socket, localAddr)
                         }
                     }
                 }
@@ -201,9 +204,9 @@ class NativeAaHandshakeManager(
                 while (isRunning && isActive) {
                     val socket = server.accept()
                     if (socket != null) {
-                        AppLog.i("NativeAA: Connection accepted (secondary radio) from ${socket.remoteDevice.name}")
+                        AppLog.i("NativeAA: Connection accepted (secondary radio [$addr]) from ${socket.remoteDevice.name} (${socket.remoteDevice.address})")
                         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-Handshake-${socket.remoteDevice.address}")) {
-                            handleHandshake(socket)
+                            handleHandshake(socket, addr)
                         }
                     }
                 }
@@ -388,11 +391,11 @@ class NativeAaHandshakeManager(
         }
     }
 
-    private suspend fun handleHandshake(socket: BluetoothSocket) = withContext(Dispatchers.IO) {
+    private suspend fun handleHandshake(socket: BluetoothSocket, localRadio: String? = null) = withContext(Dispatchers.IO) {
         handshakeInFlight = true
         try {
             val device = socket.remoteDevice
-            AppLog.i("NativeAA: Handling handshake for ${device.name} (${device.address})")
+            AppLog.i("NativeAA: Handling handshake for ${device.name} (${device.address}) on local radio [${localRadio ?: "?"}]")
 
             if (commManager.isConnected ||
                 commManager.connectionState.value is CommManager.ConnectionState.Connecting) {
@@ -460,7 +463,7 @@ class NativeAaHandshakeManager(
             // No BluetoothSocket.setSoTimeout(); force-close via watchdog to unblock readFully() on timeout.
             val watchdog = scope.launch(Dispatchers.IO) {
                 delay(HANDSHAKE_RESPONSE_TIMEOUT_MS)
-                AppLog.e("NativeAA: Handshake failed - No response from phone within ${HANDSHAKE_RESPONSE_TIMEOUT_MS / 1000}s of sending WifiStartRequest. Closing socket.")
+                AppLog.e("NativeAA: Handshake failed - No response from phone ${device.name} (${device.address}) on radio [${localRadio ?: "?"}] within ${HANDSHAKE_RESPONSE_TIMEOUT_MS / 1000}s of sending WifiStartRequest. Closing socket.")
                 try { socket.close() } catch (e: Exception) {}
             }
             val response = try {

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
@@ -60,8 +60,14 @@ class NativeAaHandshakeManager(
     private var aaServerSocket: BluetoothServerSocket? = null
     private var hfpServerSocket: BluetoothServerSocket? = null
     // Extra RFCOMM listeners opened on secondary Bluetooth radios (dual-Bluetooth head units).
-    private val extraServerSockets = java.util.Collections.synchronizedList(mutableListOf<BluetoothServerSocket>())
+    // Split by UUID so a successful handoff can close just the AA listeners (see
+    // closeAaListeners()) without taking down the HFP ones too.
+    private val extraAaServerSockets = java.util.Collections.synchronizedList(mutableListOf<BluetoothServerSocket>())
+    private val extraHfpServerSockets = java.util.Collections.synchronizedList(mutableListOf<BluetoothServerSocket>())
     private var isRunning = false
+    // Set by closeAaListeners() so the AA accept loops can tell "we closed this on purpose
+    // after a successful handoff" apart from a real socket error, for logging only.
+    @Volatile private var aaListenersClosedForSession = false
 
     private var currentSsid: String? = null
     private var currentPsk: String? = null
@@ -118,6 +124,7 @@ class NativeAaHandshakeManager(
         }
 
         isRunning = true
+        aaListenersClosedForSession = false
         // Local Bluetooth radio address; logged on every accept so a dual-radio head unit's logs
         // show which radio the phone actually reached (compare with the HU MAC in the phone's log).
         val localAddr = try { adapter.address } catch (e: Exception) { "?" }
@@ -139,7 +146,9 @@ class NativeAaHandshakeManager(
                     }
                 }
             } catch (e: Exception) {
-                if (isRunning) {
+                if (aaListenersClosedForSession) {
+                    AppLog.d("NativeAA: AA Server socket closed after successful handoff.")
+                } else if (isRunning) {
                     AppLog.e("NativeAA: AA Server socket error: ${e.message}", e)
                 } else {
                     AppLog.d("NativeAA: AA Server socket closed cleanly.")
@@ -199,7 +208,7 @@ class NativeAaHandshakeManager(
         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-RfcommServer-2")) {
             try {
                 val server = extra.listenUsingRfcommWithServiceRecord("AA BT Listener", AA_UUID)
-                extraServerSockets.add(server)
+                extraAaServerSockets.add(server)
                 AppLog.i("NativeAA: ACTIVELY LISTENING on Android Auto UUID on secondary radio [$addr]")
                 while (isRunning && isActive) {
                     val socket = server.accept()
@@ -211,14 +220,15 @@ class NativeAaHandshakeManager(
                     }
                 }
             } catch (e: Exception) {
-                if (isRunning) AppLog.e("NativeAA: Secondary AA server error [$addr]: ${e.message}", e)
+                if (aaListenersClosedForSession) AppLog.d("NativeAA: Secondary AA server closed after successful handoff [$addr].")
+                else if (isRunning) AppLog.e("NativeAA: Secondary AA server error [$addr]: ${e.message}", e)
                 else AppLog.d("NativeAA: Secondary AA server closed cleanly [$addr].")
             }
         }
         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-HfpServer-2")) {
             try {
                 val server = extra.listenUsingRfcommWithServiceRecord("Hands-Free Unit", HFP_UUID)
-                extraServerSockets.add(server)
+                extraHfpServerSockets.add(server)
                 while (isRunning && isActive) {
                     val socket = server.accept()
                     if (socket != null) {
@@ -232,6 +242,24 @@ class NativeAaHandshakeManager(
                 if (isRunning) AppLog.e("NativeAA: Secondary HFP server error [$addr]: ${e.message}", e)
                 else AppLog.d("NativeAA: Secondary HFP server closed cleanly [$addr].")
             }
+        }
+    }
+
+    /**
+     * Stop accepting new AA_UUID connections (primary + any secondary radios) after a
+     * successful handoff to WiFi. Closing just the client socket isn't enough: the phone reads
+     * that as an unexpected drop and immediately retries, and with the listener still up we'd
+     * accept, bail out (already connected), and close again — a tight reconnect storm (confirmed
+     * on-device: hundreds of accept/close cycles a second, indistinguishable from a Bluetooth
+     * pairing loop). HFP listeners are left running. Re-opened the next time start() runs, which
+     * AapService already does on disconnect.
+     */
+    private fun closeAaListeners() {
+        aaListenersClosedForSession = true
+        try { aaServerSocket?.close() } catch (e: Exception) {}
+        synchronized(extraAaServerSockets) {
+            extraAaServerSockets.forEach { try { it.close() } catch (e: Exception) {} }
+            extraAaServerSockets.clear()
         }
     }
 
@@ -492,6 +520,10 @@ class NativeAaHandshakeManager(
                 // response before we close.
                 delay(3000)
                 AppLog.i("NativeAA: Handshake session ending, releasing Bluetooth connection.")
+                // Stop accepting new AA_UUID connections too, not just this socket — otherwise
+                // the phone's immediate reconnect-retry gets accepted, bounced (already
+                // connected), and retried again in a tight loop. See closeAaListeners() kdoc.
+                closeAaListeners()
             } else {
                 AppLog.w("NativeAA: Handshake failed - Unexpected response type ${response.type}. Expected Type 2.")
             }
@@ -555,9 +587,13 @@ class NativeAaHandshakeManager(
         isRunning = false
         try { aaServerSocket?.close() } catch (e: Exception) {}
         try { hfpServerSocket?.close() } catch (e: Exception) {}
-        synchronized(extraServerSockets) {
-            extraServerSockets.forEach { try { it.close() } catch (e: Exception) {} }
-            extraServerSockets.clear()
+        synchronized(extraAaServerSockets) {
+            extraAaServerSockets.forEach { try { it.close() } catch (e: Exception) {} }
+            extraAaServerSockets.clear()
+        }
+        synchronized(extraHfpServerSockets) {
+            extraHfpServerSockets.forEach { try { it.close() } catch (e: Exception) {} }
+            extraHfpServerSockets.clear()
         }
         aaServerSocket = null
         hfpServerSocket = null

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
@@ -68,6 +68,9 @@ class NativeAaHandshakeManager(
     private var currentIp: String? = null
     private var currentBssid: String? = null
     private var pokeJob: Job? = null
+    // True while handleHandshake() runs; lets WifiDirectManager's join watchdog know a real
+    // exchange is in progress. Bounded by handleHandshake()'s own timeouts, so it can't stick true.
+    @Volatile private var handshakeInFlight = false
 
     /**
      * Updates the WiFi credentials that will be sent to the phone during the next handshake.
@@ -80,7 +83,18 @@ class NativeAaHandshakeManager(
         currentBssid = bssid
     }
 
+    /** Clears cached credentials so an in-progress wait doesn't hand out stale ones for a group
+     *  that's about to be torn down. */
+    fun invalidateCredentials() {
+        currentSsid = null
+        currentPsk = null
+        currentIp = null
+        currentBssid = null
+    }
+
     fun isActive(): Boolean = isRunning
+
+    fun isHandshakeInFlight(): Boolean = handshakeInFlight
 
     @SuppressLint("MissingPermission")
     fun start() {
@@ -375,6 +389,7 @@ class NativeAaHandshakeManager(
     }
 
     private suspend fun handleHandshake(socket: BluetoothSocket) = withContext(Dispatchers.IO) {
+        handshakeInFlight = true
         try {
             val device = socket.remoteDevice
             AppLog.i("NativeAA: Handling handshake for ${device.name} (${device.address})")
@@ -475,6 +490,7 @@ class NativeAaHandshakeManager(
         } catch (e: Exception) {
             AppLog.e("NativeAA: Handshake error: ${e.message}", e)
         } finally {
+            handshakeInFlight = false
             try { socket.close() } catch (e: Exception) {}
             AppLog.i("NativeAA: BT Handshake socket closed.")
         }

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManager.kt
@@ -476,7 +476,12 @@ class NativeAaHandshakeManager(
                 delay(1000) // [FIX] Increased delay to give phone more processing time
                 sendWifiSecurityResponse(output, ssid, psk, bssid)
                 AppLog.i("NativeAA: Handshake completed successfully on Bluetooth side.")
-                
+                // The credential exchange is done; the join watchdog no longer needs to defer
+                // for this handshake. Without this, it stayed true for the entire lifetime of
+                // the "maintain session" loop below (observed on-device stuck for 15+ minutes),
+                // permanently blocking recovery if the phone never actually joins the P2P group.
+                handshakeInFlight = false
+
                 // Keep the socket open to maintain the handshake session
                 AppLog.i("NativeAA: Maintaining Bluetooth session...")
                 while (isRunning && isActive && socket.isConnected) {

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
@@ -37,6 +37,12 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         private const val NATIVE_GROUP_MODE_5GHZ_REQUESTED = "5GHz requested"
         private const val NATIVE_GROUP_MODE_STANDARD_FALLBACK = "standard fallback"
         private const val NATIVE_GROUP_MODE_STANDARD_LEGACY = "standard (no 5GHz API)"
+        // Native AA join recovery: if no phone joins the quiet-host group within this window,
+        // tear it down and recreate a fresh one (bounded), and after a couple of tries drop the
+        // forced 5GHz band in case the phone cannot join it.
+        private const val NATIVE_JOIN_TIMEOUT_MS = 30000L
+        private const val MAX_NATIVE_JOIN_RECREATES = 4
+        private const val NATIVE_FORCE_STANDARD_AFTER = 2
     }
 
     @Volatile private var manager: WifiP2pManager? = context.getSystemService(Context.WIFI_P2P_SERVICE) as? WifiP2pManager
@@ -80,6 +86,13 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     private var native5GhzBandMismatchRetries = 0
     private var lastNativeGroupStatusMessage: String? = null
 
+    // Native AA join recovery state. The watchdog fires if the phone never joins our quiet-host
+    // group; nativeRecreateCount bounds how many times we recreate before giving up.
+    private var nativeRecreateCount = 0
+    private val nativeJoinWatchdog = Runnable {
+        if (!isClientConnected) recoverNativeGroup("no phone joined within ${NATIVE_JOIN_TIMEOUT_MS / 1000}s")
+    }
+
     private var onCredentialsReady: ((ssid: String, psk: String, ip: String, bssid: String) -> Unit)? = null
 
     fun setCredentialsListener(callback: (String, String, String, String) -> Unit) {
@@ -114,6 +127,8 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                         isGroupCreatingOrCreated = false
                         isConnected = false
                         isClientConnected = false
+                        cancelNativeJoinWatchdog()
+                        nativeRecreateCount = 0
                     }
                 }
 
@@ -152,6 +167,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                         isClientConnected = false
                         lastNativeGroupStatusMessage = null
                         isGroupCreatingOrCreated = false
+                        cancelNativeJoinWatchdog()
                     }
                 }
             }
@@ -190,7 +206,9 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     @SuppressLint("MissingPermission")
     private fun checkStuckRetryBurst() {
         val appSettings = App.provide(context).settings
-        if (appSettings.wifiConnectionMode != 2 || appSettings.helperConnectionStrategy != 1 || !isGroupOwner) {
+        val isHelperP2p = appSettings.wifiConnectionMode == 2 && appSettings.helperConnectionStrategy == 1
+        val isNative = appSettings.wifiConnectionMode == 3
+        if ((!isHelperP2p && !isNative) || !isGroupOwner) {
             tightBurstCount = 0
             return
         }
@@ -204,6 +222,12 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         if (tightBurstCount >= burstTriggerCount) {
             AppLog.w("WifiDirectManager: Detected $tightBurstCount CONNECTION_CHANGED repeats <${burstGapMs}ms apart — stuck retry loop against an already-consumed group. Self-healing.")
             tightBurstCount = 0
+            if (isNative) {
+                // Native quiet-host has no discovery loop; recreate the group with a full
+                // persistent-profile purge (bounded), the same class of fix as the helper path.
+                recoverNativeGroup("stuck PROV-DISC retry loop")
+                return
+            }
             val mgr = manager
             val ch = channel
             if (mgr != null && ch != null) {
@@ -311,9 +335,15 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 val clients = group.clientList
                 val hadClient = isClientConnected
                 isClientConnected = clients != null && clients.isNotEmpty()
+                if (isClientConnected) {
+                    // A phone joined — stop the native join watchdog and reset its budget.
+                    cancelNativeJoinWatchdog()
+                    nativeRecreateCount = 0
+                }
                 if (hadClient && !isClientConnected) {
                     AppLog.i("WifiDirectManager: Client disconnected from P2P group. Restarting discovery loop.")
                     startDiscoveryLoop()
+                    if (isNativeAaMode()) armNativeJoinWatchdog()
                 }
             } else {
                 isClientConnected = true
@@ -442,6 +472,8 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                     return
                 }
                 notifyNativeGroupStarted(ssid, frequency, band)
+                // The group is up. If no phone joins within the window, recover (recreate fresh).
+                armNativeJoinWatchdog()
             }
 
             if (ssid.isNotEmpty()) {
@@ -826,23 +858,18 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             return
         }
 
-        AppLog.i("WifiDirectManager: startNativeAaQuietHost() requested. Removing old group if any...")
+        AppLog.i("WifiDirectManager: startNativeAaQuietHost() requested. Purging old/persistent group if any...")
         nativeGroupCreationMode = NATIVE_GROUP_MODE_UNKNOWN
         lastNativeGroupStatusMessage = null
-        // The next createGroup() call generates a brand-new GO interface with a new random
-        // MAC — a cached BSSID from the group we're tearing down is now stale and must never
-        // be delivered for the new one.
-        lastKnownBssid = null
-        mgr.removeGroup(ch, object : WifiP2pManager.ActionListener {
-            override fun onSuccess() {
-                AppLog.d("WifiDirectManager: removeGroup SUCCESS. Creating quiet group...")
-                delayedCreateQuietGroup(0)
-            }
-            override fun onFailure(reason: Int) {
-                AppLog.d("WifiDirectManager: removeGroup failed (reason=$reason). This is expected if no group existed. Creating quiet group anyway...")
-                delayedCreateQuietGroup(0)
-            }
-        })
+        native5GhzBandMismatchRetries = 0
+        nativeRecreateCount = 0
+        cancelNativeJoinWatchdog()
+        // A stale persistent P2P group left over from a previous session or reboot desyncs the
+        // phone's WPS/PBC registrar into an endless "connecting" loop. removeGroup() alone keeps
+        // the persistent profile (the recreated group comes back with the same netId/SSID), so
+        // purge the profile too before creating a fresh group — the same fix #730 applied to the
+        // Helper path, which the native quiet-host path never got.
+        purgeAndCreateNativeGroup(forceStandard = false)
     }
 
     private fun delayedCreateQuietGroup(retryCount: Int) {
@@ -987,6 +1014,95 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         })
     }
 
+    // ---- Native AA join recovery (the quiet-host equivalent of #730's helper-path fixes) ----
+
+    /** Delete a persistent P2P group profile by netId via the hidden deletePersistentGroup API
+     *  (reflection), then run [onDone] regardless of outcome. */
+    @SuppressLint("MissingPermission")
+    private fun deletePersistentGroupById(netId: Int, onDone: () -> Unit) {
+        val mgr = manager
+        val ch = channel
+        if (mgr == null || ch == null || netId < 0) { onDone(); return }
+        try {
+            val method = mgr.javaClass.getMethod(
+                "deletePersistentGroup",
+                WifiP2pManager.Channel::class.java,
+                Int::class.javaPrimitiveType,
+                WifiP2pManager.ActionListener::class.java
+            )
+            method.invoke(mgr, ch, netId, object : WifiP2pManager.ActionListener {
+                override fun onSuccess() {
+                    AppLog.i("WifiDirectManager: Native AA deletePersistentGroup(netId=$netId) succeeded")
+                    onDone()
+                }
+                override fun onFailure(reason: Int) {
+                    AppLog.w("WifiDirectManager: Native AA deletePersistentGroup(netId=$netId) failed: ${getP2pErrorString(reason)}")
+                    onDone()
+                }
+            })
+        } catch (e: Exception) {
+            AppLog.w("WifiDirectManager: Native AA deletePersistentGroup reflection unavailable: ${e.message}")
+            onDone()
+        }
+    }
+
+    /** Tear down any current P2P group (active group + persistent profile) and create a fresh
+     *  native quiet-host group. When [forceStandard] is true, skip the 5GHz attempt and create a
+     *  plain (2.4GHz-capable) group, for phones that cannot join a 5GHz group owner. */
+    @SuppressLint("MissingPermission")
+    private fun purgeAndCreateNativeGroup(forceStandard: Boolean) {
+        val mgr = manager ?: return
+        val ch = channel ?: return
+        lastKnownBssid = null
+        val createFresh = {
+            if (forceStandard) standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_FALLBACK)
+            else delayedCreateQuietGroup(0)
+        }
+        mgr.requestGroupInfo(ch) { group ->
+            if (group == null) {
+                createFresh()
+                return@requestGroupInfo
+            }
+            val netId = try { group.networkId } catch (e: Exception) { -1 }
+            AppLog.i("WifiDirectManager: Native AA — purging existing group (netId=$netId) before recreate${if (forceStandard) " (forcing 2.4GHz)" else ""}")
+            mgr.removeGroup(ch, object : WifiP2pManager.ActionListener {
+                override fun onSuccess() { deletePersistentGroupById(netId) { createFresh() } }
+                override fun onFailure(reason: Int) {
+                    AppLog.w("WifiDirectManager: Native AA removeGroup before recreate failed: ${getP2pErrorString(reason)}")
+                    deletePersistentGroupById(netId) { createFresh() }
+                }
+            })
+        }
+    }
+
+    /** Recover a native quiet-host group when the phone never joins: recreate a fresh one, and
+     *  after a couple of tries drop the forced 5GHz band. Bounded by [MAX_NATIVE_JOIN_RECREATES]. */
+    private fun recoverNativeGroup(reason: String) {
+        cancelNativeJoinWatchdog()
+        if (isClientConnected) return
+        if (nativeRecreateCount >= MAX_NATIVE_JOIN_RECREATES) {
+            AppLog.w("WifiDirectManager: Native AA — phone still not connected after $nativeRecreateCount recreations ($reason); giving up until the next start.")
+            return
+        }
+        nativeRecreateCount++
+        val forceStandard = nativeRecreateCount >= NATIVE_FORCE_STANDARD_AFTER
+        AppLog.w("WifiDirectManager: Native AA recovery ($reason): recreate attempt $nativeRecreateCount/$MAX_NATIVE_JOIN_RECREATES${if (forceStandard) ", forcing 2.4GHz" else ""}.")
+        purgeAndCreateNativeGroup(forceStandard)
+    }
+
+    /** (Re)arm the native join watchdog; no-op unless we are a native-mode group owner with no
+     *  client yet. */
+    private fun armNativeJoinWatchdog() {
+        handler.removeCallbacks(nativeJoinWatchdog)
+        if (isNativeAaMode() && isGroupOwner && !isClientConnected) {
+            handler.postDelayed(nativeJoinWatchdog, NATIVE_JOIN_TIMEOUT_MS)
+        }
+    }
+
+    private fun cancelNativeJoinWatchdog() {
+        handler.removeCallbacks(nativeJoinWatchdog)
+    }
+
     private fun notifyNativeGroupStarted(ssid: String, frequency: Int, band: String) {
         val frequencyText = if (frequency > 0) "$frequency MHz" else "frequency unknown"
         val message = "Native AA WiFi Direct: $band ($frequencyText), $nativeGroupCreationMode"
@@ -1100,6 +1216,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         isClientConnected = false
         nativeGroupCreationMode = NATIVE_GROUP_MODE_UNKNOWN
         native5GhzBandMismatchRetries = 0
+        nativeRecreateCount = 0
         lastNativeGroupStatusMessage = null
         AapService.scanningState.value = false
         try { context.unregisterReceiver(receiver) } catch (e: Exception) {}

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/WifiDirectManager.kt
@@ -38,9 +38,10 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         private const val NATIVE_GROUP_MODE_STANDARD_FALLBACK = "standard fallback"
         private const val NATIVE_GROUP_MODE_STANDARD_LEGACY = "standard (no 5GHz API)"
         // Native AA join recovery: if no phone joins the quiet-host group within this window,
-        // tear it down and recreate a fresh one (bounded), and after a couple of tries drop the
-        // forced 5GHz band in case the phone cannot join it.
-        private const val NATIVE_JOIN_TIMEOUT_MS = 30000L
+        // tear it down and recreate a fresh one (bounded), dropping the forced 5GHz band after
+        // a couple of tries. 60s not 30s — a live BT reconnect was observed taking ~35s even
+        // when working, so 30s left no margin.
+        private const val NATIVE_JOIN_TIMEOUT_MS = 60000L
         private const val MAX_NATIVE_JOIN_RECREATES = 4
         private const val NATIVE_FORCE_STANDARD_AFTER = 2
     }
@@ -90,13 +91,34 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     // group; nativeRecreateCount bounds how many times we recreate before giving up.
     private var nativeRecreateCount = 0
     private val nativeJoinWatchdog = Runnable {
-        if (!isClientConnected) recoverNativeGroup("no phone joined within ${NATIVE_JOIN_TIMEOUT_MS / 1000}s")
+        if (isClientConnected) return@Runnable
+        if (isNativeHandshakeInFlight?.invoke() == true) {
+            // A handshake is exchanging credentials right now; recreating here would hand out a new SSID mid-exchange.
+            AppLog.i("WifiDirectManager: Native AA join watchdog fired but a Bluetooth handshake is in flight — deferring recovery.")
+            armNativeJoinWatchdog()
+            return@Runnable
+        }
+        recoverNativeGroup("no phone joined within ${NATIVE_JOIN_TIMEOUT_MS / 1000}s")
     }
 
     private var onCredentialsReady: ((ssid: String, psk: String, ip: String, bssid: String) -> Unit)? = null
+    // Set by AapService: whether NativeAaHandshakeManager has a live handshake in progress, so
+    // the join watchdog/self-heal never tears the group down mid-exchange.
+    private var isNativeHandshakeInFlight: (() -> Boolean)? = null
+    // Set by AapService: called right before a native group is torn down, to invalidate any
+    // not-yet-captured credentials in NativeAaHandshakeManager.
+    private var onNativeGroupInvalidated: (() -> Unit)? = null
 
     fun setCredentialsListener(callback: (String, String, String, String) -> Unit) {
         this.onCredentialsReady = callback
+    }
+
+    fun setNativeHandshakeStateProvider(provider: () -> Boolean) {
+        this.isNativeHandshakeInFlight = provider
+    }
+
+    fun setNativeGroupInvalidatedListener(callback: () -> Unit) {
+        this.onNativeGroupInvalidated = callback
     }
 
 
@@ -223,8 +245,12 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             AppLog.w("WifiDirectManager: Detected $tightBurstCount CONNECTION_CHANGED repeats <${burstGapMs}ms apart — stuck retry loop against an already-consumed group. Self-healing.")
             tightBurstCount = 0
             if (isNative) {
-                // Native quiet-host has no discovery loop; recreate the group with a full
-                // persistent-profile purge (bounded), the same class of fix as the helper path.
+                if (isNativeHandshakeInFlight?.invoke() == true) {
+                    AppLog.i("WifiDirectManager: Native AA stuck-retry-burst detected but a Bluetooth handshake is in flight — skipping recovery.")
+                    return
+                }
+                // Native quiet-host has no discovery loop; recreate the group (bounded), the
+                // same class of self-heal as the helper path.
                 recoverNativeGroup("stuck PROV-DISC retry loop")
                 return
             }
@@ -654,59 +680,23 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             // PROV-DISC retry storm (confirmed via live-device bisection against `ebab63a8`,
             // whose only change was skipping this teardown on reuse) — tear down and recreate
             // on every reuse rather than trying to detect which ones are broken.
-            // removeGroup() alone isn't enough: the recreated group keeps the same
-            // networkId/SSID unless deletePersistentGroup() purges the profile first.
-            val netId = try { group.networkId } catch (e: Exception) { -1 }
-            AppLog.i("WifiDirectManager: Existing P2P group found (netId=$netId) — deleting persistent profile and recreating fresh for a clean WPS/PBC registrar")
+            // NOTE: this used to also call deletePersistentGroup() to purge the profile (so a
+            // plain createGroup() wouldn't reuse the same SSID/netId) — confirmed on-device that
+            // call is rejected outright for every netId, including the profile's own real one.
+            // Dropped; likely a permission this app doesn't hold.
+            AppLog.i("WifiDirectManager: Existing P2P group found — removing and recreating fresh for a clean WPS/PBC registrar")
             // The next createGroup() call generates a brand-new GO interface with a new random
             // MAC — a cached BSSID from the group we're tearing down is now stale and must never
             // be delivered for the new one.
             lastKnownBssid = null
             manager?.removeGroup(channel, object : WifiP2pManager.ActionListener {
-                override fun onSuccess() { deletePersistentGroupThenCreate(netId) }
+                override fun onSuccess() { checkGroupAndCreateInFlight = false; createNewGroup(0) }
                 override fun onFailure(reason: Int) {
                     AppLog.w("WifiDirectManager: removeGroup before recreate failed: ${getP2pErrorString(reason)}")
-                    deletePersistentGroupThenCreate(netId)
-                }
-            })
-        }
-    }
-
-    // deletePersistentGroup(Channel, int, ActionListener) isn't public SDK, so it's called via
-    // reflection like setDeviceName() elsewhere in this file. Falls through to createNewGroup()
-    // regardless of outcome since removeGroup() already deactivated the group either way.
-    @SuppressLint("MissingPermission")
-    private fun deletePersistentGroupThenCreate(netId: Int) {
-        val mgr = manager
-        val ch = channel
-        if (mgr == null || ch == null || netId < 0) {
-            checkGroupAndCreateInFlight = false
-            createNewGroup(0)
-            return
-        }
-        try {
-            val method = mgr.javaClass.getMethod(
-                "deletePersistentGroup",
-                WifiP2pManager.Channel::class.java,
-                Int::class.javaPrimitiveType,
-                WifiP2pManager.ActionListener::class.java
-            )
-            method.invoke(mgr, ch, netId, object : WifiP2pManager.ActionListener {
-                override fun onSuccess() {
-                    AppLog.i("WifiDirectManager: deletePersistentGroup(netId=$netId) succeeded")
-                    checkGroupAndCreateInFlight = false
-                    createNewGroup(0)
-                }
-                override fun onFailure(reason: Int) {
-                    AppLog.w("WifiDirectManager: deletePersistentGroup(netId=$netId) failed: ${getP2pErrorString(reason)}")
                     checkGroupAndCreateInFlight = false
                     createNewGroup(0)
                 }
             })
-        } catch (e: Exception) {
-            AppLog.w("WifiDirectManager: deletePersistentGroup reflection unavailable: ${e.message}")
-            checkGroupAndCreateInFlight = false
-            createNewGroup(0)
         }
     }
 
@@ -858,18 +848,13 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             return
         }
 
-        AppLog.i("WifiDirectManager: startNativeAaQuietHost() requested. Purging old/persistent group if any...")
+        AppLog.i("WifiDirectManager: startNativeAaQuietHost() requested. Removing old group if any...")
         nativeGroupCreationMode = NATIVE_GROUP_MODE_UNKNOWN
         lastNativeGroupStatusMessage = null
         native5GhzBandMismatchRetries = 0
         nativeRecreateCount = 0
         cancelNativeJoinWatchdog()
-        // A stale persistent P2P group left over from a previous session or reboot desyncs the
-        // phone's WPS/PBC registrar into an endless "connecting" loop. removeGroup() alone keeps
-        // the persistent profile (the recreated group comes back with the same netId/SSID), so
-        // purge the profile too before creating a fresh group — the same fix #730 applied to the
-        // Helper path, which the native quiet-host path never got.
-        purgeAndCreateNativeGroup(forceStandard = false)
+        recreateNativeGroup(forceStandard = false)
     }
 
     private fun delayedCreateQuietGroup(retryCount: Int) {
@@ -1014,65 +999,32 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         })
     }
 
-    // ---- Native AA join recovery (the quiet-host equivalent of #730's helper-path fixes) ----
-
-    /** Delete a persistent P2P group profile by netId via the hidden deletePersistentGroup API
-     *  (reflection), then run [onDone] regardless of outcome. */
+    /**
+     * Tear down any current P2P group and create a fresh native quiet-host group.
+     * [forceStandard] skips the 5GHz attempt, for phones that can't join a 5GHz group owner.
+     *
+     * Used to also call deletePersistentGroup() here, mirroring #730's Helper-mode fix, but
+     * that's rejected outright on-device for every netId — likely a permission this app lacks.
+     * Dropped.
+     */
     @SuppressLint("MissingPermission")
-    private fun deletePersistentGroupById(netId: Int, onDone: () -> Unit) {
-        val mgr = manager
-        val ch = channel
-        if (mgr == null || ch == null || netId < 0) { onDone(); return }
-        try {
-            val method = mgr.javaClass.getMethod(
-                "deletePersistentGroup",
-                WifiP2pManager.Channel::class.java,
-                Int::class.javaPrimitiveType,
-                WifiP2pManager.ActionListener::class.java
-            )
-            method.invoke(mgr, ch, netId, object : WifiP2pManager.ActionListener {
-                override fun onSuccess() {
-                    AppLog.i("WifiDirectManager: Native AA deletePersistentGroup(netId=$netId) succeeded")
-                    onDone()
-                }
-                override fun onFailure(reason: Int) {
-                    AppLog.w("WifiDirectManager: Native AA deletePersistentGroup(netId=$netId) failed: ${getP2pErrorString(reason)}")
-                    onDone()
-                }
-            })
-        } catch (e: Exception) {
-            AppLog.w("WifiDirectManager: Native AA deletePersistentGroup reflection unavailable: ${e.message}")
-            onDone()
-        }
-    }
-
-    /** Tear down any current P2P group (active group + persistent profile) and create a fresh
-     *  native quiet-host group. When [forceStandard] is true, skip the 5GHz attempt and create a
-     *  plain (2.4GHz-capable) group, for phones that cannot join a 5GHz group owner. */
-    @SuppressLint("MissingPermission")
-    private fun purgeAndCreateNativeGroup(forceStandard: Boolean) {
+    private fun recreateNativeGroup(forceStandard: Boolean) {
         val mgr = manager ?: return
         val ch = channel ?: return
         lastKnownBssid = null
+        // Let an in-progress credential wait pick up the fresh group's creds, not stale ones.
+        onNativeGroupInvalidated?.invoke()
         val createFresh = {
             if (forceStandard) standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_FALLBACK)
             else delayedCreateQuietGroup(0)
         }
-        mgr.requestGroupInfo(ch) { group ->
-            if (group == null) {
+        mgr.removeGroup(ch, object : WifiP2pManager.ActionListener {
+            override fun onSuccess() { createFresh() }
+            override fun onFailure(reason: Int) {
+                AppLog.d("WifiDirectManager: Native AA removeGroup before recreate failed (reason=${getP2pErrorString(reason)}); expected if no group existed")
                 createFresh()
-                return@requestGroupInfo
             }
-            val netId = try { group.networkId } catch (e: Exception) { -1 }
-            AppLog.i("WifiDirectManager: Native AA — purging existing group (netId=$netId) before recreate${if (forceStandard) " (forcing 2.4GHz)" else ""}")
-            mgr.removeGroup(ch, object : WifiP2pManager.ActionListener {
-                override fun onSuccess() { deletePersistentGroupById(netId) { createFresh() } }
-                override fun onFailure(reason: Int) {
-                    AppLog.w("WifiDirectManager: Native AA removeGroup before recreate failed: ${getP2pErrorString(reason)}")
-                    deletePersistentGroupById(netId) { createFresh() }
-                }
-            })
-        }
+        })
     }
 
     /** Recover a native quiet-host group when the phone never joins: recreate a fresh one, and
@@ -1087,7 +1039,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         nativeRecreateCount++
         val forceStandard = nativeRecreateCount >= NATIVE_FORCE_STANDARD_AFTER
         AppLog.w("WifiDirectManager: Native AA recovery ($reason): recreate attempt $nativeRecreateCount/$MAX_NATIVE_JOIN_RECREATES${if (forceStandard) ", forcing 2.4GHz" else ""}.")
-        purgeAndCreateNativeGroup(forceStandard)
+        recreateNativeGroup(forceStandard)
     }
 
     /** (Re)arm the native join watchdog; no-op unless we are a native-mode group owner with no


### PR DESCRIPTION
Consolidates the full Native AA fix for the "Android is connecting..." loop (#706) into one PR. This replaces the two overlapping PRs we closed to avoid conflicts (#734 and #736). Every commit keeps its original author, and most of the Bluetooth-side work was found and verified on real hardware by @o-jcardenass.

What it fixes:

1. The native quiet-host path never got #730's WiFi Direct group protections, so a stale group left from a previous session or reboot kept the phone stuck connecting. (base)
2. The join watchdog raced the Bluetooth handshake and could tear the group down mid-exchange, handing the phone a new SSID. It now checks whether a handshake is in flight and defers instead. (@o-jcardenass)
3. deletePersistentGroup() is rejected on real hardware for every netId, so the purge never actually did anything. Dropped from both the native and Helper-mode (#730) paths in favor of the plain removeGroup()+createGroup() teardown that works. (@o-jcardenass)
4. The handshakeInFlight flag could stick true forever and block recovery after one connection. Reset right after the credential exchange. (@o-jcardenass)
5. The real root cause: HUR held the Bluetooth connection open indefinitely after the WiFi handoff, which the phone treats as an unexpected drop and loops on. A reference open-source wireless Android Auto dongle hit the same issue and fixed it by releasing Bluetooth right after the handoff. Ported here: releases the connection shortly after handoff and stops accepting AA connections afterward, re-opening on the next start. (@o-jcardenass)
6. Fixed isActive() to account for the AA listener now closing independently of the manager's running state. (@o-jcardenass)
7. Native accept and handshake logs now print the local Bluetooth radio, so on dual-radio head units a HUR log can be matched against the head unit MAC the phone connected to. (me)

The Bluetooth-side fixes were verified on-device by @o-jcardenass across repeated runs (clean single-connect handoff, no reconnect storms, stable sessions). Builds green.
