### PR TITLE
Fix Stop Connection leaving the phone attached to WiFi Direct

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
@@ -1084,11 +1084,12 @@ class AapService : Service(), UsbReceiver.Listener {
             nearbyManager?.stop() // Disconnect Nearby tunnel
 
             val settings = App.provide(this@AapService).settings
-            if (settings.wifiConnectionMode == 3) {
+            val mode = settings.wifiConnectionMode
+            val strategy = settings.helperConnectionStrategy
+
+            if (mode == 3) {
                 if (state.isUserExit) {
-                    // [FIX] User voluntarily exited AA. Stop the BT handshake servers and
-                    // tear down the WiFi Direct group so the phone can't auto-reconnect.
-                    AppLog.i("AapService: Native AA user exit. Stopping handshake manager and WiFi Direct group.")
+                    AppLog.i("AapService: Native AA user exit. Stopping handshake manager.")
                     nativeAaHandshakeManager?.stop()
                 } else {
                     // Unexpected disconnect — reset and re-initialize for auto-reconnect.
@@ -1100,6 +1101,21 @@ class AapService : Service(), UsbReceiver.Listener {
                     }
                 }
             }
+
+            // [FIX] User-initiated disconnect while a WiFi-Direct-hosting mode was active: tear
+            // down the P2P group so the phone's OS-level connection actually drops (previously
+            // only the AA session ended — the WiFi Direct network stayed up, with nothing to
+            // tell Wireless Helper the session had ended). Skipped on unexpected disconnects:
+            // mode==3's re-init above and scheduleReconnectIfNeeded() both want to keep/reuse
+            // the existing group for fast reconnection there. Must await CommManager's async
+            // teardown first so we never remove the P2P interface while the
+            // ByeByeRequest/socket-close is still in flight.
+            if (state.isUserExit && WifiModePolicy.usesWifiDirect(mode, strategy)) {
+                commManager.awaitDisconnectComplete()
+                AppLog.i("AapService: CommManager teardown complete. Stopping WiFi Direct group.")
+                wifiDirectManager?.stop()
+            }
+
             App.provide(this@AapService).audioDecoder.stop()
             App.provide(this@AapService).videoDecoder.stop("AapService::onDisconnect")
         }

--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/AapService.kt
@@ -1421,7 +1421,7 @@ class AapService : Service(), UsbReceiver.Listener {
         nearbyManager?.stop()
         nativeAaHandshakeManager?.stop()
 
-        val usesWifiDirect = (mode == 3) || (mode == 2 && strategy == 1)
+        val usesWifiDirect = WifiModePolicy.usesWifiDirect(mode, strategy)
         if (!usesWifiDirect) {
             AppLog.i("AapService: New mode does not use WiFi Direct. Stopping WifiDirectManager...")
             wifiDirectManager?.stop()

--- a/app/src/main/java/com/andrerinas/headunitrevived/aap/WifiModePolicy.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/aap/WifiModePolicy.kt
@@ -1,0 +1,11 @@
+package com.andrerinas.headunitrevived.aap
+
+/**
+ * Whether a given WiFi mode/strategy combination uses [com.andrerinas.headunitrevived.connection.WifiDirectManager]
+ * to run a WiFi Direct P2P group. Shared between [AapService.initWifiMode] (stop it on a
+ * *settings change*) and [AapService.onDisconnected] (stop it on a *user disconnect*) so the
+ * two call sites can't drift out of sync.
+ */
+object WifiModePolicy {
+    fun usesWifiDirect(mode: Int, strategy: Int): Boolean = (mode == 3) || (mode == 2 && strategy == 1)
+}

--- a/app/src/main/java/com/andrerinas/headunitrevived/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/connection/CommManager.kt
@@ -603,6 +603,17 @@ class CommManager(
     }
 
     /**
+     * Suspends until the most recently launched [doDisconnect] coroutine (started by
+     * [disconnect]) has finished — i.e. the ByeByeRequest has actually been sent and the
+     * physical connection actually closed, not just that [connectionState] flipped.
+     * Mirrors the `_disconnectJob?.join()` idiom already used internally by the `connect(...)`
+     * overloads (e.g. line 192).
+     */
+    suspend fun awaitDisconnectComplete() {
+        _disconnectJob?.join()
+    }
+
+    /**
      * Tears down the transport and physical connection.
      *
      * **Null-first pattern**: [_transport] and [_connection] are captured and nulled at the

--- a/app/src/test/java/com/andrerinas/headunitrevived/aap/WifiModePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/headunitrevived/aap/WifiModePolicyTest.kt
@@ -1,0 +1,28 @@
+package com.andrerinas.headunitrevived.aap
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WifiModePolicyTest {
+
+    @Test
+    fun `native AA mode always uses wifi direct regardless of strategy`() {
+        assertTrue(WifiModePolicy.usesWifiDirect(mode = 3, strategy = 0))
+        assertTrue(WifiModePolicy.usesWifiDirect(mode = 3, strategy = 1))
+        assertTrue(WifiModePolicy.usesWifiDirect(mode = 3, strategy = 2))
+    }
+
+    @Test
+    fun `helper mode uses wifi direct only with strategy 1`() {
+        assertTrue(WifiModePolicy.usesWifiDirect(mode = 2, strategy = 1))
+        assertFalse(WifiModePolicy.usesWifiDirect(mode = 2, strategy = 0))
+        assertFalse(WifiModePolicy.usesWifiDirect(mode = 2, strategy = 2))
+    }
+
+    @Test
+    fun `server and other modes never use wifi direct`() {
+        assertFalse(WifiModePolicy.usesWifiDirect(mode = 0, strategy = 0))
+        assertFalse(WifiModePolicy.usesWifiDirect(mode = 1, strategy = 1))
+    }
+}


### PR DESCRIPTION
## Summary

"Stop Connection" (the in-session exit dialog) correctly sends a `ByeByeRequest` and closes the transport socket, but never tore down the WiFi Direct P2P group HUR hosts. The existing "Native AA user exit" branch even had a comment claiming it did, but only ever called `nativeAaHandshakeManager?.stop()` (Bluetooth handshake sockets), never `wifiDirectManager?.stop()` (the only place that calls `WifiP2pManager.removeGroup()`). The plain WiFi-Direct-Helper case (mode 2, strategy 1) had no handling here at all.

Net effect: the phone stayed connected to the WiFi Direct network at the OS level after "Stop Connection", and companion apps that have no visibility into `WifiP2pManager` state (only into whether their own TCP bridge to HUR is still alive) had no way to learn the session had ended.

- Tears the group down on any user-initiated disconnect while a WiFi-Direct-hosting mode is active, for both Native AA and the Helper WiFi-Direct strategy.
- Deliberately skipped on unexpected disconnects, which want to keep/reuse the existing group for fast reconnection.
- Awaits `CommManager`'s async teardown first via a new `awaitDisconnectComplete()`, so the P2P interface is never removed while the `ByeByeRequest`/socket-close is still in flight.
- Extracts the mode/strategy "uses WiFi Direct" check into `WifiModePolicy`, shared between `initWifiMode()` and the new disconnect path, with unit test coverage.

## Test plan

- [x] `WifiModePolicyTest` (new) passes; full existing unit test suite passes with no regressions.
- [x] On-device (Native AA mode): "Stop Connection" now logs `CommManager` teardown completing, then `WifiDirectManager.stop()` running and removing the group; `dumpsys wifip2p` confirms the group is actually gone afterward (`mGroup null`, `groupFormed: false`), not just that the AA session ended.
- [x] On-device (Helper mode, WiFi Direct strategy): confirmed the companion phone app's "Connected" status correctly flips to disconnected shortly after "Stop Connection", instead of staying stuck.
- [x] Confirmed the unexpected-disconnect path is unchanged — the group is still kept alive for fast reconnection there.