### PR TITLE
Finish the Open Headunit rename in the spots the rename PRs missed

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -40,6 +40,6 @@ jobs:
       - name: Upload debug APK
         uses: actions/upload-artifact@v4
         with:
-          name: headunit-revived-github-debug
+          name: open-headunit-github-debug
           path: app/build/outputs/apk/github/debug/*.apk
           if-no-files-found: error

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -26,4 +26,4 @@ Open Headunit does not integrate any third-party analytics SDKs, advertising net
 4. Contact Us
 
 If you have any questions or suggestions about our Privacy Policy, do not hesitate to contact us via our GitHub repository:
-https://github.com/andreknieriem/headunit-revived
+https://github.com/andreknieriem/open-headunit

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 $\color{Red}\Huge{\textbf{IMPORTANT! - Rebrand of the App}}$
-Discussion: https://github.com/andreknieriem/headunit-revived/discussions/729
+Discussion: https://github.com/andreknieriem/open-headunit/discussions/729
 
 Open Headunit is an Android app that allows you to turn your Android tablet or phone into an Android Auto receiver. This project is a revived version of the original headunit project by the great Michael Reid. The original project can be found here:
 https://github.com/mikereidis/headunit
@@ -21,7 +21,7 @@ https://github.com/mikereidis/headunit
 <img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/140bbfdb-5b4f-4d49-a419-85aa91b48371" />
 
 ## How to use
-**Check out the [Wiki](https://github.com/andreknieriem/headunit-revived/wiki) for detailed documentation, setup guides and troubleshooting!**
+**Check out the [Wiki](https://github.com/andreknieriem/open-headunit/wiki) for detailed documentation, setup guides and troubleshooting!**
 
 ### Wired USB Connection
 - Connect your Android device (phone) to the tablet running Open Headunit via USB cable.
@@ -59,7 +59,7 @@ adb shell am start -a android.intent.action.VIEW -d "headunit://connect?ip=192.1
 ## Known Issues
 - **Google Maps in Portrait Mode:** Touch interactions (searching, scrolling) within Google Maps may not work as expected when using Portrait Mode on some devices. **Fix:** Try reducing the **Pixel density (DPI)** setting to **below 200** (e.g., 190) in the app settings. This often restores full functionality.
 - **Wireless Connection Drops:** If the connection drops frequently, disable **"WiFi Assistant"** or **"Switch between networks"** in your phone's WiFi settings to prevent it from killing the connection due to "no internet." Check battery saving options.
-- **Self-mode on Android 10 (Q) and below:** Google has disabled the automatic wireless projection startup for Android 10 and below in Android Auto versions 16.4 and higher. While Self-mode still works on newer Android versions, it is normally impossible to trigger projection on Android 10 and below directly with recent Google app updates. **Workaround:** You can still use Self-mode on these devices by starting the built-in Android Auto Headunit Server and connecting via Wi-Fi mode (loopback). See the [Troubleshooting Guide](https://github.com/andreknieriem/headunit-revived/wiki/Troubleshooting#self-mode-on-android-10-q-and-below) for step-by-step instructions.
+- **Self-mode on Android 10 (Q) and below:** Google has disabled the automatic wireless projection startup for Android 10 and below in Android Auto versions 16.4 and higher. While Self-mode still works on newer Android versions, it is normally impossible to trigger projection on Android 10 and below directly with recent Google app updates. **Workaround:** You can still use Self-mode on these devices by starting the built-in Android Auto Headunit Server and connecting via Wi-Fi mode (loopback). See the [Troubleshooting Guide](https://github.com/andreknieriem/open-headunit/wiki/Troubleshooting#self-mode-on-android-10-q-and-below) for step-by-step instructions.
 - **WiFi-Direct needs long to connect:** A user finds that this is related to Google Assistant instead of Gemini for AA. If you use Gemini on newer AA versions it just runs smooth again. No idea why this happens.
 - **Stuck on Android is starting** Check your video codec in the settings and set it to h264 if you have a device which does not support h265. Some devices have a broken h265 decoder and this will cause the app to stuck on "Android is starting" and never start the projection.
 

--- a/app/src/main/java/com/andrerinas/openheadunit/main/AboutFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/AboutFragment.kt
@@ -39,7 +39,7 @@ class AboutFragment : Fragment() {
         sb.append("<a href=\"https://github.com/mikereidis/headunit\">https://github.com/mikereidis/headunit</a><br/><br/>")
         sb.append("<h3>Issues, bugs, and feedback or questions</h3>")
         sb.append("If you need any help, go to the github page of this app. You will additionally can support me via <a href=\"https://www.paypal.me/anrinas\">Paypal</a><br/>")
-        sb.append("<a href=\"https://github.com/andreknieriem/headunit-revived\">https://github.com/andreknieriem/headunit-revived</a><br/><br/>")
+        sb.append("<a href=\"https://github.com/andreknieriem/open-headunit\">https://github.com/andreknieriem/open-headunit</a><br/><br/>")
 
         sb.append(parseMarkdownToHtml(readAsset("CHANGELOG.md")))
         sb.append("<br/><br/>")

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
@@ -16,13 +16,17 @@ import java.util.Date
 import java.util.Locale
 
 object SettingsBackupManager {
-    const val FORMAT = "headunit-revived-settings"
+    const val FORMAT = "open-headunit-settings"
+    // Backups exported before the rename used this format id and file name. Keep accepting
+    // them so users do not lose access to existing backups after updating.
+    const val LEGACY_FORMAT = "headunit-revived-settings"
+    private val SUPPORTED_FORMATS = setOf(FORMAT, LEGACY_FORMAT)
     const val VERSION = 1
     const val MIME_TYPE = "application/json"
     val DOCUMENT_PICKER_MIME_TYPES = arrayOf(MIME_TYPE)
     val IMPORT_MIME_TYPES = arrayOf(MIME_TYPE, "text/json", "text/plain")
 
-    private val backupFileNamePattern = Regex("""headunit-revived-settings-\d{8}-\d{6}\.json""")
+    private val backupFileNamePattern = Regex("""(?:open-headunit|headunit-revived)-settings-\d{8}-\d{6}\.json""")
 
     data class ImportData(
         val values: Map<String, Any>,
@@ -172,7 +176,7 @@ object SettingsBackupManager {
 
     fun defaultFileName(): String {
         val timestamp = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(Date())
-        return "headunit-revived-settings-$timestamp.json"
+        return "$FORMAT-$timestamp.json"
     }
 
     fun exportFromContext(context: Context): String {
@@ -206,7 +210,7 @@ object SettingsBackupManager {
 
     fun parseImportJson(json: String): ImportData {
         val root = JSONObject(json)
-        if (root.optString("format") != FORMAT) {
+        if (root.optString("format") !in SUPPORTED_FORMATS) {
             throw IllegalArgumentException("Unsupported settings backup format")
         }
         if (root.optInt("version", VERSION) > VERSION) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -476,7 +476,7 @@
     <string name="support_open_issues">Open the GitHub issues page</string>
     <string name="support_scan_qr">Or scan this QR code to open the issues list on another device.</string>
     <string name="support_github_account_warning">Note: you need a free GitHub account to create an issue.</string>
-    <string name="github_issues_url" translatable="false">https://github.com/andreknieriem/headunit-revived/issues</string>
+    <string name="github_issues_url" translatable="false">https://github.com/andreknieriem/open-headunit/issues</string>
 
     <!-- Reporting rules modal (shown from a button under the QR on the Support screen) -->
     <string name="support_rules_button">Reporting rules</string>


### PR DESCRIPTION
This builds on the rename work in #740 and #743 and cleans up the last references to the old name that were still left behind. It targets the rename-app branch so the diff stays focused on just these leftovers.

In the app:
- The About screen linked to the old repo. It now points to andreknieriem/open-headunit.
- The Support screen "open issues" link (github_issues_url) pointed at the old repo issues page. Updated to the new repo.
- Settings backup: the export format id and file name used "headunit-revived-settings". New backups now use "open-headunit-settings", but import still accepts the old format id and backup discovery still recognizes the old file names, so backups people already made keep working.

Docs and CI:
- README repo links (discussion, wiki, troubleshooting) now point to open-headunit.
- PRIVACY.md repo link updated.
- The debug APK artifact name in the build workflow updated.

Left as is on purpose:
- The signing key alias in build.gradle.kts and the keytool example in the README, since renaming those would break signing and the alias is not user facing.
- The Play Store and Amazon badge ids in the README, since those follow whatever applicationId ships.
- The headunit:// deep link scheme, which is generic and used by existing shortcuts.

Verified with compileGithubDebugKotlin on JDK 17.