### PR TITLE
Add a one-time rename notice on the home screen

### DIFF
--- a/app/src/main/java/com/andrerinas/headunitrevived/main/HomeFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/HomeFragment.kt
@@ -171,6 +171,24 @@ class HomeFragment : Fragment() {
                 }
             }
         }
+
+        maybeShowRenameNotice(appSettings)
+    }
+
+    // Shows a one-time notice about the app rename. Skipped while an auto-connect is
+    // taking over the screen so it does not flash in front of a launching projection.
+    private fun maybeShowRenameNotice(appSettings: Settings) {
+        if (appSettings.renameNoticeShown) return
+        if (commManager.isConnected) return
+        if (hasAttemptedAutoConnect || hasAutoStarted || hasAttemptedSingleUsbAutoConnect) return
+
+        appSettings.renameNoticeShown = true
+        activeDialog = MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
+            .setIcon(R.drawable.ic_rename_notice)
+            .setTitle(getString(R.string.rename_notice_title, getString(R.string.app_name)))
+            .setMessage(getString(R.string.rename_notice_message, getString(R.string.app_name)))
+            .setPositiveButton(R.string.rename_notice_button) { dialog, _ -> dialog.dismiss() }
+            .show()
     }
 
     private fun startSelfModeInternal() {

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/HomeFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/HomeFragment.kt
@@ -189,7 +189,7 @@ class HomeFragment : Fragment() {
         } catch (e: PackageManager.NameNotFoundException) {
             0L
         }
-        if (!RenameNoticePolicy.shouldOffer(firstInstallTime, System.currentTimeMillis())) return
+        if (!RenameNoticePolicy.shouldOffer(firstInstallTime)) return
 
         appSettings.renameNoticeShown = true
         activeDialog = MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/HomeFragment.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/HomeFragment.kt
@@ -175,12 +175,21 @@ class HomeFragment : Fragment() {
         maybeShowRenameNotice(appSettings)
     }
 
-    // Shows a one-time notice about the app rename. Skipped while an auto-connect is
-    // taking over the screen so it does not flash in front of a launching projection.
+    // Shows a one-time notice about the app rename. Existing users always get it once,
+    // new installs only during a window after the release. Skipped while an auto-connect
+    // is taking over the screen so it does not flash in front of a launching projection.
     private fun maybeShowRenameNotice(appSettings: Settings) {
         if (appSettings.renameNoticeShown) return
         if (commManager.isConnected) return
         if (hasAttemptedAutoConnect || hasAutoStarted || hasAttemptedSingleUsbAutoConnect) return
+
+        val firstInstallTime = try {
+            requireContext().packageManager
+                .getPackageInfo(requireContext().packageName, 0).firstInstallTime
+        } catch (e: PackageManager.NameNotFoundException) {
+            0L
+        }
+        if (!RenameNoticePolicy.shouldOffer(firstInstallTime, System.currentTimeMillis())) return
 
         appSettings.renameNoticeShown = true
         activeDialog = MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/RenameNoticePolicy.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/RenameNoticePolicy.kt
@@ -1,0 +1,23 @@
+package com.andrerinas.headunitrevived.main
+
+/**
+ * Decides who sees the one-time rename notice.
+ *
+ * Existing users (installed before the rename went live) always get it once, even if they
+ * update late. Brand-new installs only get it during a short window after the release, since
+ * a rename notice means nothing to someone who never knew the old name.
+ */
+object RenameNoticePolicy {
+
+    // Date the renamed build went live (UTC epoch millis). Set this to the actual release date.
+    const val RENAME_RELEASE_MS = 1785542400000L // 2026-08-01
+
+    // How long after the release brand-new installs still see the notice.
+    const val NEW_USER_WINDOW_MS = 30L * 24 * 60 * 60 * 1000 // 30 days
+
+    fun shouldOffer(firstInstallTimeMs: Long, nowMs: Long): Boolean {
+        val existingUser = firstInstallTimeMs in 1 until RENAME_RELEASE_MS
+        val withinNewUserWindow = nowMs < RENAME_RELEASE_MS + NEW_USER_WINDOW_MS
+        return existingUser || withinNewUserWindow
+    }
+}

--- a/app/src/main/java/com/andrerinas/headunitrevived/main/RenameNoticePolicy.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/main/RenameNoticePolicy.kt
@@ -6,6 +6,12 @@ package com.andrerinas.headunitrevived.main
  * Existing users (installed before the rename went live) always get it once, even if they
  * update late. Brand-new installs only get it during a short window after the release, since
  * a rename notice means nothing to someone who never knew the old name.
+ *
+ * The decision is based only on the install time, which is recorded once at install and never
+ * changes on updates. It does not read the current wall clock on purpose: many head units run
+ * offline with a wrong or unset system clock, and existing users must still be reached. An
+ * in-place update from the old app keeps the original (pre-release) install time, so upgraders
+ * are reliably treated as existing users.
  */
 object RenameNoticePolicy {
 
@@ -15,9 +21,9 @@ object RenameNoticePolicy {
     // How long after the release brand-new installs still see the notice.
     const val NEW_USER_WINDOW_MS = 30L * 24 * 60 * 60 * 1000 // 30 days
 
-    fun shouldOffer(firstInstallTimeMs: Long, nowMs: Long): Boolean {
-        val existingUser = firstInstallTimeMs in 1 until RENAME_RELEASE_MS
-        val withinNewUserWindow = nowMs < RENAME_RELEASE_MS + NEW_USER_WINDOW_MS
-        return existingUser || withinNewUserWindow
+    fun shouldOffer(firstInstallTimeMs: Long): Boolean {
+        // Installed before the release (existing user) or within the window afterwards.
+        // Unknown install time (0) falls on the show side, so we inform rather than stay silent.
+        return firstInstallTimeMs < RENAME_RELEASE_MS + NEW_USER_WINDOW_MS
     }
 }

--- a/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/headunitrevived/utils/Settings.kt
@@ -224,6 +224,13 @@ class Settings(private val context: Context) {
             prefs.edit().putBoolean("gesture_hint_shown", value).apply()
         }
 
+    // One-time notice telling users the app was rebranded. Shown once on the home screen.
+    var renameNoticeShown: Boolean
+        get() = prefs.getBoolean("rename_notice_shown", false)
+        set(value) {
+            prefs.edit().putBoolean("rename_notice_shown", value).apply()
+        }
+
     // Custom Insets (Screen Margins)
     var insetLeft: Int
         get() = prefs.getInt("inset-left", 0)

--- a/app/src/main/res/drawable/ic_rename_notice.xml
+++ b/app/src/main/res/drawable/ic_rename_notice.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorPrimary">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,9l1.25,-2.75L23,5l-2.75,-1.25L19,1l-1.25,2.75L15,5l2.75,1.25L19,9zM19,15l-1.25,2.75L15,19l2.75,1.25L19,23l1.25,-2.75L23,19l-2.75,-1.25L19,15zM11.5,9.5L9,4L6.5,9.5L1,12l5.5,2.5L9,20l2.5,-5.5L17,12L11.5,9.5z" />
+</vector>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -767,4 +767,7 @@
     <string name="support_rules_describe_desc">ما الذي فعلته، وما الذي توقعت حدوثه، وما الذي حدث فعلًا. لقطة شاشة أو مقطع فيديو قصير تساعد كثيرًا في المشكلات المرئية.</string>
     <string name="support_rules_oneissue_title">مشكلة واحدة لكل تقرير</string>
     <string name="support_rules_oneissue_desc">خصص كل تقرير لمشكلة واحدة حتى يمكن تتبعها وإصلاحها. افتح تقارير منفصلة للمشكلات غير المرتبطة ببعضها.</string>
+    <string name="rename_notice_title">اسم جديد، والتطبيق نفسه: %1$s</string>
+    <string name="rename_notice_message">لقد نما Headunit Revived كثيرًا بفضلكم. قطع المشروع ومجتمعه شوطًا طويلًا، ولذلك أصبح له هوية خاصة به: %1$s.\n\nنفس التطبيق، ونفس الأشخاص خلفه، وكل إعداداتك تبقى كما هي تمامًا.</string>
+    <string name="rename_notice_button">حسنًا</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -795,4 +795,7 @@
     <string name="support_rules_intro">Jsou vyžadovány jen dvě věci. Vše ostatní je volitelné, ale pomůže to váš problém vyřešit mnohem rychleji.</string>
     <string name="support_rules_section_required">Povinné</string>
     <string name="support_rules_section_recommend">Doporučení (volitelné)</string>
+    <string name="rename_notice_title">Nový název, stejná aplikace: %1$s</string>
+    <string name="rename_notice_message">Headunit Revived díky vám hodně vyrostl. Projekt i jeho komunita ušly velký kus cesty, a tak dostává vlastní identitu: %1$s.\n\nStejná aplikace, stejní lidé za ní a všechna vaše nastavení zůstávají přesně tak, jak jsou.</string>
+    <string name="rename_notice_button">Rozumím</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -772,4 +772,7 @@
     <string name="onb_ready_loading_button">Ladebildschirm einrichten</string>
     <string name="static_bssid_title">Statische BSSID</string>
     <string name="static_bssid_enter_value">BSSID-Wert (Format: XX:XX:XX:XX:XX:XX)</string>
+    <string name="rename_notice_title">Neuer Name, gleiche App: %1$s</string>
+    <string name="rename_notice_message">Headunit Revived ist dank euch stark gewachsen. Das Projekt und seine Community haben einen weiten Weg zurückgelegt und bekommen deshalb eine eigene Identität: %1$s.\n\nGleiche App, dieselben Leute dahinter, und all deine Einstellungen bleiben genau so, wie sie sind.</string>
+    <string name="rename_notice_button">Verstanden</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -804,4 +804,7 @@
     <string name="support_rules_intro">Solo se requieren dos cosas. Todo lo demás es opcional, aunque ayuda a resolver tu problema mucho más rápido.</string>
     <string name="support_rules_section_required">Obligatorio</string>
     <string name="support_rules_section_recommend">Recomendaciones (opcional)</string>
+    <string name="rename_notice_title">Nuevo nombre, la misma app: %1$s</string>
+    <string name="rename_notice_message">Headunit Revived ha crecido mucho, gracias a vosotros. El proyecto y su comunidad han recorrido un largo camino, así que ahora tiene una identidad propia: %1$s.\n\nLa misma app, la misma gente detrás, y todos tus ajustes se quedan exactamente como están.</string>
+    <string name="rename_notice_button">Entendido</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -803,4 +803,7 @@
     <string name="support_rules_intro">Solo se necesitan dos cosas. Todo lo demás es opcional, pero ayuda a resolver tu problema mucho más rápido.</string>
     <string name="support_rules_section_required">Requerido</string>
     <string name="support_rules_section_recommend">Recomendaciones (opcional)</string>
+    <string name="rename_notice_title">Nuevo nombre, la misma app: %1$s</string>
+    <string name="rename_notice_message">Headunit Revived ha crecido mucho, gracias a ustedes. El proyecto y su comunidad han recorrido un largo camino, así que ahora tiene una identidad propia: %1$s.\n\nLa misma app, la misma gente detrás, y todos tus ajustes se quedan exactamente como están.</string>
+    <string name="rename_notice_button">Entendido</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -765,4 +765,7 @@
     <string name="support_rules_describe_desc">Mit csináltál, mit vártál, és mi történt valójában. Vizuális problémáknál egy képernyőfotó vagy rövid videó sokat segít.</string>
     <string name="support_rules_oneissue_title">Egy hibajegy, egy probléma</string>
     <string name="support_rules_oneissue_desc">Minden hibajegy egyetlen problémáról szóljon, hogy könnyen nyomon követhető és javítható legyen. Egymással össze nem függő problémákhoz nyiss külön hibajegyeket.</string>
+    <string name="rename_notice_title">Új név, ugyanaz az alkalmazás: %1$s</string>
+    <string name="rename_notice_message">A Headunit Revived sokat fejlődött, nektek köszönhetően. A projekt és a közössége hosszú utat tett meg, ezért saját arculatot kap: %1$s.\n\nUgyanaz az alkalmazás, ugyanazokkal az emberekkel a háttérben, és minden beállításod pontosan úgy marad, ahogy van.</string>
+    <string name="rename_notice_button">Értem</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -772,4 +772,7 @@
     <string name="support_rules_intro">Sono richieste solo due cose. Tutto il resto è facoltativo, ma aiuta a risolvere il problema molto più in fretta.</string>
     <string name="support_rules_section_required">Obbligatorio</string>
     <string name="support_rules_section_recommend">Consigli (facoltativi)</string>
+    <string name="rename_notice_title">Nuovo nome, stessa app: %1$s</string>
+    <string name="rename_notice_message">Headunit Revived è cresciuta molto, grazie a voi. Il progetto e la sua community hanno fatto tanta strada, quindi ora l\'app ha un\'identità tutta sua: %1$s.\n\nStessa app, stesse persone dietro, e tutte le tue impostazioni restano esattamente come sono.</string>
+    <string name="rename_notice_button">Ho capito</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -773,4 +773,7 @@
     <string name="support_rules_describe_desc">何をしたか、何を期待していたか、実際に何が起きたかを書いてください。見た目の問題はスクリーンショットや短い動画があると非常に助かります。</string>
     <string name="support_rules_oneissue_title">1件のissueにつき1つの問題</string>
     <string name="support_rules_oneissue_desc">追跡・修正しやすくするために、issueは1件につき1つの問題に絞ってください。関係のない問題は別のissueを作成してください。</string>
+    <string name="rename_notice_title">名前は新しく、アプリはそのまま: %1$s</string>
+    <string name="rename_notice_message">Headunit Revived は皆さんのおかげで大きく成長しました。プロジェクトとそのコミュニティはここまで歩んできて、いよいよ独自の名前を持つことになりました: %1$s。\n\n同じアプリ、同じ開発チーム、そして設定もすべてそのまま残ります。</string>
+    <string name="rename_notice_button">了解</string>
 </resources>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -697,4 +697,7 @@
     <string name="support_rules_intro">მხოლოდ ორი რამ არის სავალდებულო. ყველა დანარჩენი სურვილისამებრ, მაგრამ ეს ძალიან აჩქარებს პრობლემის გადაჭრას.</string>
     <string name="support_rules_section_required">სავალდებულო</string>
     <string name="support_rules_section_recommend">რეკომენდაციები (სურვილისამებრ)</string>
+    <string name="rename_notice_title">ახალი სახელი, იგივე აპი: %1$s</string>
+    <string name="rename_notice_message">Headunit Revived ბევრად წინ წავიდა თქვენი წყალობით. პროექტმა და მისმა თემმა დიდი გზა გაიარა, ამიტომ ის საკუთარ იდენტობას იძენს: %1$s.\n\nიგივე აპი, იგივე ხალხი მის უკან, და ყველა თქვენი პარამეტრი ზუსტად ისე რჩება, როგორც არის.</string>
+    <string name="rename_notice_button">გასაგებია</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -769,4 +769,7 @@
     <string name="support_rules_intro">두 가지만 필요합니다. 나머지는 선택 사항이지만, 있을수록 훨씬 빠르게 해결할 수 있습니다.</string>
     <string name="support_rules_section_required">필수</string>
     <string name="support_rules_section_recommend">권장 사항 (선택)</string>
+    <string name="rename_notice_title">새 이름, 같은 앱: %1$s</string>
+    <string name="rename_notice_message">Headunit Revived는 여러분 덕분에 많이 성장했습니다. 프로젝트와 커뮤니티가 먼 길을 걸어온 만큼, 이제 고유한 이름을 갖게 되었습니다: %1$s.\n\n같은 앱, 같은 사람들, 그리고 모든 설정은 지금 그대로 유지됩니다.</string>
+    <string name="rename_notice_button">확인</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -795,4 +795,7 @@
     <string name="support_rules_intro">Er zijn maar twee dingen verplicht. De rest is optioneel, maar het helpt je probleem veel sneller op te lossen.</string>
     <string name="support_rules_section_required">Verplicht</string>
     <string name="support_rules_section_recommend">Aanbevelingen (optioneel)</string>
+    <string name="rename_notice_title">Nieuwe naam, dezelfde app: %1$s</string>
+    <string name="rename_notice_message">Headunit Revived is enorm gegroeid, dankzij jullie. Het project en de community hebben een lange weg afgelegd, dus krijgt het een eigen identiteit: %1$s.\n\nDezelfde app, dezelfde mensen erachter, en al je instellingen blijven precies zoals ze zijn.</string>
+    <string name="rename_notice_button">Begrepen</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -794,4 +794,7 @@
     <string name="support_rules_intro">Wymagane są tylko dwie rzeczy. Wszystko inne jest opcjonalne, ale bardzo przyspiesza rozwiązanie problemu.</string>
     <string name="support_rules_section_required">Wymagane</string>
     <string name="support_rules_section_recommend">Zalecenia (opcjonalne)</string>
+    <string name="rename_notice_title">Nowa nazwa, ta sama aplikacja: %1$s</string>
+    <string name="rename_notice_message">Headunit Revived bardzo się rozrósł, dzięki wam. Projekt i jego społeczność przeszły długą drogę, więc zyskuje własną tożsamość: %1$s.\n\nTa sama aplikacja, ci sami ludzie za nią, a wszystkie twoje ustawienia pozostają dokładnie takie, jakie są.</string>
+    <string name="rename_notice_button">Rozumiem</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -796,4 +796,7 @@
     <string name="support_rules_intro">Apenas duas coisas são obrigatórias. Todo o resto é opcional, mas ajuda a resolver seu problema muito mais rápido.</string>
     <string name="support_rules_section_required">Obrigatório</string>
     <string name="support_rules_section_recommend">Recomendações (opcional)</string>
+    <string name="rename_notice_title">Novo nome, o mesmo app: %1$s</string>
+    <string name="rename_notice_message">O Headunit Revived cresceu muito, graças a vocês. O projeto e sua comunidade percorreram um longo caminho, então ele está ganhando uma identidade própria: %1$s.\n\nO mesmo app, as mesmas pessoas por trás dele, e todas as suas configurações continuam exatamente como estão.</string>
+    <string name="rename_notice_button">Entendi</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -766,4 +766,7 @@
     <string name="support_rules_intro">Sunt necesare doar două lucruri. Restul este opțional, dar te ajută să-ți rezolvăm problema mult mai repede.</string>
     <string name="support_rules_section_required">Obligatoriu</string>
     <string name="support_rules_section_recommend">Recomandări (opțional)</string>
+    <string name="rename_notice_title">Nume nou, aceeași aplicație: %1$s</string>
+    <string name="rename_notice_message">Headunit Revived a crescut mult, datorită vouă. Proiectul și comunitatea sa au parcurs un drum lung, așa că își capătă o identitate proprie: %1$s.\n\nAceeași aplicație, aceiași oameni în spatele ei, iar toate setările tale rămân exact așa cum sunt.</string>
+    <string name="rename_notice_button">Am înțeles</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -794,4 +794,7 @@
     <string name="support_rules_intro">Нужно только два условия. Всё остальное необязательно, но поможет решить проблему гораздо быстрее.</string>
     <string name="support_rules_section_required">Обязательно</string>
     <string name="support_rules_section_recommend">Рекомендации (необязательно)</string>
+    <string name="rename_notice_title">Новое имя, то же приложение: %1$s</string>
+    <string name="rename_notice_message">Headunit Revived сильно вырос благодаря вам. Проект и его сообщество прошли большой путь, поэтому он получает собственное имя: %1$s.\n\nТо же приложение, те же люди за ним, и все ваши настройки остаются ровно такими, как есть.</string>
+    <string name="rename_notice_button">Понятно</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -764,4 +764,7 @@
     <string name="support_rules_describe_desc">Ne yaptığınızı, ne beklediğinizi ve gerçekte ne olduğunu yazın. Görsel sorunlar için bir ekran görüntüsü veya kısa bir video çok işe yarar.</string>
     <string name="support_rules_oneissue_title">Konu başına bir sorun</string>
     <string name="support_rules_oneissue_desc">Her konuyu tek bir sorunla sınırlı tutun ki takip edilip düzeltilebilsin. İlgisiz sorunlar için ayrı konular açın.</string>
+    <string name="rename_notice_title">Yeni isim, aynı uygulama: %1$s</string>
+    <string name="rename_notice_message">Headunit Revived sizin sayenizde çok büyüdü. Proje ve topluluğu uzun bir yol kat etti, bu yüzden kendine ait bir kimlik kazanıyor: %1$s.\n\nAynı uygulama, arkasındaki aynı ekip ve tüm ayarların tam olduğu gibi kalıyor.</string>
+    <string name="rename_notice_button">Anladım</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -796,4 +796,7 @@
     <string name="support_rules_intro">Потрібні лише дві речі. Все інше необов\'язкове, але значно прискорює вирішення проблеми.</string>
     <string name="support_rules_section_required">Обов\'язково</string>
     <string name="support_rules_section_recommend">Рекомендації (необов\'язково)</string>
+    <string name="rename_notice_title">Нова назва, той самий застосунок: %1$s</string>
+    <string name="rename_notice_message">Headunit Revived дуже виріс завдяки вам. Проєкт і його спільнота пройшли довгий шлях, тож він отримує власну назву: %1$s.\n\nТой самий застосунок, ті самі люди за ним, і всі ваші налаштування залишаються точно такими, як є.</string>
+    <string name="rename_notice_button">Зрозуміло</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -772,4 +772,7 @@
     <string name="support_rules_intro">Chỉ cần hai điều bắt buộc. Phần còn lại là tuỳ chọn, nhưng sẽ giúp giải quyết vấn đề của bạn nhanh hơn nhiều.</string>
     <string name="support_rules_section_required">Bắt buộc</string>
     <string name="support_rules_section_recommend">Khuyến nghị (tuỳ chọn)</string>
+    <string name="rename_notice_title">Tên mới, vẫn là ứng dụng đó: %1$s</string>
+    <string name="rename_notice_message">Headunit Revived đã phát triển rất nhiều, nhờ có các bạn. Dự án và cộng đồng đã đi được một chặng đường dài, nên giờ nó có một bản sắc riêng: %1$s.\n\nVẫn ứng dụng đó, vẫn những con người đứng sau, và mọi cài đặt của bạn vẫn giữ nguyên như cũ.</string>
+    <string name="rename_notice_button">Đã hiểu</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -794,4 +794,7 @@
     <string name="support_rules_describe_desc">您做了什麼、預期會發生什麼，以及實際發生了什麼。對於視覺問題，附上截圖或短片會非常有幫助。</string>
     <string name="support_rules_oneissue_title">一個 Issue 只處理一個問題</string>
     <string name="support_rules_oneissue_desc">每個 Issue 請聚焦於單一問題，方便追蹤和修復。不相關的問題請另開 Issue。</string>
+    <string name="rename_notice_title">新名字，還是同一個 App：%1$s</string>
+    <string name="rename_notice_message">多虧了大家，Headunit Revived 成長了許多。這個專案和它的社群一路走來，如今要擁有自己的名字了：%1$s。\n\n還是同一個 App，還是同一群人，你的所有設定也都原封不動。</string>
+    <string name="rename_notice_button">知道了</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -867,4 +867,9 @@
     <string name="coordinates_invalid">Invalid coordinates</string>
     <string name="coordinates_format_help">Decimal degrees, dot or comma. Example: 40.4168, -3.7038</string>
     <string name="sunrise_reference_help">The reference point used to calculate sunrise and sunset. Pick your location once; it works without GPS.</string>
+
+    <!-- One-time rename notice shown on the home screen. %1$s is the new app name. -->
+    <string name="rename_notice_title">New name, same app: %1$s</string>
+    <string name="rename_notice_message">Headunit Revived has grown a lot, thanks to you. The project and its community have come a long way, so it is getting an identity of its own: %1$s.\n\nSame app, same people behind it, and all your settings stay exactly as they are.</string>
+    <string name="rename_notice_button">Got it</string>
 </resources>

--- a/app/src/test/java/com/andrerinas/headunitrevived/main/RenameNoticePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/headunitrevived/main/RenameNoticePolicyTest.kt
@@ -7,35 +7,30 @@ import org.junit.Test
 class RenameNoticePolicyTest {
 
     private val release = RenameNoticePolicy.RENAME_RELEASE_MS
-    private val windowEnd = release + RenameNoticePolicy.NEW_USER_WINDOW_MS
+    private val cutoff = release + RenameNoticePolicy.NEW_USER_WINDOW_MS
 
     @Test
-    fun `existing user always sees it, even long after the window`() {
-        val installedBeforeRelease = release - 1000
-        assertTrue(RenameNoticePolicy.shouldOffer(installedBeforeRelease, windowEnd + 1000))
+    fun `existing user installed before the release sees it`() {
+        assertTrue(RenameNoticePolicy.shouldOffer(release - 1000))
     }
 
     @Test
     fun `new install within the window sees it`() {
-        val installedAfterRelease = release + 1000
-        assertTrue(RenameNoticePolicy.shouldOffer(installedAfterRelease, release + 1000))
+        assertTrue(RenameNoticePolicy.shouldOffer(release + 1000))
     }
 
     @Test
     fun `new install after the window does not see it`() {
-        val installedAfterRelease = release + 1000
-        assertFalse(RenameNoticePolicy.shouldOffer(installedAfterRelease, windowEnd + 1000))
+        assertFalse(RenameNoticePolicy.shouldOffer(cutoff + 1000))
     }
 
     @Test
-    fun `window end is exclusive`() {
-        val installedAfterRelease = release + 1000
-        assertFalse(RenameNoticePolicy.shouldOffer(installedAfterRelease, windowEnd))
+    fun `window cutoff is exclusive`() {
+        assertFalse(RenameNoticePolicy.shouldOffer(cutoff))
     }
 
     @Test
-    fun `unknown install time is not treated as an existing user`() {
-        assertTrue(RenameNoticePolicy.shouldOffer(0L, release + 1000))
-        assertFalse(RenameNoticePolicy.shouldOffer(0L, windowEnd + 1000))
+    fun `unknown or unset install time falls on the show side`() {
+        assertTrue(RenameNoticePolicy.shouldOffer(0L))
     }
 }

--- a/app/src/test/java/com/andrerinas/headunitrevived/main/RenameNoticePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/headunitrevived/main/RenameNoticePolicyTest.kt
@@ -1,0 +1,41 @@
+package com.andrerinas.headunitrevived.main
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RenameNoticePolicyTest {
+
+    private val release = RenameNoticePolicy.RENAME_RELEASE_MS
+    private val windowEnd = release + RenameNoticePolicy.NEW_USER_WINDOW_MS
+
+    @Test
+    fun `existing user always sees it, even long after the window`() {
+        val installedBeforeRelease = release - 1000
+        assertTrue(RenameNoticePolicy.shouldOffer(installedBeforeRelease, windowEnd + 1000))
+    }
+
+    @Test
+    fun `new install within the window sees it`() {
+        val installedAfterRelease = release + 1000
+        assertTrue(RenameNoticePolicy.shouldOffer(installedAfterRelease, release + 1000))
+    }
+
+    @Test
+    fun `new install after the window does not see it`() {
+        val installedAfterRelease = release + 1000
+        assertFalse(RenameNoticePolicy.shouldOffer(installedAfterRelease, windowEnd + 1000))
+    }
+
+    @Test
+    fun `window end is exclusive`() {
+        val installedAfterRelease = release + 1000
+        assertFalse(RenameNoticePolicy.shouldOffer(installedAfterRelease, windowEnd))
+    }
+
+    @Test
+    fun `unknown install time is not treated as an existing user`() {
+        assertTrue(RenameNoticePolicy.shouldOffer(0L, release + 1000))
+        assertFalse(RenameNoticePolicy.shouldOffer(0L, windowEnd + 1000))
+    }
+}


### PR DESCRIPTION
Adds a one-time notice on the home screen so people who had the app under the old name understand it has been rebranded.

Who sees it:
- Existing users (installed before the rename went live) get it once, even if they update late.
- Brand-new installs get it once only during a 30 day window after the release, since the notice means nothing to someone who never knew the old name.

It is skipped while an auto-connect is taking over the screen so it never flashes in front of a launching projection, and it never shows twice (stored in a simple flag).

The copy frames the change as the project growing into an identity of its own, same app, same people, settings kept. It does not mention any legal or trademark reason.

The new name is pulled from app_name, so the notice stays correct regardless of the final name. Because of that it is meant to ship with or after the rename, once app_name is the new name. It is based on main and does not depend on the rename PRs to build.

The decision is based only on the install time, not the current device clock, because many head units run offline with a wrong or unset clock. Install time is recorded once and survives updates, so upgraders are reliably treated as existing users. The logic lives in a small pure RenameNoticePolicy covered by unit tests. Set RENAME_RELEASE_MS to the actual release date (currently 2026-08-01).

Includes a small sparkle icon and translations for all 19 locales.

Verified with compileGithubDebugKotlin and the RenameNoticePolicy unit tests on JDK 17.
