### PR TITLE
Native Mode Reliability Improvements (#706)

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -31,17 +31,13 @@ class NativeAaHandshakeManager(
     companion object {
         private val AA_UUID = UUID.fromString("4de17a00-52cb-11e6-bdf4-0800200c9a66")
         private val HFP_UUID = UUID.fromString("0000111e-0000-1000-8000-00805f9b34fb")
-        // Headset Profile Audio-Gateway role. Despite the old name this repo carried
-        // ("A2DP_SOURCE_UUID"), this is not A2DP Source (real assigned number
-        // 0000110a-0000-1000-8000-00805f9b34fb) - confirmed against two independent open-source
-        // wireless Android Auto implementations (nisargjhaveri/WirelessAndroidAutoDongle,
-        // mossyhub/openautolink), which both use this exact UUID as a phone-wake target.
-        private val HSP_AG_UUID = UUID.fromString("00001112-0000-1000-8000-00805f9b34fb")
-        // Hands-Free Profile Audio-Gateway role. openautolink's _connect_device() tries this
-        // first, falling back to HSP_AG_UUID - mirrored here for the same reason: HFP is the
-        // more modern profile and more likely what a given phone/OEM stack gates wireless AA
-        // detection on.
-        private val HFP_AG_UUID = UUID.fromString("0000111f-0000-1000-8000-00805f9b34fb")
+        // Phone-wake targets, tried HFP then HSP (mirrors openautolink's ConnectProfile
+        // fallback chain). HSP_AG_UUID is the old "A2DP_SOURCE_UUID" - despite that name it was
+        // never A2DP Source (real assigned number 0000110a-...); both UUIDs are confirmed
+        // against nisargjhaveri/WirelessAndroidAutoDongle and mossyhub/openautolink, which use
+        // the same pair for this exact purpose.
+        private val HSP_AG_UUID = UUID.fromString("00001112-0000-1000-8000-00805f9b34fb") // Headset Profile AG
+        private val HFP_AG_UUID = UUID.fromString("0000111f-0000-1000-8000-00805f9b34fb") // Hands-Free Profile AG
         private const val HANDSHAKE_RESPONSE_TIMEOUT_MS = 15_000L
 
         /** Which of [allServiceNames] are secondary Bluetooth radios, i.e. not [primaryServiceName]

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -2,6 +2,7 @@ package com.andrerinas.openheadunit.connection
 
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothServerSocket
 import android.bluetooth.BluetoothSocket
 import android.content.Context
@@ -30,7 +31,17 @@ class NativeAaHandshakeManager(
     companion object {
         private val AA_UUID = UUID.fromString("4de17a00-52cb-11e6-bdf4-0800200c9a66")
         private val HFP_UUID = UUID.fromString("0000111e-0000-1000-8000-00805f9b34fb")
-        private val A2DP_SOURCE_UUID = UUID.fromString("00001112-0000-1000-8000-00805f9b34fb")
+        // Headset Profile Audio-Gateway role. Despite the old name this repo carried
+        // ("A2DP_SOURCE_UUID"), this is not A2DP Source (real assigned number
+        // 0000110a-0000-1000-8000-00805f9b34fb) - confirmed against two independent open-source
+        // wireless Android Auto implementations (nisargjhaveri/WirelessAndroidAutoDongle,
+        // mossyhub/openautolink), which both use this exact UUID as a phone-wake target.
+        private val HSP_AG_UUID = UUID.fromString("00001112-0000-1000-8000-00805f9b34fb")
+        // Hands-Free Profile Audio-Gateway role. openautolink's _connect_device() tries this
+        // first, falling back to HSP_AG_UUID - mirrored here for the same reason: HFP is the
+        // more modern profile and more likely what a given phone/OEM stack gates wireless AA
+        // detection on.
+        private val HFP_AG_UUID = UUID.fromString("0000111f-0000-1000-8000-00805f9b34fb")
         private const val HANDSHAKE_RESPONSE_TIMEOUT_MS = 15_000L
 
         /** Which of [allServiceNames] are secondary Bluetooth radios, i.e. not [primaryServiceName]
@@ -333,6 +344,30 @@ class NativeAaHandshakeManager(
     }
 
     /**
+     * Tries HFP_AG_UUID first, falling back to HSP_AG_UUID, holding whichever connects for
+     * [holdMs]. Returns true if either connected. Mirrors openautolink's ConnectProfile
+     * fallback chain (HFP_AG_UUID -> HSP_AG_UUID).
+     */
+    private suspend fun pokeDevice(device: BluetoothDevice, holdMs: Long): Boolean {
+        for (uuid in listOf(HFP_AG_UUID, HSP_AG_UUID)) {
+            var socket: BluetoothSocket? = null
+            try {
+                socket = device.createRfcommSocketToServiceRecord(uuid)
+                AppLog.i("NativeAA: Calling socket.connect() for ${device.name} via $uuid...")
+                socket.connect()
+                AppLog.i("NativeAA: Successfully poked ${device.name} via $uuid. Holding ${holdMs}ms...")
+                delay(holdMs)
+                return true
+            } catch (e: Exception) {
+                AppLog.d("NativeAA: Poke via $uuid to ${device.name} failed: ${e.message}")
+            } finally {
+                try { socket?.close() } catch (e: Exception) {}
+            }
+        }
+        return false
+    }
+
+    /**
      * Wakes up the phone by attempting a brief connection to an HFP/HSP profile, signaling it
      * to start looking for the head unit. Retried every 15s (matching the retry cadence of both
      * nisargjhaveri/WirelessAndroidAutoDongle and mossyhub/openautolink) until a real handshake
@@ -340,64 +375,56 @@ class NativeAaHandshakeManager(
      */
     fun triggerPoke() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            if (ContextCompat.checkSelfPermission(context, android.Manifest.permission.BLUETOOTH_CONNECT) 
+            if (ContextCompat.checkSelfPermission(context, android.Manifest.permission.BLUETOOTH_CONNECT)
                 != PackageManager.PERMISSION_GRANTED) {
                 AppLog.w("NativeAA: Missing BLUETOOTH_CONNECT. Cannot triggerPoke.")
                 return
             }
         }
         val adapter = BluetoothHelper.getBluetoothAdapter(context) ?: return
-        val lastMacs = settings.autoStartBluetoothDeviceMacs
 
         pokeJob?.cancel()
         pokeJob = scope.launch(Dispatchers.IO + CoroutineName("NativeAa-Wakeup")) {
             AppLog.d("NativeAA: triggerPoke() delay starting (2s)...")
             delay(2000) // Small safety delay before connecting
 
-            if (commManager.isConnected ||
-                commManager.connectionState.value is CommManager.ConnectionState.Connecting) {
-                AppLog.i("NativeAA: USB/other session became active during poke delay. Skipping poke.")
-                return@launch
-            }
-
-            val devicesToPoke = if (lastMacs.isNotEmpty()) {
-                lastMacs.mapNotNull { mac ->
-                    try {
-                        adapter.getRemoteDevice(mac)
-                    } catch (e: Exception) {
-                        null
-                    }
-                }
-            } else {
-                AppLog.w("NativeAA: No 'Auto Start BT Device' selected in settings. Poking all paired devices as fallback...")
-                adapter.bondedDevices.toList()
-            }
-
-            if (devicesToPoke.isEmpty()) {
-                AppLog.w("NativeAA: No paired Bluetooth devices found to poke.")
-                return@launch
-            }
-
-            for (device in devicesToPoke) {
-                if (!isRunning || !isActive) break
-                if (commManager.isConnected) {
-                    AppLog.i("NativeAA: USB/other session became active mid-poke. Stopping poke loop.")
+            while (isRunning && isActive && !handshakeInFlight) {
+                if (commManager.isConnected ||
+                    commManager.connectionState.value is CommManager.ConnectionState.Connecting) {
+                    AppLog.i("NativeAA: USB/other session active. Stopping poke retry loop.")
                     break
                 }
-                AppLog.i("NativeAA: Attempting active A2DP poke to device: ${device.name} (${device.address})...")
-                var socket: BluetoothSocket? = null
-                try {
-                    socket = device.createRfcommSocketToServiceRecord(A2DP_SOURCE_UUID)
-                    AppLog.i("NativeAA: Calling socket.connect() for ${device.name}...")
-                    socket.connect()
-                    AppLog.i("NativeAA: Successfully poked ${device.name}. Keeping socket alive for 15s...")
-                    delay(15000)
-                } catch (e: Exception) {
-                    AppLog.d("NativeAA: Poke for ${device.name} failed (normal if device disconnected): ${e.message}")
-                } finally {
-                    try { socket?.close() } catch (e: Exception) {}
-                    AppLog.d("NativeAA: Poke socket for ${device.name} closed in finally.")
+
+                val lastMacs = settings.autoStartBluetoothDeviceMacs
+                val devicesToPoke = if (lastMacs.isNotEmpty()) {
+                    lastMacs.mapNotNull { mac ->
+                        try {
+                            adapter.getRemoteDevice(mac)
+                        } catch (e: Exception) {
+                            null
+                        }
+                    }
+                } else {
+                    AppLog.w("NativeAA: No 'Auto Start BT Device' selected in settings. Poking all paired devices as fallback...")
+                    adapter.bondedDevices.toList()
                 }
+
+                if (devicesToPoke.isEmpty()) {
+                    AppLog.w("NativeAA: No paired Bluetooth devices found to poke.")
+                    return@launch
+                }
+
+                for (device in devicesToPoke) {
+                    if (!isRunning || !isActive || handshakeInFlight) break
+                    if (commManager.isConnected) {
+                        AppLog.i("NativeAA: USB/other session became active mid-poke. Stopping poke loop.")
+                        break
+                    }
+                    AppLog.i("NativeAA: Attempting active poke to device: ${device.name} (${device.address})...")
+                    pokeDevice(device, holdMs = 15000)
+                }
+
+                delay(15000) // retry cadence, matches both reference implementations' 15-20s interval
             }
         }
     }
@@ -420,20 +447,9 @@ class NativeAaHandshakeManager(
             
             pokeJob?.cancel()
             pokeJob = scope.launch(Dispatchers.IO + CoroutineName("NativeAa-ManualWakeup")) {
-                AppLog.i("NativeAA: Attempting manual A2DP poke to ${device.name}...")
-                var socket: BluetoothSocket? = null
-                try {
-                    socket = device.createRfcommSocketToServiceRecord(A2DP_SOURCE_UUID)
-                    AppLog.i("NativeAA: Calling socket.connect() for ${device.name}...")
-                    socket.connect()
-                    AppLog.i("NativeAA: Successfully poked ${device.name}. Keeping socket alive for 20s...")
-                    delay(20000)
-                } catch (e: Exception) {
-                    AppLog.d("NativeAA: Manual poke for ${device.name} failed: ${e.message}")
-                } finally {
-                    try { socket?.close() } catch (e: Exception) {}
-                    AppLog.i("NativeAA: Manual poke socket for ${device.name} closed in finally.")
-                }
+                AppLog.i("NativeAA: Attempting manual poke to ${device.name}...")
+                pokeDevice(device, holdMs = 20000)
+                AppLog.i("NativeAA: Manual poke to ${device.name} finished.")
             }
         } catch (e: Exception) {
             AppLog.e("NativeAA: Manual poke error", e)

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -220,11 +220,28 @@ class NativeAaHandshakeManager(
         val handles = try {
             BluetoothHelper.getAllBluetoothAdapterHandles(context)
         } catch (e: Exception) { emptyList() }
+
+        // Manual fallback: some ROMs' second radio isn't discoverable via
+        // ServiceManager.listServices() at all (blocked, or named without "bluetooth"), so
+        // automatic enumeration never finds it. Let the user force it by exact system service
+        // name instead.
+        val manualServiceName = settings.manualSecondaryBluetoothServiceName
+        val allHandles = if (manualServiceName.isNotEmpty() && handles.none { it.serviceName == manualServiceName }) {
+            val manualHandle = try { BluetoothHelper.getAdapterHandleForService(context, manualServiceName) } catch (e: Exception) { null }
+            if (manualHandle != null) {
+                AppLog.i("NativeAA: Manual secondary Bluetooth service '$manualServiceName' resolved successfully.")
+                handles + manualHandle
+            } else {
+                AppLog.w("NativeAA: Manual secondary Bluetooth service '$manualServiceName' could not be resolved to a working adapter.")
+                handles
+            }
+        } else handles
+
         val secondaryNames = filterSecondaryServiceNames(
             settings.bluetoothManagerServiceName,
-            handles.map { it.serviceName }
+            allHandles.map { it.serviceName }
         ).toSet()
-        val secondaries = handles.filter { it.serviceName in secondaryNames }
+        val secondaries = allHandles.filter { it.serviceName in secondaryNames }
         if (secondaries.isNotEmpty()) {
             AppLog.i("NativeAA: Opening AA listeners on ${secondaries.size} secondary Bluetooth radio(s) for dual-radio head units: ${secondaries.joinToString { it.serviceName }}")
             secondaries.forEach { launchExtraServers(it.serviceName, it.adapter) }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -33,6 +33,19 @@ class NativeAaHandshakeManager(
         private val A2DP_SOURCE_UUID = UUID.fromString("00001112-0000-1000-8000-00805f9b34fb")
         private const val HANDSHAKE_RESPONSE_TIMEOUT_MS = 15_000L
 
+        /** Which of [allServiceNames] are secondary Bluetooth radios, i.e. not [primaryServiceName]
+         *  (dual-Bluetooth-radio head units). Pure and unit-testable: identity is by system
+         *  service name, not MAC address, since BluetoothAdapter.getAddress() returns the fixed
+         *  placeholder "02:00:00:00:00:00" for any non-privileged app on every device since
+         *  Android 6.0 (API 23), so every real adapter instance looks identical by address alone. */
+        internal fun filterSecondaryServiceNames(
+            primaryServiceName: String,
+            allServiceNames: List<String>
+        ): List<String> {
+            val primary = primaryServiceName.ifEmpty { "bluetooth_manager" }
+            return allServiceNames.filter { it != primary }.distinct()
+        }
+
         fun checkCompatibility(context: Context): Boolean {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 if (ContextCompat.checkSelfPermission(context, android.Manifest.permission.BLUETOOTH_CONNECT) 
@@ -184,23 +197,23 @@ class NativeAaHandshakeManager(
             }
         }
 
-        // Experimental: some head units have two Bluetooth radios (e.g. "K706" and "CAR8032").
-        // The phone may be bonded to the one that is not the default, so it never reaches the
-        // listener above. Also open listeners on any other radio with a real, different address.
-        // Strict no-op on the usual single-radio device, and skipped when the address is masked
-        // (API 31+), so it cannot disturb the primary listener.
-        val primaryAddr = try { adapter.address } catch (e: Exception) { null }
-        if (primaryAddr != null && primaryAddr != "02:00:00:00:00:00") {
-            val secondaries = try {
-                BluetoothHelper.getAllBluetoothAdapters(context).filter {
-                    val a = try { it.address } catch (e: Exception) { null }
-                    a != null && a != "02:00:00:00:00:00" && a != primaryAddr
-                }
-            } catch (e: Exception) { emptyList() }
-            if (secondaries.isNotEmpty()) {
-                AppLog.i("NativeAA: Opening AA listeners on ${secondaries.size} secondary Bluetooth radio(s) for dual-radio head units")
-                secondaries.forEach { launchExtraServers(it) }
-            }
+        // Some head units have two Bluetooth radios (e.g. "K706" and "CAR8032"). The phone may
+        // be bonded to whichever one isn't the primary, so it never reaches the listener above.
+        // Match radios by system service name, not MAC address: BluetoothAdapter.getAddress()
+        // returns the fixed placeholder "02:00:00:00:00:00" for any non-privileged app since
+        // Android 6.0 (API 23), on every device - primary and secondary always look identical
+        // by address alone (see andreknieriem/headunit-revived#706).
+        val handles = try {
+            BluetoothHelper.getAllBluetoothAdapterHandles(context)
+        } catch (e: Exception) { emptyList() }
+        val secondaryNames = filterSecondaryServiceNames(
+            settings.bluetoothManagerServiceName,
+            handles.map { it.serviceName }
+        ).toSet()
+        val secondaries = handles.filter { it.serviceName in secondaryNames }
+        if (secondaries.isNotEmpty()) {
+            AppLog.i("NativeAA: Opening AA listeners on ${secondaries.size} secondary Bluetooth radio(s) for dual-radio head units: ${secondaries.joinToString { it.serviceName }}")
+            secondaries.forEach { launchExtraServers(it.serviceName, it.adapter) }
         }
     }
 
@@ -209,26 +222,26 @@ class NativeAaHandshakeManager(
      * bonded to that radio (dual-Bluetooth head units) can still reach us. Experimental, and
      * fully guarded so a bad radio cannot affect the primary listener.
      */
-    private fun launchExtraServers(extra: BluetoothAdapter) {
+    private fun launchExtraServers(serviceName: String, extra: BluetoothAdapter) {
         val addr = try { extra.address } catch (e: Exception) { "?" }
         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-RfcommServer-2")) {
             try {
                 val server = extra.listenUsingRfcommWithServiceRecord("AA BT Listener", AA_UUID)
                 extraAaServerSockets.add(server)
-                AppLog.i("NativeAA: ACTIVELY LISTENING on Android Auto UUID on secondary radio [$addr]")
+                AppLog.i("NativeAA: ACTIVELY LISTENING on Android Auto UUID on secondary radio '$serviceName' [$addr]")
                 while (isRunning && isActive) {
                     val socket = server.accept()
                     if (socket != null) {
-                        AppLog.i("NativeAA: Connection accepted (secondary radio [$addr]) from ${socket.remoteDevice.name} (${socket.remoteDevice.address})")
+                        AppLog.i("NativeAA: Connection accepted (secondary radio '$serviceName' [$addr]) from ${socket.remoteDevice.name} (${socket.remoteDevice.address})")
                         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-Handshake-${socket.remoteDevice.address}")) {
                             handleHandshake(socket, addr)
                         }
                     }
                 }
             } catch (e: Exception) {
-                if (aaListenersClosedForSession) AppLog.d("NativeAA: Secondary AA server closed after successful handoff [$addr].")
-                else if (isRunning) AppLog.e("NativeAA: Secondary AA server error [$addr]: ${e.message}", e)
-                else AppLog.d("NativeAA: Secondary AA server closed cleanly [$addr].")
+                if (aaListenersClosedForSession) AppLog.d("NativeAA: Secondary AA server closed after successful handoff ['$serviceName' $addr].")
+                else if (isRunning) AppLog.e("NativeAA: Secondary AA server error ['$serviceName' $addr]: ${e.message}", e)
+                else AppLog.d("NativeAA: Secondary AA server closed cleanly ['$serviceName' $addr].")
             }
         }
         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-HfpServer-2")) {
@@ -238,15 +251,15 @@ class NativeAaHandshakeManager(
                 while (isRunning && isActive) {
                     val socket = server.accept()
                     if (socket != null) {
-                        AppLog.i("NativeAA: HFP connection accepted (secondary radio) from ${socket.remoteDevice.name}.")
+                        AppLog.i("NativeAA: HFP connection accepted (secondary radio '$serviceName') from ${socket.remoteDevice.name}.")
                         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-HfpResponder-${socket.remoteDevice.address}")) {
                             handleHfp(socket)
                         }
                     }
                 }
             } catch (e: Exception) {
-                if (isRunning) AppLog.e("NativeAA: Secondary HFP server error [$addr]: ${e.message}", e)
-                else AppLog.d("NativeAA: Secondary HFP server closed cleanly [$addr].")
+                if (isRunning) AppLog.e("NativeAA: Secondary HFP server error ['$serviceName' $addr]: ${e.message}", e)
+                else AppLog.d("NativeAA: Secondary HFP server closed cleanly ['$serviceName' $addr].")
             }
         }
     }
@@ -320,8 +333,10 @@ class NativeAaHandshakeManager(
     }
 
     /**
-     * Wakes up the phone by attempting a brief connection to the A2DP profile.
-     * This acts as a signal for the phone to start looking for the headunit.
+     * Wakes up the phone by attempting a brief connection to an HFP/HSP profile, signaling it
+     * to start looking for the head unit. Retried every 15s (matching the retry cadence of both
+     * nisargjhaveri/WirelessAndroidAutoDongle and mossyhub/openautolink) until a real handshake
+     * starts or another session (USB/etc.) takes over, instead of giving up after a single pass.
      */
     fun triggerPoke() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -544,6 +544,15 @@ class NativeAaHandshakeManager(
             AppLog.i("  > Target IP:   $ip:5288")
             AppLog.i("  > BSSID:       $bssid")
 
+            // Some Bluetooth stacks report the RFCOMM socket "connected" slightly before the
+            // underlying channel is actually ready to carry data - writing immediately can be
+            // silently dropped on such hardware (a known real class of RFCOMM race: see the
+            // kernel's "Move pending packets from RFCOMM socket to TTY" fix for the same
+            // symptom on the HFP profile). A short delay costs nothing against either side's
+            // timeout budget (phone's own first-message timeout is ~12s, ours is 15s) but gives
+            // a flaky chip a moment to settle before the one message that matters most.
+            delay(300)
+
             AppLog.i("NativeAA: [TX] Sending WifiStartRequest (Type 1)")
             sendWifiStartRequest(output, ip, 5288)
 

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -476,6 +476,11 @@ class NativeAaHandshakeManager(
 
     private suspend fun handleHandshake(socket: BluetoothSocket, localRadio: String? = null) = withContext(Dispatchers.IO) {
         handshakeInFlight = true
+        // A real AA_UUID connection just landed - the wake poke (if one is still running) has
+        // done its job and is now just an extra, unnecessary RFCOMM/profile channel held open
+        // on the same physical radio for the remainder of its hold window, competing with this
+        // handshake for radio time. Release it immediately instead of leaving it running.
+        pokeJob?.cancel()
         try {
             val device = socket.remoteDevice
             AppLog.i("NativeAA: Handling handshake for ${device.name} (${device.address}) on local radio [${localRadio ?: "?"}]")

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -155,23 +155,26 @@ class NativeAaHandshakeManager(
 
         isRunning = true
         aaListenersClosedForSession = false
-        // Local Bluetooth radio address; logged on every accept so a dual-radio head unit's logs
-        // show which radio the phone actually reached (compare with the HU MAC in the phone's log).
-        val localAddr = try { adapter.address } catch (e: Exception) { "?" }
-        AppLog.i("NativeAA: Starting Bluetooth Handshake Servers (primary radio [$localAddr])...")
+        // Local Bluetooth radio name; logged on every accept so a dual-radio head unit's logs
+        // show which radio the phone actually reached (compare with the HU name in the phone's
+        // log). Uses adapter.name, not adapter.address: getAddress() returns the fixed masked
+        // placeholder "02:00:00:00:00:00" for any non-privileged app since Android 6.0 (API 23),
+        // but getName() returns the real radio name (confirmed on-device: e.g. "Navegadortz2").
+        val localRadioName = try { adapter.name ?: "?" } catch (e: Exception) { "?" }
+        AppLog.i("NativeAA: Starting Bluetooth Handshake Servers (primary radio [$localRadioName])...")
 
         // Start AA RFCOMM Server
         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-RfcommServer")) {
             try {
                 aaServerSocket = adapter.listenUsingRfcommWithServiceRecord("AA BT Listener", AA_UUID)
-                AppLog.i("NativeAA: ACTIVELY LISTENING on Android Auto UUID ($AA_UUID) on radio [$localAddr]... Waiting for phone to connect back!")
+                AppLog.i("NativeAA: ACTIVELY LISTENING on Android Auto UUID ($AA_UUID) on radio [$localRadioName]... Waiting for phone to connect back!")
                 while (isRunning && isActive) {
                     val socket = aaServerSocket?.accept()
                     if (socket != null) {
-                        AppLog.i("NativeAA: Connection accepted from ${socket.remoteDevice.name} (${socket.remoteDevice.address}) on local radio [$localAddr]")
+                        AppLog.i("NativeAA: Connection accepted from ${socket.remoteDevice.name} (${socket.remoteDevice.address}) on local radio [$localRadioName]")
                         // [FIX] Launch handshake in a separate coroutine so the server can accept the next connection!
                         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-Handshake-${socket.remoteDevice.address}")) {
-                            handleHandshake(socket, localAddr)
+                            handleHandshake(socket, localRadioName)
                         }
                     }
                 }
@@ -234,25 +237,27 @@ class NativeAaHandshakeManager(
      * fully guarded so a bad radio cannot affect the primary listener.
      */
     private fun launchExtraServers(serviceName: String, extra: BluetoothAdapter) {
-        val addr = try { extra.address } catch (e: Exception) { "?" }
+        // extra.name, not extra.address - see the comment on localRadioName in start(); the
+        // address is always the masked placeholder, the name is the real, useful identifier.
+        val radioName = try { extra.name ?: "?" } catch (e: Exception) { "?" }
         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-RfcommServer-2")) {
             try {
                 val server = extra.listenUsingRfcommWithServiceRecord("AA BT Listener", AA_UUID)
                 extraAaServerSockets.add(server)
-                AppLog.i("NativeAA: ACTIVELY LISTENING on Android Auto UUID on secondary radio '$serviceName' [$addr]")
+                AppLog.i("NativeAA: ACTIVELY LISTENING on Android Auto UUID on secondary radio '$serviceName' [$radioName]")
                 while (isRunning && isActive) {
                     val socket = server.accept()
                     if (socket != null) {
-                        AppLog.i("NativeAA: Connection accepted (secondary radio '$serviceName' [$addr]) from ${socket.remoteDevice.name} (${socket.remoteDevice.address})")
+                        AppLog.i("NativeAA: Connection accepted (secondary radio '$serviceName' [$radioName]) from ${socket.remoteDevice.name} (${socket.remoteDevice.address})")
                         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-Handshake-${socket.remoteDevice.address}")) {
-                            handleHandshake(socket, addr)
+                            handleHandshake(socket, radioName)
                         }
                     }
                 }
             } catch (e: Exception) {
-                if (aaListenersClosedForSession) AppLog.d("NativeAA: Secondary AA server closed after successful handoff ['$serviceName' $addr].")
-                else if (isRunning) AppLog.e("NativeAA: Secondary AA server error ['$serviceName' $addr]: ${e.message}", e)
-                else AppLog.d("NativeAA: Secondary AA server closed cleanly ['$serviceName' $addr].")
+                if (aaListenersClosedForSession) AppLog.d("NativeAA: Secondary AA server closed after successful handoff ['$serviceName' $radioName].")
+                else if (isRunning) AppLog.e("NativeAA: Secondary AA server error ['$serviceName' $radioName]: ${e.message}", e)
+                else AppLog.d("NativeAA: Secondary AA server closed cleanly ['$serviceName' $radioName].")
             }
         }
         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-HfpServer-2")) {
@@ -269,8 +274,8 @@ class NativeAaHandshakeManager(
                     }
                 }
             } catch (e: Exception) {
-                if (isRunning) AppLog.e("NativeAA: Secondary HFP server error ['$serviceName' $addr]: ${e.message}", e)
-                else AppLog.d("NativeAA: Secondary HFP server closed cleanly ['$serviceName' $addr].")
+                if (isRunning) AppLog.e("NativeAA: Secondary HFP server error ['$serviceName' $radioName]: ${e.message}", e)
+                else AppLog.d("NativeAA: Secondary HFP server closed cleanly ['$serviceName' $radioName].")
             }
         }
     }

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -128,6 +128,7 @@ class SettingsFragment : Fragment() {
     private var pendingWaitForWifi: Boolean? = null
     private var pendingWaitForWifiTimeout: Int? = null
     private var pendingBluetoothManagerServiceName: String? = null
+    private var pendingManualSecondaryBluetoothServiceName: String? = null
 
     // Flag to determine if the projection should stretch to fill the screen
     private var pendingStretchToFill: Boolean? = null
@@ -252,6 +253,7 @@ class SettingsFragment : Fragment() {
         pendingWaitForWifi = settings.waitForWifiBeforeWifiDirect
         pendingWaitForWifiTimeout = settings.waitForWifiTimeout
         pendingBluetoothManagerServiceName = settings.bluetoothManagerServiceName
+        pendingManualSecondaryBluetoothServiceName = settings.manualSecondaryBluetoothServiceName
 
         pendingInsetLeft = settings.insetLeft
         pendingInsetTop = settings.insetTop
@@ -351,6 +353,7 @@ class SettingsFragment : Fragment() {
         pendingWaitForWifi = settings.waitForWifiBeforeWifiDirect
         pendingWaitForWifiTimeout = settings.waitForWifiTimeout
         pendingBluetoothManagerServiceName = settings.bluetoothManagerServiceName
+        pendingManualSecondaryBluetoothServiceName = settings.manualSecondaryBluetoothServiceName
         pendingInsetLeft = settings.insetLeft
         pendingInsetTop = settings.insetTop
         pendingInsetRight = settings.insetRight
@@ -479,6 +482,7 @@ class SettingsFragment : Fragment() {
         pendingWaitForWifi?.let { settings.waitForWifiBeforeWifiDirect = it }
         pendingWaitForWifiTimeout?.let { settings.waitForWifiTimeout = it }
         pendingBluetoothManagerServiceName?.let { settings.bluetoothManagerServiceName = it }
+        pendingManualSecondaryBluetoothServiceName?.let { settings.manualSecondaryBluetoothServiceName = it }
 
         pendingInsetLeft?.let { settings.insetLeft = it }
         pendingInsetTop?.let { settings.insetTop = it }
@@ -582,6 +586,7 @@ class SettingsFragment : Fragment() {
                         pendingWaitForWifi != settings.waitForWifiBeforeWifiDirect ||
                         pendingWaitForWifiTimeout != settings.waitForWifiTimeout ||
                         pendingBluetoothManagerServiceName != settings.bluetoothManagerServiceName ||
+                        pendingManualSecondaryBluetoothServiceName != settings.manualSecondaryBluetoothServiceName ||
                         pendingUseLibusb != settings.useLibusb
 
         hasChanges = anyChange
@@ -809,6 +814,27 @@ class SettingsFragment : Fragment() {
                             updateSettingsList()
                         }
                         .show()
+                }
+            ))
+
+            val manualSecondary = pendingManualSecondaryBluetoothServiceName
+            items.add(SettingItem.SettingEntry(
+                stableId = "manualSecondaryBluetoothService",
+                nameResId = R.string.manual_secondary_bt_service_title,
+                value = if (manualSecondary.isNullOrEmpty()) getString(R.string.auto)
+                         else BluetoothHelper.getAdapterDescription(requireContext(), manualSecondary),
+                onClick = { _ ->
+                    DialogUtils.showTextInputDialogWithMessage(
+                        requireContext(),
+                        R.string.manual_secondary_bt_service_title,
+                        R.string.manual_secondary_bt_service_message,
+                        manualSecondary ?: "",
+                        { newVal ->
+                            pendingManualSecondaryBluetoothServiceName = newVal.trim()
+                            checkChanges()
+                            updateSettingsList()
+                        }
+                    )
                 }
             ))
         }

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
@@ -67,20 +67,27 @@ object BluetoothHelper {
         }
     }
 
+    data class BluetoothAdapterHandle(val serviceName: String, val adapter: BluetoothAdapter)
+
     /**
-     * All distinct, enabled Bluetooth adapters exposed by the system. Usually just the default
-     * radio; some head units expose a second Bluetooth chip as an extra service. Best-effort:
-     * bogus/non-adapter services resolve to null and are skipped.
+     * All distinct, enabled Bluetooth adapters exposed by the system, paired with the system
+     * service name each is backed by. Usually just the default radio; some head units expose a
+     * second Bluetooth chip as an extra service. Best-effort: bogus/non-adapter services resolve
+     * to null and are skipped.
      */
-    fun getAllBluetoothAdapters(context: Context): List<BluetoothAdapter> {
-        val result = mutableListOf<BluetoothAdapter>()
-        getDefaultAdapter(context)?.let { result.add(it) }
+    fun getAllBluetoothAdapterHandles(context: Context): List<BluetoothAdapterHandle> {
+        val result = mutableListOf<BluetoothAdapterHandle>()
+        getDefaultAdapter(context)?.let { result.add(BluetoothAdapterHandle("bluetooth_manager", it)) }
         for (service in listBluetoothServices()) {
             if (service == "bluetooth_manager") continue
-            adapterForService(context, service)?.let { result.add(it) }
+            adapterForService(context, service)?.let { result.add(BluetoothAdapterHandle(service, it)) }
         }
-        return result.filter { try { it.isEnabled } catch (e: Exception) { false } }
+        return result.filter { try { it.adapter.isEnabled } catch (e: Exception) { false } }
     }
+
+    /** All distinct, enabled Bluetooth adapters exposed by the system. See [getAllBluetoothAdapterHandles]. */
+    fun getAllBluetoothAdapters(context: Context): List<BluetoothAdapter> =
+        getAllBluetoothAdapterHandles(context).map { it.adapter }
 
     fun listBluetoothServices(): List<String> {
         val bluetoothServices = mutableListOf<String>()

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
@@ -89,6 +89,16 @@ object BluetoothHelper {
     fun getAllBluetoothAdapters(context: Context): List<BluetoothAdapter> =
         getAllBluetoothAdapterHandles(context).map { it.adapter }
 
+    /** Resolve a single, arbitrary system service name to a BluetoothAdapterHandle, if it backs a
+     *  real, enabled adapter. Used for the manual secondary-radio override in Settings, where the
+     *  user supplies a service name automatic discovery (listBluetoothServices()) didn't find. */
+    fun getAdapterHandleForService(context: Context, serviceName: String): BluetoothAdapterHandle? {
+        if (serviceName.isEmpty()) return null
+        val adapter = adapterForService(context, serviceName) ?: return null
+        return try { if (adapter.isEnabled) BluetoothAdapterHandle(serviceName, adapter) else null }
+        catch (e: Exception) { null }
+    }
+
     fun listBluetoothServices(): List<String> {
         val bluetoothServices = mutableListOf<String>()
         try {

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
@@ -91,12 +91,49 @@ object BluetoothHelper {
 
     /** Resolve a single, arbitrary system service name to a BluetoothAdapterHandle, if it backs a
      *  real, enabled adapter. Used for the manual secondary-radio override in Settings, where the
-     *  user supplies a service name automatic discovery (listBluetoothServices()) didn't find. */
+     *  user supplies a service name automatic discovery (listBluetoothServices()) didn't find.
+     *  Forgiving of the AIDL interface descriptor `adb shell service list` prints in brackets
+     *  (e.g. "com.qf.btsdk.IBTBinderPool") in place of the actual service name before the colon
+     *  (e.g. "btBinderPool") - confirmed via andreknieriem/headunit-revived#706 that users copy
+     *  the bracketed part since it's the more distinctive-looking of the two. */
     fun getAdapterHandleForService(context: Context, serviceName: String): BluetoothAdapterHandle? {
-        if (serviceName.isEmpty()) return null
-        val adapter = adapterForService(context, serviceName) ?: return null
-        return try { if (adapter.isEnabled) BluetoothAdapterHandle(serviceName, adapter) else null }
+        val input = serviceName.trim().removePrefix("[").removeSuffix("]").trim()
+        if (input.isEmpty()) return null
+        val resolvedName = if (serviceExists(input)) input else findServiceNameByInterfaceDescriptor(input) ?: input
+        val adapter = adapterForService(context, resolvedName) ?: return null
+        return try { if (adapter.isEnabled) BluetoothAdapterHandle(resolvedName, adapter) else null }
         catch (e: Exception) { null }
+    }
+
+    private fun serviceExists(name: String): Boolean = try {
+        val serviceManagerClass = Class.forName("android.os.ServiceManager")
+        val getServiceMethod = serviceManagerClass.getMethod("getService", String::class.java)
+        getServiceMethod.invoke(null, name) != null
+    } catch (e: Exception) { false }
+
+    /** Reverse-looks-up a system service by its AIDL interface descriptor (the bracketed part of
+     *  `adb shell service list` output) instead of its name (the part before the colon).
+     *  IBinder.getInterfaceDescriptor() is a standard, side-effect-free query safe to call on any
+     *  service, unlike actually invoking interface methods on a mismatched proxy - so this is safe
+     *  to run across every registered service, not just ones already known to be Bluetooth-shaped. */
+    private fun findServiceNameByInterfaceDescriptor(descriptor: String): String? {
+        return try {
+            val serviceManagerClass = Class.forName("android.os.ServiceManager")
+            val listServicesMethod = serviceManagerClass.getMethod("listServices")
+            val getServiceMethod = serviceManagerClass.getMethod("getService", String::class.java)
+            val services = listServicesMethod.invoke(null) as? Array<String> ?: return null
+            services.firstOrNull { name ->
+                try {
+                    val binder = getServiceMethod.invoke(null, name) as? IBinder
+                    binder?.interfaceDescriptor == descriptor
+                } catch (e: Exception) {
+                    false
+                }
+            }
+        } catch (e: Exception) {
+            AppLog.e("BluetoothHelper: findServiceNameByInterfaceDescriptor($descriptor) failed: ${e.message}", e)
+            null
+        }
     }
 
     fun listBluetoothServices(): List<String> {

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -1197,6 +1197,12 @@ class Settings(private val context: Context) {
         get() = prefs.getString("bluetooth-manager-service-name", "bluetooth_manager")!!
         set(value) = prefs.edit().putString("bluetooth-manager-service-name", value).apply()
 
+    // Manual fallback for dual-radio head units whose second radio isn't discoverable via
+    // ServiceManager.listServices() at all. Empty = disabled (rely on automatic discovery only).
+    var manualSecondaryBluetoothServiceName: String
+        get() = prefs.getString("manual-secondary-bt-service-name", "")!!
+        set(value) = prefs.edit().putString("manual-secondary-bt-service-name", value).apply()
+
     var hotspotSsid: String
         get() = prefs.getString("hotspot-ssid", "")!!
         set(value) = prefs.edit().putString("hotspot-ssid", value).apply()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -792,7 +792,7 @@
     <string name="bluetooth_adapter_description">Select the Bluetooth adapter/controller to use for the handshake. Useful for dual Bluetooth systems.</string>
     <string name="select_bt_adapter">Select Bluetooth Adapter</string>
     <string name="manual_secondary_bt_service_title">Manual Secondary Radio</string>
-    <string name="manual_secondary_bt_service_message">Advanced: force an extra Bluetooth radio by its exact system service name, for dual-radio units whose second radio isn\'t found automatically. Find the value via \"adb shell service list\" or an engineering menu. Leave blank to disable.</string>
+    <string name="manual_secondary_bt_service_message">Advanced: force an extra Bluetooth radio, for dual-radio units whose second radio isn\'t found automatically. Find it via \"adb shell service list\" (look for a Bluetooth-sounding entry besides bluetooth_manager) or an engineering menu, then paste either the name before the colon or the interface shown in brackets - both work. Leave blank to disable.</string>
     <!-- QR Code Generator -->
     <string name="share_hotspot_qr_title">Configure Wireless Helper</string>
     <string name="share_hotspot_qr_desc">Show QR Code for phone auto-connection</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -791,6 +791,8 @@
     <string name="bluetooth_adapter_label">Bluetooth Adapter</string>
     <string name="bluetooth_adapter_description">Select the Bluetooth adapter/controller to use for the handshake. Useful for dual Bluetooth systems.</string>
     <string name="select_bt_adapter">Select Bluetooth Adapter</string>
+    <string name="manual_secondary_bt_service_title">Manual Secondary Radio</string>
+    <string name="manual_secondary_bt_service_message">Advanced: force an extra Bluetooth radio by its exact system service name, for dual-radio units whose second radio isn\'t found automatically. Find the value via \"adb shell service list\" or an engineering menu. Leave blank to disable.</string>
     <!-- QR Code Generator -->
     <string name="share_hotspot_qr_title">Configure Wireless Helper</string>
     <string name="share_hotspot_qr_desc">Show QR Code for phone auto-connection</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -792,7 +792,7 @@
     <string name="bluetooth_adapter_description">Select the Bluetooth adapter/controller to use for the handshake. Useful for dual Bluetooth systems.</string>
     <string name="select_bt_adapter">Select Bluetooth Adapter</string>
     <string name="manual_secondary_bt_service_title">Manual Secondary Radio</string>
-    <string name="manual_secondary_bt_service_message">Advanced: force an extra Bluetooth radio, for dual-radio units whose second radio isn\'t found automatically. Find it via \"adb shell service list\" (look for a Bluetooth-sounding entry besides bluetooth_manager) or an engineering menu, then paste either the name before the colon or the interface shown in brackets - both work. Leave blank to disable.</string>
+    <string name="manual_secondary_bt_service_message">Advanced: force an extra Bluetooth radio, for dual-radio units whose second radio isn\'t found automatically. Find it via \"adb shell service list\" (look for a Bluetooth-sounding entry besides bluetooth_manager) or an engineering menu, then paste either the name before the colon or the interface shown in brackets - both work. Not guaranteed to help on every unit: some head units run a customized Bluetooth stack that this can\'t bridge to no matter what you enter here. Leave blank to disable.</string>
     <!-- QR Code Generator -->
     <string name="share_hotspot_qr_title">Configure Wireless Helper</string>
     <string name="share_hotspot_qr_desc">Show QR Code for phone auto-connection</string>

--- a/app/src/test/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManagerTest.kt
+++ b/app/src/test/java/com/andrerinas/headunitrevived/connection/NativeAaHandshakeManagerTest.kt
@@ -1,0 +1,71 @@
+package com.andrerinas.openheadunit.connection
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeAaHandshakeManagerTest {
+
+    @Test
+    fun `single-radio device has no secondaries`() {
+        val result = NativeAaHandshakeManager.filterSecondaryServiceNames(
+            "bluetooth_manager",
+            listOf("bluetooth_manager")
+        )
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `default primary plus one extra radio flags the extra as secondary`() {
+        val result = NativeAaHandshakeManager.filterSecondaryServiceNames(
+            "bluetooth_manager",
+            listOf("bluetooth_manager", "bluetooth_manager_1")
+        )
+        assertEquals(listOf("bluetooth_manager_1"), result)
+    }
+
+    @Test
+    fun `empty primary setting falls back to bluetooth_manager as primary`() {
+        val result = NativeAaHandshakeManager.filterSecondaryServiceNames(
+            "",
+            listOf("bluetooth_manager", "bluetooth_manager_1")
+        )
+        assertEquals(listOf("bluetooth_manager_1"), result)
+    }
+
+    @Test
+    fun `user-selected non-default primary makes the other radio the secondary`() {
+        val result = NativeAaHandshakeManager.filterSecondaryServiceNames(
+            "bluetooth_manager_1",
+            listOf("bluetooth_manager", "bluetooth_manager_1")
+        )
+        assertEquals(listOf("bluetooth_manager"), result)
+    }
+
+    @Test
+    fun `three radios with one selected as primary leaves the other two as secondaries`() {
+        val result = NativeAaHandshakeManager.filterSecondaryServiceNames(
+            "bluetooth_manager_1",
+            listOf("bluetooth_manager", "bluetooth_manager_1", "bluetooth_manager_2")
+        )
+        assertEquals(listOf("bluetooth_manager", "bluetooth_manager_2"), result)
+    }
+
+    @Test
+    fun `duplicate service names in the input collapse to one secondary entry`() {
+        val result = NativeAaHandshakeManager.filterSecondaryServiceNames(
+            "bluetooth_manager",
+            listOf("bluetooth_manager", "bluetooth_manager_1", "bluetooth_manager_1")
+        )
+        assertEquals(listOf("bluetooth_manager_1"), result)
+    }
+
+    @Test
+    fun `no services reported at all yields no secondaries`() {
+        val result = NativeAaHandshakeManager.filterSecondaryServiceNames(
+            "bluetooth_manager",
+            emptyList()
+        )
+        assertTrue(result.isEmpty())
+    }
+}


### PR DESCRIPTION
Supersedes #741, closed when `rename-app` was merged and deleted out from under it - rebased onto current `main`, same branch, no content lost.


## Summary

Root cause for the dual-Bluetooth-radio head units in #706 (e.g. K706/CAR8032-style units): `BluetoothAdapter.getAddress()` returns the fixed placeholder `02:00:00:00:00:00` for any non-privileged app since Android 6.0 (API 23), on every device. The secondary-radio listener added for this class of hardware gated itself on the address being non-masked, so it never actually ran on any device, ever. Fixed by identifying radios by system service name instead - the same approach the existing "Bluetooth Adapter" picker in Settings already uses successfully.

Also bundled in:
- Continuous wake-poke retries instead of a single attempt, and trying `HFP_AG_UUID` before `HSP_AG_UUID` (mirrors two independent open-source wireless Android Auto projects that solve the same "wake the phone up" problem).
- Radio-identification log lines now print the adapter's name instead of its always-masked address, so dual-radio logs are actually useful for diagnosing which radio a connection landed on.
- A manual "Secondary Radio" override in Settings > Native, as a last-resort fallback for a unit where automatic secondary-radio detection still comes up empty - accepts either the exact system service name or the AIDL interface descriptor shown by `adb shell service list`, since both have shown up in the wild as what users copy in.
- Two targeted mitigations for the "WifiStartRequest sent, no response ever" symptom on one specific dual-radio unit, informed by a phone-side Gearhead log that finally showed what happens after the message leaves HUR: the phone's own RFCOMM read never receives a single byte before its ~12s first-message timeout fires, every time, on a stable RFCOMM channel (ruling out an SDP/wrong-channel issue). (1) Cancel the in-flight wake-poke job as soon as a real handshake starts, instead of leaving it holding a second profile channel open on the same radio for the rest of its 20s window. (2) Add a 300ms delay before sending `WifiStartRequest`, since writing immediately after accept() is a real, previously-documented class of RFCOMM race (the Linux kernel's own "Move pending packets from RFCOMM socket to TTY" fix addressed the identical symptom on the HFP profile). Neither is guaranteed to be *the* fix - the true root cause looks like it's below the app layer, in that unit's Bluetooth chip/stack - but both are safe, low-risk, and directly targeted at the mechanism the log exposed.

## Test plan

- [x] `./gradlew :app:testGithubDebugUnitTest` - all tests pass, no regressions (rebased onto main after #748 merged; builds standalone).
- [x] `./gradlew assembleGithubDebug` - builds clean.
- [x] On-device: confirmed the secondary-radio listener actually opens and accepts a connection on real dual-radio hardware (previously dead code, confirmed via logs it never ran before this fix).
- [x] On-device: verified the poke retry loop cancels cleanly once a real handshake starts, no crash over a multi-minute idle window.
- [x] On-device: manual override tested with blank/bogus/duplicate-of-primary/real-but-wrong service names, all fail closed with no crash; confirmed zero impact on the normal single-radio path.
- [x] The poke-cancel and send-delay changes are not yet re-verified live on the specific hardware they target (Lion62's unit) - next step is another round of logs from him.
- [x] Still open on #706: whether the send-delay/poke-cancel changes actually resolve that unit's "no response" symptom - the true root cause may be below the app layer entirely (this unit's Bluetooth chip/stack), in which case these are best-effort mitigations, not a guaranteed fix.

Fixes/improves the dual-radio detection side of #706.

