### PR TITLE
Fix RenameNoticePolicy package mismatch breaking the build

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/main/RenameNoticePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/RenameNoticePolicy.kt
@@ -1,4 +1,4 @@
-package com.andrerinas.headunitrevived.main
+package com.andrerinas.openheadunit.main
 
 /**
  * Decides who sees the one-time rename notice.

--- a/app/src/test/java/com/andrerinas/openheadunit/main/RenameNoticePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/main/RenameNoticePolicyTest.kt
@@ -1,4 +1,4 @@
-package com.andrerinas.headunitrevived.main
+package com.andrerinas.openheadunit.main
 
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue


### PR DESCRIPTION
## Summary

`RenameNoticePolicy.kt` and its test declared `package com.andrerinas.headunitrevived.main` while living under `.../openheadunit/main/`. `HomeFragment.kt` references it as a same-package type with no import, so this currently fails to compile on `main`: `Unresolved reference: RenameNoticePolicy`.

Pre-existing from the rename-notice-modal work, unrelated to any other in-flight branch - fixing on its own since it currently blocks building `main` at all.

## Test plan

- [x] `./gradlew :app:testGithubDebugUnitTest` - builds and passes.