### PR TITLE
Make the rename notice actually show, on any screen, with both names

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
@@ -54,6 +54,7 @@ import android.widget.VideoView
 import com.bumptech.glide.Glide
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.andrerinas.openheadunit.main.QuickSettingsFragment
+import com.andrerinas.openheadunit.main.RenameNotice
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import java.io.File
 import java.util.concurrent.Executors
@@ -545,6 +546,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         isForeground = false
         AppLog.i("AapProjectionActivity: onPause")
         super.onPause()
+        RenameNotice.dismiss()
         // Clear any activity-local fullscreen override when leaving the Activity so
         // the stored settings remain authoritative on next resume.
         activityFullscreenOverride = null
@@ -574,6 +576,8 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         super.onResume()
         isForeground = true
         AppLog.i("AapProjectionActivity: onResume")
+        // Show the one-time rename notice even here, on top of an active projection.
+        RenameNotice.maybeShow(this, App.provide(this).settings)
         applyStickyOrientation()
         watchdogHandler.postDelayed(watchdogRunnable, 2000)
         watchdogHandler.postDelayed(videoWatchdogRunnable, 3000)

--- a/app/src/main/java/com/andrerinas/openheadunit/main/HomeFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/HomeFragment.kt
@@ -171,33 +171,6 @@ class HomeFragment : Fragment() {
                 }
             }
         }
-
-        maybeShowRenameNotice(appSettings)
-    }
-
-    // Shows a one-time notice about the app rename. Existing users always get it once,
-    // new installs only during a window after the release. Skipped while an auto-connect
-    // is taking over the screen so it does not flash in front of a launching projection.
-    private fun maybeShowRenameNotice(appSettings: Settings) {
-        if (appSettings.renameNoticeShown) return
-        if (commManager.isConnected) return
-        if (hasAttemptedAutoConnect || hasAutoStarted || hasAttemptedSingleUsbAutoConnect) return
-
-        val firstInstallTime = try {
-            requireContext().packageManager
-                .getPackageInfo(requireContext().packageName, 0).firstInstallTime
-        } catch (e: PackageManager.NameNotFoundException) {
-            0L
-        }
-        if (!RenameNoticePolicy.shouldOffer(firstInstallTime)) return
-
-        appSettings.renameNoticeShown = true
-        activeDialog = MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
-            .setIcon(R.drawable.ic_rename_notice)
-            .setTitle(getString(R.string.rename_notice_title, getString(R.string.app_name)))
-            .setMessage(getString(R.string.rename_notice_message, getString(R.string.app_name)))
-            .setPositiveButton(R.string.rename_notice_button) { dialog, _ -> dialog.dismiss() }
-            .show()
     }
 
     private fun startSelfModeInternal() {
@@ -639,12 +612,14 @@ class HomeFragment : Fragment() {
         updateProjectionButtonText()
         updateButtonStyle()
         updateTextColors()
+        RenameNotice.maybeShow(requireActivity(), App.provide(requireContext()).settings)
     }
 
     override fun onPause() {
         super.onPause()
         activeDialog?.dismiss()
         activeDialog = null
+        RenameNotice.dismiss()
     }
 
     private fun showNativeAaDeviceSelector() {

--- a/app/src/main/java/com/andrerinas/openheadunit/main/RenameNotice.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/RenameNotice.kt
@@ -1,0 +1,52 @@
+package com.andrerinas.openheadunit.main
+
+import android.app.Activity
+import android.content.pm.PackageManager
+import androidx.appcompat.app.AlertDialog
+import com.andrerinas.openheadunit.R
+import com.andrerinas.openheadunit.utils.Settings
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+
+/**
+ * One-time app rename notice.
+ *
+ * Shown on whatever screen is in front when the app opens, including during an auto-connect and
+ * on top of an active Android Auto projection. It is not cancelable and the "shown once" flag is
+ * only spent when the user actually taps the button, so if a screen change hides it before it is
+ * seen it simply comes back on the next screen. It still waits for onboarding to finish so it is
+ * never spent behind the wizard.
+ */
+object RenameNotice {
+
+    private var dialog: AlertDialog? = null
+
+    fun maybeShow(activity: Activity, settings: Settings) {
+        if (settings.renameNoticeShown) return
+        if (dialog?.isShowing == true) return
+        if (settings.onboardingVersion < OnboardingActivity.CURRENT_ONBOARDING_VERSION) return
+
+        val firstInstallTime = try {
+            activity.packageManager.getPackageInfo(activity.packageName, 0).firstInstallTime
+        } catch (e: PackageManager.NameNotFoundException) {
+            0L
+        }
+        if (!RenameNoticePolicy.shouldOffer(firstInstallTime)) return
+
+        dialog = MaterialAlertDialogBuilder(activity, R.style.DarkAlertDialog)
+            .setIcon(R.drawable.ic_rename_notice)
+            .setTitle(R.string.rename_notice_title)
+            .setMessage(R.string.rename_notice_message)
+            .setCancelable(false)
+            .setPositiveButton(R.string.rename_notice_button) { d, _ ->
+                // Consume the one-time flag only once the user has actually acknowledged it.
+                settings.renameNoticeShown = true
+                d.dismiss()
+            }
+            .show()
+    }
+
+    fun dismiss() {
+        dialog?.dismiss()
+        dialog = null
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -224,11 +224,14 @@ class Settings(private val context: Context) {
             prefs.edit().putBoolean("gesture_hint_shown", value).apply()
         }
 
-    // One-time notice telling users the app was rebranded. Shown once on the home screen.
+    // One-time notice telling users the app is being rebranded. Shown once on the home screen.
+    // The key is versioned on purpose: an earlier build could spend the original flag behind the
+    // onboarding wizard without the notice ever being seen, so a new key lets the corrected
+    // notice reach everyone once, including users who still carry the old flag.
     var renameNoticeShown: Boolean
-        get() = prefs.getBoolean("rename_notice_shown", false)
+        get() = prefs.getBoolean("rename_notice_shown_v2", false)
         set(value) {
-            prefs.edit().putBoolean("rename_notice_shown", value).apply()
+            prefs.edit().putBoolean("rename_notice_shown_v2", value).apply()
         }
 
     // Custom Insets (Screen Margins)

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -767,7 +767,7 @@
     <string name="support_rules_describe_desc">ما الذي فعلته، وما الذي توقعت حدوثه، وما الذي حدث فعلًا. لقطة شاشة أو مقطع فيديو قصير تساعد كثيرًا في المشكلات المرئية.</string>
     <string name="support_rules_oneissue_title">مشكلة واحدة لكل تقرير</string>
     <string name="support_rules_oneissue_desc">خصص كل تقرير لمشكلة واحدة حتى يمكن تتبعها وإصلاحها. افتح تقارير منفصلة للمشكلات غير المرتبطة ببعضها.</string>
-    <string name="rename_notice_title">اسم جديد، والتطبيق نفسه: %1$s</string>
-    <string name="rename_notice_message">لقد نما Headunit Revived كثيرًا بفضلكم. قطع المشروع ومجتمعه شوطًا طويلًا، ولذلك أصبح له هوية خاصة به: %1$s.\n\nنفس التطبيق، ونفس الأشخاص خلفه، وكل إعداداتك تبقى كما هي تمامًا.</string>
+    <string name="rename_notice_title">اسمنا يتغيّر إلى Open Headunit</string>
+    <string name="rename_notice_message">ينمو Headunit Revived بفضلكم، وهو يتحوّل إلى شيء خاص به: Open Headunit. سنطرح الاسم الجديد تدريجيًا على مدى التحديثات القادمة، لذا قد ترون الاسم القديم في بعض الأماكن لفترة.\n\nنفس التطبيق، ونفس الأشخاص خلفه، وكل إعداداتك تبقى كما هي تمامًا.</string>
     <string name="rename_notice_button">حسنًا</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -795,7 +795,7 @@
     <string name="support_rules_intro">Jsou vyžadovány jen dvě věci. Vše ostatní je volitelné, ale pomůže to váš problém vyřešit mnohem rychleji.</string>
     <string name="support_rules_section_required">Povinné</string>
     <string name="support_rules_section_recommend">Doporučení (volitelné)</string>
-    <string name="rename_notice_title">Nový název, stejná aplikace: %1$s</string>
-    <string name="rename_notice_message">Headunit Revived díky vám hodně vyrostl. Projekt i jeho komunita ušly velký kus cesty, a tak dostává vlastní identitu: %1$s.\n\nStejná aplikace, stejní lidé za ní a všechna vaše nastavení zůstávají přesně tak, jak jsou.</string>
+    <string name="rename_notice_title">Naše jméno se mění na Open Headunit</string>
+    <string name="rename_notice_message">Headunit Revived díky vám roste a stává se z něj něco vlastního: Open Headunit. Nový název zavádíme postupně během dalších aktualizací, takže na některých místech můžete ještě chvíli vidět starý název.\n\nStejná aplikace, stejní lidé za ní a všechna vaše nastavení zůstávají přesně tak, jak jsou.</string>
     <string name="rename_notice_button">Rozumím</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -772,7 +772,7 @@
     <string name="onb_ready_loading_button">Ladebildschirm einrichten</string>
     <string name="static_bssid_title">Statische BSSID</string>
     <string name="static_bssid_enter_value">BSSID-Wert (Format: XX:XX:XX:XX:XX:XX)</string>
-    <string name="rename_notice_title">Neuer Name, gleiche App: %1$s</string>
-    <string name="rename_notice_message">Headunit Revived ist dank euch stark gewachsen. Das Projekt und seine Community haben einen weiten Weg zurückgelegt und bekommen deshalb eine eigene Identität: %1$s.\n\nGleiche App, dieselben Leute dahinter, und all deine Einstellungen bleiben genau so, wie sie sind.</string>
+    <string name="rename_notice_title">Unser Name wird zu Open Headunit</string>
+    <string name="rename_notice_message">Headunit Revived wächst, dank euch, und wird zu etwas Eigenem: Open Headunit. Wir führen den neuen Namen über die nächsten Updates hinweg ein, daher siehst du an manchen Stellen vielleicht noch eine Weile den alten Namen.\n\nGleiche App, dieselben Leute dahinter, und all deine Einstellungen bleiben genau so, wie sie sind.</string>
     <string name="rename_notice_button">Verstanden</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -804,7 +804,7 @@
     <string name="support_rules_intro">Solo se requieren dos cosas. Todo lo demás es opcional, aunque ayuda a resolver tu problema mucho más rápido.</string>
     <string name="support_rules_section_required">Obligatorio</string>
     <string name="support_rules_section_recommend">Recomendaciones (opcional)</string>
-    <string name="rename_notice_title">Nuevo nombre, la misma app: %1$s</string>
-    <string name="rename_notice_message">Headunit Revived ha crecido mucho, gracias a vosotros. El proyecto y su comunidad han recorrido un largo camino, así que ahora tiene una identidad propia: %1$s.\n\nLa misma app, la misma gente detrás, y todos tus ajustes se quedan exactamente como están.</string>
+    <string name="rename_notice_title">Nuestro nombre está cambiando a Open Headunit</string>
+    <string name="rename_notice_message">Headunit Revived está creciendo, gracias a vosotros, y se está convirtiendo en algo propio: Open Headunit. Vamos a ir cambiando al nuevo nombre en las próximas actualizaciones, así que es posible que sigas viendo el nombre anterior en algunos sitios durante un tiempo.\n\nLa misma app, la misma gente detrás, y todos tus ajustes se quedan exactamente como están.</string>
     <string name="rename_notice_button">Entendido</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -803,7 +803,7 @@
     <string name="support_rules_intro">Solo se necesitan dos cosas. Todo lo demás es opcional, pero ayuda a resolver tu problema mucho más rápido.</string>
     <string name="support_rules_section_required">Requerido</string>
     <string name="support_rules_section_recommend">Recomendaciones (opcional)</string>
-    <string name="rename_notice_title">Nuevo nombre, la misma app: %1$s</string>
-    <string name="rename_notice_message">Headunit Revived ha crecido mucho, gracias a ustedes. El proyecto y su comunidad han recorrido un largo camino, así que ahora tiene una identidad propia: %1$s.\n\nLa misma app, la misma gente detrás, y todos tus ajustes se quedan exactamente como están.</string>
+    <string name="rename_notice_title">Nuestro nombre está cambiando a Open Headunit</string>
+    <string name="rename_notice_message">Headunit Revived está creciendo, gracias a ustedes, y se está convirtiendo en algo propio: Open Headunit. Vamos a ir cambiando al nuevo nombre en las próximas actualizaciones, así que es posible que sigas viendo el nombre anterior en algunos lugares por un tiempo.\n\nLa misma app, la misma gente detrás, y todos tus ajustes se quedan exactamente como están.</string>
     <string name="rename_notice_button">Entendido</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -765,7 +765,7 @@
     <string name="support_rules_describe_desc">Mit csináltál, mit vártál, és mi történt valójában. Vizuális problémáknál egy képernyőfotó vagy rövid videó sokat segít.</string>
     <string name="support_rules_oneissue_title">Egy hibajegy, egy probléma</string>
     <string name="support_rules_oneissue_desc">Minden hibajegy egyetlen problémáról szóljon, hogy könnyen nyomon követhető és javítható legyen. Egymással össze nem függő problémákhoz nyiss külön hibajegyeket.</string>
-    <string name="rename_notice_title">Új név, ugyanaz az alkalmazás: %1$s</string>
-    <string name="rename_notice_message">A Headunit Revived sokat fejlődött, nektek köszönhetően. A projekt és a közössége hosszú utat tett meg, ezért saját arculatot kap: %1$s.\n\nUgyanaz az alkalmazás, ugyanazokkal az emberekkel a háttérben, és minden beállításod pontosan úgy marad, ahogy van.</string>
+    <string name="rename_notice_title">A nevünk erre változik: Open Headunit</string>
+    <string name="rename_notice_message">A Headunit Revived nektek köszönhetően egyre nő, és valami sajáttá válik: Open Headunit. Az új nevet a következő frissítések során fokozatosan vezetjük be, így néhány helyen egy ideig még a régi nevet láthatod.\n\nUgyanaz az alkalmazás, ugyanazokkal az emberekkel a háttérben, és minden beállításod pontosan úgy marad, ahogy van.</string>
     <string name="rename_notice_button">Értem</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -772,7 +772,7 @@
     <string name="support_rules_intro">Sono richieste solo due cose. Tutto il resto è facoltativo, ma aiuta a risolvere il problema molto più in fretta.</string>
     <string name="support_rules_section_required">Obbligatorio</string>
     <string name="support_rules_section_recommend">Consigli (facoltativi)</string>
-    <string name="rename_notice_title">Nuovo nome, stessa app: %1$s</string>
-    <string name="rename_notice_message">Headunit Revived è cresciuta molto, grazie a voi. Il progetto e la sua community hanno fatto tanta strada, quindi ora l\'app ha un\'identità tutta sua: %1$s.\n\nStessa app, stesse persone dietro, e tutte le tue impostazioni restano esattamente come sono.</string>
+    <string name="rename_notice_title">Il nostro nome sta cambiando in Open Headunit</string>
+    <string name="rename_notice_message">Headunit Revived sta crescendo, grazie a voi, e sta diventando qualcosa di suo: Open Headunit. Introdurremo il nuovo nome nei prossimi aggiornamenti, quindi per un po\' potresti vedere ancora il vecchio nome in alcuni punti.\n\nStessa app, stesse persone dietro, e tutte le tue impostazioni restano esattamente come sono.</string>
     <string name="rename_notice_button">Ho capito</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -773,7 +773,7 @@
     <string name="support_rules_describe_desc">何をしたか、何を期待していたか、実際に何が起きたかを書いてください。見た目の問題はスクリーンショットや短い動画があると非常に助かります。</string>
     <string name="support_rules_oneissue_title">1件のissueにつき1つの問題</string>
     <string name="support_rules_oneissue_desc">追跡・修正しやすくするために、issueは1件につき1つの問題に絞ってください。関係のない問題は別のissueを作成してください。</string>
-    <string name="rename_notice_title">名前は新しく、アプリはそのまま: %1$s</string>
-    <string name="rename_notice_message">Headunit Revived は皆さんのおかげで大きく成長しました。プロジェクトとそのコミュニティはここまで歩んできて、いよいよ独自の名前を持つことになりました: %1$s。\n\n同じアプリ、同じ開発チーム、そして設定もすべてそのまま残ります。</string>
+    <string name="rename_notice_title">名前が Open Headunit に変わります</string>
+    <string name="rename_notice_message">Headunit Revived は皆さんのおかげで成長を続け、独自のもの、Open Headunit へと変わりつつあります。新しい名前は今後のアップデートで少しずつ切り替えていくので、しばらくは古い名前が一部に残っているかもしれません。\n\n同じアプリ、同じ開発チーム、そして設定もすべてそのまま残ります。</string>
     <string name="rename_notice_button">了解</string>
 </resources>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -697,7 +697,7 @@
     <string name="support_rules_intro">მხოლოდ ორი რამ არის სავალდებულო. ყველა დანარჩენი სურვილისამებრ, მაგრამ ეს ძალიან აჩქარებს პრობლემის გადაჭრას.</string>
     <string name="support_rules_section_required">სავალდებულო</string>
     <string name="support_rules_section_recommend">რეკომენდაციები (სურვილისამებრ)</string>
-    <string name="rename_notice_title">ახალი სახელი, იგივე აპი: %1$s</string>
-    <string name="rename_notice_message">Headunit Revived ბევრად წინ წავიდა თქვენი წყალობით. პროექტმა და მისმა თემმა დიდი გზა გაიარა, ამიტომ ის საკუთარ იდენტობას იძენს: %1$s.\n\nიგივე აპი, იგივე ხალხი მის უკან, და ყველა თქვენი პარამეტრი ზუსტად ისე რჩება, როგორც არის.</string>
+    <string name="rename_notice_title">ჩვენი სახელი იცვლება — Open Headunit</string>
+    <string name="rename_notice_message">Headunit Revived თქვენი წყალობით იზრდება და საკუთარ რაღაცად იქცევა: Open Headunit. ახალ სახელს მომდევნო განახლებების განმავლობაში თანდათან შემოვიღებთ, ამიტომ ზოგან ძველ სახელს ჯერ კიდევ დაინახავთ.\n\nიგივე აპი, იგივე ხალხი მის უკან, და ყველა თქვენი პარამეტრი ზუსტად ისე რჩება, როგორც არის.</string>
     <string name="rename_notice_button">გასაგებია</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -769,7 +769,7 @@
     <string name="support_rules_intro">두 가지만 필요합니다. 나머지는 선택 사항이지만, 있을수록 훨씬 빠르게 해결할 수 있습니다.</string>
     <string name="support_rules_section_required">필수</string>
     <string name="support_rules_section_recommend">권장 사항 (선택)</string>
-    <string name="rename_notice_title">새 이름, 같은 앱: %1$s</string>
-    <string name="rename_notice_message">Headunit Revived는 여러분 덕분에 많이 성장했습니다. 프로젝트와 커뮤니티가 먼 길을 걸어온 만큼, 이제 고유한 이름을 갖게 되었습니다: %1$s.\n\n같은 앱, 같은 사람들, 그리고 모든 설정은 지금 그대로 유지됩니다.</string>
+    <string name="rename_notice_title">이름이 Open Headunit(으)로 바뀌고 있어요</string>
+    <string name="rename_notice_message">Headunit Revived는 여러분 덕분에 성장하고 있고, 이제 고유한 이름인 Open Headunit(으)로 바뀌어 가고 있습니다. 새 이름은 앞으로의 업데이트에 걸쳐 차차 적용되니, 한동안은 일부 화면에서 예전 이름이 보일 수도 있습니다.\n\n같은 앱, 같은 사람들, 그리고 모든 설정은 지금 그대로 유지됩니다.</string>
     <string name="rename_notice_button">확인</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -795,7 +795,7 @@
     <string name="support_rules_intro">Er zijn maar twee dingen verplicht. De rest is optioneel, maar het helpt je probleem veel sneller op te lossen.</string>
     <string name="support_rules_section_required">Verplicht</string>
     <string name="support_rules_section_recommend">Aanbevelingen (optioneel)</string>
-    <string name="rename_notice_title">Nieuwe naam, dezelfde app: %1$s</string>
-    <string name="rename_notice_message">Headunit Revived is enorm gegroeid, dankzij jullie. Het project en de community hebben een lange weg afgelegd, dus krijgt het een eigen identiteit: %1$s.\n\nDezelfde app, dezelfde mensen erachter, en al je instellingen blijven precies zoals ze zijn.</string>
+    <string name="rename_notice_title">Onze naam verandert in Open Headunit</string>
+    <string name="rename_notice_message">Headunit Revived groeit, dankzij jullie, en wordt iets van zichzelf: Open Headunit. We voeren de nieuwe naam de komende updates geleidelijk door, dus je ziet op sommige plekken misschien nog een tijdje de oude naam.\n\nDezelfde app, dezelfde mensen erachter, en al je instellingen blijven precies zoals ze zijn.</string>
     <string name="rename_notice_button">Begrepen</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -794,7 +794,7 @@
     <string name="support_rules_intro">Wymagane są tylko dwie rzeczy. Wszystko inne jest opcjonalne, ale bardzo przyspiesza rozwiązanie problemu.</string>
     <string name="support_rules_section_required">Wymagane</string>
     <string name="support_rules_section_recommend">Zalecenia (opcjonalne)</string>
-    <string name="rename_notice_title">Nowa nazwa, ta sama aplikacja: %1$s</string>
-    <string name="rename_notice_message">Headunit Revived bardzo się rozrósł, dzięki wam. Projekt i jego społeczność przeszły długą drogę, więc zyskuje własną tożsamość: %1$s.\n\nTa sama aplikacja, ci sami ludzie za nią, a wszystkie twoje ustawienia pozostają dokładnie takie, jakie są.</string>
+    <string name="rename_notice_title">Nasza nazwa zmienia się na Open Headunit</string>
+    <string name="rename_notice_message">Headunit Revived rośnie, dzięki wam, i staje się czymś własnym: Open Headunit. Nową nazwę wprowadzamy stopniowo w kolejnych aktualizacjach, więc w niektórych miejscach przez pewien czas możesz jeszcze widzieć starą nazwę.\n\nTa sama aplikacja, ci sami ludzie za nią, a wszystkie twoje ustawienia pozostają dokładnie takie, jakie są.</string>
     <string name="rename_notice_button">Rozumiem</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -796,7 +796,7 @@
     <string name="support_rules_intro">Apenas duas coisas são obrigatórias. Todo o resto é opcional, mas ajuda a resolver seu problema muito mais rápido.</string>
     <string name="support_rules_section_required">Obrigatório</string>
     <string name="support_rules_section_recommend">Recomendações (opcional)</string>
-    <string name="rename_notice_title">Novo nome, o mesmo app: %1$s</string>
-    <string name="rename_notice_message">O Headunit Revived cresceu muito, graças a vocês. O projeto e sua comunidade percorreram um longo caminho, então ele está ganhando uma identidade própria: %1$s.\n\nO mesmo app, as mesmas pessoas por trás dele, e todas as suas configurações continuam exatamente como estão.</string>
+    <string name="rename_notice_title">Nosso nome está mudando para Open Headunit</string>
+    <string name="rename_notice_message">O Headunit Revived está crescendo, graças a vocês, e está se tornando algo próprio: Open Headunit. Vamos adotar o novo nome ao longo das próximas atualizações, então você ainda pode ver o nome antigo em alguns lugares por um tempo.\n\nO mesmo app, as mesmas pessoas por trás dele, e todas as suas configurações continuam exatamente como estão.</string>
     <string name="rename_notice_button">Entendi</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -766,7 +766,7 @@
     <string name="support_rules_intro">Sunt necesare doar două lucruri. Restul este opțional, dar te ajută să-ți rezolvăm problema mult mai repede.</string>
     <string name="support_rules_section_required">Obligatoriu</string>
     <string name="support_rules_section_recommend">Recomandări (opțional)</string>
-    <string name="rename_notice_title">Nume nou, aceeași aplicație: %1$s</string>
-    <string name="rename_notice_message">Headunit Revived a crescut mult, datorită vouă. Proiectul și comunitatea sa au parcurs un drum lung, așa că își capătă o identitate proprie: %1$s.\n\nAceeași aplicație, aceiași oameni în spatele ei, iar toate setările tale rămân exact așa cum sunt.</string>
+    <string name="rename_notice_title">Numele nostru se schimbă în Open Headunit</string>
+    <string name="rename_notice_message">Headunit Revived crește, datorită vouă, și devine ceva al său: Open Headunit. Introducem noul nume treptat, pe parcursul următoarelor actualizări, așa că e posibil să mai vezi numele vechi în unele locuri o vreme.\n\nAceeași aplicație, aceiași oameni în spatele ei, iar toate setările tale rămân exact așa cum sunt.</string>
     <string name="rename_notice_button">Am înțeles</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -794,7 +794,7 @@
     <string name="support_rules_intro">Нужно только два условия. Всё остальное необязательно, но поможет решить проблему гораздо быстрее.</string>
     <string name="support_rules_section_required">Обязательно</string>
     <string name="support_rules_section_recommend">Рекомендации (необязательно)</string>
-    <string name="rename_notice_title">Новое имя, то же приложение: %1$s</string>
-    <string name="rename_notice_message">Headunit Revived сильно вырос благодаря вам. Проект и его сообщество прошли большой путь, поэтому он получает собственное имя: %1$s.\n\nТо же приложение, те же люди за ним, и все ваши настройки остаются ровно такими, как есть.</string>
+    <string name="rename_notice_title">Наше имя меняется на Open Headunit</string>
+    <string name="rename_notice_message">Headunit Revived растёт благодаря вам и превращается в нечто своё: Open Headunit. Новое имя мы вводим постепенно, в течение следующих обновлений, поэтому какое-то время в некоторых местах вы ещё можете видеть старое имя.\n\nТо же приложение, те же люди за ним, и все ваши настройки остаются ровно такими, как есть.</string>
     <string name="rename_notice_button">Понятно</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -764,7 +764,7 @@
     <string name="support_rules_describe_desc">Ne yaptığınızı, ne beklediğinizi ve gerçekte ne olduğunu yazın. Görsel sorunlar için bir ekran görüntüsü veya kısa bir video çok işe yarar.</string>
     <string name="support_rules_oneissue_title">Konu başına bir sorun</string>
     <string name="support_rules_oneissue_desc">Her konuyu tek bir sorunla sınırlı tutun ki takip edilip düzeltilebilsin. İlgisiz sorunlar için ayrı konular açın.</string>
-    <string name="rename_notice_title">Yeni isim, aynı uygulama: %1$s</string>
-    <string name="rename_notice_message">Headunit Revived sizin sayenizde çok büyüdü. Proje ve topluluğu uzun bir yol kat etti, bu yüzden kendine ait bir kimlik kazanıyor: %1$s.\n\nAynı uygulama, arkasındaki aynı ekip ve tüm ayarların tam olduğu gibi kalıyor.</string>
+    <string name="rename_notice_title">Adımız Open Headunit olarak değişiyor</string>
+    <string name="rename_notice_message">Headunit Revived sizin sayenizde büyüyor ve kendine ait bir şeye dönüşüyor: Open Headunit. Yeni ismi önümüzdeki güncellemeler boyunca yavaş yavaş devreye alıyoruz, bu yüzden bir süre bazı yerlerde hâlâ eski ismi görebilirsin.\n\nAynı uygulama, arkasındaki aynı ekip ve tüm ayarların tam olduğu gibi kalıyor.</string>
     <string name="rename_notice_button">Anladım</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -796,7 +796,7 @@
     <string name="support_rules_intro">Потрібні лише дві речі. Все інше необов\'язкове, але значно прискорює вирішення проблеми.</string>
     <string name="support_rules_section_required">Обов\'язково</string>
     <string name="support_rules_section_recommend">Рекомендації (необов\'язково)</string>
-    <string name="rename_notice_title">Нова назва, той самий застосунок: %1$s</string>
-    <string name="rename_notice_message">Headunit Revived дуже виріс завдяки вам. Проєкт і його спільнота пройшли довгий шлях, тож він отримує власну назву: %1$s.\n\nТой самий застосунок, ті самі люди за ним, і всі ваші налаштування залишаються точно такими, як є.</string>
+    <string name="rename_notice_title">Наша назва змінюється на Open Headunit</string>
+    <string name="rename_notice_message">Headunit Revived росте завдяки вам і стає чимось своїм: Open Headunit. Нову назву ми впроваджуємо поступово, упродовж наступних оновлень, тож якийсь час у деяких місцях ви ще можете бачити стару назву.\n\nТой самий застосунок, ті самі люди за ним, і всі ваші налаштування залишаються точно такими, як є.</string>
     <string name="rename_notice_button">Зрозуміло</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -772,7 +772,7 @@
     <string name="support_rules_intro">Chỉ cần hai điều bắt buộc. Phần còn lại là tuỳ chọn, nhưng sẽ giúp giải quyết vấn đề của bạn nhanh hơn nhiều.</string>
     <string name="support_rules_section_required">Bắt buộc</string>
     <string name="support_rules_section_recommend">Khuyến nghị (tuỳ chọn)</string>
-    <string name="rename_notice_title">Tên mới, vẫn là ứng dụng đó: %1$s</string>
-    <string name="rename_notice_message">Headunit Revived đã phát triển rất nhiều, nhờ có các bạn. Dự án và cộng đồng đã đi được một chặng đường dài, nên giờ nó có một bản sắc riêng: %1$s.\n\nVẫn ứng dụng đó, vẫn những con người đứng sau, và mọi cài đặt của bạn vẫn giữ nguyên như cũ.</string>
+    <string name="rename_notice_title">Tên của chúng tôi đang đổi thành Open Headunit</string>
+    <string name="rename_notice_message">Headunit Revived đang lớn lên, nhờ có các bạn, và đang trở thành một cái tên của riêng mình: Open Headunit. Chúng tôi sẽ chuyển sang tên mới dần dần qua các bản cập nhật tới, nên bạn có thể vẫn thấy tên cũ ở một vài nơi trong một thời gian.\n\nVẫn ứng dụng đó, vẫn những con người đứng sau, và mọi cài đặt của bạn vẫn giữ nguyên như cũ.</string>
     <string name="rename_notice_button">Đã hiểu</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -794,7 +794,7 @@
     <string name="support_rules_describe_desc">您做了什麼、預期會發生什麼，以及實際發生了什麼。對於視覺問題，附上截圖或短片會非常有幫助。</string>
     <string name="support_rules_oneissue_title">一個 Issue 只處理一個問題</string>
     <string name="support_rules_oneissue_desc">每個 Issue 請聚焦於單一問題，方便追蹤和修復。不相關的問題請另開 Issue。</string>
-    <string name="rename_notice_title">新名字，還是同一個 App：%1$s</string>
-    <string name="rename_notice_message">多虧了大家，Headunit Revived 成長了許多。這個專案和它的社群一路走來，如今要擁有自己的名字了：%1$s。\n\n還是同一個 App，還是同一群人，你的所有設定也都原封不動。</string>
+    <string name="rename_notice_title">我們的名字正在改為 Open Headunit</string>
+    <string name="rename_notice_message">多虧了大家，Headunit Revived 正在成長，並逐漸變成屬於自己的樣子：Open Headunit。我們會在接下來的更新中慢慢換上新名字，所以有些地方你可能還會看到舊名字一陣子。\n\n還是同一個 App，還是同一群人，你的所有設定也都原封不動。</string>
     <string name="rename_notice_button">知道了</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -868,8 +868,10 @@
     <string name="coordinates_format_help">Decimal degrees, dot or comma. Example: 40.4168, -3.7038</string>
     <string name="sunrise_reference_help">The reference point used to calculate sunrise and sunset. Pick your location once; it works without GPS.</string>
 
-    <!-- One-time rename notice shown on the home screen. %1$s is the new app name. -->
-    <string name="rename_notice_title">New name, same app: %1$s</string>
-    <string name="rename_notice_message">Headunit Revived has grown a lot, thanks to you. The project and its community have come a long way, so it is getting an identity of its own: %1$s.\n\nSame app, same people behind it, and all your settings stay exactly as they are.</string>
+    <!-- One-time rename notice shown on the home screen. Both the old name ("Headunit Revived")
+         and the new name ("Open Headunit") are hardcoded on purpose, so the message reads clearly
+         even before the app name resource changes. -->
+    <string name="rename_notice_title">Our name is changing to Open Headunit</string>
+    <string name="rename_notice_message">Headunit Revived is growing, thanks to you, and it is turning into something of its own: Open Headunit. We are rolling the new name out over the next updates, so you may still see the old name in some places for a while.\n\nSame app, same people behind it, and all your settings stay exactly as they are.</string>
     <string name="rename_notice_button">Got it</string>
 </resources>


### PR DESCRIPTION
Follow-up to #746. The rename notice was merged but in practice it did not show for real users, so this makes it reliable and clearer.

What was wrong:
- On a first run or an upgrade the home screen ran the check under the onboarding wizard, spent the one-time flag, and the dialog was never actually seen.
- It was also skipped whenever an auto-connect was merely attempted (not only when connected), which is the normal case on a head unit, so it never appeared.

What this changes:
- The notice is shown from onResume, on the home screen and also on top of an active Android Auto projection, so it appears even when the app auto-connects straight into projection.
- It is not cancelable and the one-time flag is only spent when the user taps the button, so if a screen change hides it first it simply comes back on the next screen.
- It still waits until onboarding is finished so it is never spent behind the wizard.
- The flag key is versioned, so anyone who already carried the old flag (silently spent by the previous behaviour) still gets the notice once.

Text:
- Reframed as an in-progress rename (it no longer implies the change is already done) and it notes the old name may still appear in places for a while.
- Both the old name (Headunit Revived) and the new name (Open Headunit) are hardcoded in every locale, so the message reads clearly even before the app name resource changes. Updated in English and all 19 translated locales.

The audience logic (install time, offline clock safe) from #746 is unchanged.

Verified with assembleGithubDebug on JDK 17.
