### PR TITLE
Back up and restore all settings (fix settings missing from the backup)

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
@@ -146,7 +146,21 @@ object SettingsBackupManager {
         "wait-for-wifi-timeout" to ValueType.INT,
         "helper-connection-strategy" to ValueType.INT,
         "bluetooth-manager-service-name" to ValueType.STRING,
-        "use-libusb" to ValueType.BOOLEAN
+        "use-libusb" to ValueType.BOOLEAN,
+        // Custom loading screen display options. The picked image/video is copied into the app's
+        // private storage, so the media path/type cannot be restored on another install and are not
+        // backed up (only these display preferences are, and apply once the media is added again).
+        "loading-screen-show-text" to ValueType.BOOLEAN,
+        "loading-screen-keep-aspect-ratio" to ValueType.BOOLEAN,
+        "loading-screen-loop-video" to ValueType.BOOLEAN,
+        "loading-screen-scale-percent" to ValueType.INT,
+        // Wireless hotspot host credentials and manual BSSID override.
+        "hotspot-ssid" to ValueType.STRING,
+        "hotspot-password" to ValueType.STRING,
+        "static-bssid" to ValueType.STRING,
+        // Touch calibration fix and toast visibility.
+        "use_measured_touch_surface" to ValueType.BOOLEAN,
+        "show-toast-messages" to ValueType.BOOLEAN
     )
 
     private val projectionRestartKeys = setOf(


### PR DESCRIPTION
The settings backup was silently skipping several settings, so restoring a backup came back incomplete. This adds the ones that were missing so export and import are complete:

- custom loading screen display options (show text, keep aspect ratio, loop video, scale)
- wireless hotspot SSID and password
- static BSSID
- the measured touch surface fix
- toast visibility

The custom loading screen media (image or video) is deliberately not backed up, because it is copied into the app private folder and its path cannot be restored on another install.

Scoped down from the earlier migration idea: since the package is staying the same, this PR is now just the backup completeness fix. Related discussion in #751.