### PR TITLE
Keep the original Play Store package id (revert applicationId), still display as Open Headunit

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,7 +117,11 @@ android {
     }
 
     defaultConfig {
-        applicationId = "com.andrerinas.openheadunit"
+        // Keep the original Play Store application id so the app stays the same listing (reviews,
+        // installs, testers) and existing users just get a normal update. Only the display name
+        // changed to Open Headunit. The code package and namespace stay openheadunit, so the
+        // applicationId deliberately differs from the namespace, like com.google.talk for Hangouts.
+        applicationId = "com.andrerinas.headunitrevived"
         minSdk = 16
         targetSdk = 36
         versionCode = 90

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -8,7 +8,7 @@
         android:shortcutLongLabel="@string/shortcut_connect_desc">
         <intent
             android:action="com.andrerinas.openheadunit.ACTION_CONNECT"
-            android:targetPackage="com.andrerinas.openheadunit"
+            android:targetPackage="com.andrerinas.headunitrevived"
             android:targetClass="com.andrerinas.openheadunit.main.AutomationActivity" />
     </shortcut>
     <shortcut
@@ -19,7 +19,7 @@
         android:shortcutLongLabel="@string/shortcut_selfmode_desc">
         <intent
             android:action="com.andrerinas.openheadunit.ACTION_START_SELF_MODE"
-            android:targetPackage="com.andrerinas.openheadunit"
+            android:targetPackage="com.andrerinas.headunitrevived"
             android:targetClass="com.andrerinas.openheadunit.main.AutomationActivity" />
     </shortcut>
 
@@ -31,7 +31,7 @@
         android:shortcutLongLabel="@string/shortcut_disconnect_desc">
         <intent
             android:action="com.andrerinas.openheadunit.ACTION_DISCONNECT"
-            android:targetPackage="com.andrerinas.openheadunit"
+            android:targetPackage="com.andrerinas.headunitrevived"
             android:targetClass="com.andrerinas.openheadunit.main.AutomationActivity" />
     </shortcut>
 
@@ -43,7 +43,7 @@
         android:shortcutLongLabel="@string/shortcut_exit_desc">
         <intent
             android:action="com.andrerinas.openheadunit.ACTION_STOP_SERVICE"
-            android:targetPackage="com.andrerinas.openheadunit"
+            android:targetPackage="com.andrerinas.headunitrevived"
             android:targetClass="com.andrerinas.openheadunit.main.AutomationActivity" />
     </shortcut>
 
@@ -55,7 +55,7 @@
         android:shortcutLongLabel="@string/shortcut_night_mode_day_desc">
         <intent
             android:action="com.andrerinas.openheadunit.ACTION_SET_NIGHT_MODE"
-            android:targetPackage="com.andrerinas.openheadunit"
+            android:targetPackage="com.andrerinas.headunitrevived"
             android:targetClass="com.andrerinas.openheadunit.main.AutomationActivity">
             <extra android:name="state" android:value="day" />
         </intent>
@@ -69,7 +69,7 @@
         android:shortcutLongLabel="@string/shortcut_night_mode_night_desc">
         <intent
             android:action="com.andrerinas.openheadunit.ACTION_SET_NIGHT_MODE"
-            android:targetPackage="com.andrerinas.openheadunit"
+            android:targetPackage="com.andrerinas.headunitrevived"
             android:targetClass="com.andrerinas.openheadunit.main.AutomationActivity">
             <extra android:name="state" android:value="night" />
         </intent>
@@ -83,7 +83,7 @@
         android:shortcutLongLabel="@string/shortcut_night_mode_auto_desc">
         <intent
             android:action="com.andrerinas.openheadunit.ACTION_SET_NIGHT_MODE"
-            android:targetPackage="com.andrerinas.openheadunit"
+            android:targetPackage="com.andrerinas.headunitrevived"
             android:targetClass="com.andrerinas.openheadunit.main.AutomationActivity">
             <extra android:name="state" android:value="auto" />
         </intent>


### PR DESCRIPTION
Follows up #751 and the discussion in #752. This reverts only the Play Store application id so the app keeps the same listing (reviews, installs, testers) and existing users just get a normal update. Nothing user facing changes: the app still displays as Open Headunit everywhere.

What changed (two files):

- app/build.gradle.kts: applicationId back to com.andrerinas.headunitrevived. The namespace and the whole code package stay com.andrerinas.openheadunit, so the applicationId now differs from the code package. That is a supported setup, the same idea as Hangouts still being com.google.talk.
- res/xml/shortcuts.xml: the seven targetPackage values point back at the restored applicationId so the app shortcuts still resolve. The action strings and targetClass are left unchanged.

Why nothing else needs to change: FileProvider and Shizuku authorities use ${applicationId} in the manifest and context.packageName / BuildConfig.APPLICATION_ID in code, so both sides track the applicationId and stay in lockstep. The custom actions and the NAVIGATION_UPDATE permission are plain string identifiers matched name to name between the app's own sender and receiver, so they keep working regardless of the applicationId.

Builds clean, and the output APK is com.andrerinas.headunitrevived_3.2.0-beta5.apk, which confirms the applicationId took effect while the code stays openheadunit.
