### PR TITLE
Fix H.264 stream misdetected as HEVC on decoder restart

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapControl.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapControl.kt
@@ -14,6 +14,7 @@ import com.andrerinas.openheadunit.aap.protocol.proto.Input
 import com.andrerinas.openheadunit.aap.protocol.proto.Media
 import com.andrerinas.openheadunit.aap.protocol.proto.Sensors
 import com.andrerinas.openheadunit.decoder.MicRecorder
+import com.andrerinas.openheadunit.decoder.VideoDecoder
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.Settings
 
@@ -109,7 +110,7 @@ internal class AapControlMedia(
     private fun maxUnackedFor(channel: Int): Int {
         if (channel == Channel.ID_VID) {
             val softwareHevc =
-                aapTransport.settings.videoCodec == "H.265" &&
+                aapTransport.settings.videoCodec == VideoDecoder.CodecType.H265.settingsValue &&
                         aapTransport.settings.forceSoftwareDecoding &&
                         aapTransport.settings.softwareVideoDecoder == Settings.SoftwareVideoDecoder.BUNDLED_FFMPEG
             if (softwareHevc) {

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapVideo.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapVideo.kt
@@ -9,7 +9,7 @@ import java.nio.ByteBuffer
 internal class AapVideo(private val videoDecoder: VideoDecoder, private val settings: Settings, private val onFrameCorrupted: () -> Unit) {
 
     private val messageBuffer = ByteBuffer.allocate(
-        if (settings.videoCodec == VideoDecoder.CodecType.H265.mimeType) {
+        if (settings.videoCodec == "H.265") {
             Messages.DEF_BUFFER_LENGTH * 64 // ~8MB for H.265 support
         } else {
             Messages.DEF_BUFFER_LENGTH * 16 // ~2MB for H.264 legacy support
@@ -59,14 +59,14 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
         if (scLen <= 0 || scOffset + scLen >= len)
             return true
 
-        val nalType = if (settings.videoCodec == VideoDecoder.CodecType.H265.mimeType) {
+        val nalType = if (settings.videoCodec == "H.265") {
             (buf[scOffset + scLen].toInt() and 0x7E) shr 1 // H.265 NAL
         } else {
             buf[scOffset + scLen].toInt() and 0x1F // H.264 NAL
         }
 
         // Check if it's an I-Frame or VPS/SPS/PPS (types that can start a clean stream)
-        val isKeyframe = if (settings.videoCodec == VideoDecoder.CodecType.H265.mimeType) {
+        val isKeyframe = if (settings.videoCodec == "H.265") {
             nalType in 16..21 || nalType in 32..34
         } else {
             nalType == 5 || nalType == 7 || nalType == 8

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapVideo.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapVideo.kt
@@ -9,7 +9,7 @@ import java.nio.ByteBuffer
 internal class AapVideo(private val videoDecoder: VideoDecoder, private val settings: Settings, private val onFrameCorrupted: () -> Unit) {
 
     private val messageBuffer = ByteBuffer.allocate(
-        if (settings.videoCodec == "H.265") {
+        if (settings.videoCodec == VideoDecoder.CodecType.H265.settingsValue) {
             Messages.DEF_BUFFER_LENGTH * 64 // ~8MB for H.265 support
         } else {
             Messages.DEF_BUFFER_LENGTH * 16 // ~2MB for H.264 legacy support
@@ -59,14 +59,14 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
         if (scLen <= 0 || scOffset + scLen >= len)
             return true
 
-        val nalType = if (settings.videoCodec == "H.265") {
+        val nalType = if (settings.videoCodec == VideoDecoder.CodecType.H265.settingsValue) {
             (buf[scOffset + scLen].toInt() and 0x7E) shr 1 // H.265 NAL
         } else {
             buf[scOffset + scLen].toInt() and 0x1F // H.264 NAL
         }
 
         // Check if it's an I-Frame or VPS/SPS/PPS (types that can start a clean stream)
-        val isKeyframe = if (settings.videoCodec == "H.265") {
+        val isKeyframe = if (settings.videoCodec == VideoDecoder.CodecType.H265.settingsValue) {
             nalType in 16..21 || nalType in 32..34
         } else {
             nalType == 5 || nalType == 7 || nalType == 8

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/ServiceDiscoveryResponse.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/ServiceDiscoveryResponse.kt
@@ -10,6 +10,7 @@ import com.andrerinas.openheadunit.aap.protocol.Channel
 import com.andrerinas.openheadunit.aap.protocol.proto.Control
 import com.andrerinas.openheadunit.aap.protocol.proto.Media
 import com.andrerinas.openheadunit.aap.protocol.proto.Sensors
+import com.andrerinas.openheadunit.decoder.VideoDecoder
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.HeadUnitScreenConfig
 import com.google.protobuf.Message
@@ -46,7 +47,7 @@ class ServiceDiscoveryResponse(private val context: Context)
                 service.id = Channel.ID_VID
                 service.mediaSinkService = Control.Service.MediaSinkService.newBuilder().also { mediaSinkServiceBuilder ->
                     val explicitSoftwareHevc =
-                        settings.videoCodec == "H.265" &&
+                        settings.videoCodec == VideoDecoder.CodecType.H265.settingsValue &&
                                 settings.forceSoftwareDecoding &&
                                 when (settings.softwareVideoDecoder) {
                                     com.andrerinas.openheadunit.utils.Settings.SoftwareVideoDecoder.BUNDLED_FFMPEG ->

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -25,6 +25,7 @@ interface VideoDimensionsListener {
 class VideoDecoder(private val settings: Settings) {
     companion object {
         private const val TIMEOUT_US = 10000L
+        private const val MAX_RESTARTS_WITHOUT_FRAME = 3
 
         /**
          * Checks if H.265 (HEVC) hardware decoding is supported on the current device.
@@ -112,6 +113,17 @@ class VideoDecoder(private val settings: Settings) {
     private var codecConfigured = false
     private var currentCodecType = CodecType.H264
     private var currentCodecName: String? = null
+
+    // Once a codec type has been used to successfully start a decoder this session, it is
+    // "pinned": restarts reuse it directly instead of re-running detectCodecType() on
+    // whatever raw packet happens to be arriving at that instant. detectCodecType()'s NAL-type
+    // heuristic can misclassify an ordinary H.264 slice byte as an HEVC VPS/SPS/PPS NAL
+    // (e.g. nal_unit_type=1/nal_ref_idc=2 -> byte 0x41 -> 0x41 >> 1 == 32), and re-detecting on
+    // every restart let that false positive hijack an otherwise-working H.264 session.
+    private var codecTypePinned = false
+    private var restartsSinceLastFrame = 0
+    private var codecFallbackUsed = false
+    private var decoderPermanentlyFailed = false
 
     // Reuse buffers for older API levels to minimize GC pressure
     private var inputBuffers: Array<ByteBuffer>? = null
@@ -227,6 +239,10 @@ class VideoDecoder(private val settings: Settings) {
                 pps = null
                 mWidth = 0
                 mHeight = 0
+                codecTypePinned = false
+                restartsSinceLastFrame = 0
+                codecFallbackUsed = false
+                decoderPermanentlyFailed = false
             }
             // Keep VPS/SPS/PPS cached so we can re-inject them on restart
             lastFrameRenderedMs = 0L
@@ -252,11 +268,36 @@ class VideoDecoder(private val settings: Settings) {
             // Check if a restart was requested by output thread
             if (decoderNeedsRestart) {
                 AppLog.w("Decoder restart requested: $decoderRestartReason")
+
+                // Track restarts that never produced a single frame for the currently pinned
+                // codec type. A genuinely broken hardware decoder (e.g. an MTK HEVC component
+                // that can't configure at all) will keep failing here forever otherwise.
+                if (codecTypePinned && lastFrameRenderedMs == 0L) {
+                    restartsSinceLastFrame++
+                    if (restartsSinceLastFrame >= MAX_RESTARTS_WITHOUT_FRAME) {
+                        if (!codecFallbackUsed) {
+                            val fallbackType = if (currentCodecType == CodecType.H264) CodecType.H265 else CodecType.H264
+                            AppLog.e("${currentCodecType.displayName} failed $restartsSinceLastFrame times in a row without rendering a frame. Falling back to ${fallbackType.displayName}.")
+                            currentCodecType = fallbackType
+                            codecFallbackUsed = true
+                            restartsSinceLastFrame = 0
+                        } else {
+                            AppLog.e("Both codec types failed to render a frame this session. Giving up to avoid an infinite restart loop.")
+                            decoderPermanentlyFailed = true
+                        }
+                    }
+                } else if (lastFrameRenderedMs != 0L) {
+                    // Decoder was healthy before this restart; don't count it against the pin.
+                    restartsSinceLastFrame = 0
+                }
+
                 stop("restart: $decoderRestartReason")
                 decoderNeedsRestart = false
                 decoderRestartReason = null
                 onDecoderError?.invoke()
             }
+
+            if (decoderPermanentlyFailed) return
 
             // Buffer management for backward compatibility
             // Modern devices (API 21+) use the original buffer with offset/size to avoid GC pressure.
@@ -275,14 +316,21 @@ class VideoDecoder(private val settings: Settings) {
             }
 
 
-            // Initialization phase: detect codec and configuration (SPS/PPS)
+            // Initialization phase: detect codec and configuration (SPS/PPS).
+            // Only runs the detection heuristic on the very first init of the session; once a
+            // codec type is pinned (see codecTypePinned), restarts reuse it directly instead of
+            // re-sniffing arbitrary mid-stream bytes.
             if (codec == null && softwareHevcDecoder == null) {
-                val detectedType = detectCodecType(frameData, frameOffset, size)
-                val requestedType = if (codecName.contains("265")) CodecType.H265 else CodecType.H264
-                val typeToUse = if (requestedType == CodecType.H265) {
-                    CodecType.H265
+                val typeToUse = if (codecTypePinned) {
+                    currentCodecType
                 } else {
-                    detectedType ?: requestedType
+                    val detectedType = detectCodecType(frameData, frameOffset, size)
+                    val requestedType = if (codecName.contains("265")) CodecType.H265 else CodecType.H264
+                    if (requestedType == CodecType.H265) {
+                        CodecType.H265
+                    } else {
+                        detectedType ?: requestedType
+                    }
                 }
                 currentCodecType = typeToUse
 
@@ -374,6 +422,7 @@ class VideoDecoder(private val settings: Settings) {
             currentCodecName = "ffmpeg-hevc"
             running = true
             startTime = System.nanoTime()
+            codecTypePinned = true
             AppLog.i("Bundled FFmpeg HEVC decoder initialized")
         } catch (e: Exception) {
             AppLog.e("Failed to start bundled FFmpeg HEVC decoder", e)
@@ -600,6 +649,7 @@ class VideoDecoder(private val settings: Settings) {
                 outputThreadLoop()
             }.apply { name = "VideoDecoder-Output"; start() }
 
+            codecTypePinned = true
             AppLog.i("Codec initialized: $bestCodec")
         } catch (e: Exception) {
             AppLog.e("Failed to start decoder", e)

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -159,9 +159,9 @@ class VideoDecoder(private val settings: Settings) {
     val videoWidth: Int get() = mWidth
     val videoHeight: Int get() = mHeight
 
-    enum class CodecType(val mimeType: String, val displayName: String) {
-        H264("video/avc", "H.264/AVC"),
-        H265("video/hevc", "H.265/HEVC")
+    enum class CodecType(val mimeType: String, val displayName: String, val settingsValue: String) {
+        H264("video/avc", "H.264/AVC", "H.264"),
+        H265("video/hevc", "H.265/HEVC", "H.265")
     }
 
     /**

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/HeadUnitScreenConfig.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/HeadUnitScreenConfig.kt
@@ -351,7 +351,7 @@ object HeadUnitScreenConfig {
 
     private fun canNegotiateHevcHighResolution(): Boolean {
         if (VideoDecoder.isHevcSupported()) return true
-        if (currentSettings.videoCodec != "H.265" || !currentSettings.forceSoftwareDecoding) return false
+        if (currentSettings.videoCodec != VideoDecoder.CodecType.H265.settingsValue || !currentSettings.forceSoftwareDecoding) return false
         return when (currentSettings.softwareVideoDecoder) {
             Settings.SoftwareVideoDecoder.BUNDLED_FFMPEG -> VideoDecoder.isBundledHevcDecoderAvailable()
             Settings.SoftwareVideoDecoder.DEVICE_MEDIACODEC -> VideoDecoder.isHevcDecoderAvailable(includeSoftware = true)


### PR DESCRIPTION
## Summary
Fixes #749. On restart, `VideoDecoder` re-ran its byte-sniffing codec detection instead of reusing the codec type already proven to work, and the heuristic could misread an ordinary H.264 slice NAL as HEVC. Combined with stale H.264 SPS/PPS surviving the restart, this configured a real HEVC decoder with malformed config data, crashing on some hardware and looping forever (audio kept working, video didn't).

- Pin the codec type once a decoder starts successfully; only detect on true first init.
- Add a bounded restart counter with fallback to the other codec type, then give up cleanly instead of looping forever.
- Fix an unrelated but adjacent bug in `AapVideo.kt` where `settings.videoCodec` was compared against the wrong constant, so its HEVC keyframe/buffer-sizing paths were dead code.
- Centralize the settings-string comparisons on `VideoDecoder.CodecType.settingsValue` instead of duplicated literals.

## Test plan
- [x] Live-tested on a head unit: reproduced a decoder stall/restart mid-session and confirmed the codec type stayed pinned to H.264, no misdetection, recovered in under 1.5s.
- [x] Confirmed no regression in the normal first-connect path (WiFi Direct pairing + H.264 negotiation + decode init).
- [x] Waiting on @AyazIsayev testing