### PR TITLE
Fix Native AA wireless handoff and handshake reliability (#760, #706)

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -735,7 +735,13 @@ class AapService : Service(), UsbReceiver.Listener {
                 AppLog.d("AapService: WiFi credentials received, but not in Native AA mode. Skipping HandshakeManager update.")
             }
         }
-        wifiDirectManager?.setNativeHandshakeStateProvider { nativeAaHandshakeManager?.isHandshakeInFlight() == true }
+        // Settling counts as in-flight here: isHandshakeInFlight() goes false the instant Type 3
+        // is written, but the phone still has to associate, do WPS and get a DHCP lease, and
+        // recreating the group in that window hands it an SSID it can no longer join.
+        wifiDirectManager?.setNativeHandshakeStateProvider {
+            nativeAaHandshakeManager?.isHandshakeInFlight() == true ||
+                nativeAaHandshakeManager?.isHandoffSettling() == true
+        }
         wifiDirectManager?.setNativeSessionConnectedProvider { commManager.isConnected }
         wifiDirectManager?.setNativeGroupInvalidatedListener { nativeAaHandshakeManager?.invalidateCredentials() }
 
@@ -1738,8 +1744,14 @@ class AapService : Service(), UsbReceiver.Listener {
                 // onCreate() already armed everything moments ago and re-running would tear
                 // down and recreate the P2P group (new random SSID/passphrase) right as it's
                 // being delivered to the phone.
+                // A successful handoff closes the AA listeners, so isActive() is false for the
+                // whole life of a working session — without the connection check below, any
+                // later ACL_CONNECTED (the phone's own Bluetooth profiles reconnecting, or one
+                // of our pokes) would tear down a session that is projecting fine.
                 val settings = App.provide(this).settings
-                if (settings.wifiConnectionMode == 3 &&
+                val sessionUp = commManager.isConnected ||
+                    commManager.connectionState.value is CommManager.ConnectionState.Connecting
+                if (settings.wifiConnectionMode == 3 && !sessionUp &&
                     nativeAaHandshakeManager?.isActive() != true &&
                     nativeAaHandshakeManager?.isAttemptInFlight() != true) {
                     AppLog.i("AapService: Bluetooth auto-start — Native AA handshake manager was stopped, re-arming.")

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -1739,7 +1739,9 @@ class AapService : Service(), UsbReceiver.Listener {
                 // down and recreate the P2P group (new random SSID/passphrase) right as it's
                 // being delivered to the phone.
                 val settings = App.provide(this).settings
-                if (settings.wifiConnectionMode == 3 && nativeAaHandshakeManager?.isActive() != true) {
+                if (settings.wifiConnectionMode == 3 &&
+                    nativeAaHandshakeManager?.isActive() != true &&
+                    nativeAaHandshakeManager?.isAttemptInFlight() != true) {
                     AppLog.i("AapService: Bluetooth auto-start — Native AA handshake manager was stopped, re-arming.")
                     userExitedAA = false
                     userExitCooldownUntil = 0L

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -736,6 +736,7 @@ class AapService : Service(), UsbReceiver.Listener {
             }
         }
         wifiDirectManager?.setNativeHandshakeStateProvider { nativeAaHandshakeManager?.isHandshakeInFlight() == true }
+        wifiDirectManager?.setNativeSessionConnectedProvider { commManager.isConnected }
         wifiDirectManager?.setNativeGroupInvalidatedListener { nativeAaHandshakeManager?.invalidateCredentials() }
 
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicy.kt
@@ -1,0 +1,56 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * The window between "we sent the phone our WiFi credentials (Type 3)" and "the phone's TCP
+ * session actually landed", and what the rest of the app is allowed to do during it.
+ *
+ * The phone still has to associate, run WPS and get a DHCP lease after Type 3 goes out, and on
+ * slower hardware that takes far longer than the handshake itself — 21 s in a known-good 3.1.1
+ * log. Anything that touches the Bluetooth radio or takes the P2P group owner off-channel in
+ * that window can make the phone abandon the join, which surfaces as "Obtaining IP address"
+ * forever on the phone (#760).
+ *
+ * Split out as a pure object so the timing rules are unit-testable without Android, and so
+ * [com.andrerinas.openheadunit.connection.NativeAaHandshakeManager] and
+ * [com.andrerinas.openheadunit.connection.WifiDirectManager] share one definition instead of
+ * re-deriving it.
+ */
+object NativeHandoffPolicy {
+
+    /** How long to keep Bluetooth open waiting for the phone's TCP session before giving up on
+     *  this handoff and letting the wake poke retry. Generous on purpose: the cost of waiting too
+     *  long is one slow retry, the cost of waiting too little is a dead connection. */
+    const val SETTLE_TIMEOUT_MS = 45_000L
+
+    /**
+     * Whether we are still inside the post-Type-3 settling window.
+     *
+     * [settlingSinceMs] is an elapsed-realtime stamp, or 0 when no handoff is settling. The
+     * window is bounded so a missed reset can't latch the state true forever.
+     */
+    fun isSettling(settlingSinceMs: Long, nowMs: Long, timeoutMs: Long = SETTLE_TIMEOUT_MS): Boolean {
+        if (settlingSinceMs == 0L) return false
+        val elapsed = nowMs - settlingSinceMs
+        return elapsed >= 0 && elapsed < timeoutMs
+    }
+
+    /**
+     * Whether the wake poke may run. The poke opens a real RFCOMM connection to the phone's
+     * HFP/HSP service record, so it must stay off the radio while a handshake is exchanging
+     * credentials, while a handoff is settling, and once a session is up (there is nothing left
+     * to wake).
+     */
+    fun shouldPoke(settling: Boolean, handshakeInFlight: Boolean, sessionConnected: Boolean): Boolean =
+        !settling && !handshakeInFlight && !sessionConnected
+
+    /**
+     * Whether a client leaving the P2P group should restart the peer-discovery loop.
+     *
+     * Never on the Native AA path: we run a *quiet* host there and the phone finds us by SSID
+     * from the credentials we handed it over Bluetooth, never by discovery. `discoverPeers()`
+     * takes the group owner off-channel every 10 s, which is precisely what stops a retrying
+     * phone from ever completing DHCP.
+     */
+    fun shouldRestartDiscovery(nativeAaMode: Boolean, hadClient: Boolean, hasClient: Boolean): Boolean =
+        hadClient && !hasClient && !nativeAaMode
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicy.kt
@@ -22,15 +22,37 @@ object NativeHandoffPolicy {
      *  long is one slow retry, the cost of waiting too little is a dead connection. */
     const val SETTLE_TIMEOUT_MS = 45_000L
 
+    /** Longest a single credential exchange can legitimately take: the up-to-60 s wait for the
+     *  P2P group's credentials, plus the 15 s wait for the phone's Type 2, plus slack. Past this
+     *  the exchange is over however it ended, so treating it as live only suppresses recovery. */
+    const val HANDSHAKE_TIMEOUT_MS = 90_000L
+
     /**
      * Whether we are still inside the post-Type-3 settling window.
      *
      * [settlingSinceMs] is an elapsed-realtime stamp, or 0 when no handoff is settling. The
      * window is bounded so a missed reset can't latch the state true forever.
      */
-    fun isSettling(settlingSinceMs: Long, nowMs: Long, timeoutMs: Long = SETTLE_TIMEOUT_MS): Boolean {
-        if (settlingSinceMs == 0L) return false
-        val elapsed = nowMs - settlingSinceMs
+    fun isSettling(settlingSinceMs: Long, nowMs: Long, timeoutMs: Long = SETTLE_TIMEOUT_MS): Boolean =
+        isWithinWindow(settlingSinceMs, nowMs, timeoutMs)
+
+    /**
+     * Whether a credential exchange is still in progress.
+     *
+     * [startedAtMs] is an elapsed-realtime stamp, or 0 when no handshake is running. Bounded for
+     * the same reason [isSettling] is, and not merely as a belt-and-braces measure: on the #706
+     * reporter's head unit, closing the Bluetooth socket does not unblock a pending
+     * `readFully()`, so the handshake coroutine never reaches its own cleanup. A plain boolean
+     * latched true there and stayed true for the life of the process, which stopped the wake
+     * poke retrying and made `WifiDirectManager`'s join watchdog defer recovery forever.
+     */
+    fun isHandshaking(startedAtMs: Long, nowMs: Long, timeoutMs: Long = HANDSHAKE_TIMEOUT_MS): Boolean =
+        isWithinWindow(startedAtMs, nowMs, timeoutMs)
+
+    /** True when [sinceMs] is a live stamp (non-zero, not in the future) less than [timeoutMs] old. */
+    private fun isWithinWindow(sinceMs: Long, nowMs: Long, timeoutMs: Long): Boolean {
+        if (sinceMs == 0L) return false
+        val elapsed = nowMs - sinceMs
         return elapsed >= 0 && elapsed < timeoutMs
     }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicy.kt
@@ -65,6 +65,31 @@ object NativeHandoffPolicy {
     fun shouldPoke(settling: Boolean, handshakeInFlight: Boolean, sessionConnected: Boolean): Boolean =
         !settling && !handshakeInFlight && !sessionConnected
 
+    /** How many wake pokes the phone may answer without ever opening the Android Auto channel
+     *  before we say so in the log. Three is roughly 45 s of the retry cadence — long enough that
+     *  a phone which is merely slow to react has had its chance. */
+    const val SILENT_POKE_WARN_INTERVAL = 3
+
+    /**
+     * Whether to warn that the phone answers our wake pokes but never connects back.
+     *
+     * That combination has exactly one common cause, and it is not something this app can fix:
+     * the phone's Android Auto is bound to a *different* Bluetooth device that also advertises
+     * the Android Auto service record. On the #706 reporter's unit that was the head unit's own
+     * OEM Bluetooth module ("CAR8032"), a separate chip that Android on the head unit cannot see,
+     * still advertising the service after its OEM app stopped answering on it. Gearhead kept
+     * reconnecting to it every 12 s and discarded every poke from our radio as
+     * `IGNORE_DIFFERENT_BLUETOOTH_DEVICE`. Our own log showed successful pokes and nothing wrong.
+     *
+     * [everAccepted] gates it to units that have never once been reached, so a unit that connects
+     * normally and then has a bad run never sees it. Periodic rather than one-shot so it is still
+     * visible in a log exported long after the trouble started.
+     */
+    fun shouldWarnPhoneNeverCallsBack(pokesSinceLastAccept: Int, everAccepted: Boolean): Boolean =
+        !everAccepted &&
+            pokesSinceLastAccept > 0 &&
+            pokesSinceLastAccept % SILENT_POKE_WARN_INTERVAL == 0
+
     /**
      * Whether a client leaving the P2P group should restart the peer-discovery loop.
      *

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicy.kt
@@ -90,6 +90,28 @@ object NativeHandoffPolicy {
             pokesSinceLastAccept > 0 &&
             pokesSinceLastAccept % SILENT_POKE_WARN_INTERVAL == 0
 
+    /** How many handshakes may time out waiting for the phone's Type 2, back to back, before we
+     *  stop serving new ones. Roughly a minute of trying at the phone's ~12 s reconnect cadence. */
+    const val MAX_CONSECUTIVE_HANDSHAKE_FAILURES = 5
+
+    /**
+     * Whether to serve an incoming Android Auto connection at all.
+     *
+     * Exists to bound a leak we cannot otherwise close. The wait for the phone's Type 2 is a
+     * blocking read on a background coroutine, and on a head unit where `close()` does not
+     * interrupt a pending read — #706's does not — that coroutine never returns and its
+     * `Dispatchers.IO` thread is stranded for the life of the process. `cancel()` cannot help:
+     * there is no suspension point inside a blocking JNI read. Since the thread cannot be
+     * reclaimed, the only lever is to stop creating them.
+     *
+     * A hard stop rather than a growing delay, because this failure is not transient: if the
+     * stack drops our write, the 200th attempt fails exactly like the first, and each one costs a
+     * thread and radio time for nothing. The counter resets on a successful handshake, on
+     * stop()/start(), and on a manual poke — so the user's own "try again" is the way back.
+     */
+    fun shouldServeHandshake(consecutiveFailures: Int): Boolean =
+        consecutiveFailures < MAX_CONSECUTIVE_HANDSHAKE_FAILURES
+
     /**
      * Whether a client leaving the P2P group should restart the peer-discovery loop.
      *

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -100,9 +100,15 @@ class NativeAaHandshakeManager(
     // WifiDirectManager redelivers the same credentials, which was starving the poke before it
     // could ever finish.
     private var lastPokeTriggerCredentials: Triple<String, String, String>? = null
-    // True while handleHandshake() runs; lets WifiDirectManager's join watchdog know a real
-    // exchange is in progress. Bounded by handleHandshake()'s own timeouts, so it can't stick true.
-    @Volatile private var handshakeInFlight = false
+    // elapsedRealtime() when handleHandshake() started, or 0 when no exchange is running; lets
+    // WifiDirectManager's join watchdog know a real exchange is in progress.
+    //
+    // [BUG_FIX] #706: a stamp rather than a boolean because handleHandshake() cannot be relied on
+    // to clear it. On the reporter's ROCO K706 the socket close that is supposed to unblock the
+    // wait for Type 2 does not, so the coroutine never reaches its finally — three failed
+    // handshakes produced zero "BT Handshake socket closed." lines and left the old boolean true
+    // for the rest of the process. See NativeHandoffPolicy.isHandshaking.
+    @Volatile private var handshakeStartedAt = 0L
     // True for the duration of a single pokeDevice() attempt (its socket.connect() call itself
     // can fire an OS-level ACL_CONNECTED broadcast before any real handshake starts) - see
     // isAttemptInFlight().
@@ -144,7 +150,8 @@ class NativeAaHandshakeManager(
     // "believed to be running."
     fun isActive(): Boolean = isRunning && !aaListenersClosedForSession
 
-    fun isHandshakeInFlight(): Boolean = handshakeInFlight
+    fun isHandshakeInFlight(): Boolean =
+        NativeHandoffPolicy.isHandshaking(handshakeStartedAt, SystemClock.elapsedRealtime())
 
     /**
      * True between delivering the WiFi credentials (Type 3) and the phone's TCP session actually
@@ -163,7 +170,7 @@ class NativeAaHandshakeManager(
     // a delivered handoff is still settling. AutoStartReceiver's own poke can generate the
     // ACL_CONNECTED broadcast that re-triggers AapService's BT auto-start re-arm; callers
     // deciding whether it's safe to force-reinit should check this instead of isActive() alone.
-    fun isAttemptInFlight(): Boolean = handshakeInFlight || pokeAttemptInFlight || isHandoffSettling()
+    fun isAttemptInFlight(): Boolean = isHandshakeInFlight() || pokeAttemptInFlight || isHandoffSettling()
 
     @SuppressLint("MissingPermission")
     fun start() {
@@ -474,12 +481,13 @@ class NativeAaHandshakeManager(
 
             while (isRunning && isActive) {
                 val settling = isHandoffSettling()
+                val handshaking = isHandshakeInFlight()
                 val sessionUp = commManager.isConnected ||
                     commManager.connectionState.value is CommManager.ConnectionState.Connecting
-                if (!NativeHandoffPolicy.shouldPoke(settling, handshakeInFlight, sessionUp)) {
+                if (!NativeHandoffPolicy.shouldPoke(settling, handshaking, sessionUp)) {
                     AppLog.i(
                         "NativeAA: Stopping poke retry loop " +
-                            "(settling=$settling, handshake=$handshakeInFlight, session=$sessionUp)."
+                            "(settling=$settling, handshake=$handshaking, session=$sessionUp)."
                     )
                     break
                 }
@@ -504,7 +512,7 @@ class NativeAaHandshakeManager(
                 }
 
                 for (device in devicesToPoke) {
-                    if (!isRunning || !isActive || handshakeInFlight || isHandoffSettling()) break
+                    if (!isRunning || !isActive || isHandshakeInFlight() || isHandoffSettling()) break
                     if (commManager.isConnected) {
                         AppLog.i("NativeAA: USB/other session became active mid-poke. Stopping poke loop.")
                         break
@@ -546,13 +554,19 @@ class NativeAaHandshakeManager(
     }
 
     private suspend fun handleHandshake(socket: BluetoothSocket, localRadio: String? = null) = withContext(Dispatchers.IO) {
-        handshakeInFlight = true
-        // A real AA_UUID connection just landed - the wake poke (if one is still running) has
-        // done its job and is now just an extra, unnecessary RFCOMM/profile channel held open
-        // on the same physical radio for the remainder of its hold window, competing with this
-        // handshake for radio time. Release it immediately instead of leaving it running.
-        pokeJob?.cancel()
-        // The listener now stays open across the settling window, so the phone can reconnect over
+        // The wake poke is deliberately left running here. It used to be cancelled on entry, on
+        // the reasoning that a real AA_UUID connection means the poke has done its job and is now
+        // just competing for radio time — but cancelling it closes the HFP/HSP socket, and #706's
+        // phone-side Gearhead log shows the phone reacting to that within milliseconds:
+        //   GH.BtConnectionTracker: profile connection removed
+        //   GH.CurrentCarTracker:   current car bluetooth connection is lost / is gone
+        //   ...WIRELESS_SETUP_CAR_BLUETOOTH_DISAPPEAR
+        // and then, when its own first-message timer expires 12 s later, refusing to retry:
+        //   GH.WIRELESS.SETUP: WiFi Projection Protocol cannot start as HU is not present.
+        // Real head units hold the profile link across the exchange, so hold it too, until the
+        // credentials are actually delivered (see the Type 3 branch) or this handshake ends.
+
+        // The listener stays open across the settling window, so the phone can reconnect over
         // Bluetooth while an earlier handoff is still settling. That reconnect means the earlier
         // one failed: retire it rather than serving both from the same manager state.
         activeHandshakeSocket?.let { previous ->
@@ -563,6 +577,9 @@ class NativeAaHandshakeManager(
             }
         }
         activeHandshakeSocket = socket
+        // Stamped after claiming ownership above, so a superseded handshake's cleanup — which
+        // only fires when it still owns activeHandshakeSocket — can't wipe this one's stamp.
+        handshakeStartedAt = SystemClock.elapsedRealtime()
         try {
             val device = socket.remoteDevice
             AppLog.i("NativeAA: Handling handshake for ${device.name} (${device.address}) on local radio [${localRadio ?: "?"}]")
@@ -639,16 +656,24 @@ class NativeAaHandshakeManager(
             sendWifiStartRequest(output, ip, 5288)
 
             AppLog.i("NativeAA: Waiting for response from phone...")
-            // No BluetoothSocket.setSoTimeout(); force-close via watchdog to unblock readFully() on timeout.
-            val watchdog = scope.launch(Dispatchers.IO) {
-                delay(HANDSHAKE_RESPONSE_TIMEOUT_MS)
+            // There is no BluetoothSocket.setSoTimeout(), so the read has to be bounded from the
+            // outside. This used to be a watchdog that closed the socket to unblock readFully().
+            //
+            // [BUG_FIX] #706: that only works on stacks where close() actually interrupts a
+            // pending read, and the reporter's does not — his log has three "No response from
+            // phone" lines and not one "BT Handshake socket closed.", i.e. this function never
+            // unwound. Everything downstream of it stalled with it: the wake poke stopped
+            // retrying and the P2P join watchdog deferred recovery for the rest of the session.
+            // Time out the wait instead of the socket, by running the blocking read in its own
+            // coroutine and awaiting it — that resumes on schedule whether or not the read ever
+            // returns. The close is still attempted, for the stacks where it does help.
+            val reader = scope.async(Dispatchers.IO) { readProtobuf(input) }
+            val response = withTimeoutOrNull(HANDSHAKE_RESPONSE_TIMEOUT_MS) { reader.await() }
+            if (response == null) {
                 AppLog.e("NativeAA: Handshake failed - No response from phone ${device.name} (${device.address}) on radio [${localRadio ?: "?"}] within ${HANDSHAKE_RESPONSE_TIMEOUT_MS / 1000}s of sending WifiStartRequest. Closing socket.")
                 try { socket.close() } catch (e: Exception) {}
-            }
-            val response = try {
-                readProtobuf(input)
-            } finally {
-                watchdog.cancel()
+                reader.cancel()
+                return@withContext
             }
             AppLog.i("NativeAA: [RX] Received Type ${response.type} (Payload size: ${response.payload.size})")
 
@@ -660,8 +685,13 @@ class NativeAaHandshakeManager(
                 AppLog.i("NativeAA: Handshake completed successfully on Bluetooth side.")
                 // The credential exchange is done, but the phone's work has only just started —
                 // it now has to associate, run WPS and get a DHCP lease. See isHandoffSettling().
-                handshakeInFlight = false
+                handshakeStartedAt = 0L
                 handoffSettlingSince = SystemClock.elapsedRealtime()
+                // The phone has what it needs, so the wake poke held open since before this
+                // handshake has nothing left to wake. Release it now — it is an RFCOMM channel on
+                // the same physical radio the phone is about to associate over, and #760 is what
+                // happens when Bluetooth work overlaps the join.
+                pokeJob?.cancel()
 
                 // Release the Bluetooth connection once the handoff has actually happened, rather
                 // than holding it indefinitely. The real Android Auto protocol closes Bluetooth
@@ -692,7 +722,7 @@ class NativeAaHandshakeManager(
                     // happen here. Leave the listener up so the phone's own retry can be
                     // accepted (start() early-returns while isRunning, so a close here would
                     // strand us until AapService stopped and restarted the manager), and restart
-                    // the poke, which was cancelled when this handshake began.
+                    // the poke, which was cancelled once the credentials went out.
                     AppLog.w("NativeAA: No WiFi session within ${NativeHandoffPolicy.SETTLE_TIMEOUT_MS / 1000}s of delivering credentials — keeping the AA listener open and resuming the wake poke.")
                     triggerPoke()
                 }
@@ -703,11 +733,11 @@ class NativeAaHandshakeManager(
         } catch (e: Exception) {
             AppLog.e("NativeAA: Handshake error: ${e.message}", e)
         } finally {
-            handshakeInFlight = false
-            // Only clear the settling stamp if this handshake still owns it — a superseding
-            // handshake has already taken over and set its own.
+            // Only clear the stamps if this handshake still owns them — a superseding handshake
+            // has already taken over and set its own.
             if (activeHandshakeSocket === socket) {
                 activeHandshakeSocket = null
+                handshakeStartedAt = 0L
                 handoffSettlingSince = 0L
             }
             try { socket.close() } catch (e: Exception) {}
@@ -803,9 +833,10 @@ class NativeAaHandshakeManager(
         pokeJob?.cancel()
         pokeJob = null
         lastPokeTriggerCredentials = null
-        // A settle can't outlive the manager: leaving these set would keep isHandoffSettling()
-        // (and so isAttemptInFlight()) true across a restart, blocking the very poke the next
-        // start() needs.
+        // Neither a handshake nor a settle can outlive the manager: leaving these set would keep
+        // isAttemptInFlight() true across a restart, blocking the very poke the next start()
+        // needs.
+        handshakeStartedAt = 0L
         handoffSettlingSince = 0L
         activeHandshakeSocket = null
     }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -94,6 +94,10 @@ class NativeAaHandshakeManager(
     private var currentIp: String? = null
     private var currentBssid: String? = null
     private var pokeJob: Job? = null
+    // Last (ssid, ip, bssid) triggerPoke() restarted for - dedupes redundant restarts when
+    // WifiDirectManager redelivers the same credentials, which was starving the poke before it
+    // could ever finish.
+    private var lastPokeTriggerCredentials: Triple<String, String, String>? = null
     // True while handleHandshake() runs; lets WifiDirectManager's join watchdog know a real
     // exchange is in progress. Bounded by handleHandshake()'s own timeouts, so it can't stick true.
     @Volatile private var handshakeInFlight = false
@@ -407,6 +411,13 @@ class NativeAaHandshakeManager(
         }
         val adapter = BluetoothHelper.getBluetoothAdapter(context) ?: return
 
+        val credentials = Triple(currentSsid ?: "", currentIp ?: "", currentBssid ?: "")
+        if (pokeJob?.isActive == true && credentials == lastPokeTriggerCredentials) {
+            AppLog.d("NativeAA: triggerPoke() called again with unchanged credentials while a poke is already running - not restarting it.")
+            return
+        }
+        lastPokeTriggerCredentials = credentials
+
         pokeJob?.cancel()
         pokeJob = scope.launch(Dispatchers.IO + CoroutineName("NativeAa-Wakeup")) {
             AppLog.d("NativeAA: triggerPoke() delay starting (2s)...")
@@ -678,5 +689,6 @@ class NativeAaHandshakeManager(
         currentBssid = null
         pokeJob?.cancel()
         pokeJob = null
+        lastPokeTriggerCredentials = null
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -101,6 +101,10 @@ class NativeAaHandshakeManager(
     // True while handleHandshake() runs; lets WifiDirectManager's join watchdog know a real
     // exchange is in progress. Bounded by handleHandshake()'s own timeouts, so it can't stick true.
     @Volatile private var handshakeInFlight = false
+    // True for the duration of a single pokeDevice() attempt (its socket.connect() call itself
+    // can fire an OS-level ACL_CONNECTED broadcast before any real handshake starts) - see
+    // isAttemptInFlight().
+    @Volatile private var pokeAttemptInFlight = false
 
     /**
      * Updates the WiFi credentials that will be sent to the phone during the next handshake.
@@ -131,6 +135,13 @@ class NativeAaHandshakeManager(
     fun isActive(): Boolean = isRunning && !aaListenersClosedForSession
 
     fun isHandshakeInFlight(): Boolean = handshakeInFlight
+
+    // True while either a wake-up poke's socket.connect() or a real handshake is in progress.
+    // AutoStartReceiver's own poke can generate the ACL_CONNECTED broadcast that re-triggers
+    // AapService's BT auto-start re-arm; callers deciding whether it's safe to force-reinit
+    // (rather than WifiDirectManager's join watchdog, which wants isHandshakeInFlight() alone)
+    // should check this instead of isActive() alone.
+    fun isAttemptInFlight(): Boolean = handshakeInFlight || pokeAttemptInFlight
 
     @SuppressLint("MissingPermission")
     fun start() {
@@ -371,28 +382,33 @@ class NativeAaHandshakeManager(
      * fallback chain (HFP_AG_UUID -> HSP_AG_UUID).
      */
     private suspend fun pokeDevice(device: BluetoothDevice, holdMs: Long): Boolean {
-        for (uuid in listOf(HFP_AG_UUID, HSP_AG_UUID)) {
-            var socket: BluetoothSocket? = null
-            try {
-                socket = device.createRfcommSocketToServiceRecord(uuid)
-                AppLog.i("NativeAA: Calling socket.connect() for ${device.name} via $uuid...")
-                socket.connect()
-                AppLog.i("NativeAA: Successfully poked ${device.name} via $uuid. Holding ${holdMs}ms...")
-                delay(holdMs)
-                return true
-            } catch (e: CancellationException) {
-                // Rethrow instead of falling through to the next UUID: a cancelled poke (e.g.
-                // handleHandshake()'s pokeJob?.cancel() once a real handshake lands) must stop
-                // immediately, not fire another real, blocking socket.connect() on the same
-                // physical radio right as the critical WifiStartRequest send is about to happen.
-                throw e
-            } catch (e: Exception) {
-                AppLog.d("NativeAA: Poke via $uuid to ${device.name} failed: ${e.message}")
-            } finally {
-                try { socket?.close() } catch (e: Exception) {}
+        pokeAttemptInFlight = true
+        try {
+            for (uuid in listOf(HFP_AG_UUID, HSP_AG_UUID)) {
+                var socket: BluetoothSocket? = null
+                try {
+                    socket = device.createRfcommSocketToServiceRecord(uuid)
+                    AppLog.i("NativeAA: Calling socket.connect() for ${device.name} via $uuid...")
+                    socket.connect()
+                    AppLog.i("NativeAA: Successfully poked ${device.name} via $uuid. Holding ${holdMs}ms...")
+                    delay(holdMs)
+                    return true
+                } catch (e: CancellationException) {
+                    // Rethrow instead of falling through to the next UUID: a cancelled poke (e.g.
+                    // handleHandshake()'s pokeJob?.cancel() once a real handshake lands) must stop
+                    // immediately, not fire another real, blocking socket.connect() on the same
+                    // physical radio right as the critical WifiStartRequest send is about to happen.
+                    throw e
+                } catch (e: Exception) {
+                    AppLog.d("NativeAA: Poke via $uuid to ${device.name} failed: ${e.message}")
+                } finally {
+                    try { socket?.close() } catch (e: Exception) {}
+                }
             }
+            return false
+        } finally {
+            pokeAttemptInFlight = false
         }
-        return false
     }
 
     /**

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -132,6 +132,14 @@ class NativeAaHandshakeManager(
     // NativeHandoffPolicy.shouldWarnPhoneNeverCallsBack.
     @Volatile private var pokesSinceLastAccept = 0
     @Volatile private var everAcceptedAaConnection = false
+    // [BUG_FIX] #706: handshakes that timed out waiting for Type 2, back to back. Each one strands
+    // a Dispatchers.IO thread forever on a stack where close() does not interrupt a pending read,
+    // so this bounds how many we are willing to strand. See
+    // NativeHandoffPolicy.shouldServeHandshake.
+    @Volatile private var consecutiveHandshakeFailures = 0
+    // Whether the "not serving handshakes" warning has already been logged for the current
+    // backoff, so a phone retrying every ~12 s does not repeat the long explanation each time.
+    @Volatile private var loggedHandshakeBackoff = false
 
     /**
      * Updates the WiFi credentials that will be sent to the phone during the next handshake.
@@ -223,6 +231,7 @@ class NativeAaHandshakeManager(
                     val socket = aaServerSocket?.accept()
                     if (socket != null) {
                         AppLog.i("NativeAA: Connection accepted from ${socket.remoteDevice.name} (${socket.remoteDevice.address}) on local radio [$localRadioName]")
+                        if (refuseWhileBackedOff(socket)) continue
                         // [FIX] Launch handshake in a separate coroutine so the server can accept the next connection!
                         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-Handshake-${socket.remoteDevice.address}")) {
                             handleHandshake(socket, localRadioName)
@@ -317,6 +326,7 @@ class NativeAaHandshakeManager(
                     val socket = server.accept()
                     if (socket != null) {
                         AppLog.i("NativeAA: Connection accepted (secondary radio '$serviceName' [$radioName]) from ${socket.remoteDevice.name} (${socket.remoteDevice.address})")
+                        if (refuseWhileBackedOff(socket)) continue
                         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-Handshake-${socket.remoteDevice.address}")) {
                             handleHandshake(socket, radioName)
                         }
@@ -579,6 +589,9 @@ class NativeAaHandshakeManager(
         try {
             val device = adapter.getRemoteDevice(address)
             AppLog.i("NativeAA: Manual poke requested for ${device.name} ($address)")
+            // The user asking to try again is the way out of a handshake backoff — it is the only
+            // gesture the UI offers, and it means they want another attempt whatever we concluded.
+            resetHandshakeBackoff()
             
             pokeJob?.cancel()
             pokeJob = scope.launch(Dispatchers.IO + CoroutineName("NativeAa-ManualWakeup")) {
@@ -589,6 +602,38 @@ class NativeAaHandshakeManager(
         } catch (e: Exception) {
             AppLog.e("NativeAA: Manual poke error", e)
         }
+    }
+
+    /**
+     * Drop an incoming Android Auto connection instead of serving it, once too many handshakes in
+     * a row have timed out waiting for the phone's Type 2. Returns true if the socket was refused.
+     *
+     * Each timed-out handshake strands a thread that cannot be reclaimed (see
+     * [NativeHandoffPolicy.shouldServeHandshake]), so past the limit the only useful thing to do
+     * is stop starting new ones. The phone will keep reconnecting; closing immediately costs it
+     * nothing beyond the retry it was going to make anyway.
+     */
+    private fun refuseWhileBackedOff(socket: BluetoothSocket): Boolean {
+        if (NativeHandoffPolicy.shouldServeHandshake(consecutiveHandshakeFailures)) return false
+        if (!loggedHandshakeBackoff) {
+            loggedHandshakeBackoff = true
+            AppLog.w(
+                "NativeAA: $consecutiveHandshakeFailures handshakes in a row ended with no answer from the phone, " +
+                    "so this connection is being dropped instead of served. Each attempt costs a thread that " +
+                    "cannot be recovered, and this head unit's Bluetooth is not delivering our messages. " +
+                    "Use the manual poke button, or switch Android Auto mode off and on, to try again."
+            )
+        } else {
+            AppLog.d("NativeAA: Dropping Android Auto connection — still backed off after $consecutiveHandshakeFailures failed handshakes.")
+        }
+        try { socket.close() } catch (e: Exception) {}
+        return true
+    }
+
+    /** Clears the handshake backoff. Called wherever the user or the system asks for a fresh try. */
+    private fun resetHandshakeBackoff() {
+        consecutiveHandshakeFailures = 0
+        loggedHandshakeBackoff = false
     }
 
     private suspend fun handleHandshake(socket: BluetoothSocket, localRadio: String? = null) = withContext(Dispatchers.IO) {
@@ -715,9 +760,17 @@ class NativeAaHandshakeManager(
             if (response == null) {
                 AppLog.e("NativeAA: Handshake failed - No response from phone ${device.name} (${device.address}) on radio [${localRadio ?: "?"}] within ${HANDSHAKE_RESPONSE_TIMEOUT_MS / 1000}s of sending WifiStartRequest. Closing socket.")
                 try { socket.close() } catch (e: Exception) {}
+                // Best effort only: on a stack where close() does not interrupt a pending read,
+                // this cannot end `reader` — a blocking JNI read has no suspension point to
+                // cancel at — so its thread is stranded from here on. That is what
+                // consecutiveHandshakeFailures bounds; this is the one path that leaks one.
                 reader.cancel()
+                consecutiveHandshakeFailures++
                 return@withContext
             }
+            // The reader returned, so nothing is stranded and the channel is carrying data in at
+            // least one direction. Whatever the type turns out to be, this was not a silent unit.
+            resetHandshakeBackoff()
             AppLog.i("NativeAA: [RX] Received Type ${response.type} (Payload size: ${response.payload.size})")
 
             if (response.type == 2) {
@@ -885,5 +938,8 @@ class NativeAaHandshakeManager(
         // Only the per-attempt count resets: everAcceptedAaConnection is deliberately kept, so a
         // unit that has connected before is not warned just because the manager was re-armed.
         pokesSinceLastAccept = 0
+        // A mode change or a user exit is a fresh start, so the next start() serves handshakes
+        // again rather than inheriting a backoff the user cannot see.
+        resetHandshakeBackoff()
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -376,6 +376,12 @@ class NativeAaHandshakeManager(
                 AppLog.i("NativeAA: Successfully poked ${device.name} via $uuid. Holding ${holdMs}ms...")
                 delay(holdMs)
                 return true
+            } catch (e: CancellationException) {
+                // Rethrow instead of falling through to the next UUID: a cancelled poke (e.g.
+                // handleHandshake()'s pokeJob?.cancel() once a real handshake lands) must stop
+                // immediately, not fire another real, blocking socket.connect() on the same
+                // physical radio right as the critical WifiStartRequest send is about to happen.
+                throw e
             } catch (e: Exception) {
                 AppLog.d("NativeAA: Poke via $uuid to ${device.name} failed: ${e.message}")
             } finally {

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -121,6 +121,17 @@ class NativeAaHandshakeManager(
     // reconnects over Bluetooth during a settle supersedes the stale one instead of running a
     // second handleHandshake() alongside it.
     @Volatile private var activeHandshakeSocket: BluetoothSocket? = null
+    // Name of the primary Bluetooth radio we listen and poke on, captured in start(). A field
+    // rather than a local so the diagnostic below can name the radio the phone is ignoring.
+    @Volatile private var localRadioName: String = "?"
+    // [BUG_FIX] #706: how many wake pokes the phone has answered without ever opening the AA
+    // channel, and whether it ever has. The pair exists because "poke succeeds, nothing comes
+    // back" produced a head unit log with no sign of trouble at all — successful pokes and
+    // nothing else — while the phone was in fact reconnecting every 12 s to the head unit's own
+    // OEM Bluetooth module, which still advertises the Android Auto service record. See
+    // NativeHandoffPolicy.shouldWarnPhoneNeverCallsBack.
+    @Volatile private var pokesSinceLastAccept = 0
+    @Volatile private var everAcceptedAaConnection = false
 
     /**
      * Updates the WiFi credentials that will be sent to the phone during the next handshake.
@@ -200,7 +211,7 @@ class NativeAaHandshakeManager(
         // log). Uses adapter.name, not adapter.address: getAddress() returns the fixed masked
         // placeholder "02:00:00:00:00:00" for any non-privileged app since Android 6.0 (API 23),
         // but getName() returns the real radio name (confirmed on-device: e.g. "Navegadortz2").
-        val localRadioName = try { adapter.name ?: "?" } catch (e: Exception) { "?" }
+        localRadioName = try { adapter.name ?: "?" } catch (e: Exception) { "?" }
         AppLog.i("NativeAA: Starting Bluetooth Handshake Servers (primary radio [$localRadioName])...")
 
         // Start AA RFCOMM Server
@@ -420,6 +431,9 @@ class NativeAaHandshakeManager(
                     AppLog.i("NativeAA: Calling socket.connect() for ${device.name} via $uuid...")
                     socket.connect()
                     AppLog.i("NativeAA: Successfully poked ${device.name} via $uuid. Holding ${holdMs}ms...")
+                    // Counted before the hold, so a poke that is cancelled mid-hold still counts:
+                    // the phone answered, which is the whole point of the count.
+                    pokesSinceLastAccept++
                     delay(holdMs)
                     return true
                 } catch (e: CancellationException) {
@@ -521,6 +535,30 @@ class NativeAaHandshakeManager(
                     pokeDevice(device, holdMs = 15000)
                 }
 
+                // [BUG_FIX] #706: say out loud that the phone is answering but never calling back.
+                // Without this the log of a head unit in that state is indistinguishable from a
+                // healthy one waiting for the user — successful pokes and nothing else — which is
+                // what let the reporter's real cause (his phone's Android Auto was bound to the
+                // head unit's own OEM Bluetooth module, still advertising the AA service record
+                // after its OEM app stopped answering) go unnoticed for weeks. Warning, not info,
+                // so it survives a reporter log exported at the default level.
+                if (NativeHandoffPolicy.shouldWarnPhoneNeverCallsBack(
+                        pokesSinceLastAccept, everAcceptedAaConnection
+                    )
+                ) {
+                    AppLog.w(
+                        "NativeAA: The phone has answered $pokesSinceLastAccept wake pokes but has " +
+                            "never opened the Android Auto channel on radio [$localRadioName]. Its " +
+                            "Android Auto is most likely bound to a different Bluetooth device that " +
+                            "also advertises the Android Auto service — typically this head unit's " +
+                            "own OEM/factory Bluetooth module (a second name alongside this one in " +
+                            "the phone's paired list), or another car. Remove that device from the " +
+                            "phone's Bluetooth paired list and retry. If this phone has never " +
+                            "projected wirelessly to any head unit, check that it supports wireless " +
+                            "Android Auto first."
+                    )
+                }
+
                 delay(15000) // retry cadence, matches both reference implementations' 15-20s interval
             }
         }
@@ -554,6 +592,11 @@ class NativeAaHandshakeManager(
     }
 
     private suspend fun handleHandshake(socket: BluetoothSocket, localRadio: String? = null) = withContext(Dispatchers.IO) {
+        // The phone reached us. Recorded here rather than at either accept site so both the
+        // primary and the secondary-radio loops are covered by one statement.
+        everAcceptedAaConnection = true
+        pokesSinceLastAccept = 0
+
         // The wake poke is deliberately left running here. It used to be cancelled on entry, on
         // the reasoning that a real AA_UUID connection means the poke has done its job and is now
         // just competing for radio time — but cancelling it closes the HFP/HSP socket, and #706's
@@ -839,5 +882,8 @@ class NativeAaHandshakeManager(
         handshakeStartedAt = 0L
         handoffSettlingSince = 0L
         activeHandshakeSocket = null
+        // Only the per-attempt count resets: everAcceptedAaConnection is deliberately kept, so a
+        // unit that has connected before is not warned just because the manager was re-armed.
+        pokesSinceLastAccept = 0
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -7,11 +7,13 @@ import android.bluetooth.BluetoothServerSocket
 import android.bluetooth.BluetoothSocket
 import android.content.Context
 import com.andrerinas.openheadunit.aap.AapService
+import com.andrerinas.openheadunit.aap.NativeHandoffPolicy
 import com.andrerinas.openheadunit.utils.BluetoothHelper
 import com.andrerinas.openheadunit.aap.protocol.proto.Wireless
 import com.andrerinas.openheadunit.utils.AppLog
 import kotlinx.coroutines.*
 import android.os.Build
+import android.os.SystemClock
 import android.content.pm.PackageManager
 import androidx.core.content.ContextCompat
 import java.io.DataInputStream
@@ -105,6 +107,14 @@ class NativeAaHandshakeManager(
     // can fire an OS-level ACL_CONNECTED broadcast before any real handshake starts) - see
     // isAttemptInFlight().
     @Volatile private var pokeAttemptInFlight = false
+    // elapsedRealtime() when the last WifiInfoResponse (Type 3) went out, or 0 when no handoff is
+    // settling. The phone spends the next several seconds associating, doing WPS and getting a
+    // DHCP lease; see isHandoffSettling() and NativeHandoffPolicy.
+    @Volatile private var handoffSettlingSince = 0L
+    // The socket of the handshake currently being served. Kept so a phone that gives up and
+    // reconnects over Bluetooth during a settle supersedes the stale one instead of running a
+    // second handleHandshake() alongside it.
+    @Volatile private var activeHandshakeSocket: BluetoothSocket? = null
 
     /**
      * Updates the WiFi credentials that will be sent to the phone during the next handshake.
@@ -136,12 +146,24 @@ class NativeAaHandshakeManager(
 
     fun isHandshakeInFlight(): Boolean = handshakeInFlight
 
-    // True while either a wake-up poke's socket.connect() or a real handshake is in progress.
-    // AutoStartReceiver's own poke can generate the ACL_CONNECTED broadcast that re-triggers
-    // AapService's BT auto-start re-arm; callers deciding whether it's safe to force-reinit
-    // (rather than WifiDirectManager's join watchdog, which wants isHandshakeInFlight() alone)
-    // should check this instead of isActive() alone.
-    fun isAttemptInFlight(): Boolean = handshakeInFlight || pokeAttemptInFlight
+    /**
+     * True between delivering the WiFi credentials (Type 3) and the phone's TCP session actually
+     * landing — the window in which it is still associating, doing WPS and getting a DHCP lease.
+     *
+     * [isHandshakeInFlight] deliberately goes false the instant Type 3 is written, because the
+     * *credential exchange* is done at that point. The phone's work isn't: on the #760 reporter's
+     * hardware it joined the group 0.73 s after Type 3 and was still without an IP 2.4 s later.
+     * Anything that must not disturb the phone mid-join — the wake poke, the BT auto-start
+     * re-arm, WifiDirectManager's join watchdog — has to check this, not isHandshakeInFlight().
+     */
+    fun isHandoffSettling(): Boolean =
+        NativeHandoffPolicy.isSettling(handoffSettlingSince, SystemClock.elapsedRealtime())
+
+    // True while either a wake-up poke's socket.connect() or a real handshake is in progress, or
+    // a delivered handoff is still settling. AutoStartReceiver's own poke can generate the
+    // ACL_CONNECTED broadcast that re-triggers AapService's BT auto-start re-arm; callers
+    // deciding whether it's safe to force-reinit should check this instead of isActive() alone.
+    fun isAttemptInFlight(): Boolean = handshakeInFlight || pokeAttemptInFlight || isHandoffSettling()
 
     @SuppressLint("MissingPermission")
     fun start() {
@@ -416,8 +438,19 @@ class NativeAaHandshakeManager(
      * to start looking for the head unit. Retried every 15s (matching the retry cadence of both
      * nisargjhaveri/WirelessAndroidAutoDongle and mossyhub/openautolink) until a real handshake
      * starts or another session (USB/etc.) takes over, instead of giving up after a single pass.
+     *
+     * Never runs while a handoff is settling: AapService re-invokes this on every credential
+     * re-delivery, and the phone *joining our group* is itself a P2P connection change, hence a
+     * re-delivery. That turned into a real RFCOMM connect() landing in the middle of the phone's
+     * DHCP exchange (#760).
      */
     fun triggerPoke() {
+        if (isHandoffSettling()) {
+            // Info, not debug: this line is the evidence that the #760 fix is doing its job, and
+            // reporter logs default to INFO.
+            AppLog.i("NativeAA: Handoff still settling — not starting a poke that would compete with the phone's WiFi association.")
+            return
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             if (ContextCompat.checkSelfPermission(context, android.Manifest.permission.BLUETOOTH_CONNECT)
                 != PackageManager.PERMISSION_GRANTED) {
@@ -439,10 +472,15 @@ class NativeAaHandshakeManager(
             AppLog.d("NativeAA: triggerPoke() delay starting (2s)...")
             delay(2000) // Small safety delay before connecting
 
-            while (isRunning && isActive && !handshakeInFlight) {
-                if (commManager.isConnected ||
-                    commManager.connectionState.value is CommManager.ConnectionState.Connecting) {
-                    AppLog.i("NativeAA: USB/other session active. Stopping poke retry loop.")
+            while (isRunning && isActive) {
+                val settling = isHandoffSettling()
+                val sessionUp = commManager.isConnected ||
+                    commManager.connectionState.value is CommManager.ConnectionState.Connecting
+                if (!NativeHandoffPolicy.shouldPoke(settling, handshakeInFlight, sessionUp)) {
+                    AppLog.i(
+                        "NativeAA: Stopping poke retry loop " +
+                            "(settling=$settling, handshake=$handshakeInFlight, session=$sessionUp)."
+                    )
                     break
                 }
 
@@ -466,7 +504,7 @@ class NativeAaHandshakeManager(
                 }
 
                 for (device in devicesToPoke) {
-                    if (!isRunning || !isActive || handshakeInFlight) break
+                    if (!isRunning || !isActive || handshakeInFlight || isHandoffSettling()) break
                     if (commManager.isConnected) {
                         AppLog.i("NativeAA: USB/other session became active mid-poke. Stopping poke loop.")
                         break
@@ -514,6 +552,17 @@ class NativeAaHandshakeManager(
         // on the same physical radio for the remainder of its hold window, competing with this
         // handshake for radio time. Release it immediately instead of leaving it running.
         pokeJob?.cancel()
+        // The listener now stays open across the settling window, so the phone can reconnect over
+        // Bluetooth while an earlier handoff is still settling. That reconnect means the earlier
+        // one failed: retire it rather than serving both from the same manager state.
+        activeHandshakeSocket?.let { previous ->
+            if (previous !== socket) {
+                AppLog.i("NativeAA: A new handshake arrived while one was still settling — closing the previous session.")
+                handoffSettlingSince = 0L
+                try { previous.close() } catch (_: Exception) {}
+            }
+        }
+        activeHandshakeSocket = socket
         try {
             val device = socket.remoteDevice
             AppLog.i("NativeAA: Handling handshake for ${device.name} (${device.address}) on local radio [${localRadio ?: "?"}]")
@@ -609,23 +658,44 @@ class NativeAaHandshakeManager(
                 delay(1000) // [FIX] Increased delay to give phone more processing time
                 sendWifiSecurityResponse(output, ssid, psk, bssid)
                 AppLog.i("NativeAA: Handshake completed successfully on Bluetooth side.")
-                // The credential exchange is done; the join watchdog no longer needs to defer
-                // for this handshake.
+                // The credential exchange is done, but the phone's work has only just started —
+                // it now has to associate, run WPS and get a DHCP lease. See isHandoffSettling().
                 handshakeInFlight = false
+                handoffSettlingSince = SystemClock.elapsedRealtime()
 
-                // Release the Bluetooth connection shortly after handoff instead of holding it
-                // indefinitely. The real Android Auto protocol closes Bluetooth right after the
-                // WiFi credential exchange — confirmed via a reference wireless-dongle
+                // Release the Bluetooth connection once the handoff has actually happened, rather
+                // than holding it indefinitely. The real Android Auto protocol closes Bluetooth
+                // after the WiFi credential exchange — confirmed via a reference wireless-dongle
                 // implementation (nisargjhaveri/WirelessAndroidAutoDongle#17/#18), where holding
                 // it open caused the same "confusion, especially with phone calls" symptom this
-                // repo has seen reported. Short grace window for the phone to finish reading the
-                // response before we close.
-                delay(3000)
-                AppLog.i("NativeAA: Handshake session ending, releasing Bluetooth connection.")
-                // Stop accepting new AA_UUID connections too, not just this socket — otherwise
-                // the phone's immediate reconnect-retry gets accepted, bounced (already
-                // connected), and retried again in a tight loop. See closeAaListeners() kdoc.
-                closeAaListeners()
+                // repo has seen reported.
+                //
+                // [BUG_FIX] #760: this used to be a flat delay(3000). That is a race, not a grace
+                // period — the phone needs however long it needs. In the reporter's logs the
+                // phone joined the group 0.73s after Type 3 and then left it 0.17s after this
+                // close fired at T+3.0s, never having got an IP; on 3.1.1, which never closed
+                // Bluetooth at all, the same phone took 21s to associate and connected fine; on
+                // 3.2.0-beta4 the TCP session landed 110ms before the close and it worked. Wait
+                // for the session instead of guessing at it.
+                val landed = awaitWifiHandoff()
+                handoffSettlingSince = 0L
+                if (landed) {
+                    AppLog.i("NativeAA: WiFi session landed. Handshake session ending, releasing Bluetooth connection.")
+                    // Stop accepting new AA_UUID connections too, not just this socket —
+                    // otherwise the phone's immediate reconnect-retry gets accepted, bounced
+                    // (already connected), and retried again in a tight loop. See
+                    // closeAaListeners() kdoc.
+                    closeAaListeners()
+                } else {
+                    // The handoff never completed, so there is no session for a reconnect to
+                    // collide with — the reconnect storm closeAaListeners() guards against can't
+                    // happen here. Leave the listener up so the phone's own retry can be
+                    // accepted (start() early-returns while isRunning, so a close here would
+                    // strand us until AapService stopped and restarted the manager), and restart
+                    // the poke, which was cancelled when this handshake began.
+                    AppLog.w("NativeAA: No WiFi session within ${NativeHandoffPolicy.SETTLE_TIMEOUT_MS / 1000}s of delivering credentials — keeping the AA listener open and resuming the wake poke.")
+                    triggerPoke()
+                }
             } else {
                 AppLog.w("NativeAA: Handshake failed - Unexpected response type ${response.type}. Expected Type 2.")
             }
@@ -634,9 +704,36 @@ class NativeAaHandshakeManager(
             AppLog.e("NativeAA: Handshake error: ${e.message}", e)
         } finally {
             handshakeInFlight = false
+            // Only clear the settling stamp if this handshake still owns it — a superseding
+            // handshake has already taken over and set its own.
+            if (activeHandshakeSocket === socket) {
+                activeHandshakeSocket = null
+                handoffSettlingSince = 0L
+            }
             try { socket.close() } catch (e: Exception) {}
             AppLog.i("NativeAA: BT Handshake socket closed.")
         }
+    }
+
+    /**
+     * Suspends until the phone's projection session actually reaches us over WiFi, or
+     * [NativeHandoffPolicy.SETTLE_TIMEOUT_MS] elapses. Returns true if it landed.
+     *
+     * [CommManager.isConnected] covers Connected/StartingTransport, and the Connecting state
+     * covers the moment WirelessServer hands an accepted socket over — either is proof the phone
+     * finished associating, which is the only thing we were waiting for.
+     */
+    private suspend fun awaitWifiHandoff(): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + NativeHandoffPolicy.SETTLE_TIMEOUT_MS
+        while (isRunning && SystemClock.elapsedRealtime() < deadline) {
+            if (commManager.isConnected ||
+                commManager.connectionState.value is CommManager.ConnectionState.Connecting) {
+                return true
+            }
+            delay(250)
+        }
+        return commManager.isConnected ||
+            commManager.connectionState.value is CommManager.ConnectionState.Connecting
     }
 
     private fun sendWifiStartRequest(output: OutputStream, ip: String, port: Int) {
@@ -706,5 +803,10 @@ class NativeAaHandshakeManager(
         pokeJob?.cancel()
         pokeJob = null
         lastPokeTriggerCredentials = null
+        // A settle can't outlive the manager: leaving these set would keep isHandoffSettling()
+        // (and so isAttemptInFlight()) true across a restart, blocking the very poke the next
+        // start() needs.
+        handoffSettlingSince = 0L
+        activeHandshakeSocket = null
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/WifiDirectManager.kt
@@ -19,6 +19,7 @@ import androidx.core.content.ContextCompat
 import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.R
 import com.andrerinas.openheadunit.aap.AapService
+import com.andrerinas.openheadunit.aap.NativeHandoffPolicy
 import com.andrerinas.openheadunit.utils.ToastUtils
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.Settings
@@ -101,8 +102,9 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             return@Runnable
         }
         if (isNativeHandshakeInFlight?.invoke() == true) {
-            // A handshake is exchanging credentials right now; recreating here would hand out a new SSID mid-exchange.
-            AppLog.i("WifiDirectManager: Native AA join watchdog fired but a Bluetooth handshake is in flight — deferring recovery.")
+            // A handshake is exchanging credentials right now, or the phone is still joining on
+            // credentials we just handed it; recreating here would hand out a new SSID mid-flight.
+            AppLog.i("WifiDirectManager: Native AA join watchdog fired but a Bluetooth handshake or handoff is in flight — deferring recovery.")
             armNativeJoinWatchdog()
             return@Runnable
         }
@@ -110,8 +112,9 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     }
 
     private var onCredentialsReady: ((ssid: String, psk: String, ip: String, bssid: String) -> Unit)? = null
-    // Set by AapService: whether NativeAaHandshakeManager has a live handshake in progress, so
-    // the join watchdog/self-heal never tears the group down mid-exchange.
+    // Set by AapService: whether NativeAaHandshakeManager has a live handshake in progress *or*
+    // a delivered handoff still settling (the phone associating/doing DHCP after Type 3), so the
+    // join watchdog/self-heal never tears the group down mid-exchange or mid-join.
     private var isNativeHandshakeInFlight: (() -> Boolean)? = null
     // Set by AapService: whether a real AA session is connected - isClientConnected can't tell
     // that apart from nobody joining (see nativeJoinWatchdog above).
@@ -382,8 +385,21 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                     nativeRecreateCount = 0
                 }
                 if (hadClient && !isClientConnected) {
-                    AppLog.i("WifiDirectManager: Client disconnected from P2P group. Restarting discovery loop.")
-                    startDiscoveryLoop()
+                    // [BUG_FIX] #760: never rediscover on the Native AA path. We run a *quiet*
+                    // host there — the phone finds us by SSID from the credentials we handed it
+                    // over Bluetooth, never by discovery — and discoverPeers() takes the group
+                    // owner off-channel every 10s. In the reporter's logs that loop starts the
+                    // moment the phone drops mid-DHCP and then keeps every subsequent retry stuck
+                    // at "Obtaining IP address".
+                    if (NativeHandoffPolicy.shouldRestartDiscovery(
+                            nativeAaMode = isNativeAaMode(),
+                            hadClient = hadClient,
+                            hasClient = isClientConnected)) {
+                        AppLog.i("WifiDirectManager: Client disconnected from P2P group. Restarting discovery loop.")
+                        startDiscoveryLoop()
+                    } else {
+                        AppLog.i("WifiDirectManager: Client left the Native AA group; staying a quiet host instead of rediscovering.")
+                    }
                     if (isNativeAaMode()) armNativeJoinWatchdog()
                 }
             } else {

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/WifiDirectManager.kt
@@ -92,6 +92,14 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     private var nativeRecreateCount = 0
     private val nativeJoinWatchdog = Runnable {
         if (isClientConnected) return@Runnable
+        if (isNativeSessionConnected?.invoke() == true) {
+            // Native joins are out-of-band over Bluetooth, not P2P invitation, so clientList (and
+            // isClientConnected) can stay empty forever even on a fully working session.
+            AppLog.i("WifiDirectManager: Native AA join watchdog fired but a session is already connected — cancelling recovery, not tearing down a working connection.")
+            cancelNativeJoinWatchdog()
+            nativeRecreateCount = 0
+            return@Runnable
+        }
         if (isNativeHandshakeInFlight?.invoke() == true) {
             // A handshake is exchanging credentials right now; recreating here would hand out a new SSID mid-exchange.
             AppLog.i("WifiDirectManager: Native AA join watchdog fired but a Bluetooth handshake is in flight — deferring recovery.")
@@ -105,6 +113,9 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     // Set by AapService: whether NativeAaHandshakeManager has a live handshake in progress, so
     // the join watchdog/self-heal never tears the group down mid-exchange.
     private var isNativeHandshakeInFlight: (() -> Boolean)? = null
+    // Set by AapService: whether a real AA session is connected - isClientConnected can't tell
+    // that apart from nobody joining (see nativeJoinWatchdog above).
+    private var isNativeSessionConnected: (() -> Boolean)? = null
     // Set by AapService: called right before a native group is torn down, to invalidate any
     // not-yet-captured credentials in NativeAaHandshakeManager.
     private var onNativeGroupInvalidated: (() -> Unit)? = null
@@ -115,6 +126,10 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
 
     fun setNativeHandshakeStateProvider(provider: () -> Boolean) {
         this.isNativeHandshakeInFlight = provider
+    }
+
+    fun setNativeSessionConnectedProvider(provider: () -> Boolean) {
+        this.isNativeSessionConnected = provider
     }
 
     fun setNativeGroupInvalidatedListener(callback: () -> Unit) {
@@ -1032,6 +1047,11 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     private fun recoverNativeGroup(reason: String) {
         cancelNativeJoinWatchdog()
         if (isClientConnected) return
+        if (isNativeSessionConnected?.invoke() == true) {
+            AppLog.i("WifiDirectManager: recoverNativeGroup() called but a session is already connected — not tearing down a working connection.")
+            nativeRecreateCount = 0
+            return
+        }
         if (nativeRecreateCount >= MAX_NATIVE_JOIN_RECREATES) {
             AppLog.w("WifiDirectManager: Native AA — phone still not connected after $nativeRecreateCount recreations ($reason); giving up until the next start.")
             return
@@ -1046,7 +1066,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
      *  client yet. */
     private fun armNativeJoinWatchdog() {
         handler.removeCallbacks(nativeJoinWatchdog)
-        if (isNativeAaMode() && isGroupOwner && !isClientConnected) {
+        if (isNativeAaMode() && isGroupOwner && !isClientConnected && isNativeSessionConnected?.invoke() != true) {
             handler.postDelayed(nativeJoinWatchdog, NATIVE_JOIN_TIMEOUT_MS)
         }
     }

--- a/app/src/main/java/com/andrerinas/openheadunit/main/AutoStartFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/AutoStartFragment.kt
@@ -384,6 +384,7 @@ class AutoStartFragment : Fragment() {
             var disabled = false
             if (settings.autoStartOnBoot) {
                 settings.autoStartOnBoot = false
+                Settings.syncAutoStartOnBootToDeviceStorage(requireContext(), false)
                 pendingAutoStartOnBoot = false
                 disabled = true
             }
@@ -395,6 +396,7 @@ class AutoStartFragment : Fragment() {
             }
             if (settings.autoStartOnUsb) {
                 settings.autoStartOnUsb = false
+                Settings.syncAutoStartOnUsbToDeviceStorage(requireContext(), false)
                 pendingAutoStartOnUsb = false
                 disabled = true
             }

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicyTest.kt
@@ -8,6 +8,7 @@ class NativeHandoffPolicyTest {
 
     private val timeout = NativeHandoffPolicy.SETTLE_TIMEOUT_MS
     private val handshakeTimeout = NativeHandoffPolicy.HANDSHAKE_TIMEOUT_MS
+    private val silentPokeInterval = NativeHandoffPolicy.SILENT_POKE_WARN_INTERVAL
 
     @Test
     fun `no handoff is settling before any credentials go out`() {
@@ -109,6 +110,57 @@ class NativeHandoffPolicyTest {
         assertFalse(
             NativeHandoffPolicy.shouldPoke(
                 settling = false, handshakeInFlight = false, sessionConnected = true
+            )
+        )
+    }
+
+    @Test
+    fun `no warning before the phone has ignored enough pokes`() {
+        assertFalse(
+            NativeHandoffPolicy.shouldWarnPhoneNeverCallsBack(
+                pokesSinceLastAccept = 0, everAccepted = false
+            )
+        )
+        assertFalse(
+            NativeHandoffPolicy.shouldWarnPhoneNeverCallsBack(
+                pokesSinceLastAccept = silentPokeInterval - 1, everAccepted = false
+            )
+        )
+    }
+
+    @Test
+    fun `warns once the phone has answered enough pokes without ever connecting back`() {
+        assertTrue(
+            NativeHandoffPolicy.shouldWarnPhoneNeverCallsBack(
+                pokesSinceLastAccept = silentPokeInterval, everAccepted = false
+            )
+        )
+    }
+
+    @Test
+    fun `the warning repeats so it survives into a log exported much later`() {
+        assertTrue(
+            NativeHandoffPolicy.shouldWarnPhoneNeverCallsBack(
+                pokesSinceLastAccept = silentPokeInterval * 2, everAccepted = false
+            )
+        )
+        assertFalse(
+            NativeHandoffPolicy.shouldWarnPhoneNeverCallsBack(
+                pokesSinceLastAccept = silentPokeInterval * 2 + 1, everAccepted = false
+            )
+        )
+    }
+
+    @Test
+    fun `a unit that has connected before is never warned`() {
+        assertFalse(
+            NativeHandoffPolicy.shouldWarnPhoneNeverCallsBack(
+                pokesSinceLastAccept = silentPokeInterval, everAccepted = true
+            )
+        )
+        assertFalse(
+            NativeHandoffPolicy.shouldWarnPhoneNeverCallsBack(
+                pokesSinceLastAccept = silentPokeInterval * 10, everAccepted = true
             )
         )
     }

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicyTest.kt
@@ -1,0 +1,99 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeHandoffPolicyTest {
+
+    private val timeout = NativeHandoffPolicy.SETTLE_TIMEOUT_MS
+
+    @Test
+    fun `no handoff is settling before any credentials go out`() {
+        assertFalse(NativeHandoffPolicy.isSettling(settlingSinceMs = 0L, nowMs = 10_000L))
+    }
+
+    @Test
+    fun `settles for the whole window after credentials go out`() {
+        assertTrue(NativeHandoffPolicy.isSettling(settlingSinceMs = 1_000L, nowMs = 1_000L))
+        assertTrue(NativeHandoffPolicy.isSettling(settlingSinceMs = 1_000L, nowMs = 1_000L + timeout / 2))
+        assertTrue(NativeHandoffPolicy.isSettling(settlingSinceMs = 1_000L, nowMs = 1_000L + timeout - 1))
+    }
+
+    @Test
+    fun `settling expires so a missed reset cannot latch it true forever`() {
+        assertFalse(NativeHandoffPolicy.isSettling(settlingSinceMs = 1_000L, nowMs = 1_000L + timeout))
+        assertFalse(NativeHandoffPolicy.isSettling(settlingSinceMs = 1_000L, nowMs = 1_000L + timeout * 10))
+    }
+
+    @Test
+    fun `a clock that went backwards does not count as settling`() {
+        assertFalse(NativeHandoffPolicy.isSettling(settlingSinceMs = 10_000L, nowMs = 9_000L))
+    }
+
+    @Test
+    fun `poke runs only when nothing else is using the radio`() {
+        assertTrue(
+            NativeHandoffPolicy.shouldPoke(
+                settling = false, handshakeInFlight = false, sessionConnected = false
+            )
+        )
+    }
+
+    @Test
+    fun `poke is blocked while a handoff is settling`() {
+        // The #760 case: the phone joining the group re-delivers credentials, which re-invokes
+        // triggerPoke() straight into the phone's DHCP exchange.
+        assertFalse(
+            NativeHandoffPolicy.shouldPoke(
+                settling = true, handshakeInFlight = false, sessionConnected = false
+            )
+        )
+    }
+
+    @Test
+    fun `poke is blocked during a handshake and once a session is up`() {
+        assertFalse(
+            NativeHandoffPolicy.shouldPoke(
+                settling = false, handshakeInFlight = true, sessionConnected = false
+            )
+        )
+        assertFalse(
+            NativeHandoffPolicy.shouldPoke(
+                settling = false, handshakeInFlight = false, sessionConnected = true
+            )
+        )
+    }
+
+    @Test
+    fun `discovery restarts when a client leaves a non-native group`() {
+        assertTrue(
+            NativeHandoffPolicy.shouldRestartDiscovery(
+                nativeAaMode = false, hadClient = true, hasClient = false
+            )
+        )
+    }
+
+    @Test
+    fun `discovery never restarts on the native quiet-host path`() {
+        assertFalse(
+            NativeHandoffPolicy.shouldRestartDiscovery(
+                nativeAaMode = true, hadClient = true, hasClient = false
+            )
+        )
+    }
+
+    @Test
+    fun `discovery does not restart unless a client actually left`() {
+        assertFalse(
+            NativeHandoffPolicy.shouldRestartDiscovery(
+                nativeAaMode = false, hadClient = false, hasClient = false
+            )
+        )
+        assertFalse(
+            NativeHandoffPolicy.shouldRestartDiscovery(
+                nativeAaMode = false, hadClient = true, hasClient = true
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicyTest.kt
@@ -9,6 +9,7 @@ class NativeHandoffPolicyTest {
     private val timeout = NativeHandoffPolicy.SETTLE_TIMEOUT_MS
     private val handshakeTimeout = NativeHandoffPolicy.HANDSHAKE_TIMEOUT_MS
     private val silentPokeInterval = NativeHandoffPolicy.SILENT_POKE_WARN_INTERVAL
+    private val maxFailures = NativeHandoffPolicy.MAX_CONSECUTIVE_HANDSHAKE_FAILURES
 
     @Test
     fun `no handoff is settling before any credentials go out`() {
@@ -163,6 +164,25 @@ class NativeHandoffPolicyTest {
                 pokesSinceLastAccept = silentPokeInterval * 10, everAccepted = true
             )
         )
+    }
+
+    @Test
+    fun `handshakes are served until too many have timed out in a row`() {
+        assertTrue(NativeHandoffPolicy.shouldServeHandshake(consecutiveFailures = 0))
+        assertTrue(NativeHandoffPolicy.shouldServeHandshake(consecutiveFailures = maxFailures - 1))
+    }
+
+    @Test
+    fun `handshakes stop being served once the limit is reached`() {
+        assertFalse(NativeHandoffPolicy.shouldServeHandshake(consecutiveFailures = maxFailures))
+        assertFalse(NativeHandoffPolicy.shouldServeHandshake(consecutiveFailures = maxFailures + 100))
+    }
+
+    @Test
+    fun `the handshake limit leaves room for a phone that needs a few attempts`() {
+        // At the phone's ~12 s reconnect cadence this is about a minute of trying, so a transient
+        // failure recovers on its own rather than tripping the backoff.
+        assertTrue(maxFailures >= 3)
     }
 
     @Test

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicyTest.kt
@@ -7,6 +7,7 @@ import org.junit.Test
 class NativeHandoffPolicyTest {
 
     private val timeout = NativeHandoffPolicy.SETTLE_TIMEOUT_MS
+    private val handshakeTimeout = NativeHandoffPolicy.HANDSHAKE_TIMEOUT_MS
 
     @Test
     fun `no handoff is settling before any credentials go out`() {
@@ -29,6 +30,53 @@ class NativeHandoffPolicyTest {
     @Test
     fun `a clock that went backwards does not count as settling`() {
         assertFalse(NativeHandoffPolicy.isSettling(settlingSinceMs = 10_000L, nowMs = 9_000L))
+    }
+
+    @Test
+    fun `no handshake is in flight before one starts`() {
+        assertFalse(NativeHandoffPolicy.isHandshaking(startedAtMs = 0L, nowMs = 10_000L))
+    }
+
+    @Test
+    fun `handshake counts as in flight for the whole exchange window`() {
+        assertTrue(NativeHandoffPolicy.isHandshaking(startedAtMs = 1_000L, nowMs = 1_000L))
+        assertTrue(
+            NativeHandoffPolicy.isHandshaking(
+                startedAtMs = 1_000L, nowMs = 1_000L + handshakeTimeout / 2
+            )
+        )
+        assertTrue(
+            NativeHandoffPolicy.isHandshaking(
+                startedAtMs = 1_000L, nowMs = 1_000L + handshakeTimeout - 1
+            )
+        )
+    }
+
+    @Test
+    fun `handshake expires so a coroutine that never unwinds cannot latch it true`() {
+        // #706: on that head unit closing the socket does not unblock the pending read, so
+        // handleHandshake()'s cleanup never runs. Without this bound the old boolean stayed true
+        // for the life of the process, stopping the wake poke and the P2P join watchdog.
+        assertFalse(
+            NativeHandoffPolicy.isHandshaking(startedAtMs = 1_000L, nowMs = 1_000L + handshakeTimeout)
+        )
+        assertFalse(
+            NativeHandoffPolicy.isHandshaking(
+                startedAtMs = 1_000L, nowMs = 1_000L + handshakeTimeout * 10
+            )
+        )
+    }
+
+    @Test
+    fun `a clock that went backwards does not count as handshaking`() {
+        assertFalse(NativeHandoffPolicy.isHandshaking(startedAtMs = 10_000L, nowMs = 9_000L))
+    }
+
+    @Test
+    fun `the handshake window outlasts the longest legitimate exchange`() {
+        // 60s waiting for P2P credentials plus 15s waiting for the phone's Type 2, so the bound
+        // must not expire under a slow-but-working handshake.
+        assertTrue(NativeHandoffPolicy.isHandshaking(startedAtMs = 1_000L, nowMs = 1_000L + 75_000L))
     }
 
     @Test


### PR DESCRIPTION

## Summary

Two Native-mode (wireless mode 3) fixes that touch the same files, so they ship together.

**#760, phone stuck on "Obtaining IP address".** After sending the phone our WiFi credentials (Type 3) we closed the Bluetooth link on a fixed 3 s timer, and the quiet host kept calling `discoverPeers()` while the phone was still joining. The phone needs longer than 3 s to associate, run WPS and get a DHCP lease (21 s in a known-good 3.1.1 log), and `discoverPeers()` takes the group owner off-channel every 10 s meanwhile. 3.1.1 worked because it never closed the link at all. Bluetooth is now held until the WiFi session reports up, bounded at 45 s, and the group owner stays on-channel on the native path.

**#706, log looks healthy but the phone never connects.** The wait for the phone's Type 2 was bounded by a watchdog that closed the socket to interrupt `readFully()`. That only works where `close()` interrupts a pending read, and the reporter's stack does not, so `handleHandshake()` never unwound: handshake state stayed latched for the life of the process, the wake poke stopped retrying, and the P2P join watchdog deferred recovery forever. The read now runs under `withTimeoutOrNull` and resumes on schedule whether or not it ever returns.

## Changes

| File | What |
|---|---|
| `aap/NativeHandoffPolicy.kt` (new) | Pure policy object with the timing rules both managers need: `isSettling`, `isHandshaking`, `shouldPoke`, `shouldWarnPhoneNeverCallsBack`, `shouldServeHandshake`, `shouldRestartDiscovery`. The two windows are bounded stamps, not booleans, so a coroutine that never unwinds cannot latch them true. |
| `connection/NativeAaHandshakeManager.kt` | Hold Bluetooth until the WiFi session lands instead of 3 s; run the Type 2 read under `withTimeoutOrNull` and unwind on timeout; stop serving handshakes after 5 consecutive timeouts; warn when the phone answers pokes but never opens the AA channel; stop `pokeDevice()` swallowing cancellation and firing a second connect. |
| `connection/WifiDirectManager.kt` | Never restart peer discovery on the native quiet-host path; sync auto-start-on-boot/USB to device-protected storage when disabled. |
| `aap/AapService.kt` | Stop our own HFP poke self-triggering a Bluetooth auto-start re-arm; stop the native join watchdog tearing down live sessions. |
| `main/AutoStartFragment.kt` | Settings write path for the auto-start sync. |
| `test/.../NativeHandoffPolicyTest.kt` (new) | 22 JVM unit tests covering every rule in the policy object. |

## Worth a closer look

`shouldServeHandshake` is the only hard stop here. The Type 2 wait is a blocking read with no suspension point, so where `close()` does not interrupt it the coroutine's `Dispatchers.IO` thread is stranded for the life of the process. That pool caps at 64 and the reporter's phone reconnects every ~12.8 s, so unbounded retrying exhausts it in about 15 minutes. Only timeouts increment the counter; a reader that returns clears it, and so do `stop()` and a manual poke, so the UI's "try again" is always a way back.

## Verification

CI green on the branch head: **Build (github debug)** and **Unit tests (github debug)** both pass.

Confirmed on-device by the #760 reporter, on the hardware that showed the fault:

- 5/5 successful connections with the #760 fixes: https://github.com/andreknieriem/open-headunit/issues/760#issuecomment-5182718700
- 8/8 with the #706 commits added, 5 started from the app and 3 by connecting Bluetooth manually from the phone: https://github.com/andreknieriem/open-headunit/issues/760#issuecomment-5186305558

## Out of scope

This does not fix #706's root cause. On that head unit the RFCOMM write never reaches the air (an HCI trace shows 15 complete sessions and not one data frame), and nothing in this app can make the OEM Bluetooth module answer. These commits bound what the failure costs and name the likely cause in the log.

A failed handoff now takes up to 45 s to fall back to a poke retry instead of 3 s. That is the intended trade: the 3 s timer is what broke #760.

APK: https://github.com/o-jcardenass/open-headunit/releases/download/v.3.2.0-fixes/OHU3.2.0_debug.apk
