### PR TITLE
Fix the setup wizard breaking the display, and make DPI and resolution consistent

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
@@ -15,6 +15,7 @@ import android.view.TextureView
 import android.view.View
 import android.widget.Button
 import android.widget.FrameLayout
+import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
@@ -137,7 +138,9 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
             }
             val lastFrame = videoDecoder.lastFrameRenderedMs
             if (lastFrame == 0L) {
-                // First frame hasn't arrived yet — handled by the starting overlay
+                // First frame hasn't arrived yet — handled by the starting overlay. If the phone is
+                // streaming video but nothing draws, offer to switch renderer (issue #767).
+                maybeOfferRendererConfirm()
                 watchdogHandler.postDelayed(this, 2000)
                 return
             }
@@ -279,6 +282,18 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
     // user's chosen viewMode is restored on the next launch.
     private var forcedViewModeOverride: Settings.ViewMode? = null
 
+    // Renderer confirmation banner (issue #767): lets the user escape a wrong/broken renderer that
+    // leaves a black screen while audio keeps working. A broken SurfaceView cannot be detected
+    // automatically (it reports no drawn frames), so we ask the user directly.
+    private var rendererBanner: View? = null
+    private var rendererConfirmResolved = false
+    private var projectionStartMs = 0L
+    private val rendererConfirmNoFrameMs = 6000L
+    // "Phone still streaming" window for the offer. Kept comfortably above the 2s watchdog interval
+    // so a burst of keyframes (~every 2s on the AA logo) doesn't fall outside the window and hide
+    // the offer for a genuinely connected phone.
+    private val rendererConfirmPhoneAliveMs = 4000L
+
     private fun maybeRecoverFromDisplayStall() {
         if (!::projectionView.isInitialized) return
         if (overlayState != OverlayState.HIDDEN) return
@@ -335,6 +350,9 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
             AppLog.w("Display stall ($reason) again on $effectiveMode. Falling back to SurfaceView for this session. See issue #650.")
             forcedViewModeOverride = Settings.ViewMode.SURFACE
             Toast.makeText(this, R.string.renderer_fallback_surface, Toast.LENGTH_LONG).show()
+            // SurfaceView can't be observed for stalls (issue #767); if it too shows black, offer the
+            // manual escape so the user isn't stranded on the terminal fallback.
+            showRendererConfirmBanner()
         } else {
             AppLog.w("Display stall ($reason). Rebuilding projection view (attempt $displayStallRecoveries). See issue #650.")
         }
@@ -343,6 +361,99 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         prevLongFrameCount = 0L
         longFrameTickWindow.fill(0L)
         recreateProjectionView()
+    }
+
+    /** Offer the renderer confirmation when the phone is actively streaming video but nothing has
+     * been drawn for a while (the broken-renderer case that cannot be detected automatically). */
+    private fun maybeOfferRendererConfirm() {
+        if (rendererConfirmResolved || rendererBanner != null) return
+        if (videoDecoder.lastFrameRenderedMs > 0L) return
+        val input = videoDecoder.lastInputBytesReceivedMs
+        if (input <= 0L) return
+        val now = SystemClock.elapsedRealtime()
+        if (now - input > rendererConfirmPhoneAliveMs) return
+        if (projectionStartMs == 0L || now - projectionStartMs < rendererConfirmNoFrameMs) return
+        showRendererConfirmBanner()
+    }
+
+    /** A dismissible bottom bar: "Do you see the screen?" with Yes / Switch renderer. */
+    private fun showRendererConfirmBanner() {
+        runOnUiThread {
+            if (rendererBanner != null || rendererConfirmResolved) return@runOnUiThread
+            val container = findViewById<FrameLayout>(R.id.container) ?: return@runOnUiThread
+            fun dp(v: Int) = (v * resources.displayMetrics.density).toInt()
+            val bar = LinearLayout(this).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+                setBackgroundColor(0xE6000000.toInt())
+                setPadding(dp(16), dp(10), dp(16), dp(10))
+            }
+            val label = TextView(this).apply {
+                text = getString(R.string.renderer_confirm_question)
+                setTextColor(Color.WHITE)
+                layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+            }
+            val yes = Button(this).apply {
+                text = getString(R.string.renderer_confirm_yes)
+                setOnClickListener {
+                    settings.pendingRendererConfirm = false
+                    rendererConfirmResolved = true
+                    dismissRendererConfirmBanner()
+                }
+            }
+            val switch = Button(this).apply {
+                text = getString(R.string.renderer_confirm_switch)
+                setOnClickListener { cycleRenderer() }
+            }
+            bar.addView(label)
+            bar.addView(yes)
+            bar.addView(switch)
+            bar.layoutParams = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                Gravity.BOTTOM
+            )
+            container.addView(bar)
+            rendererBanner = bar
+            bar.bringToFront()
+            // One-shot: offering the escape once is enough. Clearing the flag here (not only on
+            // "Yes") stops the banner from re-appearing on every future session if the user drives
+            // off without tapping. A genuinely broken renderer still re-offers via the no-frame path.
+            settings.pendingRendererConfirm = false
+        }
+    }
+
+    private fun dismissRendererConfirmBanner() {
+        runOnUiThread {
+            rendererBanner?.let { (it.parent as? FrameLayout)?.removeView(it) }
+            rendererBanner = null
+        }
+    }
+
+    /** Rotate the rendering backend live (TextureView -> SurfaceView -> GLES) and rebuild, so the
+     * user can find one that draws. Clears any stall-recovery override so the manual choice wins. */
+    private fun cycleRenderer() {
+        val order = listOf(Settings.ViewMode.TEXTURE, Settings.ViewMode.SURFACE, Settings.ViewMode.GLES)
+        val current = forcedViewModeOverride ?: settings.viewMode
+        val next = order[(order.indexOf(current).coerceAtLeast(0) + 1) % order.size]
+        forcedViewModeOverride = null
+        settings.viewMode = next
+        settings.commit()
+        // Reset stall recovery so the #650 watchdog does not immediately re-escalate the new backend.
+        displayStallRecoveries = 0
+        lastDisplayStallRecoveryMs = 0L
+        val label = when (next) {
+            Settings.ViewMode.SURFACE -> "SurfaceView"
+            Settings.ViewMode.TEXTURE -> "TextureView"
+            Settings.ViewMode.GLES -> "GLES20"
+        }
+        Toast.makeText(this, getString(R.string.renderer_switched_to, label), Toast.LENGTH_SHORT).show()
+        // Drop the current bar and rebuild on the new backend, then re-offer so the user can keep
+        // cycling if this one is also blank (the new backend may decode frames yet still show black,
+        // which nothing can detect automatically).
+        dismissRendererConfirmBanner()
+        recreateProjectionView()
+        showRendererConfirmBanner()
     }
 
     private val nightModeReceiver = object : BroadcastReceiver() {
@@ -422,6 +533,9 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
                     when (state) {
                         is CommManager.ConnectionState.Disconnected -> {
                             watchdogHandler.removeCallbacksAndMessages(null)
+                            // Don't leave the renderer bar floating over the reconnecting/exit UI;
+                            // if the renderer is still broken after a reconnect it re-offers itself.
+                            dismissRendererConfirmBanner()
                             if (!state.isClean && !state.isUserExit) {
                                 AppLog.w("AapProjectionActivity: Disconnected unexpectedly.")
                                 Toast.makeText(this@AapProjectionActivity, getString(R.string.wifi_disconnect_toast), Toast.LENGTH_LONG).show()
@@ -528,6 +642,12 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         videoDecoder.onFirstFrameListener = {
             runOnUiThread {
                 hideLoadingOverlay(loadingOverlay)
+
+                // The wizard changed the renderer: the picture is up, so ask the user to confirm it
+                // (issue #767). If they don't, the auto-offer above still catches a broken renderer.
+                if (settings.pendingRendererConfirm && !rendererConfirmResolved) {
+                    showRendererConfirmBanner()
+                }
 
                 // Show one-time gesture hint
                 if (!settings.gestureHintShown) {
@@ -1460,6 +1580,8 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         }
 
         projectionView.addCallback(this)
+        // Baseline for the "no frame drawn while streaming" renderer check (issue #767).
+        projectionStartMs = SystemClock.elapsedRealtime()
     }
 
     private fun setupFpsCounter() {

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -58,8 +58,14 @@ class VideoDecoder(private val settings: Settings) {
          * Checks if ANY H.265 (HEVC) hardware decoding is present, regardless of reliability.
          * Used for MANUAL codec selection (User override).
          */
+        // Hardware HEVC support is fixed for a device, but the check scans the whole MediaCodecList,
+        // so cache it: this is called on UI-thread paths (resolution/DPI recommendation).
+        @Volatile
+        private var cachedHwHevcSupported: Boolean? = null
+
         fun isHevcSupported(): Boolean {
-            return isHevcDecoderAvailable(includeSoftware = false)
+            cachedHwHevcSupported?.let { return it }
+            return isHevcDecoderAvailable(includeSoftware = false).also { cachedHwHevcSupported = it }
         }
 
         /**

--- a/app/src/main/java/com/andrerinas/openheadunit/main/DpiSettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/DpiSettingsFragment.kt
@@ -16,6 +16,8 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.R
+import com.andrerinas.openheadunit.utils.Settings
+import com.andrerinas.openheadunit.utils.SystemOptimizer
 import com.andrerinas.openheadunit.view.DpiPickerView
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.button.MaterialButton
@@ -35,6 +37,7 @@ class DpiSettingsFragment : Fragment() {
     private lateinit var picker: DpiPickerView
     private lateinit var autoSwitch: SwitchMaterial
     private lateinit var autoDesc: TextView
+    private lateinit var overPanelWarning: TextView
     private var saveButton: MaterialButton? = null
 
     private var initialValue = 0
@@ -50,12 +53,17 @@ class DpiSettingsFragment : Fragment() {
         picker = view.findViewById(R.id.dpi_picker)
         autoSwitch = view.findViewById(R.id.dpi_auto_switch)
         autoDesc = view.findViewById(R.id.dpi_auto_desc)
+        overPanelWarning = view.findViewById(R.id.dpi_over_panel_warning)
 
         setupToolbar()
 
         // Show which DPI "Automatic" actually uses (the device's own density).
         val detected = detectedDensityDpi()
         autoDesc.text = getString(R.string.dpi_automatic_desc_format, detected)
+
+        // If the chosen resolution exceeds the panel, the DPI is computed for the capped resolution
+        // the device will actually project, so flag it (issue #767).
+        updateOverPanelWarning()
 
         initialValue = settings.dpiPixelDensity
         val auto = initialValue == 0
@@ -134,6 +142,11 @@ class DpiSettingsFragment : Fragment() {
     }
 
     private fun detectedDensityDpi(): Int {
+        val m = realMetrics()
+        return if (m.densityDpi > 0) m.densityDpi else 160
+    }
+
+    private fun realMetrics(): DisplayMetrics {
         val m = DisplayMetrics()
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -144,7 +157,24 @@ class DpiSettingsFragment : Fragment() {
             }
         } catch (_: Exception) {
         }
-        return if (m.densityDpi > 0) m.densityDpi else 160
+        return m
+    }
+
+    /** Warn (in red) when the chosen resolution is higher than the panel: the DPI is then computed
+     * for the capped resolution the device actually projects, not the one the user picked. */
+    private fun updateOverPanelWarning() {
+        val m = realMetrics()
+        val ceiling = SystemOptimizer.recommendedResolution(m.widthPixels, m.heightPixels)
+        val chosen = Settings.Resolution.fromId(settings.resolutionId)
+        val over = m.widthPixels > 0 && chosen != null && chosen != Settings.Resolution.AUTO &&
+            (chosen.width > ceiling.width || chosen.height > ceiling.height)
+        if (over) {
+            overPanelWarning.text =
+                getString(R.string.dpi_resolution_over_panel_warning, chosen!!.resName, ceiling.resName)
+            overPanelWarning.visibility = View.VISIBLE
+        } else {
+            overPanelWarning.visibility = View.GONE
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/andrerinas/openheadunit/main/OnboardingActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/OnboardingActivity.kt
@@ -273,6 +273,7 @@ class OnboardingActivity : BaseActivity() {
             setPanelResolution(m.widthPixels, m.heightPixels)
             dpi = settings.dpiPixelDensity.takeIf { it != 0 } ?: recommendedDpi()
         }
+        updateDpiOverPanelWarning()
 
         // --- Appearance: full theme + night-mode pickers; more options live in Settings ---
         updateThemeButtonText()
@@ -602,18 +603,55 @@ class OnboardingActivity : BaseActivity() {
     private fun recommendedDpi(): Int =
         SystemOptimizer(this).calculateOptimalSettings(selectedSize, selectedPortrait).recommendedDpi
 
+    /** Warn (in red) when the current resolution is higher than the panel: the DPI is computed for
+     * the capped resolution the device actually projects (issue #767). Relevant mainly for
+     * upgraders who forced a resolution above their panel; fresh installs get a fitted value. */
+    private fun updateDpiOverPanelWarning() {
+        val warn = findViewById<TextView>(R.id.onb_dpi_over_panel_warning) ?: return
+        val m = realMetrics()
+        val ceiling = SystemOptimizer.recommendedResolution(m.widthPixels, m.heightPixels)
+        val chosen = Settings.Resolution.fromId(settings.resolutionId)
+        val over = m.widthPixels > 0 && chosen != null && chosen != Settings.Resolution.AUTO &&
+            (chosen.width > ceiling.width || chosen.height > ceiling.height)
+        if (over) {
+            warn.text = getString(R.string.dpi_resolution_over_panel_warning, chosen!!.resName, ceiling.resName)
+            warn.visibility = View.VISIBLE
+        } else {
+            warn.visibility = View.GONE
+        }
+    }
+
+    /**
+     * True for users who already ran the app before this wizard version (finished the old wizard,
+     * or an earlier onboarding). Their display settings are a working config we must not overwrite.
+     */
+    private fun isUpgrader(): Boolean =
+        settings.hasCompletedSetupWizard ||
+            settings.onboardingVersion in 1 until CURRENT_ONBOARDING_VERSION
+
     /** Writes the recommended display settings plus the DPI chosen in the picker. Called when
      * leaving the Display and Android Auto size steps, so no separate Apply tap is needed. */
     private fun applyDisplaySettings() {
         val result = SystemOptimizer(this).calculateOptimalSettings(selectedSize, selectedPortrait)
-        // Cap the applied resolution to what the physical panel supports (no upscaling waste).
         val panel = realMetrics()
-        settings.resolutionId = SystemOptimizer.recommendedResolution(panel.widthPixels, panel.heightPixels).id
-        settings.videoCodec = result.recommendedVideoCodec
-        settings.viewMode = result.recommendedViewMode
+        // Only auto-apply the video setup on a genuinely fresh install. Upgraders already have a
+        // working config (view mode, codec, resolution, orientation), and silently overwriting it
+        // has stranded users on a black screen (issue #767), so we leave those untouched and only
+        // apply the DPI the user set in the picker.
+        if (!isUpgrader()) {
+            val previousViewMode = settings.viewMode
+            // Set the resolution the panel warrants (the shared panel ceiling; mild downscaling of a
+            // slightly-larger standard resolution is allowed, heavy downscaling is not — see panelCeiling).
+            settings.resolutionId = SystemOptimizer.recommendedResolution(panel.widthPixels, panel.heightPixels).id
+            settings.videoCodec = result.recommendedVideoCodec
+            settings.viewMode = result.recommendedViewMode
+            settings.screenOrientation = result.suggestedOrientation
+            // If we changed the renderer, confirm the picture on the first projection.
+            if (settings.viewMode != previousViewMode) settings.pendingRendererConfirm = true
+        }
         settings.dpiPixelDensity = dpiPicker?.dpi ?: result.recommendedDpi
-        settings.screenOrientation = result.suggestedOrientation
         settings.commit()
+        updateDpiOverPanelWarning()
     }
 
     // --- Appearance (reuse the same option arrays as the settings screen) ---

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -1893,11 +1893,14 @@ class SettingsFragment : Fragment() {
             .setSingleChoiceItems(labels, pendingResolution ?: 0) { dialog, which ->
                 dialog.dismiss()
                 val picked = Settings.Resolution.fromId(which)
-                val longSide = maxOf(pw, ph)
+                val panelKnown = pw > 0 && ph > 0
                 when {
-                    picked == null -> {}
-                    picked.width > 0 && longSide > 0 && picked.width > longSide ->
-                        showResolutionTooHighDialog(which, recommended.id, longSide, minOf(pw, ph))
+                    picked == null || picked == Settings.Resolution.AUTO -> applyResolution(which)
+                    // "Higher than the panel" now means the same thing everywhere: it exceeds the
+                    // shared panel ceiling (recommended), which is also what the runtime cap and the
+                    // DPI use (issue #767).
+                    panelKnown && (picked.width > recommended.width || picked.height > recommended.height) ->
+                        showResolutionTooHighDialog(which, recommended.id, recommended.resName)
                     picked.width >= HIGH_BANDWIDTH_WIDTH ->
                         showResolutionBandwidthDialog(which, recommended.id)
                     else -> applyResolution(which)
@@ -1906,10 +1909,10 @@ class SettingsFragment : Fragment() {
             .show()
     }
 
-    private fun showResolutionTooHighDialog(pickedId: Int, recommendedId: Int, panelLong: Int, panelShort: Int) {
+    private fun showResolutionTooHighDialog(pickedId: Int, recommendedId: Int, recommendedName: String) {
         MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
             .setTitle(R.string.resolution_too_high_title)
-            .setMessage(getString(R.string.resolution_too_high_message, panelLong, panelShort))
+            .setMessage(getString(R.string.resolution_too_high_message, recommendedName))
             .setPositiveButton(R.string.resolution_use_recommended) { _, _ -> applyResolution(recommendedId) }
             .setNegativeButton(R.string.resolution_use_anyway) { _, _ -> applyResolution(pickedId) }
             .show()

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/HeadUnitScreenConfig.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/HeadUnitScreenConfig.kt
@@ -187,29 +187,37 @@ object HeadUnitScreenConfig {
 
     // Native standard resolution for a given panel size, mirroring the AUTO selection so the
     // resolution cap never advertises more than the panel warrants (issue #650).
+    /** Map a resolution class to the proto type for the current orientation (shared by the manual
+     * selection path and the panel cap, so both agree). */
+    private fun protoForResolution(
+        res: Settings.Resolution,
+        portrait: Boolean
+    ): Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType {
+        val landscape = res.codec
+            ?: Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._800x480
+        if (!portrait) return landscape
+        return when (res) {
+            Settings.Resolution._800x480 -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._720x1280
+            Settings.Resolution._1280x720 -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._720x1280
+            Settings.Resolution._1920x1080 -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._1080x1920
+            Settings.Resolution._2560x1440 -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._1440x2560
+            Settings.Resolution._3840x2160 -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._2160x3840
+            else -> landscape
+        }
+    }
+
+    /**
+     * The proto resolution the physical panel warrants, in the display's orientation. Delegates to
+     * SystemOptimizer.panelCeiling (the shared source of truth) so the runtime cap agrees with the
+     * settings "too high" warning and the DPI calculation (issue #767).
+     */
     private fun autoResolutionForPanel(
         w: Int,
         h: Int,
         portrait: Boolean,
         canHevc: Boolean
     ): Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType {
-        return if (portrait) {
-            if (w > 720 || h > 1280) {
-                Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._1080x1920
-            } else {
-                Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._720x1280
-            }
-        } else {
-            when {
-                w <= 800 && h <= 480 -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._800x480
-                (w >= 3840 || h >= 2160) && VideoDecoder.isHevcSupported() && Build.VERSION.SDK_INT >= 24 ->
-                    Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._3840x2160
-                (w >= 2560 || h >= 1440) && canHevc && Build.VERSION.SDK_INT >= 24 ->
-                    Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._2560x1440
-                w > 1280 || h > 720 -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._1920x1080
-                else -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._1280x720
-            }
-        }
+        return protoForResolution(SystemOptimizer.panelCeiling(w, h, canHevc), portrait)
     }
 
     private fun pixelsOf(type: Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType): Long {
@@ -268,20 +276,10 @@ object HeadUnitScreenConfig {
                 }
             }
         } else {
-            // Manual selection: Map to correct orientation
-            val codec = selectedResolution?.codec ?: Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._800x480
-            negotiatedResolutionType = if (isPortraitDisplay) {
-                when (selectedResolution) {
-                    Settings.Resolution._800x480 -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._720x1280
-                    Settings.Resolution._1280x720 -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._720x1280
-                    Settings.Resolution._1920x1080 -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._1080x1920
-                    Settings.Resolution._2560x1440 -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._1440x2560
-                    Settings.Resolution._3840x2160 -> Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._2160x3840
-                    else -> codec
-                }
-            } else {
-                codec
-            }
+            // Manual selection: map to the correct orientation via the shared helper.
+            negotiatedResolutionType = protoForResolution(
+                selectedResolution ?: Settings.Resolution._800x480, isPortraitDisplay
+            )
         }
 
         // Cap the negotiated resolution to what the physical panel warrants, so we never ask the

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -392,6 +392,13 @@ class Settings(private val context: Context) {
         }
         set(value) { prefs.edit().putInt("onboarding-version", value).apply() }
 
+    // One-shot: the wizard changed the rendering backend, so on the next projection we ask the user
+    // to confirm the picture is visible (a wrong renderer can leave a black screen while audio still
+    // works, and a broken SurfaceView cannot be detected automatically). See issue #767.
+    var pendingRendererConfirm: Boolean
+        get() = prefs.getBoolean("pending-renderer-confirm", false)
+        set(value) { prefs.edit().putBoolean("pending-renderer-confirm", value).apply() }
+
     // How the user primarily connects. Drives which options are surfaced in the Basic tab
     // (e.g. cable users do not see the Wireless Connection group there). UNSET shows everything.
     var primaryConnection: ConnectionKind

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SystemOptimizer.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SystemOptimizer.kt
@@ -49,24 +49,23 @@ class SystemOptimizer(private val context: Context) {
 
         val width = metrics.widthPixels.toFloat()
         val height = metrics.heightPixels.toFloat()
-        val densityDpi = metrics.densityDpi
-        val pixelDiagonal = sqrt(width * width + height * height)
         val aspectRatio = if (width > height) width / height else height / width
-        
-        val hasH265 = checkH265HardwareSupport()
-        
-        // 1. Resolution Recommendation
-        val recResId = when {
-            width >= 2560 && hasH265 -> 4
-            // Only recommend 1080p for genuinely >=1920-wide panels. The old rule also fired on
-            // densityDpi >= 320, which mis-set 1080p on small high-DPI head units and made them
-            // downscale every frame (issue #650). Small panels now default to 720p.
-            width >= 1920 -> 3
-            else -> 2
-        }
 
-        // 2. DPI Strategy
-        val calculatedDpi = (pixelDiagonal / sizePreset.diagonalInch) * 1.2f
+        val hasH265 = checkH265HardwareSupport()
+
+        // 1. Resolution: the single "panel ceiling" source of truth (see panelCeiling), so the
+        // recommended resolution, the runtime cap and the DPI below all agree.
+        val panelCeil = panelCeiling(metrics.widthPixels, metrics.heightPixels, hasH265)
+
+        // 2. DPI Strategy. Derive the density from the resolution Android Auto will actually draw
+        // (the panel-capped resolution), not the raw panel pixels: when we downscale a small
+        // high-DPI panel, the surface AA renders is smaller, so using the panel pixels over-reports
+        // the density (issue #767). Diagonal of the effective surface / physical inches, nudged up
+        // a little for the car viewing distance.
+        val effectiveDiagonalPx = sqrt(
+            (panelCeil.width * panelCeil.width + panelCeil.height * panelCeil.height).toFloat()
+        )
+        val calculatedDpi = (effectiveDiagonalPx / sizePreset.diagonalInch) * LEGIBILITY_FACTOR
         var recDpi = calculatedDpi.toInt()
 
         // 3. View Mode Recommendation
@@ -75,14 +74,16 @@ class SystemOptimizer(private val context: Context) {
             // so we recommend TextureView instead.
             Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP -> Settings.ViewMode.TEXTURE
 
-            // 5.0 - 8.1 used to get GLES here, but sampling the hardware decoder's external
-            // texture in-app via GLES forces a per-frame color conversion on some SoCs (notably
-            // MediaTek's MDP), which collapses playback to a few fps (issue #650). When the
-            // device can decode video in hardware, a direct SurfaceView avoids that path. GLES
-            // is only kept for devices without hardware HEVC, which may fall back to the software
-            // YUV sink that GLES provides.
+            // 5.0 - 8.1: start on the safe, observable TextureView rather than forcing SurfaceView
+            // up front. SurfaceView renders directly but is a blind spot for the display-stall
+            // watchdog (it reports no drawn frames), so if it happens to be broken on a device the
+            // user is stranded with no automatic recovery (issue #767). TextureView failures ARE
+            // observable, so on the MediaTek MDP devices where the external-texture path collapses
+            // to a few fps (issue #650) the watchdog detects the stall and escalates to SurfaceView
+            // on its own. GLES is only kept for devices without hardware HEVC, which may fall back
+            // to the software YUV sink that GLES provides.
             Build.VERSION.SDK_INT <= Build.VERSION_CODES.O_MR1 ->
-                if (hasH265) Settings.ViewMode.SURFACE else Settings.ViewMode.GLES
+                if (hasH265) Settings.ViewMode.TEXTURE else Settings.ViewMode.GLES
 
             // Modern devices are usually fine with the default TextureView
             else -> Settings.ViewMode.TEXTURE
@@ -99,7 +100,7 @@ class SystemOptimizer(private val context: Context) {
         recDpi = recDpi.coerceAtLeast(110)
 
         return OptimizationResult(
-            recommendedResolutionId = recResId,
+            recommendedResolutionId = panelCeil.id,
             recommendedDpi = recDpi,
             recommendedVideoCodec = if (hasH265) "H.265" else "H.264",
             recommendedViewMode = recViewMode,
@@ -111,17 +112,42 @@ class SystemOptimizer(private val context: Context) {
 
     companion object {
         /**
-         * The largest standard video resolution that physically fits the panel (no upscaling
-         * waste). Compared in landscape terms (long side x short side). Falls back to 480p.
+         * Small upward nudge on the computed density so the Android Auto UI reads well at the car
+         * viewing distance (the panel is farther from the eyes than a phone). Kept modest so the
+         * result stays near the ~150-170 dpi range that works well on head units instead of the
+         * larger, more cramped UI a raw physical-DPI value would give.
          */
-        fun recommendedResolution(realWidthPx: Int, realHeightPx: Int): Settings.Resolution {
+        private const val LEGIBILITY_FACTOR = 1.1f
+
+        /**
+         * The single source of truth for the largest resolution a physical panel warrants, shared
+         * by the recommended resolution, the runtime resolution cap (HeadUnitScreenConfig) and the
+         * DPI calculation, so all three always agree (issue #767). Bucketed by the panel's real
+         * pixels, in landscape terms (long side x short side); 1440p/4K are gated behind hardware
+         * HEVC on a recent enough Android, matching what the phone will actually stream. Mild
+         * downscaling (e.g. 1080p onto a 1024x600 panel) is allowed on purpose; only genuinely
+         * small panels are dropped to 720p/480p, which avoids the heavy per-frame downscale that
+         * overloads the MediaTek MDP scaler (issue #650).
+         */
+        fun panelCeiling(realWidthPx: Int, realHeightPx: Int, canHevc: Boolean): Settings.Resolution {
             val longSide = maxOf(realWidthPx, realHeightPx)
             val shortSide = minOf(realWidthPx, realHeightPx)
-            if (longSide <= 0) return Settings.Resolution._1280x720
-            return Settings.Resolution.allResolutions
-                .filter { it.width in 1..longSide && it.height in 1..shortSide }
-                .maxByOrNull { it.width }
-                ?: Settings.Resolution._800x480
+            val hevcHiRes = canHevc && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+            return when {
+                longSide <= 0 -> Settings.Resolution._1280x720
+                longSide <= 800 && shortSide <= 480 -> Settings.Resolution._800x480
+                (longSide >= 3840 || shortSide >= 2160) && hevcHiRes -> Settings.Resolution._3840x2160
+                (longSide >= 2560 || shortSide >= 1440) && hevcHiRes -> Settings.Resolution._2560x1440
+                longSide > 1280 || shortSide > 720 -> Settings.Resolution._1920x1080
+                else -> Settings.Resolution._1280x720
+            }
         }
+
+        /**
+         * The resolution the panel warrants. Thin wrapper over [panelCeiling] (the shared source of
+         * truth) so the recommended label, the wizard and the runtime cap never diverge.
+         */
+        fun recommendedResolution(realWidthPx: Int, realHeightPx: Int): Settings.Resolution =
+            panelCeiling(realWidthPx, realHeightPx, com.andrerinas.openheadunit.decoder.VideoDecoder.isHevcSupported())
     }
 }

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -297,6 +297,14 @@
                     android:layout_marginTop="8dp"
                     android:textAppearance="?attr/textAppearanceCaption" />
                 <TextView
+                    android:id="@+id/onb_dpi_over_panel_warning"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:textColor="?attr/colorError"
+                    android:textAppearance="?attr/textAppearanceCaption"
+                    android:visibility="gone" />
+                <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="12dp"

--- a/app/src/main/res/layout/fragment_dpi_settings.xml
+++ b/app/src/main/res/layout/fragment_dpi_settings.xml
@@ -69,6 +69,15 @@
                 android:layout_marginTop="16dp" />
 
             <TextView
+                android:id="@+id/dpi_over_panel_warning"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:textColor="?attr/colorError"
+                android:textAppearance="?attr/textAppearanceCaption"
+                android:visibility="gone" />
+
+            <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -594,6 +594,11 @@
 
     <string name="btn_show_qr">عرض رمز QR</string>
     <string name="renderer_fallback_surface">ظل الفيديو يتجمد، لذا تم تبديل العرض إلى SurfaceView لهذه الجلسة. إذا كان مستقرًا، فاضبط وضع العرض على SurfaceView في الإعدادات.</string>
+    <string name="dpi_resolution_over_panel_warning">الدقة التي اخترتها (%1$s) أعلى من شاشتك. لذا تم تحديدها إلى %2$s، ويُحسب DPI على هذا الأساس. إذا بدا العرض غير سليم، فاستخدم الدقة الموصى بها (%2$s).</string>
+    <string name="renderer_confirm_question">هل ترى شاشة Android Auto؟</string>
+    <string name="renderer_confirm_yes">نعم</string>
+    <string name="renderer_confirm_switch">تبديل العارض</string>
+    <string name="renderer_switched_to">العارض: %1$s</string>
 
     <string name="self_mode_overlay_permission_description">للسماح للوضع الذاتي بالبدء بشكل موثوق في الخلفية، يرجى تفعيل إذن \"الظهور فوق التطبيقات الأخرى\" في الشاشة التالية.</string>
 
@@ -721,7 +726,7 @@
     <string name="resolution_recommended_format">%1$s (موصى به)</string>
     <string name="resolution_high_bandwidth_format">%1$s · نطاق ترددي عالٍ</string>
     <string name="resolution_too_high_title">الدقة أعلى من الشاشة</string>
-    <string name="resolution_too_high_message">شاشتك %1$d x %2$d بكسل. الدقة الأعلى تستهلك نطاقًا تردديًا أكبر دون تحسين الجودة، لأن الشاشة لا يمكنها عرضها.</string>
+    <string name="resolution_too_high_message">هذه أعلى مما تدعمه شاشتك. تقتصر الصورة على ما يمكن لشاشتك عرضه (%1$s)، لذا فإن الدقة الأعلى تستهلك نطاقًا تردديًا أكبر فقط دون تحسين الجودة.</string>
     <string name="resolution_high_bandwidth_title">يلزم نطاق ترددي أعلى</string>
     <string name="resolution_high_bandwidth_message">تستهلك هذه الدقة نطاقًا تردديًا أكبر بكثير وتحتاج اتصالًا قويًا: شبكة WiFi جيدة بتردد 5GHz أو اتصال USB مستقر. إذا لاحظت تقطعًا، فاختر دقة أقل.</string>
     <string name="resolution_use_anyway">استخدام على أي حال</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -594,6 +594,11 @@
 
     <string name="btn_show_qr">Zobrazit QR kód</string>
     <string name="renderer_fallback_surface">Video se pořád zasekávalo, proto bylo zobrazení pro tuto relaci přepnuto na SurfaceView. Pokud je to stabilní, nastavte Režim zobrazení na SurfaceView v Nastavení.</string>
+    <string name="dpi_resolution_over_panel_warning">Vámi zvolené rozlišení (%1$s) je vyšší než váš panel. Je omezeno na %2$s a DPI se počítá pro tuto hodnotu. Pokud to vypadá špatně, použijte doporučené rozlišení (%2$s).</string>
+    <string name="renderer_confirm_question">Vidíte obrazovku Android Auto?</string>
+    <string name="renderer_confirm_yes">Ano</string>
+    <string name="renderer_confirm_switch">Přepnout vykreslování</string>
+    <string name="renderer_switched_to">Vykreslování: %1$s</string>
 
     <string name="self_mode_overlay_permission_description">Chcete-li umožnit spolehlivé spuštění vlastního režimu na pozadí, povolte v další obrazovce oprávnění „Zobrazit nad ostatními aplikacemi“.</string>
 
@@ -719,7 +724,7 @@
     <string name="resolution_recommended_format">%1$s (Doporučeno)</string>
     <string name="resolution_high_bandwidth_format">%1$s · vysoký datový tok</string>
     <string name="resolution_too_high_title">Rozlišení vyšší než obrazovka</string>
-    <string name="resolution_too_high_message">Obrazovka má %1$d x %2$d pixelů. Vyšší rozlišení spotřebuje více dat bez zlepšení kvality, protože panel je nedokáže zobrazit.</string>
+    <string name="resolution_too_high_message">Toto je vyšší, než váš panel podporuje. Obraz je omezen na to, co váš panel dokáže zobrazit (%1$s), takže vyšší rozlišení jen spotřebuje více dat bez zlepšení kvality.</string>
     <string name="resolution_high_bandwidth_title">Potřeba vyšší datový tok</string>
     <string name="resolution_high_bandwidth_message">Toto rozlišení spotřebuje mnohem více dat a vyžaduje silné připojení: kvalitní WiFi 5GHz nebo stabilní USB. Pokud zaznamenáte lagy, zvolte nižší rozlišení.</string>
     <string name="resolution_use_anyway">Přesto použít</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -602,6 +602,11 @@
 
     <string name="btn_show_qr">QR-Code anzeigen</string>
     <string name="renderer_fallback_surface">Das Video ist immer wieder eingefroren, daher wurde die Anzeige für diese Sitzung auf SurfaceView umgestellt. Wenn es stabil läuft, stelle den View-Modus in den Einstellungen auf SurfaceView.</string>
+    <string name="dpi_resolution_over_panel_warning">Die gewählte Auflösung (%1$s) ist höher als dein Panel. Sie wird auf %2$s begrenzt, und die DPI wird dafür berechnet. Wenn es falsch aussieht, verwende die empfohlene Auflösung (%2$s).</string>
+    <string name="renderer_confirm_question">Siehst du den Android-Auto-Bildschirm?</string>
+    <string name="renderer_confirm_yes">Ja</string>
+    <string name="renderer_confirm_switch">Renderer wechseln</string>
+    <string name="renderer_switched_to">Renderer: %1$s</string>
     <string name="su_needed_keymaps_warning">Warnung: Dein Headunit muss entweder gerooted sein oder Shizuku installiert haben. Falls das der Fall ist, musst du die SU-Privilegien erlauben, sobald danach gefragt wird. Lenkradtasten werden keine Funktion haben, solange dies nicht behoben ist.</string>
 
     <string name="self_mode_overlay_permission_description">Damit der Self Mode zuverlässig im Hintergrund starten kann, aktivieren Sie bitte die Berechtigung \"Über anderen Apps einblenden\" im nächsten Bildschirm.</string>
@@ -728,7 +733,7 @@
     <string name="resolution_recommended_format">%1$s (Empfohlen)</string>
     <string name="resolution_high_bandwidth_format">%1$s · hohe Bandbreite</string>
     <string name="resolution_too_high_title">Auflösung höher als der Bildschirm</string>
-    <string name="resolution_too_high_message">Dein Bildschirm hat %1$d x %2$d Pixel. Eine höhere Auflösung verbraucht mehr Bandbreite ohne Qualitätsgewinn, da das Panel sie nicht darstellen kann.</string>
+    <string name="resolution_too_high_message">Das ist höher als von deinem Panel unterstützt. Das Bild ist auf das begrenzt, was dein Panel anzeigen kann (%1$s), eine höhere Auflösung verbraucht also nur mehr Bandbreite ohne bessere Qualität.</string>
     <string name="resolution_high_bandwidth_title">Mehr Bandbreite nötig</string>
     <string name="resolution_high_bandwidth_message">Diese Auflösung verbraucht viel mehr Bandbreite und braucht eine starke Verbindung: ein gutes 5GHz-WiFi oder eine stabile USB-Verbindung. Bei Rucklern wähle eine niedrigere Auflösung.</string>
     <string name="resolution_use_anyway">Trotzdem verwenden</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -602,6 +602,11 @@
 
     <string name="btn_show_qr">Mostrar código QR</string>
     <string name="renderer_fallback_surface">El vídeo se seguía congelando, así que la pantalla se cambió a SurfaceView durante esta sesión. Si va estable, pon el Modo de vista en SurfaceView en Ajustes.</string>
+    <string name="dpi_resolution_over_panel_warning">La resolución elegida (%1$s) es más alta que tu panel. Se limita a %2$s y el DPI se calcula para eso. Si se ve mal, usa la resolución recomendada (%2$s).</string>
+    <string name="renderer_confirm_question">¿Ves la pantalla de Android Auto?</string>
+    <string name="renderer_confirm_yes">Sí</string>
+    <string name="renderer_confirm_switch">Cambiar renderizador</string>
+    <string name="renderer_switched_to">Renderizador: %1$s</string>
 
     <string name="self_mode_overlay_permission_description">Para permitir que el Modo autónomo se inicie de manera confiable en segundo plano, active el permiso \"Mostrar sobre outras aplicaciones\" en la siguiente pantalla.</string>
 
@@ -728,7 +733,7 @@
     <string name="resolution_recommended_format">%1$s (Recomendada)</string>
     <string name="resolution_high_bandwidth_format">%1$s · mucho ancho de banda</string>
     <string name="resolution_too_high_title">Resolución mayor que la pantalla</string>
-    <string name="resolution_too_high_message">Tu pantalla es de %1$d x %2$d píxeles. Una resolución mayor consume más ancho de banda sin mejorar la calidad, porque el panel no puede mostrarla.</string>
+    <string name="resolution_too_high_message">Esto es más de lo que admite tu panel. La imagen se limita a lo que tu panel puede mostrar (%1$s), así que una resolución mayor solo usa más ancho de banda sin mejorar la calidad.</string>
     <string name="resolution_high_bandwidth_title">Se necesita más ancho de banda</string>
     <string name="resolution_high_bandwidth_message">Esta resolución consume mucho más ancho de banda y necesita una conexión fuerte: un buen WiFi de 5GHz o una conexión USB estable. Si notas lags, elige una resolución más baja.</string>
     <string name="resolution_use_anyway">Usar de todas formas</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -602,6 +602,11 @@
 
     <string name="btn_show_qr">Mostrar código QR</string>
     <string name="renderer_fallback_surface">El video se seguía congelando, así que la pantalla se cambió a SurfaceView por esta sesión. Si va estable, pon el Modo de vista en SurfaceView en Ajustes.</string>
+    <string name="dpi_resolution_over_panel_warning">La resolución elegida (%1$s) es más alta que tu panel. Se limita a %2$s y el DPI se calcula para eso. Si se ve mal, usa la resolución recomendada (%2$s).</string>
+    <string name="renderer_confirm_question">¿Ves la pantalla de Android Auto?</string>
+    <string name="renderer_confirm_yes">Sí</string>
+    <string name="renderer_confirm_switch">Cambiar renderizador</string>
+    <string name="renderer_switched_to">Renderizador: %1$s</string>
 
     <string name="self_mode_overlay_permission_description">Para permitir que el Modo Propio se inicie de manera confiable en segundo plano, active el permiso \"Mostrar sobre outras aplicaciones\" en la siguiente pantalla.</string>
 
@@ -730,7 +735,7 @@
     <string name="resolution_recommended_format">%1$s (Recomendada)</string>
     <string name="resolution_high_bandwidth_format">%1$s · mucho ancho de banda</string>
     <string name="resolution_too_high_title">Resolución mayor que la pantalla</string>
-    <string name="resolution_too_high_message">Tu pantalla es de %1$d x %2$d píxeles. Una resolución mayor consume más ancho de banda sin mejorar la calidad, porque el panel no puede mostrarla.</string>
+    <string name="resolution_too_high_message">Esto es más de lo que admite tu panel. La imagen se limita a lo que tu panel puede mostrar (%1$s), así que una resolución mayor solo usa más ancho de banda sin mejorar la calidad.</string>
     <string name="resolution_high_bandwidth_title">Se necesita más ancho de banda</string>
     <string name="resolution_high_bandwidth_message">Esta resolución consume mucho más ancho de banda y necesita una conexión fuerte: un buen WiFi de 5GHz o una conexión USB estable. Si notas lags, elige una resolución más baja.</string>
     <string name="resolution_use_anyway">Usar de todos modos</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -593,6 +593,11 @@
 
     <string name="btn_show_qr">QR-kód megjelenítése</string>
     <string name="renderer_fallback_surface">A videó folyamatosan lefagyott, ezért a megjelenítés erre a munkamenetre SurfaceView-ra váltott. Ha stabil, állítsd a Megjelenítési módot SurfaceView-ra a Beállításokban.</string>
+    <string name="dpi_resolution_over_panel_warning">A választott felbontás (%1$s) magasabb, mint a paneled. %2$s értékre korlátozódik, és a DPI ehhez van kiszámítva. Ha rosszul néz ki, használd az ajánlott felbontást (%2$s).</string>
+    <string name="renderer_confirm_question">Látod az Android Auto képernyőt?</string>
+    <string name="renderer_confirm_yes">Igen</string>
+    <string name="renderer_confirm_switch">Megjelenítő váltása</string>
+    <string name="renderer_switched_to">Megjelenítő: %1$s</string>
 
     <string name="self_mode_overlay_permission_description">A Saját mód háttérben történő megbízható indításához engedélyezze a „Megjelenítés más alkalmazások felett” jogosultságot a következő képernyőn.</string>
 
@@ -718,7 +723,7 @@
     <string name="resolution_recommended_format">%1$s (Ajánlott)</string>
     <string name="resolution_high_bandwidth_format">%1$s · nagy sávszélesség</string>
     <string name="resolution_too_high_title">A képernyőnél nagyobb felbontás</string>
-    <string name="resolution_too_high_message">A képernyőd %1$d x %2$d pixel. A nagyobb felbontás több sávszélességet használ minőségjavulás nélkül, mert a panel nem tudja megjeleníteni.</string>
+    <string name="resolution_too_high_message">Ez magasabb, mint amit a paneled támogat. A kép arra korlátozódik, amit a paneled meg tud jeleníteni (%1$s), így a magasabb felbontás csak több sávszélességet használ minőségjavulás nélkül.</string>
     <string name="resolution_high_bandwidth_title">Nagyobb sávszélesség szükséges</string>
     <string name="resolution_high_bandwidth_message">Ez a felbontás sokkal több sávszélességet használ, és erős kapcsolatot igényel: jó 5GHz-es WiFi vagy stabil USB. Ha akadozást tapasztalsz, válassz alacsonyabb felbontást.</string>
     <string name="resolution_use_anyway">Mégis használ</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -601,6 +601,11 @@
 
     <string name="btn_show_qr">Mostra codice QR</string>
     <string name="renderer_fallback_surface">Il video continuava a bloccarsi, quindi la visualizzazione è passata a SurfaceView per questa sessione. Se è stabile, imposta la Modalità visualizzazione su SurfaceView nelle Impostazioni.</string>
+    <string name="dpi_resolution_over_panel_warning">La risoluzione scelta (%1$s) è più alta del tuo pannello. È limitata a %2$s e il DPI è calcolato per quella. Se sembra sbagliata, usa la risoluzione consigliata (%2$s).</string>
+    <string name="renderer_confirm_question">Vedi la schermata di Android Auto?</string>
+    <string name="renderer_confirm_yes">Sì</string>
+    <string name="renderer_confirm_switch">Cambia renderer</string>
+    <string name="renderer_switched_to">Renderer: %1$s</string>
 
     <string name="self_mode_overlay_permission_description">Per consentire l\'avvio affidabile della Modalità Personale in background, abilita l\'autorizzazione \"Mostra sopra altre app\" nella schermata successiva.</string>
 
@@ -726,7 +731,7 @@
     <string name="resolution_recommended_format">%1$s (Consigliata)</string>
     <string name="resolution_high_bandwidth_format">%1$s · banda elevata</string>
     <string name="resolution_too_high_title">Risoluzione superiore allo schermo</string>
-    <string name="resolution_too_high_message">Il tuo schermo è %1$d x %2$d pixel. Una risoluzione più alta consuma più banda senza migliorare la qualità, perché il pannello non può mostrarla.</string>
+    <string name="resolution_too_high_message">Questa è più alta di quanto supporti il tuo pannello. L\'immagine è limitata a ciò che il tuo pannello può mostrare (%1$s), quindi una risoluzione più alta usa solo più banda senza migliorare la qualità.</string>
     <string name="resolution_high_bandwidth_title">Serve più banda</string>
     <string name="resolution_high_bandwidth_message">Questa risoluzione consuma molta più banda e richiede una connessione forte: un buon WiFi a 5GHz o una connessione USB stabile. Se noti lag, scegli una risoluzione più bassa.</string>
     <string name="resolution_use_anyway">Usa comunque</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -602,6 +602,11 @@
 
     <string name="btn_show_qr">QRコードを表示</string>
     <string name="renderer_fallback_surface">映像がフリーズし続けたため、このセッションでは表示を SurfaceView に切り替えました。安定している場合は、設定でビューモードを SurfaceView に設定してください。</string>
+    <string name="dpi_resolution_over_panel_warning">選択した解像度 (%1$s) はパネルより高いため、%2$s に制限され、DPI もそれに合わせて計算されます。表示がおかしい場合は推奨解像度 (%2$s) を使用してください。</string>
+    <string name="renderer_confirm_question">Android Auto の画面が表示されていますか？</string>
+    <string name="renderer_confirm_yes">はい</string>
+    <string name="renderer_confirm_switch">レンダラーを切り替える</string>
+    <string name="renderer_switched_to">レンダラー: %1$s</string>
 
     <string name="self_mode_overlay_permission_description">単独モードをバックグラウンドから安定して起動できるようにするため、次の画面で「他のアプリの上に重ねて表示」の権限を有効にしてください。</string>
     <string name="delete">削除</string>
@@ -726,7 +731,7 @@
     <string name="resolution_recommended_format">%1$s（推奨）</string>
     <string name="resolution_high_bandwidth_format">%1$s · 高帯域</string>
     <string name="resolution_too_high_title">画面より高い解像度</string>
-    <string name="resolution_too_high_message">画面は %1$d x %2$d ピクセルです。これより高い解像度は帯域を多く使うだけで、パネルが表示できないため画質は向上しません。</string>
+    <string name="resolution_too_high_message">これはパネルが対応する解像度より高い設定です。表示はパネルが表示できる範囲 (%1$s) に制限されるため、これより高い解像度は帯域を多く使うだけで画質は向上しません。</string>
     <string name="resolution_high_bandwidth_title">より高い帯域が必要</string>
     <string name="resolution_high_bandwidth_message">この解像度は帯域を大幅に消費し、安定した接続（良好な 5GHz WiFi または安定した USB 接続）が必要です。遅延が出たら低い解像度を選んでください。</string>
     <string name="resolution_use_anyway">そのまま使用</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -581,6 +581,11 @@
 
     <string name="btn_show_qr">QR კოდის ჩვენება</string>
     <string name="renderer_fallback_surface">ვიდეო მუდმივად იყინებოდა, ამიტომ ამ სესიისთვის ჩვენება გადაერთო SurfaceView-ზე. თუ სტაბილურია, პარამეტრებში დააყენეთ ხედვის რეჟიმი SurfaceView-ზე.</string>
+    <string name="dpi_resolution_over_panel_warning">თქვენ მიერ არჩეული გარჩევადობა (%1$s) თქვენს პანელზე მაღალია. ის შეზღუდულია %2$s-მდე და DPI სწორედ ამისთვის გამოითვლება. თუ ცუდად გამოიყურება, გამოიყენეთ რეკომენდებული გარჩევადობა (%2$s).</string>
+    <string name="renderer_confirm_question">ხედავთ Android Auto-ს ეკრანს?</string>
+    <string name="renderer_confirm_yes">დიახ</string>
+    <string name="renderer_confirm_switch">რენდერერის შეცვლა</string>
+    <string name="renderer_switched_to">რენდერერი: %1$s</string>
 
     <string name="self_mode_overlay_permission_description">ავტონომიური რეჟიმის ფონურ რეჟიმში საიმედოდ გასაშვებად, გთხოვთ, შემდეგ ეკრანზე ჩართოთ ნებართვა „სხვა აპებზე ჩვენება“.</string>
 
@@ -652,7 +657,7 @@
     <string name="resolution_recommended_format">%1$s (რეკომენდებული)</string>
     <string name="resolution_high_bandwidth_format">%1$s · მაღალი გამტარუნარიანობა</string>
     <string name="resolution_too_high_title">გარჩევადობა ეკრანზე მაღალია</string>
-    <string name="resolution_too_high_message">თქვენი ეკრანი %1$d x %2$d პიქსელია. უფრო მაღალი გარჩევადობა მეტ გამტარუნარიანობას ხარჯავს ხარისხის გაუმჯობესების გარეშე, რადგან პანელი მას ვერ აჩვენებს.</string>
+    <string name="resolution_too_high_message">ეს თქვენს პანელზე მხარდაჭერილ მაჩვენებელზე მაღალია. გამოსახულება შეზღუდულია იმით, რისი ჩვენებაც თქვენს პანელს შეუძლია (%1$s), ამიტომ უფრო მაღალი გარჩევადობა მხოლოდ მეტ გამტარუნარიანობას ხარჯავს ხარისხის გაუმჯობესების გარეშე.</string>
     <string name="resolution_high_bandwidth_title">საჭიროა მეტი გამტარუნარიანობა</string>
     <string name="resolution_high_bandwidth_message">ეს გარჩევადობა გაცილებით მეტ გამტარუნარიანობას ხარჯავს და საჭიროებს მდგრад კავშირს: კარგ 5GHz WiFi-ს ან სტაბილურ USB-ს. თუ შეფერხებას შეამჩნევთ, აირჩიეთ დაბალი გარჩევადობა.</string>
     <string name="resolution_use_anyway">მაინც გამოყენება</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -600,6 +600,11 @@
     <string name="use_libusb_description">USB 통신에 libusb를 사용합니다. 비활성화 시 Android 표준 USB API를 사용합니다.</string>
     <string name="btn_show_qr">QR 코드 표시</string>
     <string name="renderer_fallback_surface">영상이 계속 멈춰서 이번 세션 동안 화면을 SurfaceView로 전환했습니다. 안정적이면 설정에서 뷰 모드를 SurfaceView로 지정하세요.</string>
+    <string name="dpi_resolution_over_panel_warning">선택한 해상도(%1$s)가 패널보다 높습니다. %2$s로 제한되며 DPI도 이에 맞춰 계산됩니다. 화면이 이상하면 권장 해상도(%2$s)를 사용하세요.</string>
+    <string name="renderer_confirm_question">Android Auto 화면이 보이나요?</string>
+    <string name="renderer_confirm_yes">예</string>
+    <string name="renderer_confirm_switch">렌더러 전환</string>
+    <string name="renderer_switched_to">렌더러: %1$s</string>
     <string name="self_mode_overlay_permission_description">단독 모드가 백그라운드에서 안정적으로 시작되도록 하려면 다음 화면에서 \"다른 앱 위에 표시\" 권한을 허용해 주세요.</string>
     <string name="delete">삭제</string>
     <string name="night_mode_coordinates">좌표</string>
@@ -723,7 +728,7 @@
     <string name="resolution_recommended_format">%1$s (권장)</string>
     <string name="resolution_high_bandwidth_format">%1$s · 높은 대역폭</string>
     <string name="resolution_too_high_title">화면보다 높은 해상도</string>
-    <string name="resolution_too_high_message">화면은 %1$d x %2$d 픽셀입니다. 더 높은 해상도는 대역폭만 더 쓰고 화질은 좋아지지 않습니다. 패널이 표시할 수 없기 때문입니다.</string>
+    <string name="resolution_too_high_message">이 값은 패널이 지원하는 것보다 높습니다. 화면은 패널이 표시할 수 있는 범위(%1$s)로 제한되므로, 더 높은 해상도는 대역폭만 더 쓰고 화질은 좋아지지 않습니다.</string>
     <string name="resolution_high_bandwidth_title">더 높은 대역폭 필요</string>
     <string name="resolution_high_bandwidth_message">이 해상도는 훨씬 많은 대역폭을 사용하며 안정적인 연결(양호한 5GHz WiFi 또는 안정적인 USB)이 필요합니다. 지연이 있으면 더 낮은 해상도를 선택하세요.</string>
     <string name="resolution_use_anyway">그래도 사용</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -594,6 +594,11 @@
 
     <string name="btn_show_qr">QR-code tonen</string>
     <string name="renderer_fallback_surface">De video bleef bevriezen, daarom is de weergave voor deze sessie overgeschakeld naar SurfaceView. Als het stabiel is, stel View modes in op SurfaceView in Instellingen.</string>
+    <string name="dpi_resolution_over_panel_warning">De gekozen resolutie (%1$s) is hoger dan je scherm. Deze is beperkt tot %2$s en de DPI wordt daarvoor berekend. Als het er verkeerd uitziet, gebruik dan de aanbevolen resolutie (%2$s).</string>
+    <string name="renderer_confirm_question">Zie je het Android Auto-scherm?</string>
+    <string name="renderer_confirm_yes">Ja</string>
+    <string name="renderer_confirm_switch">Renderer wisselen</string>
+    <string name="renderer_switched_to">Renderer: %1$s</string>
 
     <string name="self_mode_overlay_permission_description">Om de Self-modus betrouwbaar op de achtergrond te laten starten, schakelt u de machtiging \"Weergeven over andere apps\" in op het volgende scherm.</string>
 
@@ -719,7 +724,7 @@
     <string name="resolution_recommended_format">%1$s (Aanbevolen)</string>
     <string name="resolution_high_bandwidth_format">%1$s · veel bandbreedte</string>
     <string name="resolution_too_high_title">Resolutie hoger dan het scherm</string>
-    <string name="resolution_too_high_message">Je scherm is %1$d x %2$d pixels. Een hogere resolutie gebruikt meer bandbreedte zonder betere kwaliteit, omdat het scherm het niet kan tonen.</string>
+    <string name="resolution_too_high_message">Dit is hoger dan je scherm ondersteunt. Het beeld is beperkt tot wat je scherm kan tonen (%1$s), dus een hogere resolutie gebruikt alleen meer bandbreedte zonder betere kwaliteit.</string>
     <string name="resolution_high_bandwidth_title">Meer bandbreedte nodig</string>
     <string name="resolution_high_bandwidth_message">Deze resolutie gebruikt veel meer bandbreedte en heeft een sterke verbinding nodig: een goede 5GHz-WiFi of een stabiele USB-verbinding. Bij haperingen kies je een lagere resolutie.</string>
     <string name="resolution_use_anyway">Toch gebruiken</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -595,6 +595,11 @@
 
     <string name="btn_show_qr">Pokaż kod QR</string>
     <string name="renderer_fallback_surface">Obraz ciągle się zawieszał, więc wyświetlanie zostało przełączone na SurfaceView na czas tej sesji. Jeśli działa stabilnie, ustaw Tryb widoku na SurfaceView w Ustawieniach.</string>
+    <string name="dpi_resolution_over_panel_warning">Wybrana rozdzielczość (%1$s) jest wyższa niż twój panel. Jest ograniczona do %2$s, a DPI jest dla niej wyliczane. Jeśli wygląda źle, użyj zalecanej rozdzielczości (%2$s).</string>
+    <string name="renderer_confirm_question">Czy widzisz ekran Android Auto?</string>
+    <string name="renderer_confirm_yes">Tak</string>
+    <string name="renderer_confirm_switch">Zmień renderowanie</string>
+    <string name="renderer_switched_to">Renderowanie: %1$s</string>
 
     <string name="self_mode_overlay_permission_description">Aby umożliwić niezawodne uruchamianie trybu własnego w tle, włącz uprawnienie \"Wyświetlaj nad innymi aplikacjami\" na następnym ekranie.</string>
 
@@ -720,7 +725,7 @@
     <string name="resolution_recommended_format">%1$s (Zalecana)</string>
     <string name="resolution_high_bandwidth_format">%1$s · duże pasmo</string>
     <string name="resolution_too_high_title">Rozdzielczość wyższa niż ekran</string>
-    <string name="resolution_too_high_message">Twój ekran ma %1$d x %2$d pikseli. Wyższa rozdzielczość zużywa więcej pasma bez poprawy jakości, bo panel nie może jej wyświetlić.</string>
+    <string name="resolution_too_high_message">To więcej, niż obsługuje twój panel. Obraz jest ograniczony do tego, co panel może wyświetlić (%1$s), więc wyższa rozdzielczość tylko zużywa więcej pasma bez poprawy jakości.</string>
     <string name="resolution_high_bandwidth_title">Potrzeba większego pasma</string>
     <string name="resolution_high_bandwidth_message">Ta rozdzielczość zużywa znacznie więcej pasma i wymaga silnego połączenia: dobrego WiFi 5GHz lub stabilnego USB. Jeśli zauważysz lagi, wybierz niższą rozdzielczość.</string>
     <string name="resolution_use_anyway">Użyj mimo to</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -595,6 +595,11 @@
 
     <string name="btn_show_qr">Mostrar código QR</string>
     <string name="renderer_fallback_surface">O vídeo continuava travando, então a exibição foi trocada para SurfaceView nesta sessão. Se ficar estável, defina o Modo de visualização como SurfaceView nas Configurações.</string>
+    <string name="dpi_resolution_over_panel_warning">A resolução escolhida (%1$s) é maior que o seu painel. Ela é limitada a %2$s, e o DPI é calculado para isso. Se ficar estranho, use a resolução recomendada (%2$s).</string>
+    <string name="renderer_confirm_question">Você vê a tela do Android Auto?</string>
+    <string name="renderer_confirm_yes">Sim</string>
+    <string name="renderer_confirm_switch">Trocar renderizador</string>
+    <string name="renderer_switched_to">Renderizador: %1$s</string>
 
     <string name="self_mode_overlay_permission_description">Para permitir que o Modo Próprio inicie de forma confiável em segundo plano, ative a permissão \"Sobrepor a outros aplicativos\" na próxima tela.</string>
 
@@ -721,7 +726,7 @@
     <string name="resolution_recommended_format">%1$s (Recomendada)</string>
     <string name="resolution_high_bandwidth_format">%1$s · muita banda</string>
     <string name="resolution_too_high_title">Resolução maior que a tela</string>
-    <string name="resolution_too_high_message">Sua tela é de %1$d x %2$d pixels. Uma resolução maior usa mais banda sem melhorar a qualidade, porque o painel não consegue exibi-la.</string>
+    <string name="resolution_too_high_message">Isto é maior do que o seu painel suporta. A imagem fica limitada ao que o seu painel consegue mostrar (%1$s), então uma resolução maior só usa mais banda sem melhorar a qualidade.</string>
     <string name="resolution_high_bandwidth_title">É necessária mais banda</string>
     <string name="resolution_high_bandwidth_message">Esta resolução usa muito mais banda e precisa de uma conexão forte: um bom WiFi de 5GHz ou uma conexão USB estável. Se notar travamentos, escolha uma resolução menor.</string>
     <string name="resolution_use_anyway">Usar mesmo assim</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -595,6 +595,11 @@
 
     <string name="btn_show_qr">Afișează codul QR</string>
     <string name="renderer_fallback_surface">Videoclipul continua să se blocheze, așa că afișarea a fost comutată pe SurfaceView pentru această sesiune. Dacă este stabil, setează Mod de vizualizare pe SurfaceView în Setări.</string>
+    <string name="dpi_resolution_over_panel_warning">Rezoluția aleasă (%1$s) este mai mare decât panoul tău. Este limitată la %2$s, iar DPI este calculat pentru aceasta. Dacă arată greșit, folosește rezoluția recomandată (%2$s).</string>
+    <string name="renderer_confirm_question">Vezi ecranul Android Auto?</string>
+    <string name="renderer_confirm_yes">Da</string>
+    <string name="renderer_confirm_switch">Schimbă randarea</string>
+    <string name="renderer_switched_to">Randare: %1$s</string>
 
     <string name="self_mode_overlay_permission_description">Pentru a permite Modului Personal să pornească fiabil în fundal, activați permisiunea „Afișare peste alte aplicații” în ecranul următor.</string>
 
@@ -720,7 +725,7 @@
     <string name="resolution_recommended_format">%1$s (Recomandat)</string>
     <string name="resolution_high_bandwidth_format">%1$s · lățime de bandă mare</string>
     <string name="resolution_too_high_title">Rezoluție mai mare decât ecranul</string>
-    <string name="resolution_too_high_message">Ecranul tău are %1$d x %2$d pixeli. O rezoluție mai mare folosește mai multă lățime de bandă fără a îmbunătăți calitatea, deoarece panoul nu o poate afișa.</string>
+    <string name="resolution_too_high_message">Aceasta este mai mare decât acceptă panoul tău. Imaginea este limitată la ceea ce poate afișa panoul (%1$s), așa că o rezoluție mai mare folosește doar mai multă lățime de bandă fără a îmbunătăți calitatea.</string>
     <string name="resolution_high_bandwidth_title">Este nevoie de mai multă lățime de bandă</string>
     <string name="resolution_high_bandwidth_message">Această rezoluție folosește mult mai multă lățime de bandă și necesită o conexiune puternică: un WiFi 5GHz bun sau o conexiune USB stabilă. Dacă observi întreruperi, alege o rezoluție mai mică.</string>
     <string name="resolution_use_anyway">Folosește oricum</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -593,6 +593,11 @@
 
     <string name="btn_show_qr">Показать QR-код</string>
     <string name="renderer_fallback_surface">Видео постоянно зависало, поэтому отображение переключено на SurfaceView на эту сессию. Если работает стабильно, установите Режим отображения на SurfaceView в настройках.</string>
+    <string name="dpi_resolution_over_panel_warning">Выбранное разрешение (%1$s) выше вашей панели. Оно ограничено до %2$s, и DPI рассчитывается для него. Если выглядит неправильно, используйте рекомендуемое разрешение (%2$s).</string>
+    <string name="renderer_confirm_question">Вы видите экран Android Auto?</string>
+    <string name="renderer_confirm_yes">Да</string>
+    <string name="renderer_confirm_switch">Сменить рендерер</string>
+    <string name="renderer_switched_to">Рендерер: %1$s</string>
 
     <string name="self_mode_overlay_permission_description">Чтобы автономный режим надежно запускался в фоновом режиме, включите разрешение «Отображение поверх других приложений» на следующем экране.</string>
 
@@ -719,7 +724,7 @@
     <string name="resolution_recommended_format">%1$s (Рекомендуется)</string>
     <string name="resolution_high_bandwidth_format">%1$s · высокий трафик</string>
     <string name="resolution_too_high_title">Разрешение выше экрана</string>
-    <string name="resolution_too_high_message">Экран %1$d x %2$d пикселей. Более высокое разрешение увеличивает трафик без улучшения качества, так как панель не может его отобразить.</string>
+    <string name="resolution_too_high_message">Это выше, чем поддерживает ваша панель. Изображение ограничено тем, что панель может показать (%1$s), поэтому более высокое разрешение только увеличивает трафик без улучшения качества.</string>
     <string name="resolution_high_bandwidth_title">Нужен больший трафик</string>
     <string name="resolution_high_bandwidth_message">Это разрешение потребляет намного больше трафика и требует устойчивого соединения: хорошего WiFi 5 ГГц или стабильного USB. При задержках выберите разрешение ниже.</string>
     <string name="resolution_use_anyway">Всё равно использовать</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -590,6 +590,11 @@
 
     <string name="btn_show_qr">QR Kodunu Göster</string>
     <string name="renderer_fallback_surface">Video sürekli donduğu için görüntü bu oturum boyunca SurfaceView\'e geçirildi. Kararlıysa, Ayarlar\'da Görünüm modunu SurfaceView olarak ayarla.</string>
+    <string name="dpi_resolution_over_panel_warning">Seçtiğiniz çözünürlük (%1$s) panelinizden yüksek. %2$s ile sınırlanıyor ve DPI buna göre hesaplanıyor. Bozuk görünüyorsa önerilen çözünürlüğü (%2$s) kullanın.</string>
+    <string name="renderer_confirm_question">Android Auto ekranını görüyor musunuz?</string>
+    <string name="renderer_confirm_yes">Evet</string>
+    <string name="renderer_confirm_switch">Oluşturucuyu değiştir</string>
+    <string name="renderer_switched_to">Oluşturucu: %1$s</string>
 
     <string name="self_mode_overlay_permission_description">Kendi Modunun arka planda güvenilir bir şekilde başlatılabilmesi için lütfen bir sonraki ekranda \"Diğer uygulamaların üzerinde göster\" iznini etkinleştirin.</string>
 
@@ -716,7 +721,7 @@
     <string name="resolution_recommended_format">%1$s (Önerilen)</string>
     <string name="resolution_high_bandwidth_format">%1$s · yüksek bant genişliği</string>
     <string name="resolution_too_high_title">Çözünürlük ekrandan yüksek</string>
-    <string name="resolution_too_high_message">Ekranınız %1$d x %2$d piksel. Daha yüksek çözünürlük, panel gösteremediği için kaliteyi artırmadan daha fazla bant genişliği kullanır.</string>
+    <string name="resolution_too_high_message">Bu, panelinizin desteklediğinden daha yüksek. Görüntü, panelinizin gösterebildiğiyle (%1$s) sınırlıdır, bu yüzden daha yüksek çözünürlük yalnızca kaliteyi artırmadan daha fazla bant genişliği kullanır.</string>
     <string name="resolution_high_bandwidth_title">Daha fazla bant genişliği gerekiyor</string>
     <string name="resolution_high_bandwidth_message">Bu çözünürlük çok daha fazla bant genişliği kullanır ve güçlü bir bağlantı gerektirir: iyi bir 5GHz WiFi veya kararlı bir USB bağlantısı. Takılma fark ederseniz daha düşük bir çözünürlük seçin.</string>
     <string name="resolution_use_anyway">Yine de kullan</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -595,6 +595,11 @@
 
     <string name="btn_show_qr">Показати QR-код</string>
     <string name="renderer_fallback_surface">Відео постійно зависало, тому відображення переключено на SurfaceView на цю сесію. Якщо працює стабільно, встановіть Режим перегляду на SurfaceView у налаштуваннях.</string>
+    <string name="dpi_resolution_over_panel_warning">Обрана роздільність (%1$s) вища за вашу панель. Її обмежено до %2$s, і DPI розраховується для неї. Якщо виглядає неправильно, використайте рекомендовану роздільність (%2$s).</string>
+    <string name="renderer_confirm_question">Ви бачите екран Android Auto?</string>
+    <string name="renderer_confirm_yes">Так</string>
+    <string name="renderer_confirm_switch">Змінити рендерер</string>
+    <string name="renderer_switched_to">Рендерер: %1$s</string>
 
     <string name="self_mode_overlay_permission_description">Щоб дозволити автономному режиму надійно запускатися у фоновому режимі, увімкніть дозвіл \"Відображення поверх інших додатків\" на наступному екрані.</string>
 
@@ -721,7 +726,7 @@
     <string name="resolution_recommended_format">%1$s (Рекомендовано)</string>
     <string name="resolution_high_bandwidth_format">%1$s · високий трафік</string>
     <string name="resolution_too_high_title">Роздільність вища за екран</string>
-    <string name="resolution_too_high_message">Екран %1$d x %2$d пікселів. Вища роздільність збільшує трафік без покращення якості, бо панель не може її показати.</string>
+    <string name="resolution_too_high_message">Це вище, ніж підтримує ваша панель. Зображення обмежене тим, що панель може показати (%1$s), тож вища роздільність лише збільшує трафік без покращення якості.</string>
     <string name="resolution_high_bandwidth_title">Потрібен більший трафік</string>
     <string name="resolution_high_bandwidth_message">Ця роздільність споживає набагато більше трафіку й потребує стабільного зʼєднання: хорошого WiFi 5 ГГц або стабільного USB. Якщо помітите лаги, виберіть нижчу роздільність.</string>
     <string name="resolution_use_anyway">Все одно використати</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -600,6 +600,11 @@
 
     <string name="btn_show_qr">Hiển thị mã QR</string>
     <string name="renderer_fallback_surface">Video liên tục bị đứng, nên màn hình đã chuyển sang SurfaceView cho phiên này. Nếu ổn định, hãy đặt Chế độ hiển thị thành SurfaceView trong Cài đặt.</string>
+    <string name="dpi_resolution_over_panel_warning">Độ phân giải bạn chọn (%1$s) cao hơn màn hình của bạn. Nó bị giới hạn ở %2$s và DPI được tính theo mức đó. Nếu trông không đúng, hãy dùng độ phân giải khuyến nghị (%2$s).</string>
+    <string name="renderer_confirm_question">Bạn có thấy màn hình Android Auto không?</string>
+    <string name="renderer_confirm_yes">Có</string>
+    <string name="renderer_confirm_switch">Đổi bộ dựng hình</string>
+    <string name="renderer_switched_to">Bộ dựng hình: %1$s</string>
 
     <string name="self_mode_overlay_permission_description">Để cho phép Chế độ Tự chạy khởi động ổn định từ nền, vui lòng bật quyền \"Hiển thị trên các ứng dụng khác\" trong màn hình tiếp theo.</string>
 
@@ -725,7 +730,7 @@
     <string name="resolution_recommended_format">%1$s (Khuyến nghị)</string>
     <string name="resolution_high_bandwidth_format">%1$s · băng thông cao</string>
     <string name="resolution_too_high_title">Độ phân giải cao hơn màn hình</string>
-    <string name="resolution_too_high_message">Màn hình của bạn là %1$d x %2$d pixel. Độ phân giải cao hơn dùng nhiều băng thông hơn mà không cải thiện chất lượng, vì màn hình không thể hiển thị.</string>
+    <string name="resolution_too_high_message">Đây là mức cao hơn màn hình của bạn hỗ trợ. Hình ảnh bị giới hạn theo những gì màn hình có thể hiển thị (%1$s), nên độ phân giải cao hơn chỉ dùng nhiều băng thông hơn mà không cải thiện chất lượng.</string>
     <string name="resolution_high_bandwidth_title">Cần băng thông cao hơn</string>
     <string name="resolution_high_bandwidth_message">Độ phân giải này dùng nhiều băng thông hơn và cần kết nối mạnh: WiFi 5GHz tốt hoặc kết nối USB ổn định. Nếu thấy giật, hãy chọn độ phân giải thấp hơn.</string>
     <string name="resolution_use_anyway">Vẫn dùng</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -594,6 +594,11 @@
 
     <string name="btn_show_qr">顯示 QR 碼</string>
     <string name="renderer_fallback_surface">影像持續卡住，因此本次連線已切換為 SurfaceView。若運作穩定，請在設定中將檢視模式設為 SurfaceView。</string>
+    <string name="dpi_resolution_over_panel_warning">你選擇的解析度 (%1$s) 高於你的面板。它會限制為 %2$s，DPI 也依此計算。若顯示異常，請使用建議解析度 (%2$s)。</string>
+    <string name="renderer_confirm_question">你看得到 Android Auto 畫面嗎？</string>
+    <string name="renderer_confirm_yes">是</string>
+    <string name="renderer_confirm_switch">切換轉譯器</string>
+    <string name="renderer_switched_to">轉譯器：%1$s</string>
 
     <string name="self_mode_overlay_permission_description">為使單獨模式能在背景穩定啟動，請在下一個畫面啟用「顯示在其他應用程式上層」的權限。</string>
     <string name="delete">刪除</string>
@@ -718,7 +723,7 @@
     <string name="resolution_recommended_format">%1$s（建議）</string>
     <string name="resolution_high_bandwidth_format">%1$s · 高頻寬</string>
     <string name="resolution_too_high_title">解析度高於螢幕</string>
-    <string name="resolution_too_high_message">你的螢幕為 %1$d x %2$d 像素。更高的解析度會佔用更多頻寬卻不會提升畫質，因為面板無法顯示。</string>
+    <string name="resolution_too_high_message">這高於你的面板所支援的解析度。畫面會限制在面板能顯示的範圍 (%1$s)，因此更高的解析度只會佔用更多頻寬，卻不會提升畫質。</string>
     <string name="resolution_high_bandwidth_title">需要更高頻寬</string>
     <string name="resolution_high_bandwidth_message">此解析度會佔用更多頻寬，需要穩定的連線：良好的 5GHz WiFi 或穩定的 USB 連線。若出現延遲，請選擇較低的解析度。</string>
     <string name="resolution_use_anyway">仍要使用</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,11 +127,18 @@
     <string name="resolution_recommended_format">%1$s (Recommended)</string>
     <string name="resolution_high_bandwidth_format">%1$s · high bandwidth</string>
     <string name="resolution_too_high_title">Resolution higher than the screen</string>
-    <string name="resolution_too_high_message">Your screen is %1$d x %2$d pixels. A higher resolution uses more bandwidth without improving quality, because the panel cannot display it.</string>
+    <string name="resolution_too_high_message">This is higher than your panel supports. The image is limited to what your panel can show (%1$s), so a higher resolution only uses more bandwidth without improving quality.</string>
     <string name="resolution_high_bandwidth_title">Higher bandwidth needed</string>
     <string name="resolution_high_bandwidth_message">This resolution uses much more bandwidth and needs a strong connection: a good 5GHz WiFi, or a stable USB connection. If you notice lag, choose a lower resolution.</string>
     <string name="resolution_use_anyway">Use anyway</string>
     <string name="resolution_use_recommended">Use recommended</string>
+    <!-- DPI: warning when the chosen resolution is higher than the panel supports -->
+    <string name="dpi_resolution_over_panel_warning">Your chosen resolution (%1$s) is higher than your panel. It is limited to %2$s, and the DPI is calculated for that. If it looks off, use the recommended resolution (%2$s).</string>
+    <!-- First-projection renderer confirmation (issue #767) -->
+    <string name="renderer_confirm_question">Do you see the Android Auto screen?</string>
+    <string name="renderer_confirm_yes">Yes</string>
+    <string name="renderer_confirm_switch">Switch renderer</string>
+    <string name="renderer_switched_to">Renderer: %1$s</string>
     <string name="onb_connection_all_detail">Shows both the USB and WiFi settings.</string>
     <string name="onb_connection_warning">Choosing a connection type hides the settings that do not apply to it, in both Basic and Advanced. To see them again, pick a different mode in the connection settings later.</string>
     <string name="onb_more_appearance">More appearance settings</string>


### PR DESCRIPTION
Some head units ended up on a black Android Auto screen (audio still working) after going through the new setup wizard (#767). I traced it down: the black screen was the renderer, not the DPI or the resolution. The wizard was writing SurfaceView on devices where SurfaceView does not draw, and since a broken SurfaceView reports no frames, the stall watchdog from #650 could not recover it.

While I was in there I also fixed the DPI calculation and unified the resolution rules, which is where the confusing "recommended values look wrong" reports were coming from.

## Wizard
- It no longer overwrites the display config (view mode, codec, resolution, orientation) for people who already had the app working. Only fresh installs get the recommendation.
- Fresh installs now start on TextureView instead of SurfaceView on 5.0 to 8.1 with HEVC. TextureView failures are observable, so the existing stall watchdog can still escalate to SurfaceView on its own if a device needs it.
- After the wizard changes the renderer, the first projection shows a small "Do you see the screen?" bar with a "Switch renderer" action that rotates the backend live. It also appears when the phone is streaming video but nothing is drawn, and when the watchdog escalates to SurfaceView, so a blank renderer that cannot be detected in software is no longer a dead end.

## DPI
- The recommended DPI was computed from the raw panel pixels. When the picture is downscaled that over-reports the density. It is now computed from the resolution Android Auto actually draws (the panel-capped one).
- The old 1.2 multiplier is now a named, documented legibility factor set to 1.1.

## Resolution
- There were three different definitions of "what fits the panel" (the too-high warning, the runtime cap and the recommendation) and they disagreed at the edges, so the warning could say one thing and the engine do another. They are unified into a single panel-ceiling source of truth, so the warning, the cap and the DPI always agree.
- When a chosen resolution is above the panel, the image is still limited to what the panel supports (hard cap, unchanged), and the dialog now says so honestly instead of implying the higher value will be used.
- The DPI screen and the wizard DPI step now warn, in red, when the chosen resolution is above the panel and the DPI is computed for the capped one.

Also cached the hardware HEVC check since it scans the whole codec list and is now used on UI paths, and updated the translations for all locales.

Related to #767 and #715.
