### PR TITLE
fix: move mic timestamp inside encrypted payload (byte 4)

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
@@ -454,12 +454,13 @@ class AapTransport(
 
     override fun onMicDataAvailable(mic_buf: ByteArray, mic_audio_len: Int) {
         if (mic_audio_len > 64) {  // If we read at least 64 bytes of audio data
-            val length = mic_audio_len + 10
+            val length = mic_audio_len + 12  // 4 header + 8 timestamp + PCM
             val data = ByteArray(length)
             data[0] = Channel.ID_MIC.toByte()
             data[1] = 0x0b
-            Utils.put_time(2, data, SystemClock.elapsedRealtime())
-            System.arraycopy(mic_buf, 0, data, 10, mic_audio_len)
+            // Timestamp at byte 4 so the full 8 bytes are inside the encrypted payload (HEADER_SIZE=4)
+            Utils.put_time(4, data, SystemClock.elapsedRealtime())
+            System.arraycopy(mic_buf, 0, data, 12, mic_audio_len)
             send(AapMessage(Channel.ID_MIC, 0x0b.toByte(), -1, 2, length, data))
         }
     }


### PR DESCRIPTION
## Problem

Microphone input fails silently on Android 11+. The phone receives mic audio packets but cannot parse them, so voice commands and assistant features don't work.

## Root Cause

The mic audio timestamp was placed at **byte 2** in the packet, which falls within the **plaintext header area** (bytes 0–3, `HEADER_SIZE=4`). The SSL/TLS layer encrypts everything from byte 4 onward, but the receiver expects the timestamp to be inside the encrypted payload.

### Packet layout (broken)

| Offset | Size | Field | Area |
|--------|------|-------|------|
| 0 | 1 | Channel ID (0x07) | Plaintext header |
| 1 | 1 | Flags (0x0b) | Plaintext header |
| 2 | 8 | **Timestamp** (wrong position) | **Plaintext** — should be encrypted |
| 10 | N | PCM audio data | Encrypted payload |

The `sendEncryptedMessage` function (`AapTransport.kt:157–163`) encrypts from byte `HEADER_SIZE` (4) onward:

```kotlin
ssl.encrypt(AapMessage.HEADER_SIZE, length - AapMessage.HEADER_SIZE, data)
```

With the timestamp at byte 2, it's sent in plaintext while the receiver expects it encrypted at byte 4.

### Packet layout (fixed)

| Offset | Size | Field | Area |
|--------|------|-------|------|
| 0 | 1 | Channel ID (0x07) | Plaintext header |
| 1 | 1 | Flags (0x0b) | Plaintext header |
| 2 | 2 | Payload length | Plaintext header |
| 4 | 8 | **Timestamp** (correct position) | Encrypted payload |
| 12 | N | PCM audio data | Encrypted payload |

## Fix

Move the timestamp from byte 2 to byte 4, inside the encrypted payload:

- Buffer size: `mic_audio_len + 10` → `mic_audio_len + 12` (4 header + 8 timestamp + PCM)
- Timestamp offset: `put_time(2, ...)` → `put_time(4, ...)`
- PCM data offset: `arraycopy(..., 10, ...)` → `arraycopy(..., 12, ...)`

## Protocol References

- **[open-android-auto audio.md](https://github.com/mrmees/open-android-auto/blob/main/docs/channels/audio.md)** — Documents raw mic audio as "raw PCM with 8-byte timestamp header" using wire IDs 0x0000/0x0001
- **[DeepWiki: AapTransport](https://deepwiki.com/andreknieriem/headunit-revived/2.3-aaptransport-and-protocol-message-handling)** — Documents HEADER_SIZE=4 and the encryption boundary

## Testing

Verified on two physical Android devices (Xiaomi M2003J15SC running Android 11, and another device running Android 12) — mic works with only this protocol fix applied. No other changes (AudioRecord.Builder, adaptive gain, session management) were needed.