### PR TITLE
Fix/video throughput telemetry and keyframe lockout

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapVideo.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapVideo.kt
@@ -21,15 +21,47 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
     private var isAssemblingFrame = false
     private var waitingForKeyframe = false
 
+    // Set when a P-frame lockout was armed while the throttle refused the keyframe request that
+    // ends it. See sendDeferredKeyframeRequestIfDue().
+    private var deferredKeyframeRequest = false
+
     private fun markCorruptAndRequestRecovery() {
         isFrameCorrupt = true
         waitingForKeyframe = true // Lock out P-Frames until an I-Frame arrives
         val now = android.os.SystemClock.elapsedRealtime()
-        if (now - lastKeyframeRequestMs > 1000) {
+        if (VideoRecoveryPolicy.canRequestKeyframe(now, lastKeyframeRequestMs)) {
             lastKeyframeRequestMs = now
+            deferredKeyframeRequest = false
             AppLog.w("AapVideo: Frame corrupted, requesting keyframe to recover stream")
             onFrameCorrupted()
+        } else {
+            // The throttle covers the request but not the lockout above, which drops every
+            // frame until a keyframe arrives. Nothing else asks for one, so the lockout would
+            // sit until the phone happens to send a keyframe on its own - the whole interval is
+            // discarded video. Record the debt and pay it in process() once the throttle allows.
+            deferredKeyframeRequest = true
         }
+    }
+
+    /**
+     * Sends a keyframe request that [markCorruptAndRequestRecovery] had to defer.
+     *
+     * Called per incoming video packet, so the request lands within a frame or two of the
+     * throttle expiring without needing a scheduler on this thread.
+     */
+    private fun sendDeferredKeyframeRequestIfDue() {
+        if (!deferredKeyframeRequest) return
+        if (!waitingForKeyframe) {
+            // The stream recovered on a keyframe the phone sent anyway; nothing left to ask for.
+            deferredKeyframeRequest = false
+            return
+        }
+        val now = android.os.SystemClock.elapsedRealtime()
+        if (!VideoRecoveryPolicy.isDeferredRequestDue(now, lastKeyframeRequestMs, true)) return
+        lastKeyframeRequestMs = now
+        deferredKeyframeRequest = false
+        AppLog.w("AapVideo: Still waiting for a keyframe, sending the deferred recovery request")
+        onFrameCorrupted()
     }
 
     private fun checkKeyframe(message: AapMessage): Boolean {
@@ -76,6 +108,7 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
             AppLog.i("AapVideo: Keyframe received, resuming stream.")
             waitingForKeyframe = false
             isFrameCorrupt = false
+            deferredKeyframeRequest = false
         } else {
             return true // Drop this P-Frame, we are still waiting for a Keyframe!
         }
@@ -118,6 +151,7 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
     }
 
     fun process(message: AapMessage): Boolean {
+        sendDeferredKeyframeRequestIfDue()
         // Fix smearing happening after some while
         checkFragmentState(message)
         if (checkKeyframe(message))

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/VideoRecoveryPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/VideoRecoveryPolicy.kt
@@ -1,0 +1,31 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Pacing rules for [AapVideo]'s stream recovery.
+ *
+ * Recovering from a corrupt or dropped frame means asking the phone for a fresh keyframe, which
+ * [AapTransport] implements as a video-focus loss/regain cycle. That is expensive and briefly
+ * visible, so requests are rate limited. But the same recovery also locks out every P-frame until
+ * a keyframe arrives, and a lockout with no request behind it can only end on the phone's own
+ * keyframe cadence - seconds of discarded video. These two rules keep the throttle from stranding
+ * a lockout: one decides when a request may go out, the other when a request the throttle
+ * suppressed has become due.
+ */
+object VideoRecoveryPolicy {
+
+    /** Minimum spacing between keyframe requests, in milliseconds. */
+    const val KEYFRAME_REQUEST_THROTTLE_MS = 1000L
+
+    /** Whether enough time has passed since [lastRequestMs] to send another keyframe request. */
+    fun canRequestKeyframe(nowMs: Long, lastRequestMs: Long): Boolean =
+        nowMs - lastRequestMs > KEYFRAME_REQUEST_THROTTLE_MS
+
+    /**
+     * Whether a request that [canRequestKeyframe] previously suppressed should now be sent.
+     *
+     * [deferred] is the caller's record that it armed a P-frame lockout without being allowed to
+     * ask for the keyframe that ends it.
+     */
+    fun isDeferredRequestDue(nowMs: Long, lastRequestMs: Long, deferred: Boolean): Boolean =
+        deferred && canRequestKeyframe(nowMs, lastRequestMs)
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -39,6 +39,19 @@ class VideoDecoder(private val settings: Settings) {
         private const val SYNC_STALL_RESET_MS = 60000L
         private const val MAX_SYNC_STALL_RESTARTS = 4
 
+        // Interval of the decode/render throughput summary. This exists because a slow picture
+        // is otherwise unattributable from a user-submitted log: the only rendered-frame count
+        // the decoder keeps reaches the opt-in on-screen overlay and never the log, so "the
+        // codec is slow" and "the codec keeps up and the display consumer drops the frames"
+        // produce byte-identical logs. Reporting rendered alongside fed separates the two.
+        private const val THROUGHPUT_LOG_INTERVAL_MS = 5000L
+
+        // Throttle for reporting a stall the watchdog saw but declined to act on. Once the
+        // cooldown or the restart cap below suppresses a restart, that branch takes no action
+        // and would otherwise print nothing, so a decoder degrading past its restart budget is
+        // indistinguishable in the log from one that is running perfectly.
+        private const val SYNC_STALL_SUPPRESSED_LOG_INTERVAL_MS = 10000L
+
         /**
          * Checks if H.265 (HEVC) hardware decoding is supported on the current device.
          */
@@ -140,6 +153,19 @@ class VideoDecoder(private val settings: Settings) {
     // sync_stall cooldown/cap state (issue #742) - see SYNC_STALL_* constants.
     private var syncStallRestartCount = 0
     private var lastSyncStallRestartMs = 0L
+    private var lastSyncStallSuppressedLogMs = 0L
+
+    // Throughput counters for the periodic telemetry tick - see THROUGHPUT_LOG_INTERVAL_MS.
+    // Session-monotonic so each has exactly one writer: framesFed/framesDropped from decode()
+    // (under this object's monitor), framesRendered from the output thread. The output thread
+    // reads all three and keeps its own last-logged snapshots to derive per-interval deltas.
+    @Volatile private var framesFed = 0L
+    @Volatile private var framesDropped = 0L
+    @Volatile private var framesRendered = 0L
+    private var lastThroughputLogMs = 0L
+    private var lastLoggedFramesFed = 0L
+    private var lastLoggedFramesDropped = 0L
+    private var lastLoggedFramesRendered = 0L
 
     // Reuse buffers for older API levels to minimize GC pressure
     private var inputBuffers: Array<ByteBuffer>? = null
@@ -266,6 +292,17 @@ class VideoDecoder(private val settings: Settings) {
             lastFrameRenderedMs = 0L
             syntheticPtsUs = 0L
             loggedFirstSoftwareFrame = false
+            // The FPS window and the throughput counters must not straddle a restart, or the
+            // first sample afterwards is averaged over the whole teardown and reads near zero.
+            frameCount = 0
+            lastFpsLogTime = 0L
+            framesFed = 0L
+            framesDropped = 0L
+            framesRendered = 0L
+            lastThroughputLogMs = 0L
+            lastLoggedFramesFed = 0L
+            lastLoggedFramesDropped = 0L
+            lastLoggedFramesRendered = 0L
             AppLog.i("Decoder stopped: $reason")
         }
     }
@@ -422,9 +459,11 @@ class VideoDecoder(private val settings: Settings) {
                     // (issue #755 follow-up). A truly stuck decoder is still caught by
                     // outputThreadLoop's sync_stall watchdog.
                     AppLog.w("Input buffer full. Dropping frame.")
+                    framesDropped++
                     return false
                 }
             }
+            framesFed++
         }
         return true
     }
@@ -478,6 +517,9 @@ class VideoDecoder(private val settings: Settings) {
         onFirstFrameListener?.let { it(); onFirstFrameListener = null }
 
         frameCount += renderedFrames
+        // The bundled decoder has no output thread, so drive the throughput tick from here.
+        framesRendered += renderedFrames
+        logThroughput()
         val now = System.currentTimeMillis()
         val elapsed = now - lastFpsLogTime
         if (elapsed >= 1000) {
@@ -803,6 +845,43 @@ class VideoDecoder(private val settings: Settings) {
     }
 
     /**
+     * Periodic decode/render throughput summary.
+     *
+     * `rendered` counts buffers actually handed to the surface and `fed` counts frames accepted
+     * into the codec's input queue, so the two together locate a slow picture: `fed` high with
+     * `rendered` low is a slow codec, both high is a display consumer that cannot keep up with
+     * one, and `dropped` rising is input-queue backpressure.
+     *
+     * Called from the output thread on every loop iteration. That loop turns over at least every
+     * 10ms (dequeueOutputBuffer's timeout) whether or not a frame came out, so the tick still
+     * fires while nothing is rendering - which is the case most worth reporting.
+     */
+    private fun logThroughput() {
+        val now = SystemClock.elapsedRealtime()
+        if (lastThroughputLogMs == 0L) {
+            lastThroughputLogMs = now
+            return
+        }
+        val elapsed = now - lastThroughputLogMs
+        if (elapsed < THROUGHPUT_LOG_INTERVAL_MS) return
+
+        val rendered = framesRendered - lastLoggedFramesRendered
+        val fed = framesFed - lastLoggedFramesFed
+        val dropped = framesDropped - lastLoggedFramesDropped
+        lastThroughputLogMs = now
+        lastLoggedFramesRendered = framesRendered
+        lastLoggedFramesFed = framesFed
+        lastLoggedFramesDropped = framesDropped
+
+        val renderedFps = rendered * 1000 / elapsed
+        val fedFps = fed * 1000 / elapsed
+        AppLog.i(
+            "Throughput over ${elapsed}ms: rendered=$rendered (${renderedFps}fps), " +
+                "fed=$fed (${fedFps}fps), dropped=$dropped, codec=$currentCodecName"
+        )
+    }
+
+    /**
      * Dedicated thread to pull decoded frames and render them to the surface.
      */
     private fun outputThreadLoop() {
@@ -828,6 +907,7 @@ class VideoDecoder(private val settings: Settings) {
                     onFirstFrameListener?.let { it(); onFirstFrameListener = null }
 
                     frameCount++
+                    framesRendered++
 
                     val now = System.currentTimeMillis()
                     val elapsed = now - lastFpsLogTime
@@ -842,6 +922,8 @@ class VideoDecoder(private val settings: Settings) {
                 } else if (outputIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
                     handleOutputFormatChange(currentCodec.outputFormat)
                 }
+
+                logThroughput()
 
                 // Stall detection: if we rendered at least one frame but haven't
                 // produced output in SYNC_STALL_THRESHOLD_MS, the decoder is likely dead-but-active.
@@ -863,6 +945,14 @@ class VideoDecoder(private val settings: Settings) {
                         AppLog.w("Decoder stall detected (no output for ${stallGap}ms). Forcing restart ($syncStallRestartCount/$MAX_SYNC_STALL_RESTARTS).")
                         scheduleRestart("sync_stall")
                         break
+                    }
+                    // Suppressed by the cooldown or the cap. Report it, throttled: the branch
+                    // above is the only thing that ever mentions a stall, so once it stops
+                    // firing a decoder that has exhausted its restart budget keeps stalling
+                    // with an entirely clean log and reads as healthy.
+                    if (now - lastSyncStallSuppressedLogMs >= SYNC_STALL_SUPPRESSED_LOG_INTERVAL_MS) {
+                        lastSyncStallSuppressedLogMs = now
+                        AppLog.w("Decoder stall detected (no output for ${stallGap}ms) but restart suppressed ($syncStallRestartCount/$MAX_SYNC_STALL_RESTARTS used, ${SYNC_STALL_COOLDOWN_MS}ms cooldown). Still spinning on output.")
                     }
                 }
             } catch (e: Exception) {

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -52,6 +52,11 @@ class VideoDecoder(private val settings: Settings) {
         // indistinguishable in the log from one that is running perfectly.
         private const val SYNC_STALL_SUPPRESSED_LOG_INTERVAL_MS = 10000L
 
+        // Widest buffer alignment any decoder pads a picture dimension out to. Used to sanity
+        // check a reported crop rectangle against the buffer geometry: a real crop is at most
+        // this far below the buffer, so anything further off is not describing this stream.
+        private const val MAX_ALIGNMENT_PADDING = 64
+
         /**
          * Checks if H.265 (HEVC) hardware decoding is supported on the current device.
          */
@@ -232,12 +237,21 @@ class VideoDecoder(private val settings: Settings) {
         val cropWidth = if (cropLeft != null && cropRight != null) cropRight - cropLeft + 1 else 0
         val cropHeight = if (cropTop != null && cropBottom != null) cropBottom - cropTop + 1 else 0
 
-        // A crop wider or taller than the buffer means the decoder reported something inconsistent;
-        // the buffer geometry is the safer of the two in that case.
-        val width = if (cropWidth in 1..bufferWidth) cropWidth else bufferWidth
-        val height = if (cropHeight in 1..bufferHeight) cropHeight else bufferHeight
-        return width to height
+        return croppedOr(cropWidth, bufferWidth) to croppedOr(cropHeight, bufferHeight)
     }
+
+    /**
+     * [crop] if it is a plausible visible extent for a buffer of [buffer] pixels, else [buffer].
+     *
+     * Padding only ever rounds a dimension *up* to an alignment boundary, and no decoder aligns
+     * more coarsely than [MAX_ALIGNMENT_PADDING], so a trustworthy crop sits just below the buffer
+     * size. Anything further away is a decoder filling the crop keys with placeholders rather than
+     * describing this stream - zeros are the dangerous case, since a 0..0 crop reads as a legal
+     * 1-pixel extent and would otherwise be propagated as the video size and handed to
+     * MediaCodec on the next restart.
+     */
+    private fun croppedOr(crop: Int, buffer: Int): Int =
+        if (buffer > 0 && crop in (buffer - MAX_ALIGNMENT_PADDING)..buffer) crop else buffer
 
     /**
      * Handles dynamic video dimension changes during the session.

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -207,12 +207,44 @@ class VideoDecoder(private val settings: Settings) {
     }
 
     /**
+     * The visible picture size described by a decoder output format.
+     *
+     * KEY_WIDTH/KEY_HEIGHT carry the buffer geometry, which vendors are free to pad out to their
+     * macroblock alignment - Intel's AVC component reports 736 for a 720-line stream. Taking that
+     * verbatim propagates a video size the stream does not have: the projection view scales to an
+     * aspect ratio that is off by the padding, and a later restart reconfigures MediaCodec for the
+     * padded height. The crop rectangle is the authoritative visible region, so prefer it and fall
+     * back to the buffer geometry only where a decoder omits it.
+     */
+    private fun displaySizeOf(format: MediaFormat): Pair<Int, Int> {
+        fun key(name: String): Int? =
+            try { if (format.containsKey(name)) format.getInteger(name) else null } catch (e: Exception) { null }
+
+        val bufferWidth = key(MediaFormat.KEY_WIDTH) ?: mWidth
+        val bufferHeight = key(MediaFormat.KEY_HEIGHT) ?: mHeight
+
+        // Inclusive bounds, so the visible extent is right - left + 1.
+        val cropLeft = key("crop-left")
+        val cropRight = key("crop-right")
+        val cropTop = key("crop-top")
+        val cropBottom = key("crop-bottom")
+
+        val cropWidth = if (cropLeft != null && cropRight != null) cropRight - cropLeft + 1 else 0
+        val cropHeight = if (cropTop != null && cropBottom != null) cropBottom - cropTop + 1 else 0
+
+        // A crop wider or taller than the buffer means the decoder reported something inconsistent;
+        // the buffer geometry is the safer of the two in that case.
+        val width = if (cropWidth in 1..bufferWidth) cropWidth else bufferWidth
+        val height = if (cropHeight in 1..bufferHeight) cropHeight else bufferHeight
+        return width to height
+    }
+
+    /**
      * Handles dynamic video dimension changes during the session.
      */
     private fun handleOutputFormatChange(format: MediaFormat) {
         AppLog.i("Output Format Changed: $format")
-        val newWidth = try { format.getInteger(MediaFormat.KEY_WIDTH) } catch (e: Exception) { mWidth }
-        val newHeight = try { format.getInteger(MediaFormat.KEY_HEIGHT) } catch (e: Exception) { mHeight }
+        val (newWidth, newHeight) = displaySizeOf(format)
         if (mWidth != newWidth || mHeight != newHeight) {
             AppLog.i("Video dimensions changed via format: ${newWidth}x$newHeight")
             mWidth = newWidth

--- a/app/src/main/java/com/andrerinas/openheadunit/view/TextureProjectionView.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/view/TextureProjectionView.kt
@@ -30,6 +30,16 @@ class TextureProjectionView @JvmOverloads constructor(
     private var prevDrawMs: Long = 0L
     private val longFrameThresholdMs = 1200L
 
+    // Displayed-frame telemetry. VideoDecoder's throughput tick reports what it hands to the
+    // surface; this reports what the compositor actually put on screen. Only the difference
+    // between the two identifies a unit whose decoder keeps up while its picture does not, and
+    // this callback is the sole place that difference is observable - a TextureView composites
+    // through an external texture, so a consumer too slow to sample it silently loses frames
+    // rather than applying backpressure the decoder could notice.
+    private var drawnSinceLogValue: Long = 0L
+    private var lastDrawLogMs: Long = 0L
+    private val drawLogIntervalMs = 5000L
+
     init {
         surfaceTextureListener = this
     }
@@ -40,7 +50,9 @@ class TextureProjectionView @JvmOverloads constructor(
 
     override fun setVideoSize(width: Int, height: Int) {
         if (videoWidth == width && videoHeight == height) return
-        AppLog.i("TextureProjectionView", "Video size set to ${width}x$height")
+        // AppLog has no (tag, message) overload - the second argument was being consumed as a
+        // format parameter, so this line only ever printed "TextureProjectionView".
+        AppLog.i("TextureProjectionView: Video size set to ${width}x$height")
         videoWidth = width
         videoHeight = height
         ProjectionViewScaler.updateScale(this, videoWidth, videoHeight)
@@ -94,6 +106,19 @@ class TextureProjectionView @JvmOverloads constructor(
         }
         prevDrawMs = now
         lastFrameDrawnMsValue = now
+
+        drawnSinceLogValue++
+        if (lastDrawLogMs == 0L) {
+            lastDrawLogMs = now
+        } else {
+            val elapsed = now - lastDrawLogMs
+            if (elapsed >= drawLogIntervalMs) {
+                val fps = drawnSinceLogValue * 1000 / elapsed
+                AppLog.i("TextureProjectionView: displayed $drawnSinceLogValue frames in ${elapsed}ms (${fps}fps), longFrames=$longFrameEventsValue")
+                drawnSinceLogValue = 0L
+                lastDrawLogMs = now
+            }
+        }
     }
 
     override fun lastFrameDrawnMs(): Long = lastFrameDrawnMsValue

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/VideoRecoveryPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/VideoRecoveryPolicyTest.kt
@@ -1,0 +1,61 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.VideoRecoveryPolicy.KEYFRAME_REQUEST_THROTTLE_MS
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VideoRecoveryPolicyTest {
+
+    @Test
+    fun `a request is allowed once the throttle window has fully elapsed`() {
+        val last = 10_000L
+        assertFalse(VideoRecoveryPolicy.canRequestKeyframe(last, last))
+        assertFalse(
+            VideoRecoveryPolicy.canRequestKeyframe(last + KEYFRAME_REQUEST_THROTTLE_MS, last)
+        )
+        assertTrue(
+            VideoRecoveryPolicy.canRequestKeyframe(last + KEYFRAME_REQUEST_THROTTLE_MS + 1, last)
+        )
+    }
+
+    @Test
+    fun `the first request of a session is always allowed`() {
+        assertTrue(VideoRecoveryPolicy.canRequestKeyframe(nowMs = 12_345L, lastRequestMs = 0L))
+    }
+
+    @Test
+    fun `a deferred request stays pending until the throttle expires`() {
+        val last = 10_000L
+        assertFalse(
+            VideoRecoveryPolicy.isDeferredRequestDue(last + 500L, last, deferred = true)
+        )
+        assertTrue(
+            VideoRecoveryPolicy.isDeferredRequestDue(
+                last + KEYFRAME_REQUEST_THROTTLE_MS + 1, last, deferred = true
+            )
+        )
+    }
+
+    @Test
+    fun `nothing is due when no request was deferred`() {
+        val last = 10_000L
+        assertFalse(
+            VideoRecoveryPolicy.isDeferredRequestDue(
+                last + KEYFRAME_REQUEST_THROTTLE_MS + 1, last, deferred = false
+            )
+        )
+    }
+
+    @Test
+    fun `a deferred request never overtakes the throttle it was deferred by`() {
+        // The pairing that matters: whenever a request is suppressed, the deferred check must
+        // agree it is not yet due, so no path can send two requests inside one throttle window.
+        val last = 10_000L
+        for (offset in 0L..KEYFRAME_REQUEST_THROTTLE_MS) {
+            val now = last + offset
+            assertFalse(VideoRecoveryPolicy.canRequestKeyframe(now, last))
+            assertFalse(VideoRecoveryPolicy.isDeferredRequestDue(now, last, deferred = true))
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #766, for the low-fps reports on #757 and #755. Built and run on a head unit.

**Throughput logging.** Nothing output-side has ever reached the log. `VideoDecoder` counts rendered frames, but `onFpsChanged` only feeds the on-screen overlay, gated on `settings.showFpsCounter`, so "the codec is slow" and "the codec keeps up and the display drops the frames" produce identical logs. `VideoDecoder` now reports rendered / fed / dropped every 5s, and `TextureProjectionView` reports displayed frames, which is the only place that difference is observable. Also resets the FPS window in `stop()` (it straddled restarts, so the first sample after one read near zero) and logs when the `sync_stall` watchdog is suppressed by its cooldown or 4-restart cap. Past the cap it took no action and printed nothing, so a decoder out of restart budget read as healthy. No behaviour change.

**Keyframe lockout.** `markCorruptAndRequestRecovery()` throttles the keyframe request but not the P-frame lockout it arms, so a corruption inside the throttle window locks the stream out with nothing to end it, and it sits there until the phone emits a keyframe on its own. 1.58s of discarded video in #757's log, 0.62s in #755's. Before #766 an overflow restarted the decoder and never armed the lockout, so this is new exposure. Suppressed requests are now remembered and sent from `process()` once the throttle expires, which lands within a frame or two without adding a scheduler to the transport thread. Pacing rules extracted into `VideoRecoveryPolicy` with unit tests.

**Crop rect.** `handleOutputFormatChange()` read `KEY_WIDTH`/`KEY_HEIGHT`, which describe the output buffer, not the picture. Intel's AVC component pads to its macroblock alignment and reports `height=736, crop-bottom=719` for a 720-line stream, so the projection view scaled to a wrong aspect and the next restart configured MediaCodec at the padded height. Now prefers the crop rectangle, falling back to the buffer geometry where a decoder omits it. MediaTek's AVC already reports honestly and is unaffected.

**Scope.** Two real bugs and the instrumentation to diagnose the rest; it probably does not fix either reported frame rate on its own. #757's unit is on TextureView, which `SystemOptimizer` picks unconditionally below Lollipop. That rule is unchanged since `v.3.2.0-beta4`, so it is not a regression, but it is the strongest remaining candidate there, and it needs a reporter test rather than a code change. #755's unit is on SurfaceView, which has no display-side signal at all, which is what the decoder-side counter is for.

APK: https://github.com/o-jcardenass/open-headunit/releases/download/v.3.2.0-fixes/OHU3.2.0_debug.apk
