### PR TITLE
fixing location jumping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+### v.3.2.2
+- Fixing location jumping, especially on lower speeds
+
 ### v.3.2.1
 - Fixing new welcome screen, thanks to @andrecuellar
 - Fixing screen flicker every 10s thanks to @o-jcardenass

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ adb shell am start -a android.intent.action.VIEW -d "headunit://connect?ip=192.1
 - more customization options for the UI and the app itself
 
 ## Changelog
+### v.3.2.2
+- Fixing location jumping, especially on lower speeds
+
 ### v.3.2.1
 - Fixing new welcome screen reappears, thanks to @andrecuellar
 - Fixing screen flicker every 10s thanks to @o-jcardenass

--- a/app/src/main/java/com/andrerinas/openheadunit/AapBroadcastReceiver.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/AapBroadcastReceiver.kt
@@ -41,11 +41,6 @@ class AapBroadcastReceiver : BroadcastReceiver() {
             // Feed the single source of truth for geofence / night-by-area evaluation.
             com.andrerinas.openheadunit.location.LocationHolder.update(location)
 
-            // Apply Fake Speed if enabled
-            if (component.settings.fakeSpeed) {
-                location.speed = 0.5f // 0.5 m/s corresponds to 500 mm/s in Emil's logic
-            }
-
             if (component.settings.useGpsForNavigation) {
                 component.commManager.send(LocationUpdateEvent(location))
             }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/LocationUpdateEvent.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/LocationUpdateEvent.kt
@@ -9,18 +9,25 @@ class LocationUpdateEvent(location: Location)
 
     companion object {
         private fun makeProto(location: Location): Message {
-            return Sensors.SensorBatch.newBuilder().also {
-                it.addLocationData(
-                        Sensors.SensorBatch.LocationData.newBuilder().apply {
-                            timestamp = location.time
-                            latitude = (location.latitude * 1E7).toInt()
-                            longitude = (location.longitude * 1E7).toInt()
+            return Sensors.SensorBatch.newBuilder().also { batch ->
+                batch.addLocationData(
+                    Sensors.SensorBatch.LocationData.newBuilder().apply {
+                        timestamp = location.time
+                        latitude = (location.latitude * 1E7).toInt()
+                        longitude = (location.longitude * 1E7).toInt()
+                        if (location.hasAltitude()) {
                             altitude = (location.altitude * 1E2).toInt()
+                        }
+                        if (location.hasBearing()) {
                             bearing = (location.bearing * 1E6).toInt()
-                            // AA expects speed in mm/s (m/s * 1000)
+                        }
+                        if (location.hasSpeed()) {
                             speed = (location.speed * 1E3).toInt()
+                        }
+                        if (location.hasAccuracy()) {
                             accuracy = (location.accuracy * 1E3).toInt()
                         }
+                    }
                 )
             }.build()
         }


### PR DESCRIPTION
### Root Cause Analysis
When "Use GPS for Navigation" was enabled, the app sent GPS location fixes from your tablet to Android Auto (Google Maps / Waze). However, if "Fake Speed" was turned on, AapBroadcastReceiver overwrote the real GPS speed in every location update with a hardcoded 0.5 m/s (~1.1 mph / 1.8 km/h).

This created a severe mismatch inside navigation apps (Google Maps / Waze):

1. At lower speeds (~35 mph) near intersections: Google Maps received real GPS coordinates moving 15 meters every second, but the embedded location data claimed the vehicle was moving at only 1.1 mph.
Maps' dead-reckoning and map-matching algorithms resolved this contradiction by assuming the vehicle was turning onto a side street or rotating in place -> causing the map UI to spin/rotate until the next GPS update snapped it back to the main road.
2. At higher speeds (highway): The GPS coordinate delta per second was large enough that Maps' navigation engine prioritized coordinate displacement over the reported low speed, making the issue much less noticeable.

_(Note: Video and keyboard lockouts while driving are controlled separately via DrivingStatus = UNRESTRICTED in Open-Headunit, so overriding the GPS speed was unnecessary and harmful to navigation)._

Fix Applied
In the latest codebase update:

1. Fixed GPS Speed Passthrough: Removed the speed override from the GPS location pipeline. Navigation apps now receive the real, accurate GPS speed from your device.
2. Proper Optional Location Checks: Added checks for hasBearing(), hasSpeed(), hasAltitude(), and hasAccuracy() before populating the location protobuf batch to prevent sending stale or zeroed heading values.

This fix will be included in the next release. Thanks again for reporting this!