### PR TITLE
Default the wizard to H.264, only recommend H.265 above Full HD

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SystemOptimizer.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SystemOptimizer.kt
@@ -99,10 +99,16 @@ class SystemOptimizer(private val context: Context) {
 
         recDpi = recDpi.coerceAtLeast(110)
 
+        // Default to H.264. Many head units report HEVC support they cannot actually play back, so
+        // only recommend H.265 when the panel is above Full HD (1440p/4K), where H.264 bandwidth
+        // stops being practical and the saving is worth the risk. panelCeil.width > 1920 means the
+        // panel warrants more than 1080p.
+        val recommendedCodec = if (hasH265 && panelCeil.width > 1920) "H.265" else "H.264"
+
         return OptimizationResult(
             recommendedResolutionId = panelCeil.id,
             recommendedDpi = recDpi,
-            recommendedVideoCodec = if (hasH265) "H.265" else "H.264",
+            recommendedVideoCodec = recommendedCodec,
             recommendedViewMode = recViewMode,
             isWidescreen = aspectRatio > 1.7f,
             suggestedOrientation = if (isPortraitTarget) Settings.ScreenOrientation.PORTRAIT else Settings.ScreenOrientation.LANDSCAPE,


### PR DESCRIPTION
Follow-up to #775, from the discussion there.

The wizard was recommending H.265 whenever the head unit reported hardware HEVC support. A lot of units report HEVC they cannot actually play back, so this backfired on some devices.

The wizard now defaults to H.264, and only recommends H.265 when the panel is above Full HD (1440p or 4K), where H.264 bandwidth stops being practical and the saving is worth the risk. The runtime already caps the resolution to the panel, so this lines up with what is actually sent.

Nothing else changes. Existing installs keep their codec (the wizard does not overwrite the display config of upgraders), this only affects the recommendation on a fresh setup.
