### PR TITLE
Experimental Feat - Native AA Hotspot route

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -722,7 +722,14 @@ class AapService : Service(), UsbReceiver.Listener {
             }
         }
 
-        initWifiModeWithOptionalWait()
+        // Decided here as well as inside initWifiMode() so a paused start skips the wait-for-WiFi
+        // machinery entirely rather than setting it up and being turned away at the end of it.
+        if (applyBootLoopGuard()) {
+            AppLog.w("AapService: Wireless bring-up paused by the boot-loop guard. USB and the rest of the app are unaffected.")
+        } else {
+            initWifiModeWithOptionalWait()
+        }
+        scheduleBootLoopStrikeClear()
         wifiDirectManager?.setCredentialsListener { ssid, psk, ip, bssid ->
             onNativeCredentials(ssid, psk, ip, bssid)
         }
@@ -1433,6 +1440,15 @@ class AapService : Service(), UsbReceiver.Listener {
 
     /** Starts [WirelessServer] if the user has configured server WiFi mode. */
     private fun initWifiMode(force: Boolean = false) {
+        // Every automatic entry point lands here, including the Bluetooth auto-start that fires
+        // when the phone comes into range — which on a looping unit would walk straight back into
+        // the crash the guard was set to avoid. Explicit user actions release the pause first, so
+        // this only ever blocks a start nobody asked for.
+        if (Settings.isWirelessPausedByBootLoop(this)) {
+            AppLog.w("AapService: Wireless bring-up requested, but it is paused by the boot-loop guard. Open the app to re-enable it.")
+            return
+        }
+
         val settings = App.provide(this).settings
         val mode = settings.wifiConnectionMode
         val strategy = settings.helperConnectionStrategy
@@ -1702,7 +1718,12 @@ class AapService : Service(), UsbReceiver.Listener {
 
         when (intent?.action) {
             ACTION_START_SELF_MODE       -> startSelfMode()
-            ACTION_START_WIRELESS        -> initWifiMode()
+            ACTION_START_WIRELESS        -> {
+                // Asked for from the UI, so the user is present: release the boot-loop pause
+                // rather than silently ignoring them.
+                Settings.clearBootLoopState(this)
+                initWifiMode()
+            }
             ACTION_START_WIRELESS_SCAN   -> {
                 val settings = App.provide(this).settings
                 val mode = settings.wifiConnectionMode
@@ -1711,6 +1732,7 @@ class AapService : Service(), UsbReceiver.Listener {
                 // [FIX] Reset exit flags on manual scan start
                 userExitedAA = false
                 userExitCooldownUntil = 0L
+                Settings.clearBootLoopState(this)
                 initWifiMode(force = true)
 
                 if (mode == 2 && strategy == 2) {
@@ -2445,6 +2467,93 @@ class AapService : Service(), UsbReceiver.Listener {
     }
 
     // -------------------------------------------------------------------------
+    // Boot-loop guard
+    // -------------------------------------------------------------------------
+
+    /**
+     * Whether to skip wireless bring-up because starting it appears to be crashing the device, and
+     * posts the notice explaining that if so.
+     *
+     * See [BootLoopPolicy]. The decision is taken from the strike count the receiver has already
+     * written, so it needs nothing from the start intent and can run here in onCreate.
+     */
+    private fun applyBootLoopGuard(): Boolean {
+        if (Settings.isWirelessPausedByBootLoop(this)) {
+            AppLog.w("AapService: Wireless is still paused from an earlier boot loop. Open the app to re-enable it.")
+            notifyBootLoopPause()
+            return true
+        }
+        val strikes = Settings.getBootLoopStrikes(this)
+        if (!BootLoopPolicy.shouldPauseWireless(strikes)) return false
+
+        AppLog.w(
+            "AapService: $strikes boot-started runs in a row ended before " +
+                "${BootLoopPolicy.HEALTHY_RUN_MS / 1000}s. Pausing wireless bring-up — on some head units " +
+                "the WiFi stack takes the whole system down when a phone joins, and auto-start then " +
+                "repeats it forever."
+        )
+        Settings.setWirelessPausedByBootLoop(this, true)
+        notifyBootLoopPause()
+        return true
+    }
+
+    /**
+     * Clears the strikes once this run has lasted long enough to count as healthy.
+     *
+     * Deliberately time-based rather than hung off a successful connection: on the head unit this
+     * guard was written for, one cycle reached a complete projection session with audio playing and
+     * the system died anyway, so a connection-based signal would reset the count every pass.
+     */
+    private fun scheduleBootLoopStrikeClear() {
+        if (Settings.getBootLoopStrikes(this) == 0) return
+        serviceScope.launch {
+            delay(BootLoopPolicy.HEALTHY_RUN_MS)
+            AppLog.i("AapService: This run has lasted ${BootLoopPolicy.HEALTHY_RUN_MS / 1000}s. Clearing the boot-loop strikes.")
+            Settings.setBootLoopStrikes(this@AapService, 0)
+        }
+    }
+
+    /**
+     * Tells the user wireless was left off and what to do about it. Names the WiFi Direct join when
+     * that is the configuration, because on the units this happens to, switching the Native AA
+     * transport to the head unit's own hotspot avoids the P2P path altogether.
+     */
+    private fun notifyBootLoopPause() {
+        val settings = App.provide(this).settings
+        val onNativeWifiDirect = settings.wifiConnectionMode == 3 &&
+            NativeTransport.fromSetting(settings.nativeApTransport) == NativeTransport.WIFI_DIRECT
+        val text = getString(
+            if (onNativeWifiDirect) R.string.boot_loop_paused_native_wifi_direct
+            else R.string.boot_loop_paused_generic
+        )
+
+        val launchIntent = Intent(this, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            putExtra(MainActivity.EXTRA_LAUNCH_SOURCE, "Boot-loop guard")
+        }
+        val piFlags = PendingIntent.FLAG_UPDATE_CURRENT or
+            (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0)
+        val pi = PendingIntent.getActivity(this, 201, launchIntent, piFlags)
+
+        val notification = NotificationCompat.Builder(this, App.bootStartChannel)
+            .setSmallIcon(R.drawable.ic_stat_aa)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setContentTitle(getString(R.string.boot_loop_paused_title))
+            .setContentText(text)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+            .setContentIntent(pi)
+            .setAutoCancel(true)
+            .build()
+
+        try {
+            (getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
+                .notify(BOOT_LOOP_NOTIFICATION_ID, notification)
+        } catch (e: Exception) {
+            AppLog.w("AapService: Could not post the boot-loop notice: ${e.message}")
+        }
+    }
+
+    // -------------------------------------------------------------------------
     // Self Mode
     // -------------------------------------------------------------------------
 
@@ -2781,6 +2890,7 @@ class AapService : Service(), UsbReceiver.Listener {
         val scanningState = MutableStateFlow(false)
 
         private const val BOOT_START_NOTIFICATION_ID = 42
+        private const val BOOT_LOOP_NOTIFICATION_ID = 43
         private const val PROJECTION_LAUNCH_NOTIFICATION_ID = 43
 
         // Service action strings used with startService() and sendBroadcast()

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -74,6 +74,7 @@ import com.andrerinas.openheadunit.utils.VpnControl
 import com.andrerinas.openheadunit.connection.CarKeyReceiver
 import com.andrerinas.openheadunit.connection.NativeAaHandshakeManager
 import com.andrerinas.openheadunit.connection.NearbyManager
+import com.andrerinas.openheadunit.connection.SoftApCredentialsProvider
 import com.andrerinas.openheadunit.connection.carkey.CarKeysManager
 import com.andrerinas.openheadunit.main.BackgroundNotification
 import com.andrerinas.openheadunit.utils.SUExecutor
@@ -106,6 +107,9 @@ class AapService : Service(), UsbReceiver.Listener {
     private lateinit var usbReceiver: UsbReceiver
     private var nightModeManager: NightModeManager? = null
     private var wifiDirectManager: WifiDirectManager? = null
+    // The hotspot transport's credential source, the alternative to wifiDirectManager for mode 3.
+    // Constructed alongside it so both can be wired once; only one of the two is start()ed.
+    private var softApCredentialsProvider: SoftApCredentialsProvider? = null
     private var nativeAaHandshakeManager: NativeAaHandshakeManager? = null
     private var nearbyManager: NearbyManager? = null
     private var wifiAutoStartReceiver: WifiAutoStartReceiver? = null
@@ -702,6 +706,7 @@ class AapService : Service(), UsbReceiver.Listener {
 
         nativeAaHandshakeManager = NativeAaHandshakeManager(this, serviceScope)
         wifiDirectManager = WifiDirectManager(this)
+        softApCredentialsProvider = SoftApCredentialsProvider(this, serviceScope, App.provide(this).settings)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             try {
@@ -719,21 +724,7 @@ class AapService : Service(), UsbReceiver.Listener {
 
         initWifiModeWithOptionalWait()
         wifiDirectManager?.setCredentialsListener { ssid, psk, ip, bssid ->
-            val appSettings = App.provide(this).settings
-            if (appSettings.wifiConnectionMode == 3) {
-                AppLog.i("AapService: Received WiFi credentials from manager (SSID=$ssid, IP=$ip). Updating and Triggering Poke.")
-                nativeAaHandshakeManager?.updateWifiCredentials(ssid, psk, ip, bssid)
-                if (commManager.isConnected ||
-                    commManager.connectionState.value is CommManager.ConnectionState.Connecting) {
-                    AppLog.i("AapService: USB/other session already active. Skipping auto-poke to avoid pulling phone into wireless flow.")
-                } else if (!userExitedAA) {
-                    nativeAaHandshakeManager?.triggerPoke()
-                } else {
-                    AppLog.i("AapService: userExitedAA is true. Skipping auto-poke.")
-                }
-            } else {
-                AppLog.d("AapService: WiFi credentials received, but not in Native AA mode. Skipping HandshakeManager update.")
-            }
+            onNativeCredentials(ssid, psk, ip, bssid)
         }
         // Settling counts as in-flight here: isHandshakeInFlight() goes false the instant Type 3
         // is written, but the phone still has to associate, do WPS and get a DHCP lease, and
@@ -744,6 +735,10 @@ class AapService : Service(), UsbReceiver.Listener {
         }
         wifiDirectManager?.setNativeSessionConnectedProvider { commManager.isConnected }
         wifiDirectManager?.setNativeGroupInvalidatedListener { nativeAaHandshakeManager?.invalidateCredentials() }
+        softApCredentialsProvider?.setCredentialsListener { ssid, psk, ip, bssid ->
+            onNativeCredentials(ssid, psk, ip, bssid)
+        }
+        softApCredentialsProvider?.setInvalidatedListener { nativeAaHandshakeManager?.invalidateCredentials() }
 
 
         checkAlreadyConnectedUsb()
@@ -1127,7 +1122,7 @@ class AapService : Service(), UsbReceiver.Listener {
             // the existing group for fast reconnection there. Must await CommManager's async
             // teardown first so we never remove the P2P interface while the
             // ByeByeRequest/socket-close is still in flight.
-            if (state.isUserExit && WifiModePolicy.usesWifiDirect(mode, strategy)) {
+            if (state.isUserExit && WifiModePolicy.usesWifiDirect(mode, strategy, nativeTransport())) {
                 commManager.awaitDisconnectComplete()
                 AppLog.i("AapService: CommManager teardown complete. Stopping WiFi Direct group.")
                 wifiDirectManager?.stop()
@@ -1453,8 +1448,9 @@ class AapService : Service(), UsbReceiver.Listener {
         networkDiscovery?.stop()
         nearbyManager?.stop()
         nativeAaHandshakeManager?.stop()
+        softApCredentialsProvider?.stop()
 
-        val usesWifiDirect = WifiModePolicy.usesWifiDirect(mode, strategy)
+        val usesWifiDirect = WifiModePolicy.usesWifiDirect(mode, strategy, nativeTransport())
         if (!usesWifiDirect) {
             AppLog.i("AapService: New mode does not use WiFi Direct. Stopping WifiDirectManager...")
             wifiDirectManager?.stop()
@@ -1503,9 +1499,16 @@ class AapService : Service(), UsbReceiver.Listener {
 
             // Mode 3: Native AA Wireless
             if (mode == 3) {
-                // Start WiFi Direct as a "quiet host" (P2P Group for phone to join)
-                // We let WifiDirectManager handle the WiFi state (enabling if needed)
-                wifiDirectManager?.startNativeAaQuietHost()
+                if (nativeTransport() == NativeTransport.HOTSPOT) {
+                    // Read this device's own access point instead of hosting a P2P group. The AP
+                    // itself is the user's to switch on; the provider only resolves and watches it.
+                    AppLog.i("AapService: Native AA on the head unit hotspot — resolving access point credentials.")
+                    softApCredentialsProvider?.start()
+                } else {
+                    // Start WiFi Direct as a "quiet host" (P2P Group for phone to join)
+                    // We let WifiDirectManager handle the WiFi state (enabling if needed)
+                    wifiDirectManager?.startNativeAaQuietHost()
+                }
 
                 // Start the official Bluetooth handshake servers
                 nativeAaHandshakeManager?.start()
@@ -1609,6 +1612,7 @@ class AapService : Service(), UsbReceiver.Listener {
         stopForeground(true)
         stopWirelessServer()
         wifiDirectManager?.stop()
+        softApCredentialsProvider?.stop()
         nearbyManager?.stop()
         try {
             mediaSession?.let {
@@ -2152,10 +2156,40 @@ class AapService : Service(), UsbReceiver.Listener {
      * Triggers a refresh of the WiFi Direct "quiet host" state.
      * Called by NativeAaHandshakeManager if it's waiting for credentials that haven't arrived yet.
      */
+    /**
+     * Credentials for the network the phone should join, from whichever transport produced them.
+     * Both mode-3 transports funnel through here so the poke rules stay in one place.
+     */
+    private fun onNativeCredentials(ssid: String, psk: String, ip: String, bssid: String) {
+        val appSettings = App.provide(this).settings
+        if (appSettings.wifiConnectionMode != 3) {
+            AppLog.d("AapService: WiFi credentials received, but not in Native AA mode. Skipping HandshakeManager update.")
+            return
+        }
+        AppLog.i("AapService: Received WiFi credentials from manager (SSID=$ssid, IP=$ip). Updating and Triggering Poke.")
+        nativeAaHandshakeManager?.updateWifiCredentials(ssid, psk, ip, bssid)
+        if (commManager.isConnected ||
+            commManager.connectionState.value is CommManager.ConnectionState.Connecting) {
+            AppLog.i("AapService: USB/other session already active. Skipping auto-poke to avoid pulling phone into wireless flow.")
+        } else if (!userExitedAA) {
+            nativeAaHandshakeManager?.triggerPoke()
+        } else {
+            AppLog.i("AapService: userExitedAA is true. Skipping auto-poke.")
+        }
+    }
+
+    /** The transport mode 3 is configured to use. Read fresh: the user can change it in settings. */
+    private fun nativeTransport(): NativeTransport =
+        NativeTransport.fromSetting(App.provide(this).settings.nativeApTransport)
+
     fun triggerWifiDirectRefresh() {
-        AppLog.i("AapService: WiFi Direct refresh requested.")
         val mode = App.provide(this).settings.wifiConnectionMode
-        if (mode == 3) {
+        if (mode != 3) return
+        if (nativeTransport() == NativeTransport.HOTSPOT) {
+            AppLog.i("AapService: Access point refresh requested.")
+            softApCredentialsProvider?.refresh()
+        } else {
+            AppLog.i("AapService: WiFi Direct refresh requested.")
             wifiDirectManager?.startNativeAaQuietHost()
         }
     }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/BootLoopPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/BootLoopPolicy.kt
@@ -1,0 +1,49 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * When to stop bringing wireless up automatically because doing so appears to be crashing the
+ * device.
+ *
+ * Auto-start on boot turns a single system-level crash into an endless cycle: the system dies, the
+ * head unit soft-reboots, `LOCKED_BOOT_COMPLETED` arrives, we start, we bring up the wireless mode,
+ * and it dies again. Measured on a reporter's MT8163 unit at a 20–26 s period across seven
+ * consecutive processes in two separate logs, with nothing in between to break it.
+ *
+ * The app cannot see why the system died — the log ends mid-frame with no stack — so this counts
+ * the only thing it can observe: boot-started runs that did not last. Three in a row and wireless
+ * bring-up is skipped, leaving the rest of the app (USB especially) working and the user with a
+ * notice explaining what to do.
+ *
+ * Pure so the counting rules are testable without Android; the persistence and the notice live in
+ * [com.andrerinas.openheadunit.app.BootCompleteReceiver] and
+ * [com.andrerinas.openheadunit.aap.AapService].
+ */
+object BootLoopPolicy {
+
+    /** Boot-started runs that must fail in a row before wireless bring-up is paused. */
+    const val STRIKES_BEFORE_PAUSE = 3
+
+    /**
+     * How long a boot-started run must survive to count as healthy.
+     *
+     * Chosen against the measured lifetimes: the crash-loop processes lived 8, 9, 10 and 15 s,
+     * while the two runs that reached a real session lived 48 s and 173 s. Short enough that an
+     * ordinary trip clears it, long enough that a unit dying on connect never does.
+     */
+    const val HEALTHY_RUN_MS = 30_000L
+
+    /** The strike count after another boot-started run begins. */
+    fun nextStrikes(current: Int): Int = if (current < 0) 1 else current + 1
+
+    /** Whether to skip wireless bring-up on this run. */
+    fun shouldPauseWireless(strikes: Int): Boolean = strikes >= STRIKES_BEFORE_PAUSE
+
+    /**
+     * Whether a run that lasted [runMs] counts as healthy, clearing the strikes.
+     *
+     * Deliberately not "did a session connect": on the reporter's unit one cycle reached a complete
+     * projection session with audio playing and died anyway, so a session-based signal would reset
+     * the count on every pass and the guard would never trip.
+     */
+    fun clearsStrikes(runMs: Long): Boolean = runMs >= HEALTHY_RUN_MS
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/NativeCredentialsPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/NativeCredentialsPolicy.kt
@@ -46,6 +46,16 @@ enum class UnusableBssidAction {
  * - **Hotspot** omits the field and sends. aa-proxy-rs and ZLink both ship without one, so an
  *   ordinary AP is identified by SSID; aborting would kill the route on every device with a
  *   masked AP MAC, which is most of them.
+ *
+ * That last justification is now known to be too strong. A current Gearhead joins with a
+ * `WifiNetworkSpecifier`, which matches SSID *and* BSSID under a full `ff:ff:ff:ff:ff:ff` mask: it
+ * answered credentials with no BSSID with `WIFI_INVALID_BSSID` and a type 6 `status=-3`, every
+ * attempt, and never fell back to matching on the name. Measured 2026-08-05, phone-to-phone.
+ *
+ * Sending anyway is still the better of the two, and deliberately kept: the field is optional in the
+ * protocol, other clients do accept it missing, and a rejection arrives as a message we can explain
+ * — where aborting produces nothing to read at all. What changed is that the omission is now the
+ * first suspect when the phone refuses, so the handshake says so rather than leaving it implied.
  */
 object NativeCredentialsPolicy {
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/NativeCredentialsPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/NativeCredentialsPolicy.kt
@@ -1,0 +1,84 @@
+package com.andrerinas.openheadunit.aap
+
+/** Which network the Native AA mode puts the phone on. */
+enum class NativeTransport {
+    /** A WiFi Direct P2P group with this head unit as group owner. The default. */
+    WIFI_DIRECT,
+
+    /** This head unit's own WPA2 access point, as the OEM ZLink app uses. Experimental. */
+    HOTSPOT;
+
+    companion object {
+        /** [Settings.nativeApTransport][com.andrerinas.openheadunit.utils.Settings.nativeApTransport]
+         *  as a transport, defaulting to [WIFI_DIRECT] for any value we do not recognise. */
+        fun fromSetting(value: Int): NativeTransport = if (value == 1) HOTSPOT else WIFI_DIRECT
+    }
+}
+
+/** What the framework says about this device's own access point. */
+enum class SoftApState {
+    /** An access point is running. */
+    ENABLED,
+
+    /** The framework is sure there is not one — off, still coming up, or failed. */
+    NOT_ENABLED,
+
+    /** Could not be asked. `getWifiApState()` is not public API and is blocked on some devices. */
+    UNKNOWN
+}
+
+/** What to do when the credentials we are about to send carry no usable BSSID. */
+enum class UnusableBssidAction {
+    /** Do not send them at all. */
+    ABORT,
+
+    /** Send them with the BSSID field left out entirely. */
+    OMIT_AND_CONTINUE
+}
+
+/**
+ * Whether a set of credentials is fit to hand the phone. The interesting case is a missing BSSID,
+ * where the answer differs by transport:
+ *
+ * - **WiFi Direct** aborts. Measured, not cautious: a masked BSSID there means the phone rejects
+ *   the credentials anyway, and the usual cause (location services off) is fixable once the log
+ *   says so rather than showing a healthy-looking handshake and a phone that never arrives.
+ * - **Hotspot** omits the field and sends. aa-proxy-rs and ZLink both ship without one, so an
+ *   ordinary AP is identified by SSID; aborting would kill the route on every device with a
+ *   masked AP MAC, which is most of them.
+ */
+object NativeCredentialsPolicy {
+
+    /** Whether [bssid] is a real address rather than absent, blank or a masking placeholder. */
+    fun isUsableBssid(bssid: String?): Boolean = SoftApBssidPolicy.isUsable(bssid)
+
+    /** What to do when [isUsableBssid] said no. */
+    fun onUnusableBssid(transport: NativeTransport): UnusableBssidAction = when (transport) {
+        NativeTransport.WIFI_DIRECT -> UnusableBssidAction.ABORT
+        NativeTransport.HOTSPOT -> UnusableBssidAction.OMIT_AND_CONTINUE
+    }
+
+    /**
+     * Whether to advertise a network the framework says is not running.
+     *
+     * The failure this prevents, measured on a Unisoc head unit: with the real access point down,
+     * the cellular bridge `seth_lte0` was the only interface up with a private address, so the app
+     * paired the right network name with an address no phone could reach and logged SUCCESS. Name
+     * exclusions alone cannot fix that class of thing — the list has needed extending three times —
+     * because it is a guess about which unknown interfaces are not access points.
+     *
+     * Two exemptions, and only two:
+     *
+     * - [SoftApState.UNKNOWN] never refuses. `getWifiApState()` is not public API and is blocked
+     *   outright on some devices, and a question we could not ask is not a question answered no.
+     * - [interfaceNamedByUser] never refuses. Naming the interface is a specific claim about which
+     *   network is up, and it is the escape hatch for a vendor that starts hostapd outside the
+     *   framework — where the state read is silent while the access point is plainly there.
+     *
+     * A hand-typed *SSID* is deliberately not an exemption, though it was once: it names a network,
+     * not an interface, and it is required on any device that refuses the config-read API — so
+     * exempting it disabled this check on exactly the hardware that needed it.
+     */
+    fun shouldPublishCredentials(apState: SoftApState, interfaceNamedByUser: Boolean): Boolean =
+        apState != SoftApState.NOT_ENABLED || interfaceNamedByUser
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/NativeCredentialsPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/NativeCredentialsPolicy.kt
@@ -32,8 +32,8 @@ enum class UnusableBssidAction {
     /** Do not send them at all. */
     ABORT,
 
-    /** Send them with the BSSID field left out entirely. */
-    OMIT_AND_CONTINUE
+    /** Send them with the BSSID field present but empty — never absent. See [NativeCredentialsPolicy]. */
+    SEND_WITH_EMPTY_BSSID
 }
 
 /**
@@ -43,19 +43,27 @@ enum class UnusableBssidAction {
  * - **WiFi Direct** aborts. Measured, not cautious: a masked BSSID there means the phone rejects
  *   the credentials anyway, and the usual cause (location services off) is fixable once the log
  *   says so rather than showing a healthy-looking handshake and a phone that never arrives.
- * - **Hotspot** omits the field and sends. aa-proxy-rs and ZLink both ship without one, so an
- *   ordinary AP is identified by SSID; aborting would kill the route on every device with a
- *   masked AP MAC, which is most of them.
+ * - **Hotspot** sends anyway, with the field empty. Not because an empty one works — it does not —
+ *   but because the phone's refusal is a message we can explain, where aborting leaves nothing to
+ *   read, and because the route stays open for any client that is less strict than the one measured.
  *
- * That last justification is now known to be too strong. A current Gearhead joins with a
- * `WifiNetworkSpecifier`, which matches SSID *and* BSSID under a full `ff:ff:ff:ff:ff:ff` mask: it
- * answered credentials with no BSSID with `WIFI_INVALID_BSSID` and a type 6 `status=-3`, every
- * attempt, and never fell back to matching on the name. Measured 2026-08-05, phone-to-phone.
+ * The justification this used to carry — that aa-proxy-rs and ZLink ship without a BSSID, so an
+ * ordinary AP is identified by SSID — was wrong, and it is worth recording how wrong. Both reference
+ * implementations declare `required string bssid = 3` in a byte-identical proto2 schema, and both
+ * read it from the access point's own interface: aa-proxy-rs takes `mac_address_by_name(iface)` and
+ * **fails to start** with "No MAC address found" if it cannot, and WirelessAndroidAutoDongle
+ * defaults it to `getMacAddress("wlan0")`. Neither has a no-BSSID mode. The one aa-proxy-rs path
+ * that has no address to hand sets an empty string, precisely because `required` forbids dropping
+ * the field, with a comment anticipating that phones may need a real one.
  *
- * Sending anyway is still the better of the two, and deliberately kept: the field is optional in the
- * protocol, other clients do accept it missing, and a rejection arrives as a message we can explain
- * — where aborting produces nothing to read at all. What changed is that the omission is now the
- * first suspect when the phone refuses, so the handshake says so rather than leaving it implied.
+ * The phone side agrees. A current Gearhead joins with a `WifiNetworkSpecifier`, which matches SSID
+ * *and* BSSID under a full `ff:ff:ff:ff:ff:ff` mask: credentials with no BSSID drew
+ * `WIFI_INVALID_BSSID` and a type 6 `status=-3` on every attempt, with no fallback to matching on
+ * the name. Measured 2026-08-05, phone-to-phone.
+ *
+ * So a missing BSSID is a failure everywhere it has been looked at, and the static BSSID setting is
+ * the fix rather than a workaround. What this policy still buys is the *shape* of the failure: one
+ * explained refusal instead of a silent abort.
  */
 object NativeCredentialsPolicy {
 
@@ -65,7 +73,7 @@ object NativeCredentialsPolicy {
     /** What to do when [isUsableBssid] said no. */
     fun onUnusableBssid(transport: NativeTransport): UnusableBssidAction = when (transport) {
         NativeTransport.WIFI_DIRECT -> UnusableBssidAction.ABORT
-        NativeTransport.HOTSPOT -> UnusableBssidAction.OMIT_AND_CONTINUE
+        NativeTransport.HOTSPOT -> UnusableBssidAction.SEND_WITH_EMPTY_BSSID
     }
 
     /**

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicy.kt
@@ -21,6 +21,12 @@ object NativeHandoffPolicy {
      *  long is one slow retry, the cost of waiting too little is a dead connection. */
     const val SETTLE_TIMEOUT_MS = 45_000L
 
+    /** Hard ceiling on the settling window once the phone's own progress reports
+     *  ([com.andrerinas.openheadunit.aap.WppAction.ExtendSettle]) have extended it. Without a cap,
+     *  a phone that keeps saying "still joining" and never arrives holds the Bluetooth channel
+     *  open and the wake poke suppressed indefinitely. Three 15 s extensions past the base window. */
+    const val MAX_SETTLE_MS = 90_000L
+
     /** Longest a single credential exchange can legitimately take: the up-to-60 s wait for the
      *  P2P group's credentials, plus the 15 s wait for the phone's Type 2, plus slack. Past this
      *  the exchange is over however it ended, so treating it as live only suppresses recovery. */

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicy.kt
@@ -4,11 +4,10 @@ package com.andrerinas.openheadunit.aap
  * The window between "we sent the phone our WiFi credentials (Type 3)" and "the phone's TCP
  * session actually landed", and what the rest of the app is allowed to do during it.
  *
- * The phone still has to associate, run WPS and get a DHCP lease after Type 3 goes out, and on
- * slower hardware that takes far longer than the handshake itself — 21 s in a known-good 3.1.1
- * log. Anything that touches the Bluetooth radio or takes the P2P group owner off-channel in
- * that window can make the phone abandon the join, which surfaces as "Obtaining IP address"
- * forever on the phone (#760).
+ * The phone still has to associate, run WPS and get a DHCP lease after Type 3 goes out —
+ * measured at 21 s on slow hardware, far longer than the handshake itself. Touching the Bluetooth
+ * radio or taking the P2P group owner off-channel in that window makes the phone abandon the
+ * join, which it shows as "Obtaining IP address" forever.
  *
  * Split out as a pure object so the timing rules are unit-testable without Android, and so
  * [com.andrerinas.openheadunit.connection.NativeAaHandshakeManager] and
@@ -39,12 +38,11 @@ object NativeHandoffPolicy {
     /**
      * Whether a credential exchange is still in progress.
      *
-     * [startedAtMs] is an elapsed-realtime stamp, or 0 when no handshake is running. Bounded for
-     * the same reason [isSettling] is, and not merely as a belt-and-braces measure: on the #706
-     * reporter's head unit, closing the Bluetooth socket does not unblock a pending
-     * `readFully()`, so the handshake coroutine never reaches its own cleanup. A plain boolean
-     * latched true there and stayed true for the life of the process, which stopped the wake
-     * poke retrying and made `WifiDirectManager`'s join watchdog defer recovery forever.
+     * [startedAtMs] is an elapsed-realtime stamp, or 0 when no handshake is running. Bounded, and
+     * not merely as a belt-and-braces measure: on head units where closing the Bluetooth socket
+     * does not unblock a pending `readFully()`, the handshake coroutine never reaches its cleanup.
+     * A plain boolean latched true there for the life of the process, stopping the wake poke and
+     * making `WifiDirectManager`'s join watchdog defer recovery forever.
      */
     fun isHandshaking(startedAtMs: Long, nowMs: Long, timeoutMs: Long = HANDSHAKE_TIMEOUT_MS): Boolean =
         isWithinWindow(startedAtMs, nowMs, timeoutMs)
@@ -73,13 +71,12 @@ object NativeHandoffPolicy {
     /**
      * Whether to warn that the phone answers our wake pokes but never connects back.
      *
-     * That combination has exactly one common cause, and it is not something this app can fix:
-     * the phone's Android Auto is bound to a *different* Bluetooth device that also advertises
-     * the Android Auto service record. On the #706 reporter's unit that was the head unit's own
-     * OEM Bluetooth module ("CAR8032"), a separate chip that Android on the head unit cannot see,
-     * still advertising the service after its OEM app stopped answering on it. Gearhead kept
-     * reconnecting to it every 12 s and discarded every poke from our radio as
-     * `IGNORE_DIFFERENT_BLUETOOTH_DEVICE`. Our own log showed successful pokes and nothing wrong.
+     * That combination has one common cause and this app cannot fix it: the phone's Android Auto
+     * is bound to a *different* Bluetooth device that also advertises the Android Auto service
+     * record — typically the head unit's own OEM module, a separate chip Android on the unit
+     * cannot see, still advertising after its OEM app stopped answering. Gearhead reconnects to it
+     * every 12 s and discards our pokes as `IGNORE_DIFFERENT_BLUETOOTH_DEVICE`, while our log
+     * shows successful pokes and nothing wrong.
      *
      * [everAccepted] gates it to units that have never once been reached, so a unit that connects
      * normally and then has a bad run never sees it. Periodic rather than one-shot so it is still
@@ -97,12 +94,11 @@ object NativeHandoffPolicy {
     /**
      * Whether to serve an incoming Android Auto connection at all.
      *
-     * Exists to bound a leak we cannot otherwise close. The wait for the phone's Type 2 is a
-     * blocking read on a background coroutine, and on a head unit where `close()` does not
-     * interrupt a pending read — #706's does not — that coroutine never returns and its
-     * `Dispatchers.IO` thread is stranded for the life of the process. `cancel()` cannot help:
-     * there is no suspension point inside a blocking JNI read. Since the thread cannot be
-     * reclaimed, the only lever is to stop creating them.
+     * Bounds a leak we cannot otherwise close. The wait for the phone's Type 2 is a blocking read
+     * on a background coroutine, and where `close()` does not interrupt a pending read that
+     * coroutine never returns — its `Dispatchers.IO` thread is stranded for the life of the
+     * process, and `cancel()` cannot help because a blocking JNI read has no suspension point.
+     * The thread cannot be reclaimed, so the only lever is to stop creating them.
      *
      * A hard stop rather than a growing delay, because this failure is not transient: if the
      * stack drops our write, the 200th attempt fails exactly like the first, and each one costs a

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/SoftApBssidPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/SoftApBssidPolicy.kt
@@ -1,0 +1,51 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Picks the BSSID to advertise for our own access point, best source first.
+ *
+ * A chain rather than one source because `NetworkInterface.getHardwareAddress()` returns null or a
+ * placeholder on plenty of devices since Android 6.0, while `/sys/class/net/<iface>/address` still
+ * works on most head units. Pure and tested: case, placeholder detection and empty-vs-null are
+ * easy to get subtly wrong and impossible to check by reading a log.
+ */
+object SoftApBssidPolicy {
+
+    /**
+     * Android's masking placeholders. Note what is *not* here: anything merely beginning with
+     * `02:`. That bit marks a locally-administered MAC and Android's own soft AP routinely uses a
+     * randomised one, so rejecting the range would discard the BSSID this exists to find.
+     */
+    private val PLACEHOLDERS = setOf("00:00:00:00:00:00", "02:00:00:00:00:00")
+
+    /** Six hex pairs separated by colons or dashes. */
+    private val MAC_SHAPE = Regex("^[0-9a-fA-F]{2}([:-][0-9a-fA-F]{2}){5}$")
+
+    /**
+     * The first usable address of [staticOverride], [shellMac] and [hardwareAddress], normalised to
+     * colon-separated upper case, or "" if none yields one. What to do about "" differs by
+     * transport — see [NativeCredentialsPolicy].
+     */
+    fun choose(staticOverride: String?, shellMac: String?, hardwareAddress: String?): String =
+        listOf(staticOverride, shellMac, hardwareAddress)
+            .firstOrNull { isUsable(it) }
+            ?.let { normalise(it) }
+            ?: ""
+
+    /**
+     * Whether [mac] is a real address.
+     *
+     * [BUG_FIX] Checks the shape, not a list of known non-addresses. The setting this reads first
+     * stores the string "0" when it is unset, which is not MAC-shaped but passed the old
+     * placeholder check, won the chain over the real interface MAC, and was published verbatim —
+     * the phone then rejected the credentials on every retry. A free-text field can produce any
+     * number of such values, so validate what an address looks like instead.
+     */
+    fun isUsable(mac: String?): Boolean {
+        val trimmed = mac?.trim().orEmpty()
+        if (!MAC_SHAPE.matches(trimmed)) return false
+        return normalise(trimmed).lowercase() !in PLACEHOLDERS
+    }
+
+    /** Dashes to colons, upper case. Accepts either separator so a hand-typed address still works. */
+    private fun normalise(mac: String): String = mac.trim().replace('-', ':').uppercase()
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/SoftApNetworkPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/SoftApNetworkPolicy.kt
@@ -1,0 +1,105 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * One network interface, reduced to the four things that decide whether it is the head unit's
+ * access point. Built from `java.net.NetworkInterface` by the caller so the choice itself stays
+ * testable without a device.
+ */
+data class ApInterfaceCandidate(
+    val name: String,
+    val isLoopback: Boolean,
+    val isUp: Boolean,
+    /** The interface's own site-local IPv4 address, or null if it has none. */
+    val siteLocalIpv4: String?
+)
+
+/**
+ * Which network interface is the hotspot we are hosting.
+ *
+ * No public API answers this — `WifiManager` will not give an ordinary app its own soft AP's
+ * address — so the interface is recognised from outside, by shape as well as name: vendors are
+ * inconsistent, and ZLink's head unit serves Android Auto off a plain `wlan0`. Getting it wrong
+ * hands the phone an address it cannot reach.
+ */
+object SoftApNetworkPolicy {
+
+    /**
+     * Names we prefer, best first. An interface that matches none of these is still eligible —
+     * a vendor can call it anything — it just loses to one that does.
+     *
+     * MediaTek's `ra0`/`rai0` access points are deliberately absent. Two letters is too loose a
+     * prefix to match on, and they do not need to be here: an unrecognised name is still eligible,
+     * so once `apcli*` is excluded below, `ra0` wins on an MTK unit by being what is left.
+     */
+    private val PREFERRED_PREFIXES = listOf("ap", "swlan", "softap", "wlan")
+
+    /**
+     * Interfaces that can hold a site-local IPv4 and are never an access point.
+     *
+     * `p2p-*` is the WiFi Direct transport, which has its own credential source. `tun*`/`dummy*`
+     * is this app's own VPN service, which parks a 10.x address on the device while it runs.
+     *
+     * `apcli*` and `sta*` are stations wearing an access point's name. On MediaTek and Ralink
+     * drivers `apcli0` is the AP *client* — the interface that joins someone else's network,
+     * configured `mode: sta` — while `ra0` is the access point; without this exclusion `apcli0`
+     * would rank best of all, since it starts with "ap". `sta*` is the same trap spelled the
+     * obvious way, and is what aa-proxy-rs names its own managed station interface.
+     *
+     * `seth_lte*` is a Unisoc cellular bridge. It is up and holds a private address the moment
+     * there is signal, so with the real access point down it was the only candidate left and got
+     * advertised as one — the right network name against an address no phone could reach.
+     *
+     * This list is a guess about which unknown interfaces are *not* access points, and it has
+     * needed extending three times. [NativeCredentialsPolicy.shouldPublishCredentials] is the
+     * defence that does not depend on knowing every name in advance.
+     */
+    private val EXCLUDED_PREFIXES = listOf("p2p-", "tun", "dummy", "apcli", "sta", "seth_lte")
+
+    /**
+     * The interface most likely to be our access point, or null if none qualifies. Must be up and
+     * hold a site-local IPv4 — a running AP has one, and it is the address the phone is given.
+     *
+     * [stationIpv4] is this device's address on the WiFi network it is *joined to*, if any. It is
+     * the one thing that reliably separates the access point from the station interface: on a real
+     * head unit the AP runs as `wlan2` while `wlan0` is the station, and the two are
+     * indistinguishable by name. Pass null when the device is not associated with anything.
+     */
+    fun pickApInterface(
+        candidates: List<ApInterfaceCandidate>,
+        stationIpv4: String? = null
+    ): ApInterfaceCandidate? = eligible(candidates, stationIpv4).minByOrNull { rank(it.name) }
+
+    /**
+     * Everything [pickApInterface] considered, for a caller that wants to say so. More than one
+     * survivor means the choice came down to the name, which is a guess — worth a log line, since
+     * picking wrong hands the phone an address it cannot reach and nothing else reports it.
+     */
+    fun eligible(
+        candidates: List<ApInterfaceCandidate>,
+        stationIpv4: String? = null
+    ): List<ApInterfaceCandidate> = candidates.filter { isEligible(it, stationIpv4) }
+
+    /**
+     * Whether [candidate] is an access point this device is hosting.
+     *
+     * Same rules as [pickApInterface] applied to one interface, for callers asking "is there an
+     * access point at all" rather than "which of these is it".
+     */
+    fun isApHost(candidate: ApInterfaceCandidate, stationIpv4: String? = null): Boolean =
+        isEligible(candidate, stationIpv4)
+
+    private fun isEligible(candidate: ApInterfaceCandidate, stationIpv4: String?): Boolean =
+        candidate.isUp && !candidate.isLoopback && candidate.siteLocalIpv4 != null &&
+            !isExcluded(candidate.name) &&
+            !(stationIpv4 != null && candidate.siteLocalIpv4 == stationIpv4)
+
+    private fun isExcluded(name: String): Boolean =
+        name.lowercase().let { lower -> EXCLUDED_PREFIXES.any { lower.startsWith(it) } }
+
+    /** Lower is better; anything unrecognised sorts last but is still usable. */
+    private fun rank(name: String): Int {
+        val lower = name.lowercase()
+        val index = PREFERRED_PREFIXES.indexOfFirst { lower.startsWith(it) }
+        return if (index >= 0) index else PREFERRED_PREFIXES.size
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/VideoStarvationPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/VideoStarvationPolicy.kt
@@ -1,0 +1,52 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * When to tell the user that the link cannot carry the video stream they have asked for.
+ *
+ * The failure this exists to name, measured 2026-08-05 on a head unit hotspot: over a 2.4 GHz
+ * access point at 1080p/60 the phone completed the Bluetooth handshake, joined the network, opened
+ * the AAP session and the video channel — and then closed the socket 0.04–4.2 s later, having sent
+ * **not one video frame**. Thirty-two times in under five minutes, each cycle looking like a fresh,
+ * healthy connection right up to the moment it ended. On the same access point, same band, same
+ * everything, an 800x480/30 stream held for as long as it was watched; and at 1080p/60 on 5 GHz it
+ * held too. So this is a throughput ceiling, not a broken route — and the phone's own reason
+ * (`GAL_SOCKET_CONNECTION_FAILED`) never reaches our log.
+ *
+ * We cannot read the band an access point is running on: `SoftApInfo`'s frequency needs
+ * NETWORK_SETTINGS, which no ordinary app holds. What we can see is the shape — a session that
+ * reached SSL and then died having rendered nothing, over and over. That is specific enough to act
+ * on, and nothing else produces it: a phone that never joins never gets this far, and a decoder
+ * that cannot handle the codec renders nothing but does not take the socket down with it.
+ *
+ * Deliberately a streak rather than a single occurrence. One starved session is ordinary — a phone
+ * being unplugged mid-bring-up looks exactly like this once — and advice given on the strength of
+ * one is advice that will sometimes be wrong.
+ */
+object VideoStarvationPolicy {
+
+    /** How many sessions in a row must end without a frame before the advice is worth giving. */
+    const val ADVISE_AFTER_STARVED_SESSIONS = 3
+
+    /**
+     * Whether the session that just ended should produce the advice, given how many have now ended
+     * in a row without rendering a frame.
+     *
+     * True on exactly the [ADVISE_AFTER_STARVED_SESSIONS]th, never after: the reconnect loop this
+     * fires inside runs every few seconds, and a line repeated thirty times is one a reader learns
+     * to scroll past. Say it once, and let the streak keep counting for anyone reading the numbers.
+     */
+    fun shouldAdvise(consecutiveStarvedSessions: Int): Boolean =
+        consecutiveStarvedSessions == ADVISE_AFTER_STARVED_SESSIONS
+
+    /**
+     * The streak after a session that [reachedHandshake] and rendered frames or not.
+     *
+     * A session that never reached the handshake is not counted either way — it never had a chance
+     * to carry video, so it neither proves starvation nor clears a run of it.
+     */
+    fun nextStreak(current: Int, reachedHandshake: Boolean, renderedAnyFrame: Boolean): Int = when {
+        !reachedHandshake -> current
+        renderedAnyFrame -> 0
+        else -> current + 1
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/WifiModePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/WifiModePolicy.kt
@@ -7,5 +7,16 @@ package com.andrerinas.openheadunit.aap
  * two call sites can't drift out of sync.
  */
 object WifiModePolicy {
-    fun usesWifiDirect(mode: Int, strategy: Int): Boolean = (mode == 3) || (mode == 2 && strategy == 1)
+    /**
+     * [transport] applies to mode 3 only, and is the whole reason this takes a third argument:
+     * on the hotspot route the answer must be false, because the caller reacts to a true by
+     * force-disabling the hotspot before starting P2P — which would tear down the very access
+     * point the route is about to advertise.
+     */
+    fun usesWifiDirect(
+        mode: Int,
+        strategy: Int,
+        transport: NativeTransport = NativeTransport.WIFI_DIRECT
+    ): Boolean =
+        (mode == 3 && transport == NativeTransport.WIFI_DIRECT) || (mode == 2 && strategy == 1)
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/WppFraming.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/WppFraming.kt
@@ -1,0 +1,66 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * The wire framing of the Android Auto WiFi Projection Protocol, as spoken over the RFCOMM channel
+ * before the phone joins our network.
+ *
+ * Every message is four header bytes followed by the payload:
+ *
+ * ```
+ *   0   1   2   3   4 ...
+ * +---+---+---+---+--------------+
+ * | payload len   |  message type | protobuf payload
+ * |  uint16 BE    |   uint16 BE   |
+ * +---+---+---+---+--------------+
+ * ```
+ *
+ * Both fields are big-endian, byte-for-byte what aa-proxy-rs's dongle writes — the check that this
+ * is the protocol and not one head unit's habits.
+ *
+ * Pure and tested because it is the one part of the exchange that can be wrong in a way no log
+ * shows: a header we build by hand and the phone silently discards. Sizes above 255 exercise the
+ * high byte; what we send stays well under it, what we receive is not ours to bound.
+ */
+object WppFraming {
+
+    /** Bytes of header in front of every payload. */
+    const val HEADER_SIZE = 4
+
+    /** Largest payload the length field can describe. */
+    const val MAX_PAYLOAD_SIZE = 0xFFFF
+
+    /**
+     * The four header bytes for a [payloadSize]-byte payload of message type [type].
+     *
+     * @throws IllegalArgumentException if [payloadSize] will not fit. Loud rather than truncating:
+     *   a wrapped length desynchronises the receiver permanently.
+     */
+    fun encodeHeader(payloadSize: Int, type: Int): ByteArray {
+        require(payloadSize in 0..MAX_PAYLOAD_SIZE) {
+            "WPP payload size $payloadSize does not fit in a uint16 length field"
+        }
+        require(type in 0..0xFFFF) { "WPP message type $type does not fit in a uint16 type field" }
+        return byteArrayOf(
+            ((payloadSize shr 8) and 0xFF).toByte(),
+            (payloadSize and 0xFF).toByte(),
+            ((type shr 8) and 0xFF).toByte(),
+            (type and 0xFF).toByte()
+        )
+    }
+
+    /** A complete frame: header for [payload] of message type [type], then the payload itself. */
+    fun encodeFrame(payload: ByteArray, type: Int): ByteArray =
+        encodeHeader(payload.size, type) + payload
+
+    /** The payload length declared by a [HEADER_SIZE]-byte header. */
+    fun decodePayloadSize(header: ByteArray): Int {
+        require(header.size >= HEADER_SIZE) { "WPP header needs $HEADER_SIZE bytes, got ${header.size}" }
+        return ((header[0].toInt() and 0xFF) shl 8) or (header[1].toInt() and 0xFF)
+    }
+
+    /** The message type declared by a [HEADER_SIZE]-byte header. */
+    fun decodeType(header: ByteArray): Int {
+        require(header.size >= HEADER_SIZE) { "WPP header needs $HEADER_SIZE bytes, got ${header.size}" }
+        return ((header[2].toInt() and 0xFF) shl 8) or (header[3].toInt() and 0xFF)
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/WppHandshakeSession.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/WppHandshakeSession.kt
@@ -130,8 +130,8 @@ class WppHandshakeSession(private val versionExchangeEnabled: Boolean) {
         /** How much longer to wait each time the phone says it is still joining. */
         const val SETTLE_EXTENSION_MS = 15_000L
 
-        /** Our protocol version. A guess — no capture has been decoded yet — bounded by the
-         *  setting, which turns the whole exchange off if it proves wrong. */
+        /** Our protocol version. A guess — no capture of a real head unit's Type 4 has been
+         *  decoded — which is why the setting that sends it is off by default. */
         const val WPP_VERSION_MAJOR = 1
         const val WPP_VERSION_MINOR = 1
     }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/WppHandshakeSession.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/WppHandshakeSession.kt
@@ -1,0 +1,329 @@
+package com.andrerinas.openheadunit.aap
+
+/** Message types of the WiFi Projection Protocol. See `wireless.proto` for the payload shapes. */
+object WppMessageType {
+    /** Head unit -> phone: where to open the projection session. */
+    const val START_REQUEST = 1
+    /** Phone -> head unit: asking for the network credentials. */
+    const val INFO_REQUEST = 2
+    /** Head unit -> phone: the credentials. */
+    const val INFO_RESPONSE = 3
+    /** Head unit -> phone: our protocol version, opening the modern handshake. */
+    const val VERSION_REQUEST = 4
+    /** Phone -> head unit: its protocol version. */
+    const val VERSION_RESPONSE = 5
+    /** Phone -> head unit: whether it managed to join our network. */
+    const val CONNECT_STATUS = 6
+    /** Phone -> head unit: acknowledges [START_REQUEST]. */
+    const val START_RESPONSE = 7
+    /** Keepalive, either direction. A request is answered by echoing its payload back as a response. */
+    const val PING_REQUEST = 8
+    const val PING_RESPONSE = 9
+    /** Not sent; defined so a capture can be read. */
+    const val SETUP_INFO = 11
+}
+
+/** Where a [WppHandshakeSession] is in the exchange. */
+enum class WppStage {
+    /** Nothing sent yet. */
+    NEW,
+    /** [WppMessageType.VERSION_REQUEST] is out; waiting for the phone's version, briefly. */
+    AWAIT_VERSION,
+    /** Waiting for this head unit's own WiFi credentials to become available. */
+    AWAIT_CREDENTIALS,
+    /** [WppMessageType.START_REQUEST] is out; waiting for the phone to ask for credentials. */
+    AWAIT_INFO_REQUEST,
+    /** Credentials delivered; the phone is associating, doing WPS and getting a DHCP lease. */
+    SETTLING,
+    /** The phone's projection session landed. */
+    DONE,
+    /** The exchange ended without a session. */
+    FAILED
+}
+
+/** Something that happened to a handshake. Fed to [WppHandshakeSession.on]. */
+sealed class WppEvent {
+    /** The Bluetooth channel is up and has had its settle delay. */
+    object SocketReady : WppEvent()
+    /** This head unit's SSID/PSK/IP are known. */
+    object CredentialsReady : WppEvent()
+    /** They never became available, and waiting longer will not help. */
+    object CredentialsUnavailable : WppEvent()
+    /**
+     * A message arrived from the phone. [status] is the parsed status field for the types that
+     * carry one (5, 6, 7), or null when the message has no status or could not be parsed — an
+     * unparseable message is never read as a failure report.
+     */
+    data class MessageReceived(val type: Int, val status: Int? = null) : WppEvent()
+    /** The current stage's deadline ([WppHandshakeSession.currentStageTimeoutMs]) elapsed. */
+    object StageTimeout : WppEvent()
+    /** The phone's projection session reached us over WiFi. */
+    object TcpSessionUp : WppEvent()
+    /** The settling window elapsed with no session. */
+    object SettleTimeout : WppEvent()
+}
+
+/**
+ * What the caller should do about it. The session performs no I/O of its own — that is the whole
+ * point of it being pure — so every effect leaves as one of these.
+ */
+sealed class WppAction {
+    object SendVersionRequest : WppAction()
+    object SendStartRequest : WppAction()
+    /** Send the credentials. In [WppStage.SETTLING] this is a re-send of the same ones. */
+    object SendInfoResponse : WppAction()
+    /**
+     * Echo the payload of the ping that produced this action back as a
+     * [WppMessageType.PING_RESPONSE]. Raw bytes, so the reply cannot be wrong.
+     */
+    object SendPingResponse : WppAction()
+    /** The phone is still working on it — push the settling deadline out. */
+    object ExtendSettle : WppAction()
+    object CompleteSuccess : WppAction()
+    /**
+     * [phoneWasSilent] is true when the phone never sent a single message — the signature of a
+     * head unit whose Bluetooth stack drops our writes, not of a phone-side problem. It is what
+     * the handshake backoff counts.
+     */
+    data class Fail(val reason: String, val phoneWasSilent: Boolean) : WppAction()
+    /** Restart the wake poke. Only ever emitted once the phone has given up on this handoff. */
+    object ResumePoke : WppAction()
+}
+
+/**
+ * The Android Auto wireless handshake, as a state machine with no Android in it.
+ *
+ * The exchange this models is the modern one, cross-checked against aa-proxy-rs's reference dongle
+ * and the OEM ZLink app:
+ *
+ * ```
+ *   HU -> 4 WifiVersionRequest        (optional; real head units send it, aa-proxy's dongle does not)
+ *   HU <- 5 WifiVersionResponse
+ *   HU -> 1 WifiStartRequest
+ *   HU <- 2 WifiInfoRequest
+ *   HU -> 3 WifiInfoResponse          credentials
+ *   HU <- 7 WifiStartResponse         acknowledgement
+ *   HU <- 6 WifiConnectStatus         did the phone actually get on the network
+ * ```
+ *
+ * What this replaces sent 1, read one message, sent 3 and stopped listening. Types 6 and 7 arrive
+ * *after* type 3, so it never saw them — hence no way to tell "still associating" from "gave up",
+ * and a timer where the phone was willing to say.
+ *
+ * Pure so the ordering rules can be tested; they cannot be, on a real Bluetooth socket. Not
+ * thread-safe: one session per handshake coroutine.
+ *
+ * @param versionExchangeEnabled whether to open with [WppMessageType.VERSION_REQUEST]. False sends
+ *   exactly what shipped before it existed.
+ */
+class WppHandshakeSession(private val versionExchangeEnabled: Boolean) {
+
+    companion object {
+        /** How long to wait for the phone's version response before carrying on without it.
+         *  Short on purpose: it must not eat into the phone's own ~12 s first-message budget. */
+        const val VERSION_RESPONSE_TIMEOUT_MS = 3_000L
+
+        /** How long the phone has to ask for credentials after [WppMessageType.START_REQUEST].
+         *  Unchanged from the value this replaces. */
+        const val INFO_REQUEST_TIMEOUT_MS = 15_000L
+
+        /** How much longer to wait each time the phone says it is still joining. */
+        const val SETTLE_EXTENSION_MS = 15_000L
+
+        /** Our protocol version. A guess — no capture has been decoded yet — bounded by the
+         *  setting, which turns the whole exchange off if it proves wrong. */
+        const val WPP_VERSION_MAJOR = 1
+        const val WPP_VERSION_MINOR = 1
+    }
+
+    var stage: WppStage = WppStage.NEW
+        private set
+
+    /** How many messages the phone has sent. Zero at the end of a handshake means the phone never
+     *  answered anything, which is what the backoff in `NativeAaHandshakeManager` counts. */
+    var messagesReceived: Int = 0
+        private set
+
+    /** The phone asked for credentials before we were ready to send them. */
+    private var pendingInfoRequest = false
+
+    /** Credentials arrived while we were still waiting on the version response. */
+    private var credentialsLatched = false
+
+    /** Total time allowed in [WppStage.SETTLING], grown by [WppAction.ExtendSettle]. */
+    private var settleBudgetMs = NativeHandoffPolicy.SETTLE_TIMEOUT_MS
+
+    /**
+     * How long the current stage may last before its timeout event is due, or null when the stage
+     * has no deadline of its own. Measured from when the stage was entered; re-read it after every
+     * [on] call, since [WppAction.ExtendSettle] grows it.
+     */
+    fun currentStageTimeoutMs(): Long? = when (stage) {
+        WppStage.AWAIT_VERSION -> VERSION_RESPONSE_TIMEOUT_MS
+        WppStage.AWAIT_INFO_REQUEST -> INFO_REQUEST_TIMEOUT_MS
+        WppStage.SETTLING -> settleBudgetMs
+        // AWAIT_CREDENTIALS is bounded by the caller's own credential wait, which ends in
+        // CredentialsReady or CredentialsUnavailable; NEW, DONE and FAILED never expire.
+        else -> null
+    }
+
+    /** True once the exchange is over, either way. */
+    fun isTerminal(): Boolean = stage == WppStage.DONE || stage == WppStage.FAILED
+
+    /**
+     * Feed [event] in and get back what to do about it, in order. Safe to call after the session
+     * has finished: a terminal session ignores everything and returns nothing.
+     */
+    fun on(event: WppEvent): List<WppAction> {
+        if (isTerminal()) return emptyList()
+
+        if (event is WppEvent.MessageReceived) {
+            messagesReceived++
+            // A ping can arrive at any point in the exchange and is answered the same way
+            // everywhere, so it never reaches the per-stage logic below and never changes stage.
+            if (event.type == WppMessageType.PING_REQUEST) return listOf(WppAction.SendPingResponse)
+            if (event.type == WppMessageType.PING_RESPONSE) return emptyList()
+        }
+
+        return when (stage) {
+            WppStage.NEW -> onNew(event)
+            WppStage.AWAIT_VERSION -> onAwaitVersion(event)
+            WppStage.AWAIT_CREDENTIALS -> onAwaitCredentials(event)
+            WppStage.AWAIT_INFO_REQUEST -> onAwaitInfoRequest(event)
+            WppStage.SETTLING -> onSettling(event)
+            WppStage.DONE, WppStage.FAILED -> emptyList()
+        }
+    }
+
+    private fun onNew(event: WppEvent): List<WppAction> = when (event) {
+        is WppEvent.SocketReady ->
+            if (versionExchangeEnabled) {
+                stage = WppStage.AWAIT_VERSION
+                listOf(WppAction.SendVersionRequest)
+            } else {
+                enterAwaitCredentials()
+            }
+        is WppEvent.CredentialsReady -> { credentialsLatched = true; emptyList() }
+        is WppEvent.CredentialsUnavailable -> fail("no WiFi credentials to hand the phone")
+        else -> emptyList()
+    }
+
+    private fun onAwaitVersion(event: WppEvent): List<WppAction> = when {
+        event is WppEvent.MessageReceived && event.type == WppMessageType.VERSION_RESPONSE ->
+            enterAwaitCredentials()
+        // No answer to type 4. Phones complete the rest of the exchange without it, so carrying
+        // on beats failing on an optional step.
+        event is WppEvent.StageTimeout -> enterAwaitCredentials()
+        // Some phones skip the version response and ask for credentials straight away. Latch it:
+        // still answered, just not before type 1 goes out.
+        event is WppEvent.MessageReceived && event.type == WppMessageType.INFO_REQUEST -> {
+            pendingInfoRequest = true
+            enterAwaitCredentials()
+        }
+        // Hold credentials that resolve early rather than jumping the queue: ordering 4 before 1
+        // is the only reason to send type 4 at all.
+        event is WppEvent.CredentialsReady -> { credentialsLatched = true; emptyList() }
+        event is WppEvent.CredentialsUnavailable -> fail("no WiFi credentials to hand the phone")
+        else -> emptyList()
+    }
+
+    private fun onAwaitCredentials(event: WppEvent): List<WppAction> = when {
+        event is WppEvent.CredentialsReady -> credentialsBecameAvailable()
+        event is WppEvent.MessageReceived && event.type == WppMessageType.INFO_REQUEST -> {
+            pendingInfoRequest = true
+            emptyList()
+        }
+        event is WppEvent.CredentialsUnavailable -> fail("no WiFi credentials to hand the phone")
+        else -> emptyList()
+    }
+
+    private fun onAwaitInfoRequest(event: WppEvent): List<WppAction> = when {
+        event is WppEvent.MessageReceived && event.type == WppMessageType.INFO_REQUEST -> {
+            stage = WppStage.SETTLING
+            listOf(WppAction.SendInfoResponse)
+        }
+        event is WppEvent.MessageReceived && event.type == WppMessageType.START_RESPONSE ->
+            if (isFailureStatus(event.status)) {
+                fail("phone rejected the projection endpoint (WifiStartResponse status=${event.status})")
+            } else {
+                emptyList()
+            }
+        event is WppEvent.StageTimeout ->
+            fail("phone did not ask for credentials within ${INFO_REQUEST_TIMEOUT_MS / 1000}s of WifiStartRequest")
+        event is WppEvent.CredentialsUnavailable -> fail("WiFi credentials went away mid-handshake")
+        else -> emptyList()
+    }
+
+    private fun onSettling(event: WppEvent): List<WppAction> = when {
+        event is WppEvent.TcpSessionUp -> {
+            stage = WppStage.DONE
+            listOf(WppAction.CompleteSuccess)
+        }
+        event is WppEvent.MessageReceived &&
+            (event.type == WppMessageType.CONNECT_STATUS || event.type == WppMessageType.START_RESPONSE) ->
+            if (isFailureStatus(event.status)) {
+                // The phone has stopped trying, so nothing is left to disturb: this and the
+                // settle timeout are the only places where restarting the poke is safe.
+                fail("phone reported join failure (type ${event.type}, status=${event.status})") +
+                    WppAction.ResumePoke
+            } else if (event.type == WppMessageType.CONNECT_STATUS) {
+                extendSettle()
+            } else {
+                // A successful type 7 is an acknowledgement, not progress on the join.
+                emptyList()
+            }
+        // aa-proxy-rs re-sends the credentials when the phone asks twice; a phone that asks again
+        // has not given up, and refusing it would strand a handoff that could still complete.
+        event is WppEvent.MessageReceived && event.type == WppMessageType.INFO_REQUEST ->
+            listOf(WppAction.SendInfoResponse)
+        // Today's behaviour: leave the listeners open and let the wake poke retry.
+        event is WppEvent.SettleTimeout -> {
+            stage = WppStage.FAILED
+            listOf(WppAction.ResumePoke)
+        }
+        else -> emptyList()
+    }
+
+    /** Enter [WppStage.AWAIT_CREDENTIALS], acting immediately if the credentials already landed. */
+    private fun enterAwaitCredentials(): List<WppAction> {
+        stage = WppStage.AWAIT_CREDENTIALS
+        return if (credentialsLatched) credentialsBecameAvailable() else emptyList()
+    }
+
+    private fun credentialsBecameAvailable(): List<WppAction> {
+        credentialsLatched = true
+        return if (pendingInfoRequest) {
+            // It asked while the network was still coming up: answer both back to back rather
+            // than wait for it to ask again.
+            stage = WppStage.SETTLING
+            listOf(WppAction.SendStartRequest, WppAction.SendInfoResponse)
+        } else {
+            stage = WppStage.AWAIT_INFO_REQUEST
+            listOf(WppAction.SendStartRequest)
+        }
+    }
+
+    private fun extendSettle(): List<WppAction> {
+        val extended = settleBudgetMs + SETTLE_EXTENSION_MS
+        if (extended > NativeHandoffPolicy.MAX_SETTLE_MS) {
+            // Capped: a phone that says "still joining" forever would otherwise hold the
+            // Bluetooth channel open and the wake poke suppressed indefinitely.
+            return emptyList()
+        }
+        settleBudgetMs = extended
+        return listOf(WppAction.ExtendSettle)
+    }
+
+    private fun fail(reason: String): List<WppAction> {
+        stage = WppStage.FAILED
+        return listOf(WppAction.Fail(reason, phoneWasSilent = messagesReceived == 0))
+    }
+
+    /**
+     * Whether a status field reports a failure. Only `!= 0` counts, never a particular value —
+     * the meanings of the non-zero codes are not known (a real phone answers -8 on type 5 during
+     * an exchange that goes on to succeed). Null is not a failure either: an unparseable message
+     * must never abort a handshake that was going fine.
+     */
+    private fun isFailureStatus(status: Int?): Boolean = status != null && status != 0
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/proto/Wireless.java
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/proto/Wireless.java
@@ -323,6 +323,10 @@ public final class Wireless {
     int getStatus();
   }
   /**
+   * <pre>
+   * Type 1, head unit -&gt; phone. Where to open the projection session once associated.
+   * </pre>
+   *
    * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiStartRequest}
    */
   public static final class WifiStartRequest extends
@@ -648,6 +652,10 @@ public final class Wireless {
       return builder;
     }
     /**
+     * <pre>
+     * Type 1, head unit -&gt; phone. Where to open the projection session once associated.
+     * </pre>
+     *
      * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiStartRequest}
      */
     public static final class Builder extends
@@ -1075,6 +1083,413 @@ public final class Wireless {
 
   }
 
+  public interface WifiInfoRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.andrerinas.openheadunit.aap.protocol.proto.WifiInfoRequest)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * <pre>
+   * Type 2, phone -&gt; head unit. Empty: the phone asking for the network credentials. Modelled so
+   * the payload can be parsed rather than merely counted.
+   * </pre>
+   *
+   * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiInfoRequest}
+   */
+  public static final class WifiInfoRequest extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:com.andrerinas.openheadunit.aap.protocol.proto.WifiInfoRequest)
+      WifiInfoRequestOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use WifiInfoRequest.newBuilder() to construct.
+    private WifiInfoRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private WifiInfoRequest() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new WifiInfoRequest();
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiInfoRequest_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiInfoRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest.class, com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest.Builder.class);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest)) {
+        return super.equals(obj);
+      }
+      com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest other = (com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest) obj;
+
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * Type 2, phone -&gt; head unit. Empty: the phone asking for the network credentials. Modelled so
+     * the payload can be parsed rather than merely counted.
+     * </pre>
+     *
+     * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiInfoRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:com.andrerinas.openheadunit.aap.protocol.proto.WifiInfoRequest)
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiInfoRequest_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiInfoRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest.class, com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest.Builder.class);
+      }
+
+      // Construct using com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest.newBuilder()
+      private Builder() {
+
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiInfoRequest_descriptor;
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest getDefaultInstanceForType() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest build() {
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest buildPartial() {
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest result = new com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest(this);
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest) {
+          return mergeFrom((com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest other) {
+        if (other == com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:com.andrerinas.openheadunit.aap.protocol.proto.WifiInfoRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:com.andrerinas.openheadunit.aap.protocol.proto.WifiInfoRequest)
+    private static final com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest();
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<WifiInfoRequest>
+        PARSER = new com.google.protobuf.AbstractParser<WifiInfoRequest>() {
+      @java.lang.Override
+      public WifiInfoRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<WifiInfoRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<WifiInfoRequest> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiInfoRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   public interface WifiInfoResponseOrBuilder extends
       // @@protoc_insertion_point(interface_extends:com.andrerinas.openheadunit.aap.protocol.proto.WifiInfoResponse)
       com.google.protobuf.MessageOrBuilder {
@@ -1114,45 +1529,54 @@ public final class Wireless {
         getKeyBytes();
 
     /**
-     * <code>required string bssid = 3;</code>
+     * <code>optional string bssid = 3;</code>
      * @return Whether the bssid field is set.
      */
     boolean hasBssid();
     /**
-     * <code>required string bssid = 3;</code>
+     * <code>optional string bssid = 3;</code>
      * @return The bssid.
      */
     java.lang.String getBssid();
     /**
-     * <code>required string bssid = 3;</code>
+     * <code>optional string bssid = 3;</code>
      * @return The bytes for bssid.
      */
     com.google.protobuf.ByteString
         getBssidBytes();
 
     /**
-     * <code>required .com.andrerinas.openheadunit.aap.protocol.proto.SecurityMode security_mode = 4;</code>
+     * <code>optional .com.andrerinas.openheadunit.aap.protocol.proto.SecurityMode security_mode = 4;</code>
      * @return Whether the securityMode field is set.
      */
     boolean hasSecurityMode();
     /**
-     * <code>required .com.andrerinas.openheadunit.aap.protocol.proto.SecurityMode security_mode = 4;</code>
+     * <code>optional .com.andrerinas.openheadunit.aap.protocol.proto.SecurityMode security_mode = 4;</code>
      * @return The securityMode.
      */
     com.andrerinas.openheadunit.aap.protocol.proto.Wireless.SecurityMode getSecurityMode();
 
     /**
-     * <code>required .com.andrerinas.openheadunit.aap.protocol.proto.AccessPointType access_point_type = 5;</code>
+     * <code>optional .com.andrerinas.openheadunit.aap.protocol.proto.AccessPointType access_point_type = 5;</code>
      * @return Whether the accessPointType field is set.
      */
     boolean hasAccessPointType();
     /**
-     * <code>required .com.andrerinas.openheadunit.aap.protocol.proto.AccessPointType access_point_type = 5;</code>
+     * <code>optional .com.andrerinas.openheadunit.aap.protocol.proto.AccessPointType access_point_type = 5;</code>
      * @return The accessPointType.
      */
     com.andrerinas.openheadunit.aap.protocol.proto.Wireless.AccessPointType getAccessPointType();
   }
   /**
+   * <pre>
+   * Type 3, head unit -&gt; phone. The credentials themselves.
+   *
+   * bssid, security_mode and access_point_type were required. Optional now because a hotspot
+   * cannot always resolve a real BSSID, and aa-proxy-rs omits the field outright when it has none.
+   * Wire-compatible: proto2 encodes optional and required identically for a field that is set, so
+   * this only drops a build()-time assertion.
+   * </pre>
+   *
    * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiInfoResponse}
    */
   public static final class WifiInfoResponse extends
@@ -1295,7 +1719,7 @@ public final class Wireless {
     @SuppressWarnings("serial")
     private volatile java.lang.Object bssid_ = "";
     /**
-     * <code>required string bssid = 3;</code>
+     * <code>optional string bssid = 3;</code>
      * @return Whether the bssid field is set.
      */
     @java.lang.Override
@@ -1303,7 +1727,7 @@ public final class Wireless {
       return ((bitField0_ & 0x00000004) != 0);
     }
     /**
-     * <code>required string bssid = 3;</code>
+     * <code>optional string bssid = 3;</code>
      * @return The bssid.
      */
     @java.lang.Override
@@ -1322,7 +1746,7 @@ public final class Wireless {
       }
     }
     /**
-     * <code>required string bssid = 3;</code>
+     * <code>optional string bssid = 3;</code>
      * @return The bytes for bssid.
      */
     @java.lang.Override
@@ -1343,14 +1767,14 @@ public final class Wireless {
     public static final int SECURITY_MODE_FIELD_NUMBER = 4;
     private int securityMode_ = 0;
     /**
-     * <code>required .com.andrerinas.openheadunit.aap.protocol.proto.SecurityMode security_mode = 4;</code>
+     * <code>optional .com.andrerinas.openheadunit.aap.protocol.proto.SecurityMode security_mode = 4;</code>
      * @return Whether the securityMode field is set.
      */
     @java.lang.Override public boolean hasSecurityMode() {
       return ((bitField0_ & 0x00000008) != 0);
     }
     /**
-     * <code>required .com.andrerinas.openheadunit.aap.protocol.proto.SecurityMode security_mode = 4;</code>
+     * <code>optional .com.andrerinas.openheadunit.aap.protocol.proto.SecurityMode security_mode = 4;</code>
      * @return The securityMode.
      */
     @java.lang.Override public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.SecurityMode getSecurityMode() {
@@ -1361,14 +1785,14 @@ public final class Wireless {
     public static final int ACCESS_POINT_TYPE_FIELD_NUMBER = 5;
     private int accessPointType_ = 0;
     /**
-     * <code>required .com.andrerinas.openheadunit.aap.protocol.proto.AccessPointType access_point_type = 5;</code>
+     * <code>optional .com.andrerinas.openheadunit.aap.protocol.proto.AccessPointType access_point_type = 5;</code>
      * @return Whether the accessPointType field is set.
      */
     @java.lang.Override public boolean hasAccessPointType() {
       return ((bitField0_ & 0x00000010) != 0);
     }
     /**
-     * <code>required .com.andrerinas.openheadunit.aap.protocol.proto.AccessPointType access_point_type = 5;</code>
+     * <code>optional .com.andrerinas.openheadunit.aap.protocol.proto.AccessPointType access_point_type = 5;</code>
      * @return The accessPointType.
      */
     @java.lang.Override public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.AccessPointType getAccessPointType() {
@@ -1388,18 +1812,6 @@ public final class Wireless {
         return false;
       }
       if (!hasKey()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasBssid()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasSecurityMode()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasAccessPointType()) {
         memoizedIsInitialized = 0;
         return false;
       }
@@ -1618,6 +2030,15 @@ public final class Wireless {
       return builder;
     }
     /**
+     * <pre>
+     * Type 3, head unit -&gt; phone. The credentials themselves.
+     *
+     * bssid, security_mode and access_point_type were required. Optional now because a hotspot
+     * cannot always resolve a real BSSID, and aa-proxy-rs omits the field outright when it has none.
+     * Wire-compatible: proto2 encodes optional and required identically for a field that is set, so
+     * this only drops a build()-time assertion.
+     * </pre>
+     *
      * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiInfoResponse}
      */
     public static final class Builder extends
@@ -1789,15 +2210,6 @@ public final class Wireless {
           return false;
         }
         if (!hasKey()) {
-          return false;
-        }
-        if (!hasBssid()) {
-          return false;
-        }
-        if (!hasSecurityMode()) {
-          return false;
-        }
-        if (!hasAccessPointType()) {
           return false;
         }
         return true;
@@ -2037,14 +2449,14 @@ public final class Wireless {
 
       private java.lang.Object bssid_ = "";
       /**
-       * <code>required string bssid = 3;</code>
+       * <code>optional string bssid = 3;</code>
        * @return Whether the bssid field is set.
        */
       public boolean hasBssid() {
         return ((bitField0_ & 0x00000004) != 0);
       }
       /**
-       * <code>required string bssid = 3;</code>
+       * <code>optional string bssid = 3;</code>
        * @return The bssid.
        */
       public java.lang.String getBssid() {
@@ -2062,7 +2474,7 @@ public final class Wireless {
         }
       }
       /**
-       * <code>required string bssid = 3;</code>
+       * <code>optional string bssid = 3;</code>
        * @return The bytes for bssid.
        */
       public com.google.protobuf.ByteString
@@ -2079,7 +2491,7 @@ public final class Wireless {
         }
       }
       /**
-       * <code>required string bssid = 3;</code>
+       * <code>optional string bssid = 3;</code>
        * @param value The bssid to set.
        * @return This builder for chaining.
        */
@@ -2092,7 +2504,7 @@ public final class Wireless {
         return this;
       }
       /**
-       * <code>required string bssid = 3;</code>
+       * <code>optional string bssid = 3;</code>
        * @return This builder for chaining.
        */
       public Builder clearBssid() {
@@ -2102,7 +2514,7 @@ public final class Wireless {
         return this;
       }
       /**
-       * <code>required string bssid = 3;</code>
+       * <code>optional string bssid = 3;</code>
        * @param value The bytes for bssid to set.
        * @return This builder for chaining.
        */
@@ -2117,14 +2529,14 @@ public final class Wireless {
 
       private int securityMode_ = 0;
       /**
-       * <code>required .com.andrerinas.openheadunit.aap.protocol.proto.SecurityMode security_mode = 4;</code>
+       * <code>optional .com.andrerinas.openheadunit.aap.protocol.proto.SecurityMode security_mode = 4;</code>
        * @return Whether the securityMode field is set.
        */
       @java.lang.Override public boolean hasSecurityMode() {
         return ((bitField0_ & 0x00000008) != 0);
       }
       /**
-       * <code>required .com.andrerinas.openheadunit.aap.protocol.proto.SecurityMode security_mode = 4;</code>
+       * <code>optional .com.andrerinas.openheadunit.aap.protocol.proto.SecurityMode security_mode = 4;</code>
        * @return The securityMode.
        */
       @java.lang.Override
@@ -2133,7 +2545,7 @@ public final class Wireless {
         return result == null ? com.andrerinas.openheadunit.aap.protocol.proto.Wireless.SecurityMode.UNKNOWN_SECURITY_MODE : result;
       }
       /**
-       * <code>required .com.andrerinas.openheadunit.aap.protocol.proto.SecurityMode security_mode = 4;</code>
+       * <code>optional .com.andrerinas.openheadunit.aap.protocol.proto.SecurityMode security_mode = 4;</code>
        * @param value The securityMode to set.
        * @return This builder for chaining.
        */
@@ -2147,7 +2559,7 @@ public final class Wireless {
         return this;
       }
       /**
-       * <code>required .com.andrerinas.openheadunit.aap.protocol.proto.SecurityMode security_mode = 4;</code>
+       * <code>optional .com.andrerinas.openheadunit.aap.protocol.proto.SecurityMode security_mode = 4;</code>
        * @return This builder for chaining.
        */
       public Builder clearSecurityMode() {
@@ -2159,14 +2571,14 @@ public final class Wireless {
 
       private int accessPointType_ = 0;
       /**
-       * <code>required .com.andrerinas.openheadunit.aap.protocol.proto.AccessPointType access_point_type = 5;</code>
+       * <code>optional .com.andrerinas.openheadunit.aap.protocol.proto.AccessPointType access_point_type = 5;</code>
        * @return Whether the accessPointType field is set.
        */
       @java.lang.Override public boolean hasAccessPointType() {
         return ((bitField0_ & 0x00000010) != 0);
       }
       /**
-       * <code>required .com.andrerinas.openheadunit.aap.protocol.proto.AccessPointType access_point_type = 5;</code>
+       * <code>optional .com.andrerinas.openheadunit.aap.protocol.proto.AccessPointType access_point_type = 5;</code>
        * @return The accessPointType.
        */
       @java.lang.Override
@@ -2175,7 +2587,7 @@ public final class Wireless {
         return result == null ? com.andrerinas.openheadunit.aap.protocol.proto.Wireless.AccessPointType.STATIC : result;
       }
       /**
-       * <code>required .com.andrerinas.openheadunit.aap.protocol.proto.AccessPointType access_point_type = 5;</code>
+       * <code>optional .com.andrerinas.openheadunit.aap.protocol.proto.AccessPointType access_point_type = 5;</code>
        * @param value The accessPointType to set.
        * @return This builder for chaining.
        */
@@ -2189,7 +2601,7 @@ public final class Wireless {
         return this;
       }
       /**
-       * <code>required .com.andrerinas.openheadunit.aap.protocol.proto.AccessPointType access_point_type = 5;</code>
+       * <code>optional .com.andrerinas.openheadunit.aap.protocol.proto.AccessPointType access_point_type = 5;</code>
        * @return This builder for chaining.
        */
       public Builder clearAccessPointType() {
@@ -2262,16 +2674,4515 @@ public final class Wireless {
 
   }
 
+  public interface WifiVersionRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.andrerinas.openheadunit.aap.protocol.proto.WifiVersionRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional int32 major = 1;</code>
+     * @return Whether the major field is set.
+     */
+    boolean hasMajor();
+    /**
+     * <code>optional int32 major = 1;</code>
+     * @return The major.
+     */
+    int getMajor();
+
+    /**
+     * <code>optional int32 minor = 2;</code>
+     * @return Whether the minor field is set.
+     */
+    boolean hasMinor();
+    /**
+     * <code>optional int32 minor = 2;</code>
+     * @return The minor.
+     */
+    int getMinor();
+  }
+  /**
+   * <pre>
+   * Type 4, head unit -&gt; phone. Opens the modern handshake by declaring our protocol version. Real
+   * head units send this first, aa-proxy-rs's dongle does not, hence the setting. Only major/minor
+   * are defined — the rest is revision dependent and we never have to read one.
+   * </pre>
+   *
+   * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiVersionRequest}
+   */
+  public static final class WifiVersionRequest extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:com.andrerinas.openheadunit.aap.protocol.proto.WifiVersionRequest)
+      WifiVersionRequestOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use WifiVersionRequest.newBuilder() to construct.
+    private WifiVersionRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private WifiVersionRequest() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new WifiVersionRequest();
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionRequest_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest.class, com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int MAJOR_FIELD_NUMBER = 1;
+    private int major_ = 0;
+    /**
+     * <code>optional int32 major = 1;</code>
+     * @return Whether the major field is set.
+     */
+    @java.lang.Override
+    public boolean hasMajor() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>optional int32 major = 1;</code>
+     * @return The major.
+     */
+    @java.lang.Override
+    public int getMajor() {
+      return major_;
+    }
+
+    public static final int MINOR_FIELD_NUMBER = 2;
+    private int minor_ = 0;
+    /**
+     * <code>optional int32 minor = 2;</code>
+     * @return Whether the minor field is set.
+     */
+    @java.lang.Override
+    public boolean hasMinor() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <code>optional int32 minor = 2;</code>
+     * @return The minor.
+     */
+    @java.lang.Override
+    public int getMinor() {
+      return minor_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeInt32(1, major_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        output.writeInt32(2, minor_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(1, major_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(2, minor_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest)) {
+        return super.equals(obj);
+      }
+      com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest other = (com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest) obj;
+
+      if (hasMajor() != other.hasMajor()) return false;
+      if (hasMajor()) {
+        if (getMajor()
+            != other.getMajor()) return false;
+      }
+      if (hasMinor() != other.hasMinor()) return false;
+      if (hasMinor()) {
+        if (getMinor()
+            != other.getMinor()) return false;
+      }
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasMajor()) {
+        hash = (37 * hash) + MAJOR_FIELD_NUMBER;
+        hash = (53 * hash) + getMajor();
+      }
+      if (hasMinor()) {
+        hash = (37 * hash) + MINOR_FIELD_NUMBER;
+        hash = (53 * hash) + getMinor();
+      }
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * Type 4, head unit -&gt; phone. Opens the modern handshake by declaring our protocol version. Real
+     * head units send this first, aa-proxy-rs's dongle does not, hence the setting. Only major/minor
+     * are defined — the rest is revision dependent and we never have to read one.
+     * </pre>
+     *
+     * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiVersionRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:com.andrerinas.openheadunit.aap.protocol.proto.WifiVersionRequest)
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionRequest_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest.class, com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest.Builder.class);
+      }
+
+      // Construct using com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest.newBuilder()
+      private Builder() {
+
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        bitField0_ = 0;
+        major_ = 0;
+        minor_ = 0;
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionRequest_descriptor;
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest getDefaultInstanceForType() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest build() {
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest buildPartial() {
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest result = new com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest result) {
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.major_ = major_;
+          to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.minor_ = minor_;
+          to_bitField0_ |= 0x00000002;
+        }
+        result.bitField0_ |= to_bitField0_;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest) {
+          return mergeFrom((com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest other) {
+        if (other == com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest.getDefaultInstance()) return this;
+        if (other.hasMajor()) {
+          setMajor(other.getMajor());
+        }
+        if (other.hasMinor()) {
+          setMinor(other.getMinor());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 8: {
+                major_ = input.readInt32();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 8
+              case 16: {
+                minor_ = input.readInt32();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      private int bitField0_;
+
+      private int major_ ;
+      /**
+       * <code>optional int32 major = 1;</code>
+       * @return Whether the major field is set.
+       */
+      @java.lang.Override
+      public boolean hasMajor() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>optional int32 major = 1;</code>
+       * @return The major.
+       */
+      @java.lang.Override
+      public int getMajor() {
+        return major_;
+      }
+      /**
+       * <code>optional int32 major = 1;</code>
+       * @param value The major to set.
+       * @return This builder for chaining.
+       */
+      public Builder setMajor(int value) {
+
+        major_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 major = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearMajor() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        major_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private int minor_ ;
+      /**
+       * <code>optional int32 minor = 2;</code>
+       * @return Whether the minor field is set.
+       */
+      @java.lang.Override
+      public boolean hasMinor() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <code>optional int32 minor = 2;</code>
+       * @return The minor.
+       */
+      @java.lang.Override
+      public int getMinor() {
+        return minor_;
+      }
+      /**
+       * <code>optional int32 minor = 2;</code>
+       * @param value The minor to set.
+       * @return This builder for chaining.
+       */
+      public Builder setMinor(int value) {
+
+        minor_ = value;
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 minor = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearMinor() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        minor_ = 0;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:com.andrerinas.openheadunit.aap.protocol.proto.WifiVersionRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:com.andrerinas.openheadunit.aap.protocol.proto.WifiVersionRequest)
+    private static final com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest();
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<WifiVersionRequest>
+        PARSER = new com.google.protobuf.AbstractParser<WifiVersionRequest>() {
+      @java.lang.Override
+      public WifiVersionRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<WifiVersionRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<WifiVersionRequest> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface WifiVersionResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.andrerinas.openheadunit.aap.protocol.proto.WifiVersionResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional int32 major = 1;</code>
+     * @return Whether the major field is set.
+     */
+    boolean hasMajor();
+    /**
+     * <code>optional int32 major = 1;</code>
+     * @return The major.
+     */
+    int getMajor();
+
+    /**
+     * <code>optional int32 minor = 2;</code>
+     * @return Whether the minor field is set.
+     */
+    boolean hasMinor();
+    /**
+     * <code>optional int32 minor = 2;</code>
+     * @return The minor.
+     */
+    int getMinor();
+
+    /**
+     * <code>optional string device_serial = 3;</code>
+     * @return Whether the deviceSerial field is set.
+     */
+    boolean hasDeviceSerial();
+    /**
+     * <code>optional string device_serial = 3;</code>
+     * @return The deviceSerial.
+     */
+    java.lang.String getDeviceSerial();
+    /**
+     * <code>optional string device_serial = 3;</code>
+     * @return The bytes for deviceSerial.
+     */
+    com.google.protobuf.ByteString
+        getDeviceSerialBytes();
+
+    /**
+     * <code>optional int32 status = 4;</code>
+     * @return Whether the status field is set.
+     */
+    boolean hasStatus();
+    /**
+     * <code>optional int32 status = 4;</code>
+     * @return The status.
+     */
+    int getStatus();
+
+    /**
+     * <code>optional int32 selected_wifi_channel_type = 5;</code>
+     * @return Whether the selectedWifiChannelType field is set.
+     */
+    boolean hasSelectedWifiChannelType();
+    /**
+     * <code>optional int32 selected_wifi_channel_type = 5;</code>
+     * @return The selectedWifiChannelType.
+     */
+    int getSelectedWifiChannelType();
+  }
+  /**
+   * <pre>
+   * Type 5, phone -&gt; head unit. Parsed for the log only; nothing branches on it. status is int32:
+   * a real phone answered -8 here, which a sint32 declaration rendered as 2147483644.
+   * </pre>
+   *
+   * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiVersionResponse}
+   */
+  public static final class WifiVersionResponse extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:com.andrerinas.openheadunit.aap.protocol.proto.WifiVersionResponse)
+      WifiVersionResponseOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use WifiVersionResponse.newBuilder() to construct.
+    private WifiVersionResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private WifiVersionResponse() {
+      deviceSerial_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new WifiVersionResponse();
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionResponse_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse.class, com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int MAJOR_FIELD_NUMBER = 1;
+    private int major_ = 0;
+    /**
+     * <code>optional int32 major = 1;</code>
+     * @return Whether the major field is set.
+     */
+    @java.lang.Override
+    public boolean hasMajor() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>optional int32 major = 1;</code>
+     * @return The major.
+     */
+    @java.lang.Override
+    public int getMajor() {
+      return major_;
+    }
+
+    public static final int MINOR_FIELD_NUMBER = 2;
+    private int minor_ = 0;
+    /**
+     * <code>optional int32 minor = 2;</code>
+     * @return Whether the minor field is set.
+     */
+    @java.lang.Override
+    public boolean hasMinor() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <code>optional int32 minor = 2;</code>
+     * @return The minor.
+     */
+    @java.lang.Override
+    public int getMinor() {
+      return minor_;
+    }
+
+    public static final int DEVICE_SERIAL_FIELD_NUMBER = 3;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object deviceSerial_ = "";
+    /**
+     * <code>optional string device_serial = 3;</code>
+     * @return Whether the deviceSerial field is set.
+     */
+    @java.lang.Override
+    public boolean hasDeviceSerial() {
+      return ((bitField0_ & 0x00000004) != 0);
+    }
+    /**
+     * <code>optional string device_serial = 3;</code>
+     * @return The deviceSerial.
+     */
+    @java.lang.Override
+    public java.lang.String getDeviceSerial() {
+      java.lang.Object ref = deviceSerial_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          deviceSerial_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string device_serial = 3;</code>
+     * @return The bytes for deviceSerial.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getDeviceSerialBytes() {
+      java.lang.Object ref = deviceSerial_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        deviceSerial_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int STATUS_FIELD_NUMBER = 4;
+    private int status_ = 0;
+    /**
+     * <code>optional int32 status = 4;</code>
+     * @return Whether the status field is set.
+     */
+    @java.lang.Override
+    public boolean hasStatus() {
+      return ((bitField0_ & 0x00000008) != 0);
+    }
+    /**
+     * <code>optional int32 status = 4;</code>
+     * @return The status.
+     */
+    @java.lang.Override
+    public int getStatus() {
+      return status_;
+    }
+
+    public static final int SELECTED_WIFI_CHANNEL_TYPE_FIELD_NUMBER = 5;
+    private int selectedWifiChannelType_ = 0;
+    /**
+     * <code>optional int32 selected_wifi_channel_type = 5;</code>
+     * @return Whether the selectedWifiChannelType field is set.
+     */
+    @java.lang.Override
+    public boolean hasSelectedWifiChannelType() {
+      return ((bitField0_ & 0x00000010) != 0);
+    }
+    /**
+     * <code>optional int32 selected_wifi_channel_type = 5;</code>
+     * @return The selectedWifiChannelType.
+     */
+    @java.lang.Override
+    public int getSelectedWifiChannelType() {
+      return selectedWifiChannelType_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeInt32(1, major_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        output.writeInt32(2, minor_);
+      }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, deviceSerial_);
+      }
+      if (((bitField0_ & 0x00000008) != 0)) {
+        output.writeInt32(4, status_);
+      }
+      if (((bitField0_ & 0x00000010) != 0)) {
+        output.writeInt32(5, selectedWifiChannelType_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(1, major_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(2, minor_);
+      }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, deviceSerial_);
+      }
+      if (((bitField0_ & 0x00000008) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(4, status_);
+      }
+      if (((bitField0_ & 0x00000010) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(5, selectedWifiChannelType_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse)) {
+        return super.equals(obj);
+      }
+      com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse other = (com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse) obj;
+
+      if (hasMajor() != other.hasMajor()) return false;
+      if (hasMajor()) {
+        if (getMajor()
+            != other.getMajor()) return false;
+      }
+      if (hasMinor() != other.hasMinor()) return false;
+      if (hasMinor()) {
+        if (getMinor()
+            != other.getMinor()) return false;
+      }
+      if (hasDeviceSerial() != other.hasDeviceSerial()) return false;
+      if (hasDeviceSerial()) {
+        if (!getDeviceSerial()
+            .equals(other.getDeviceSerial())) return false;
+      }
+      if (hasStatus() != other.hasStatus()) return false;
+      if (hasStatus()) {
+        if (getStatus()
+            != other.getStatus()) return false;
+      }
+      if (hasSelectedWifiChannelType() != other.hasSelectedWifiChannelType()) return false;
+      if (hasSelectedWifiChannelType()) {
+        if (getSelectedWifiChannelType()
+            != other.getSelectedWifiChannelType()) return false;
+      }
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasMajor()) {
+        hash = (37 * hash) + MAJOR_FIELD_NUMBER;
+        hash = (53 * hash) + getMajor();
+      }
+      if (hasMinor()) {
+        hash = (37 * hash) + MINOR_FIELD_NUMBER;
+        hash = (53 * hash) + getMinor();
+      }
+      if (hasDeviceSerial()) {
+        hash = (37 * hash) + DEVICE_SERIAL_FIELD_NUMBER;
+        hash = (53 * hash) + getDeviceSerial().hashCode();
+      }
+      if (hasStatus()) {
+        hash = (37 * hash) + STATUS_FIELD_NUMBER;
+        hash = (53 * hash) + getStatus();
+      }
+      if (hasSelectedWifiChannelType()) {
+        hash = (37 * hash) + SELECTED_WIFI_CHANNEL_TYPE_FIELD_NUMBER;
+        hash = (53 * hash) + getSelectedWifiChannelType();
+      }
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * Type 5, phone -&gt; head unit. Parsed for the log only; nothing branches on it. status is int32:
+     * a real phone answered -8 here, which a sint32 declaration rendered as 2147483644.
+     * </pre>
+     *
+     * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiVersionResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:com.andrerinas.openheadunit.aap.protocol.proto.WifiVersionResponse)
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionResponse_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse.class, com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse.Builder.class);
+      }
+
+      // Construct using com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse.newBuilder()
+      private Builder() {
+
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        bitField0_ = 0;
+        major_ = 0;
+        minor_ = 0;
+        deviceSerial_ = "";
+        status_ = 0;
+        selectedWifiChannelType_ = 0;
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionResponse_descriptor;
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse getDefaultInstanceForType() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse build() {
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse buildPartial() {
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse result = new com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse result) {
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.major_ = major_;
+          to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.minor_ = minor_;
+          to_bitField0_ |= 0x00000002;
+        }
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.deviceSerial_ = deviceSerial_;
+          to_bitField0_ |= 0x00000004;
+        }
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          result.status_ = status_;
+          to_bitField0_ |= 0x00000008;
+        }
+        if (((from_bitField0_ & 0x00000010) != 0)) {
+          result.selectedWifiChannelType_ = selectedWifiChannelType_;
+          to_bitField0_ |= 0x00000010;
+        }
+        result.bitField0_ |= to_bitField0_;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse) {
+          return mergeFrom((com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse other) {
+        if (other == com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse.getDefaultInstance()) return this;
+        if (other.hasMajor()) {
+          setMajor(other.getMajor());
+        }
+        if (other.hasMinor()) {
+          setMinor(other.getMinor());
+        }
+        if (other.hasDeviceSerial()) {
+          deviceSerial_ = other.deviceSerial_;
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
+        if (other.hasStatus()) {
+          setStatus(other.getStatus());
+        }
+        if (other.hasSelectedWifiChannelType()) {
+          setSelectedWifiChannelType(other.getSelectedWifiChannelType());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 8: {
+                major_ = input.readInt32();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 8
+              case 16: {
+                minor_ = input.readInt32();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 26: {
+                deviceSerial_ = input.readBytes();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 26
+              case 32: {
+                status_ = input.readInt32();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 32
+              case 40: {
+                selectedWifiChannelType_ = input.readInt32();
+                bitField0_ |= 0x00000010;
+                break;
+              } // case 40
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      private int bitField0_;
+
+      private int major_ ;
+      /**
+       * <code>optional int32 major = 1;</code>
+       * @return Whether the major field is set.
+       */
+      @java.lang.Override
+      public boolean hasMajor() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>optional int32 major = 1;</code>
+       * @return The major.
+       */
+      @java.lang.Override
+      public int getMajor() {
+        return major_;
+      }
+      /**
+       * <code>optional int32 major = 1;</code>
+       * @param value The major to set.
+       * @return This builder for chaining.
+       */
+      public Builder setMajor(int value) {
+
+        major_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 major = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearMajor() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        major_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private int minor_ ;
+      /**
+       * <code>optional int32 minor = 2;</code>
+       * @return Whether the minor field is set.
+       */
+      @java.lang.Override
+      public boolean hasMinor() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <code>optional int32 minor = 2;</code>
+       * @return The minor.
+       */
+      @java.lang.Override
+      public int getMinor() {
+        return minor_;
+      }
+      /**
+       * <code>optional int32 minor = 2;</code>
+       * @param value The minor to set.
+       * @return This builder for chaining.
+       */
+      public Builder setMinor(int value) {
+
+        minor_ = value;
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 minor = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearMinor() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        minor_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object deviceSerial_ = "";
+      /**
+       * <code>optional string device_serial = 3;</code>
+       * @return Whether the deviceSerial field is set.
+       */
+      public boolean hasDeviceSerial() {
+        return ((bitField0_ & 0x00000004) != 0);
+      }
+      /**
+       * <code>optional string device_serial = 3;</code>
+       * @return The deviceSerial.
+       */
+      public java.lang.String getDeviceSerial() {
+        java.lang.Object ref = deviceSerial_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            deviceSerial_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string device_serial = 3;</code>
+       * @return The bytes for deviceSerial.
+       */
+      public com.google.protobuf.ByteString
+          getDeviceSerialBytes() {
+        java.lang.Object ref = deviceSerial_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          deviceSerial_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string device_serial = 3;</code>
+       * @param value The deviceSerial to set.
+       * @return This builder for chaining.
+       */
+      public Builder setDeviceSerial(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        deviceSerial_ = value;
+        bitField0_ |= 0x00000004;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string device_serial = 3;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearDeviceSerial() {
+        deviceSerial_ = getDefaultInstance().getDeviceSerial();
+        bitField0_ = (bitField0_ & ~0x00000004);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string device_serial = 3;</code>
+       * @param value The bytes for deviceSerial to set.
+       * @return This builder for chaining.
+       */
+      public Builder setDeviceSerialBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        deviceSerial_ = value;
+        bitField0_ |= 0x00000004;
+        onChanged();
+        return this;
+      }
+
+      private int status_ ;
+      /**
+       * <code>optional int32 status = 4;</code>
+       * @return Whether the status field is set.
+       */
+      @java.lang.Override
+      public boolean hasStatus() {
+        return ((bitField0_ & 0x00000008) != 0);
+      }
+      /**
+       * <code>optional int32 status = 4;</code>
+       * @return The status.
+       */
+      @java.lang.Override
+      public int getStatus() {
+        return status_;
+      }
+      /**
+       * <code>optional int32 status = 4;</code>
+       * @param value The status to set.
+       * @return This builder for chaining.
+       */
+      public Builder setStatus(int value) {
+
+        status_ = value;
+        bitField0_ |= 0x00000008;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 status = 4;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearStatus() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        status_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private int selectedWifiChannelType_ ;
+      /**
+       * <code>optional int32 selected_wifi_channel_type = 5;</code>
+       * @return Whether the selectedWifiChannelType field is set.
+       */
+      @java.lang.Override
+      public boolean hasSelectedWifiChannelType() {
+        return ((bitField0_ & 0x00000010) != 0);
+      }
+      /**
+       * <code>optional int32 selected_wifi_channel_type = 5;</code>
+       * @return The selectedWifiChannelType.
+       */
+      @java.lang.Override
+      public int getSelectedWifiChannelType() {
+        return selectedWifiChannelType_;
+      }
+      /**
+       * <code>optional int32 selected_wifi_channel_type = 5;</code>
+       * @param value The selectedWifiChannelType to set.
+       * @return This builder for chaining.
+       */
+      public Builder setSelectedWifiChannelType(int value) {
+
+        selectedWifiChannelType_ = value;
+        bitField0_ |= 0x00000010;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 selected_wifi_channel_type = 5;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearSelectedWifiChannelType() {
+        bitField0_ = (bitField0_ & ~0x00000010);
+        selectedWifiChannelType_ = 0;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:com.andrerinas.openheadunit.aap.protocol.proto.WifiVersionResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:com.andrerinas.openheadunit.aap.protocol.proto.WifiVersionResponse)
+    private static final com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse();
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<WifiVersionResponse>
+        PARSER = new com.google.protobuf.AbstractParser<WifiVersionResponse>() {
+      @java.lang.Override
+      public WifiVersionResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<WifiVersionResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<WifiVersionResponse> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiVersionResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface WifiConnectStatusOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.andrerinas.openheadunit.aap.protocol.proto.WifiConnectStatus)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional int32 status = 1;</code>
+     * @return Whether the status field is set.
+     */
+    boolean hasStatus();
+    /**
+     * <code>optional int32 status = 1;</code>
+     * @return The status.
+     */
+    int getStatus();
+  }
+  /**
+   * <pre>
+   * Type 6, phone -&gt; head unit: did it get onto our network. The only join feedback that works on
+   * both transports — WiFi Direct also has the P2P client list, a hotspot has no public equivalent.
+   * Observed 0 for success. Plain int32, not sint32: a capture of a real phone's type 5 carried -8,
+   * which read back as 2147483644 while these were declared sint32 (zigzag). Only ==0 vs !=0 is
+   * branched on either way, so that was a wrong log number rather than a wrong decision.
+   * </pre>
+   *
+   * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiConnectStatus}
+   */
+  public static final class WifiConnectStatus extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:com.andrerinas.openheadunit.aap.protocol.proto.WifiConnectStatus)
+      WifiConnectStatusOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use WifiConnectStatus.newBuilder() to construct.
+    private WifiConnectStatus(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private WifiConnectStatus() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new WifiConnectStatus();
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiConnectStatus_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiConnectStatus_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus.class, com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int STATUS_FIELD_NUMBER = 1;
+    private int status_ = 0;
+    /**
+     * <code>optional int32 status = 1;</code>
+     * @return Whether the status field is set.
+     */
+    @java.lang.Override
+    public boolean hasStatus() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>optional int32 status = 1;</code>
+     * @return The status.
+     */
+    @java.lang.Override
+    public int getStatus() {
+      return status_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeInt32(1, status_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(1, status_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus)) {
+        return super.equals(obj);
+      }
+      com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus other = (com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus) obj;
+
+      if (hasStatus() != other.hasStatus()) return false;
+      if (hasStatus()) {
+        if (getStatus()
+            != other.getStatus()) return false;
+      }
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasStatus()) {
+        hash = (37 * hash) + STATUS_FIELD_NUMBER;
+        hash = (53 * hash) + getStatus();
+      }
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * Type 6, phone -&gt; head unit: did it get onto our network. The only join feedback that works on
+     * both transports — WiFi Direct also has the P2P client list, a hotspot has no public equivalent.
+     * Observed 0 for success. Plain int32, not sint32: a capture of a real phone's type 5 carried -8,
+     * which read back as 2147483644 while these were declared sint32 (zigzag). Only ==0 vs !=0 is
+     * branched on either way, so that was a wrong log number rather than a wrong decision.
+     * </pre>
+     *
+     * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiConnectStatus}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:com.andrerinas.openheadunit.aap.protocol.proto.WifiConnectStatus)
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatusOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiConnectStatus_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiConnectStatus_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus.class, com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus.Builder.class);
+      }
+
+      // Construct using com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus.newBuilder()
+      private Builder() {
+
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        bitField0_ = 0;
+        status_ = 0;
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiConnectStatus_descriptor;
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus getDefaultInstanceForType() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus build() {
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus buildPartial() {
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus result = new com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus result) {
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.status_ = status_;
+          to_bitField0_ |= 0x00000001;
+        }
+        result.bitField0_ |= to_bitField0_;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus) {
+          return mergeFrom((com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus other) {
+        if (other == com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus.getDefaultInstance()) return this;
+        if (other.hasStatus()) {
+          setStatus(other.getStatus());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 8: {
+                status_ = input.readInt32();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 8
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      private int bitField0_;
+
+      private int status_ ;
+      /**
+       * <code>optional int32 status = 1;</code>
+       * @return Whether the status field is set.
+       */
+      @java.lang.Override
+      public boolean hasStatus() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>optional int32 status = 1;</code>
+       * @return The status.
+       */
+      @java.lang.Override
+      public int getStatus() {
+        return status_;
+      }
+      /**
+       * <code>optional int32 status = 1;</code>
+       * @param value The status to set.
+       * @return This builder for chaining.
+       */
+      public Builder setStatus(int value) {
+
+        status_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 status = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearStatus() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        status_ = 0;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:com.andrerinas.openheadunit.aap.protocol.proto.WifiConnectStatus)
+    }
+
+    // @@protoc_insertion_point(class_scope:com.andrerinas.openheadunit.aap.protocol.proto.WifiConnectStatus)
+    private static final com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus();
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<WifiConnectStatus>
+        PARSER = new com.google.protobuf.AbstractParser<WifiConnectStatus>() {
+      @java.lang.Override
+      public WifiConnectStatus parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<WifiConnectStatus> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<WifiConnectStatus> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiConnectStatus getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface WifiStartResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.andrerinas.openheadunit.aap.protocol.proto.WifiStartResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string ip_address = 1;</code>
+     * @return Whether the ipAddress field is set.
+     */
+    boolean hasIpAddress();
+    /**
+     * <code>optional string ip_address = 1;</code>
+     * @return The ipAddress.
+     */
+    java.lang.String getIpAddress();
+    /**
+     * <code>optional string ip_address = 1;</code>
+     * @return The bytes for ipAddress.
+     */
+    com.google.protobuf.ByteString
+        getIpAddressBytes();
+
+    /**
+     * <code>optional int32 status = 3;</code>
+     * @return Whether the status field is set.
+     */
+    boolean hasStatus();
+    /**
+     * <code>optional int32 status = 3;</code>
+     * @return The status.
+     */
+    int getStatus();
+  }
+  /**
+   * <pre>
+   * Type 7, phone -&gt; head unit. Acknowledges type 1 and reports the address it will connect from.
+   * Field 2 is unclaimed on purpose — it is not observed and guessing at it would mis-parse.
+   * </pre>
+   *
+   * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiStartResponse}
+   */
+  public static final class WifiStartResponse extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:com.andrerinas.openheadunit.aap.protocol.proto.WifiStartResponse)
+      WifiStartResponseOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use WifiStartResponse.newBuilder() to construct.
+    private WifiStartResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private WifiStartResponse() {
+      ipAddress_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new WifiStartResponse();
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiStartResponse_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiStartResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse.class, com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int IP_ADDRESS_FIELD_NUMBER = 1;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object ipAddress_ = "";
+    /**
+     * <code>optional string ip_address = 1;</code>
+     * @return Whether the ipAddress field is set.
+     */
+    @java.lang.Override
+    public boolean hasIpAddress() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>optional string ip_address = 1;</code>
+     * @return The ipAddress.
+     */
+    @java.lang.Override
+    public java.lang.String getIpAddress() {
+      java.lang.Object ref = ipAddress_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          ipAddress_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string ip_address = 1;</code>
+     * @return The bytes for ipAddress.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getIpAddressBytes() {
+      java.lang.Object ref = ipAddress_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        ipAddress_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int STATUS_FIELD_NUMBER = 3;
+    private int status_ = 0;
+    /**
+     * <code>optional int32 status = 3;</code>
+     * @return Whether the status field is set.
+     */
+    @java.lang.Override
+    public boolean hasStatus() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <code>optional int32 status = 3;</code>
+     * @return The status.
+     */
+    @java.lang.Override
+    public int getStatus() {
+      return status_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, ipAddress_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        output.writeInt32(3, status_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, ipAddress_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(3, status_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse)) {
+        return super.equals(obj);
+      }
+      com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse other = (com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse) obj;
+
+      if (hasIpAddress() != other.hasIpAddress()) return false;
+      if (hasIpAddress()) {
+        if (!getIpAddress()
+            .equals(other.getIpAddress())) return false;
+      }
+      if (hasStatus() != other.hasStatus()) return false;
+      if (hasStatus()) {
+        if (getStatus()
+            != other.getStatus()) return false;
+      }
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasIpAddress()) {
+        hash = (37 * hash) + IP_ADDRESS_FIELD_NUMBER;
+        hash = (53 * hash) + getIpAddress().hashCode();
+      }
+      if (hasStatus()) {
+        hash = (37 * hash) + STATUS_FIELD_NUMBER;
+        hash = (53 * hash) + getStatus();
+      }
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * Type 7, phone -&gt; head unit. Acknowledges type 1 and reports the address it will connect from.
+     * Field 2 is unclaimed on purpose — it is not observed and guessing at it would mis-parse.
+     * </pre>
+     *
+     * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiStartResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:com.andrerinas.openheadunit.aap.protocol.proto.WifiStartResponse)
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiStartResponse_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiStartResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse.class, com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse.Builder.class);
+      }
+
+      // Construct using com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse.newBuilder()
+      private Builder() {
+
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        bitField0_ = 0;
+        ipAddress_ = "";
+        status_ = 0;
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiStartResponse_descriptor;
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse getDefaultInstanceForType() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse build() {
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse buildPartial() {
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse result = new com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse result) {
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.ipAddress_ = ipAddress_;
+          to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.status_ = status_;
+          to_bitField0_ |= 0x00000002;
+        }
+        result.bitField0_ |= to_bitField0_;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse) {
+          return mergeFrom((com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse other) {
+        if (other == com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse.getDefaultInstance()) return this;
+        if (other.hasIpAddress()) {
+          ipAddress_ = other.ipAddress_;
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
+        if (other.hasStatus()) {
+          setStatus(other.getStatus());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                ipAddress_ = input.readBytes();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 24: {
+                status_ = input.readInt32();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 24
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object ipAddress_ = "";
+      /**
+       * <code>optional string ip_address = 1;</code>
+       * @return Whether the ipAddress field is set.
+       */
+      public boolean hasIpAddress() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>optional string ip_address = 1;</code>
+       * @return The ipAddress.
+       */
+      public java.lang.String getIpAddress() {
+        java.lang.Object ref = ipAddress_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            ipAddress_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string ip_address = 1;</code>
+       * @return The bytes for ipAddress.
+       */
+      public com.google.protobuf.ByteString
+          getIpAddressBytes() {
+        java.lang.Object ref = ipAddress_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          ipAddress_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string ip_address = 1;</code>
+       * @param value The ipAddress to set.
+       * @return This builder for chaining.
+       */
+      public Builder setIpAddress(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        ipAddress_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string ip_address = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearIpAddress() {
+        ipAddress_ = getDefaultInstance().getIpAddress();
+        bitField0_ = (bitField0_ & ~0x00000001);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string ip_address = 1;</code>
+       * @param value The bytes for ipAddress to set.
+       * @return This builder for chaining.
+       */
+      public Builder setIpAddressBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        ipAddress_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+
+      private int status_ ;
+      /**
+       * <code>optional int32 status = 3;</code>
+       * @return Whether the status field is set.
+       */
+      @java.lang.Override
+      public boolean hasStatus() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <code>optional int32 status = 3;</code>
+       * @return The status.
+       */
+      @java.lang.Override
+      public int getStatus() {
+        return status_;
+      }
+      /**
+       * <code>optional int32 status = 3;</code>
+       * @param value The status to set.
+       * @return This builder for chaining.
+       */
+      public Builder setStatus(int value) {
+
+        status_ = value;
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 status = 3;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearStatus() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        status_ = 0;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:com.andrerinas.openheadunit.aap.protocol.proto.WifiStartResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:com.andrerinas.openheadunit.aap.protocol.proto.WifiStartResponse)
+    private static final com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse();
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<WifiStartResponse>
+        PARSER = new com.google.protobuf.AbstractParser<WifiStartResponse>() {
+      @java.lang.Override
+      public WifiStartResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<WifiStartResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<WifiStartResponse> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiStartResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface WifiPingRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.andrerinas.openheadunit.aap.protocol.proto.WifiPingRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional int64 timestamp = 1;</code>
+     * @return Whether the timestamp field is set.
+     */
+    boolean hasTimestamp();
+    /**
+     * <code>optional int64 timestamp = 1;</code>
+     * @return The timestamp.
+     */
+    long getTimestamp();
+  }
+  /**
+   * <pre>
+   * Types 8 and 9: a keepalive the phone may interject anywhere. We answer type 8 by echoing its
+   * raw payload as a type 9 without parsing, so these are for reading captures, not for the reply.
+   * </pre>
+   *
+   * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiPingRequest}
+   */
+  public static final class WifiPingRequest extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:com.andrerinas.openheadunit.aap.protocol.proto.WifiPingRequest)
+      WifiPingRequestOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use WifiPingRequest.newBuilder() to construct.
+    private WifiPingRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private WifiPingRequest() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new WifiPingRequest();
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingRequest_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest.class, com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int TIMESTAMP_FIELD_NUMBER = 1;
+    private long timestamp_ = 0L;
+    /**
+     * <code>optional int64 timestamp = 1;</code>
+     * @return Whether the timestamp field is set.
+     */
+    @java.lang.Override
+    public boolean hasTimestamp() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>optional int64 timestamp = 1;</code>
+     * @return The timestamp.
+     */
+    @java.lang.Override
+    public long getTimestamp() {
+      return timestamp_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeInt64(1, timestamp_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(1, timestamp_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest)) {
+        return super.equals(obj);
+      }
+      com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest other = (com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest) obj;
+
+      if (hasTimestamp() != other.hasTimestamp()) return false;
+      if (hasTimestamp()) {
+        if (getTimestamp()
+            != other.getTimestamp()) return false;
+      }
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasTimestamp()) {
+        hash = (37 * hash) + TIMESTAMP_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getTimestamp());
+      }
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * Types 8 and 9: a keepalive the phone may interject anywhere. We answer type 8 by echoing its
+     * raw payload as a type 9 without parsing, so these are for reading captures, not for the reply.
+     * </pre>
+     *
+     * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiPingRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:com.andrerinas.openheadunit.aap.protocol.proto.WifiPingRequest)
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingRequest_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest.class, com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest.Builder.class);
+      }
+
+      // Construct using com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest.newBuilder()
+      private Builder() {
+
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        bitField0_ = 0;
+        timestamp_ = 0L;
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingRequest_descriptor;
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest getDefaultInstanceForType() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest build() {
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest buildPartial() {
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest result = new com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest result) {
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.timestamp_ = timestamp_;
+          to_bitField0_ |= 0x00000001;
+        }
+        result.bitField0_ |= to_bitField0_;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest) {
+          return mergeFrom((com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest other) {
+        if (other == com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest.getDefaultInstance()) return this;
+        if (other.hasTimestamp()) {
+          setTimestamp(other.getTimestamp());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 8: {
+                timestamp_ = input.readInt64();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 8
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      private int bitField0_;
+
+      private long timestamp_ ;
+      /**
+       * <code>optional int64 timestamp = 1;</code>
+       * @return Whether the timestamp field is set.
+       */
+      @java.lang.Override
+      public boolean hasTimestamp() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>optional int64 timestamp = 1;</code>
+       * @return The timestamp.
+       */
+      @java.lang.Override
+      public long getTimestamp() {
+        return timestamp_;
+      }
+      /**
+       * <code>optional int64 timestamp = 1;</code>
+       * @param value The timestamp to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTimestamp(long value) {
+
+        timestamp_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 timestamp = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearTimestamp() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        timestamp_ = 0L;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:com.andrerinas.openheadunit.aap.protocol.proto.WifiPingRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:com.andrerinas.openheadunit.aap.protocol.proto.WifiPingRequest)
+    private static final com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest();
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<WifiPingRequest>
+        PARSER = new com.google.protobuf.AbstractParser<WifiPingRequest>() {
+      @java.lang.Override
+      public WifiPingRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<WifiPingRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<WifiPingRequest> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface WifiPingResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.andrerinas.openheadunit.aap.protocol.proto.WifiPingResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional int64 timestamp = 1;</code>
+     * @return Whether the timestamp field is set.
+     */
+    boolean hasTimestamp();
+    /**
+     * <code>optional int64 timestamp = 1;</code>
+     * @return The timestamp.
+     */
+    long getTimestamp();
+  }
+  /**
+   * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiPingResponse}
+   */
+  public static final class WifiPingResponse extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:com.andrerinas.openheadunit.aap.protocol.proto.WifiPingResponse)
+      WifiPingResponseOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use WifiPingResponse.newBuilder() to construct.
+    private WifiPingResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private WifiPingResponse() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new WifiPingResponse();
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingResponse_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse.class, com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int TIMESTAMP_FIELD_NUMBER = 1;
+    private long timestamp_ = 0L;
+    /**
+     * <code>optional int64 timestamp = 1;</code>
+     * @return Whether the timestamp field is set.
+     */
+    @java.lang.Override
+    public boolean hasTimestamp() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>optional int64 timestamp = 1;</code>
+     * @return The timestamp.
+     */
+    @java.lang.Override
+    public long getTimestamp() {
+      return timestamp_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeInt64(1, timestamp_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(1, timestamp_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse)) {
+        return super.equals(obj);
+      }
+      com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse other = (com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse) obj;
+
+      if (hasTimestamp() != other.hasTimestamp()) return false;
+      if (hasTimestamp()) {
+        if (getTimestamp()
+            != other.getTimestamp()) return false;
+      }
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasTimestamp()) {
+        hash = (37 * hash) + TIMESTAMP_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getTimestamp());
+      }
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiPingResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:com.andrerinas.openheadunit.aap.protocol.proto.WifiPingResponse)
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingResponse_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse.class, com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse.Builder.class);
+      }
+
+      // Construct using com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse.newBuilder()
+      private Builder() {
+
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        bitField0_ = 0;
+        timestamp_ = 0L;
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingResponse_descriptor;
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse getDefaultInstanceForType() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse build() {
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse buildPartial() {
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse result = new com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse result) {
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.timestamp_ = timestamp_;
+          to_bitField0_ |= 0x00000001;
+        }
+        result.bitField0_ |= to_bitField0_;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse) {
+          return mergeFrom((com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse other) {
+        if (other == com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse.getDefaultInstance()) return this;
+        if (other.hasTimestamp()) {
+          setTimestamp(other.getTimestamp());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 8: {
+                timestamp_ = input.readInt64();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 8
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      private int bitField0_;
+
+      private long timestamp_ ;
+      /**
+       * <code>optional int64 timestamp = 1;</code>
+       * @return Whether the timestamp field is set.
+       */
+      @java.lang.Override
+      public boolean hasTimestamp() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>optional int64 timestamp = 1;</code>
+       * @return The timestamp.
+       */
+      @java.lang.Override
+      public long getTimestamp() {
+        return timestamp_;
+      }
+      /**
+       * <code>optional int64 timestamp = 1;</code>
+       * @param value The timestamp to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTimestamp(long value) {
+
+        timestamp_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 timestamp = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearTimestamp() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        timestamp_ = 0L;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:com.andrerinas.openheadunit.aap.protocol.proto.WifiPingResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:com.andrerinas.openheadunit.aap.protocol.proto.WifiPingResponse)
+    private static final com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse();
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<WifiPingResponse>
+        PARSER = new com.google.protobuf.AbstractParser<WifiPingResponse>() {
+      @java.lang.Override
+      public WifiPingResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<WifiPingResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<WifiPingResponse> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiPingResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface WifiSetupInfoOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.andrerinas.openheadunit.aap.protocol.proto.WifiSetupInfo)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional int32 major = 1;</code>
+     * @return Whether the major field is set.
+     */
+    boolean hasMajor();
+    /**
+     * <code>optional int32 major = 1;</code>
+     * @return The major.
+     */
+    int getMajor();
+
+    /**
+     * <code>optional int32 minor = 2;</code>
+     * @return Whether the minor field is set.
+     */
+    boolean hasMinor();
+    /**
+     * <code>optional int32 minor = 2;</code>
+     * @return The minor.
+     */
+    int getMinor();
+  }
+  /**
+   * <pre>
+   * Type 11. Defined so a capture can be read; not sent.
+   * </pre>
+   *
+   * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiSetupInfo}
+   */
+  public static final class WifiSetupInfo extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:com.andrerinas.openheadunit.aap.protocol.proto.WifiSetupInfo)
+      WifiSetupInfoOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use WifiSetupInfo.newBuilder() to construct.
+    private WifiSetupInfo(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private WifiSetupInfo() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new WifiSetupInfo();
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiSetupInfo_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiSetupInfo_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo.class, com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int MAJOR_FIELD_NUMBER = 1;
+    private int major_ = 0;
+    /**
+     * <code>optional int32 major = 1;</code>
+     * @return Whether the major field is set.
+     */
+    @java.lang.Override
+    public boolean hasMajor() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>optional int32 major = 1;</code>
+     * @return The major.
+     */
+    @java.lang.Override
+    public int getMajor() {
+      return major_;
+    }
+
+    public static final int MINOR_FIELD_NUMBER = 2;
+    private int minor_ = 0;
+    /**
+     * <code>optional int32 minor = 2;</code>
+     * @return Whether the minor field is set.
+     */
+    @java.lang.Override
+    public boolean hasMinor() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <code>optional int32 minor = 2;</code>
+     * @return The minor.
+     */
+    @java.lang.Override
+    public int getMinor() {
+      return minor_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeInt32(1, major_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        output.writeInt32(2, minor_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(1, major_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(2, minor_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo)) {
+        return super.equals(obj);
+      }
+      com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo other = (com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo) obj;
+
+      if (hasMajor() != other.hasMajor()) return false;
+      if (hasMajor()) {
+        if (getMajor()
+            != other.getMajor()) return false;
+      }
+      if (hasMinor() != other.hasMinor()) return false;
+      if (hasMinor()) {
+        if (getMinor()
+            != other.getMinor()) return false;
+      }
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasMajor()) {
+        hash = (37 * hash) + MAJOR_FIELD_NUMBER;
+        hash = (53 * hash) + getMajor();
+      }
+      if (hasMinor()) {
+        hash = (37 * hash) + MINOR_FIELD_NUMBER;
+        hash = (53 * hash) + getMinor();
+      }
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * Type 11. Defined so a capture can be read; not sent.
+     * </pre>
+     *
+     * Protobuf type {@code com.andrerinas.openheadunit.aap.protocol.proto.WifiSetupInfo}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:com.andrerinas.openheadunit.aap.protocol.proto.WifiSetupInfo)
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfoOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiSetupInfo_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiSetupInfo_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo.class, com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo.Builder.class);
+      }
+
+      // Construct using com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo.newBuilder()
+      private Builder() {
+
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        bitField0_ = 0;
+        major_ = 0;
+        minor_ = 0;
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiSetupInfo_descriptor;
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo getDefaultInstanceForType() {
+        return com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo build() {
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo buildPartial() {
+        com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo result = new com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo result) {
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.major_ = major_;
+          to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.minor_ = minor_;
+          to_bitField0_ |= 0x00000002;
+        }
+        result.bitField0_ |= to_bitField0_;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo) {
+          return mergeFrom((com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo other) {
+        if (other == com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo.getDefaultInstance()) return this;
+        if (other.hasMajor()) {
+          setMajor(other.getMajor());
+        }
+        if (other.hasMinor()) {
+          setMinor(other.getMinor());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 8: {
+                major_ = input.readInt32();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 8
+              case 16: {
+                minor_ = input.readInt32();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      private int bitField0_;
+
+      private int major_ ;
+      /**
+       * <code>optional int32 major = 1;</code>
+       * @return Whether the major field is set.
+       */
+      @java.lang.Override
+      public boolean hasMajor() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>optional int32 major = 1;</code>
+       * @return The major.
+       */
+      @java.lang.Override
+      public int getMajor() {
+        return major_;
+      }
+      /**
+       * <code>optional int32 major = 1;</code>
+       * @param value The major to set.
+       * @return This builder for chaining.
+       */
+      public Builder setMajor(int value) {
+
+        major_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 major = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearMajor() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        major_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private int minor_ ;
+      /**
+       * <code>optional int32 minor = 2;</code>
+       * @return Whether the minor field is set.
+       */
+      @java.lang.Override
+      public boolean hasMinor() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <code>optional int32 minor = 2;</code>
+       * @return The minor.
+       */
+      @java.lang.Override
+      public int getMinor() {
+        return minor_;
+      }
+      /**
+       * <code>optional int32 minor = 2;</code>
+       * @param value The minor to set.
+       * @return This builder for chaining.
+       */
+      public Builder setMinor(int value) {
+
+        minor_ = value;
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 minor = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearMinor() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        minor_ = 0;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:com.andrerinas.openheadunit.aap.protocol.proto.WifiSetupInfo)
+    }
+
+    // @@protoc_insertion_point(class_scope:com.andrerinas.openheadunit.aap.protocol.proto.WifiSetupInfo)
+    private static final com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo();
+    }
+
+    public static com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<WifiSetupInfo>
+        PARSER = new com.google.protobuf.AbstractParser<WifiSetupInfo>() {
+      @java.lang.Override
+      public WifiSetupInfo parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<WifiSetupInfo> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<WifiSetupInfo> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.andrerinas.openheadunit.aap.protocol.proto.Wireless.WifiSetupInfo getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiStartRequest_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiStartRequest_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiInfoRequest_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiInfoRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiInfoResponse_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiInfoResponse_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionRequest_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionResponse_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionResponse_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiConnectStatus_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiConnectStatus_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiStartResponse_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiStartResponse_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingRequest_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingResponse_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingResponse_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiSetupInfo_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiSetupInfo_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -2281,22 +7192,32 @@ public final class Wireless {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\012\016wireless.proto\022.com.andrerinas.openhea" +
-      "dunit.aap.protocol.proto\"D\012\020WifiStartReq" +
-      "uest\022\022\012\012ip_address\030\001 \002(\011\022\014\012\004port\030\002 \002(\005\022\016" +
-      "\012\006status\030\003 \001(\005\"\355\001\012\020WifiInfoResponse\022\014\012\004s" +
-      "sid\030\001 \002(\011\022\013\012\003key\030\002 \002(\011\022\015\012\005bssid\030\003 \002(\011\022S\012" +
-      "\015security_mode\030\004 \002(\0162<.com.andrerinas.op" +
-      "enheadunit.aap.protocol.proto.SecurityMo" +
-      "de\022Z\012\021access_point_type\030\005 \002(\0162?.com.andr" +
-      "erinas.openheadunit.aap.protocol.proto.A" +
-      "ccessPointType**\012\017AccessPointType\022\012\012\006STA" +
-      "TIC\020\000\022\013\012\007DYNAMIC\020\001*\312\001\012\014SecurityMode\022\031\012\025U" +
-      "NKNOWN_SECURITY_MODE\020\000\022\010\012\004OPEN\020\001\022\012\012\006WEP_" +
-      "64\020\002\022\013\012\007WEP_128\020\003\022\020\012\014WPA_PERSONAL\020\004\022\021\012\015W" +
-      "PA2_PERSONAL\020\010\022\025\012\021WPA_WPA2_PERSONAL\020\014\022\022\012" +
-      "\016WPA_ENTERPRISE\020\024\022\023\012\017WPA2_ENTERPRISE\020\030\022\027" +
-      "\012\023WPA_WPA2_ENTERPRISE\020\034"
+      "\n\016wireless.proto\022.com.andrerinas.openhea" +
+      "dunit.aap.protocol.proto\"D\n\020WifiStartReq" +
+      "uest\022\022\n\nip_address\030\001 \002(\t\022\014\n\004port\030\002 \002(\005\022\016" +
+      "\n\006status\030\003 \001(\005\"\021\n\017WifiInfoRequest\"\355\001\n\020Wi" +
+      "fiInfoResponse\022\014\n\004ssid\030\001 \002(\t\022\013\n\003key\030\002 \002(" +
+      "\t\022\r\n\005bssid\030\003 \001(\t\022S\n\rsecurity_mode\030\004 \001(\0162" +
+      "<.com.andrerinas.openheadunit.aap.protoc" +
+      "ol.proto.SecurityMode\022Z\n\021access_point_ty" +
+      "pe\030\005 \001(\0162?.com.andrerinas.openheadunit.a" +
+      "ap.protocol.proto.AccessPointType\"2\n\022Wif" +
+      "iVersionRequest\022\r\n\005major\030\001 \001(\005\022\r\n\005minor\030" +
+      "\002 \001(\005\"~\n\023WifiVersionResponse\022\r\n\005major\030\001 " +
+      "\001(\005\022\r\n\005minor\030\002 \001(\005\022\025\n\rdevice_serial\030\003 \001(" +
+      "\t\022\016\n\006status\030\004 \001(\005\022\"\n\032selected_wifi_chann" +
+      "el_type\030\005 \001(\005\"#\n\021WifiConnectStatus\022\016\n\006st" +
+      "atus\030\001 \001(\005\"7\n\021WifiStartResponse\022\022\n\nip_ad" +
+      "dress\030\001 \001(\t\022\016\n\006status\030\003 \001(\005\"$\n\017WifiPingR" +
+      "equest\022\021\n\ttimestamp\030\001 \001(\003\"%\n\020WifiPingRes" +
+      "ponse\022\021\n\ttimestamp\030\001 \001(\003\"-\n\rWifiSetupInf" +
+      "o\022\r\n\005major\030\001 \001(\005\022\r\n\005minor\030\002 \001(\005**\n\017Acces" +
+      "sPointType\022\n\n\006STATIC\020\000\022\013\n\007DYNAMIC\020\001*\312\001\n\014" +
+      "SecurityMode\022\031\n\025UNKNOWN_SECURITY_MODE\020\000\022" +
+      "\010\n\004OPEN\020\001\022\n\n\006WEP_64\020\002\022\013\n\007WEP_128\020\003\022\020\n\014WP" +
+      "A_PERSONAL\020\004\022\021\n\rWPA2_PERSONAL\020\010\022\025\n\021WPA_W" +
+      "PA2_PERSONAL\020\014\022\022\n\016WPA_ENTERPRISE\020\024\022\023\n\017WP" +
+      "A2_ENTERPRISE\020\030\022\027\n\023WPA_WPA2_ENTERPRISE\020\034"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -2308,12 +7229,60 @@ public final class Wireless {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiStartRequest_descriptor,
         new java.lang.String[] { "IpAddress", "Port", "Status", });
-    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiInfoResponse_descriptor =
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiInfoRequest_descriptor =
       getDescriptor().getMessageTypes().get(1);
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiInfoRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiInfoRequest_descriptor,
+        new java.lang.String[] { });
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiInfoResponse_descriptor =
+      getDescriptor().getMessageTypes().get(2);
     internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiInfoResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiInfoResponse_descriptor,
         new java.lang.String[] { "Ssid", "Key", "Bssid", "SecurityMode", "AccessPointType", });
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionRequest_descriptor =
+      getDescriptor().getMessageTypes().get(3);
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionRequest_descriptor,
+        new java.lang.String[] { "Major", "Minor", });
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionResponse_descriptor =
+      getDescriptor().getMessageTypes().get(4);
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiVersionResponse_descriptor,
+        new java.lang.String[] { "Major", "Minor", "DeviceSerial", "Status", "SelectedWifiChannelType", });
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiConnectStatus_descriptor =
+      getDescriptor().getMessageTypes().get(5);
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiConnectStatus_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiConnectStatus_descriptor,
+        new java.lang.String[] { "Status", });
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiStartResponse_descriptor =
+      getDescriptor().getMessageTypes().get(6);
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiStartResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiStartResponse_descriptor,
+        new java.lang.String[] { "IpAddress", "Status", });
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingRequest_descriptor =
+      getDescriptor().getMessageTypes().get(7);
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingRequest_descriptor,
+        new java.lang.String[] { "Timestamp", });
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingResponse_descriptor =
+      getDescriptor().getMessageTypes().get(8);
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiPingResponse_descriptor,
+        new java.lang.String[] { "Timestamp", });
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiSetupInfo_descriptor =
+      getDescriptor().getMessageTypes().get(9);
+    internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiSetupInfo_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_com_andrerinas_openheadunit_aap_protocol_proto_WifiSetupInfo_descriptor,
+        new java.lang.String[] { "Major", "Minor", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/app/src/main/java/com/andrerinas/openheadunit/app/BootCompleteReceiver.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/app/BootCompleteReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.content.ContextCompat
 import com.andrerinas.openheadunit.aap.AapService
+import com.andrerinas.openheadunit.aap.BootLoopPolicy
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.Settings
 import android.os.UserManager
@@ -32,7 +33,14 @@ class BootCompleteReceiver : BroadcastReceiver() {
         val wifiEnabled = Settings.isAutoStartOnWifiEnabled(context)
 
         if (bootEnabled) {
-            AppLog.i("Boot auto-start: starting AapService with BOOT_START (trigger=$action)")
+            // Take a strike before starting. The service clears it once this run has lasted long
+            // enough to count as healthy; if the device dies first, the strike stands and the next
+            // boot is one closer to pausing wireless bring-up. Counted here rather than in the
+            // service because only this side knows the start came from a boot — EXTRA_BOOT_START
+            // does not reach AapService until onStartCommand, after onCreate has already run.
+            val strikes = BootLoopPolicy.nextStrikes(Settings.getBootLoopStrikes(context))
+            Settings.setBootLoopStrikes(context, strikes)
+            AppLog.i("Boot auto-start: starting AapService with BOOT_START (trigger=$action, boot-start #$strikes since the last healthy run)")
             val serviceIntent = Intent(context, AapService::class.java).apply {
                 putExtra(EXTRA_BOOT_START, true)
             }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
@@ -5,6 +5,7 @@ import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
 import com.andrerinas.openheadunit.aap.AapSslContext
 import com.andrerinas.openheadunit.aap.AapTransport
+import com.andrerinas.openheadunit.aap.VideoStarvationPolicy
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.main.BackgroundNotification
 import com.andrerinas.openheadunit.ssl.SingleKeyKeyManager
@@ -137,6 +138,11 @@ class CommManager(
      * device is fully closed before `openDevice()` is called on it again.
      */
     @Volatile private var _disconnectJob: kotlinx.coroutines.Job? = null
+
+    // Whether the session now ending ever completed its handshake, and how many sessions in a row
+    // have completed one and then carried no video at all. See VideoStarvationPolicy.
+    @Volatile private var sessionReachedHandshake = false
+    @Volatile private var starvedSessionStreak = 0
 
     private val _backgroundNotification = BackgroundNotification(context)
 
@@ -328,6 +334,9 @@ class CommManager(
                     _transport!!.onUpdateUiConfigReplyReceived = { onUpdateUiConfigReplyReceived?.invoke() }
                 }
                 if (_transport?.startHandshake(_connection!!) == true) {
+                    // A session that got this far had a working link to carry video on. See
+                    // VideoStarvationPolicy for what it means when one ends without carrying any.
+                    sessionReachedHandshake = true
                     _connectionState.emit(ConnectionState.HandshakeComplete)
                 } else {
                     _connectionState.emit(ConnectionState.Error("Handshake failed"))
@@ -636,6 +645,10 @@ class CommManager(
         _connection = null
         lastKeyEvents.clear()
         keyStates.clear()
+        // Read before stopping the decoder, which clears the stamp. Self-guarding against the
+        // re-entrant second call described above: the flag is consumed here, so the second pass
+        // sees a session that never reached the handshake and counts nothing.
+        noteSessionEnded(renderedAnyFrame = videoDecoder.lastFrameRenderedMs > 0L)
         try {
             // Only send ByeByeRequest when we are initiating the disconnect (e.g. user pressed
             // disconnect). When the transport self-quit (read error, soTimeout), the connection
@@ -653,6 +666,30 @@ class CommManager(
             if (_connectionState.value !is ConnectionState.Disconnected) {
                 _connectionState.value = ConnectionState.Disconnected()
             }
+        }
+    }
+
+    /**
+     * Counts a finished session against [VideoStarvationPolicy] and, on a long enough run of
+     * sessions that carried no video at all, says what that means and what to do about it.
+     *
+     * The phone gives no reason we can see — it closes the socket and our read reports a plain EOF
+     * — so without this the log shows nothing but a healthy connection repeating forever.
+     */
+    private fun noteSessionEnded(renderedAnyFrame: Boolean) {
+        val reachedHandshake = sessionReachedHandshake
+        sessionReachedHandshake = false
+        starvedSessionStreak = VideoStarvationPolicy.nextStreak(
+            starvedSessionStreak, reachedHandshake, renderedAnyFrame
+        )
+        if (VideoStarvationPolicy.shouldAdvise(starvedSessionStreak)) {
+            AppLog.w(
+                "CommManager: $starvedSessionStreak sessions in a row ended without a single video " +
+                    "frame arriving. The phone is connecting and then giving up on the video stream, " +
+                    "which is what a WiFi link too slow to carry it looks like. Measured on a 2.4 GHz " +
+                    "access point at 1080p/60, where the same link held 800x480/30 indefinitely: move " +
+                    "the access point to 5 GHz, or lower the resolution and frame rate in Video settings."
+            )
         }
     }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
@@ -337,6 +337,7 @@ class CommManager(
                     // A session that got this far had a working link to carry video on. See
                     // VideoStarvationPolicy for what it means when one ends without carrying any.
                     sessionReachedHandshake = true
+                    videoDecoder.framesRenderedThisSession = 0L
                     _connectionState.emit(ConnectionState.HandshakeComplete)
                 } else {
                     _connectionState.emit(ConnectionState.Error("Handshake failed"))
@@ -645,10 +646,13 @@ class CommManager(
         _connection = null
         lastKeyEvents.clear()
         keyStates.clear()
-        // Read before stopping the decoder, which clears the stamp. Self-guarding against the
-        // re-entrant second call described above: the flag is consumed here, so the second pass
-        // sees a session that never reached the handshake and counts nothing.
-        noteSessionEnded(renderedAnyFrame = videoDecoder.lastFrameRenderedMs > 0L)
+        // Counts frames over the whole session rather than reading lastFrameRenderedMs, which the
+        // decoder zeroes every time the projection surface goes away — leaving projection before
+        // disconnecting is normal, and would otherwise make every such session look starved.
+        // Self-guarding against the re-entrant second call described above: the flag is consumed
+        // here, so the second pass sees a session that never reached the handshake and counts
+        // nothing.
+        noteSessionEnded(renderedAnyFrame = videoDecoder.framesRenderedThisSession > 0L)
         try {
             // Only send ByeByeRequest when we are initiating the disconnect (e.g. user pressed
             // disconnect). When the transport self-quit (read error, soTimeout), the connection

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -103,11 +103,11 @@ class NativeAaHandshakeManager(
     // elapsedRealtime() when handleHandshake() started, or 0 when no exchange is running; lets
     // WifiDirectManager's join watchdog know a real exchange is in progress.
     //
-    // [BUG_FIX] #706: a stamp rather than a boolean because handleHandshake() cannot be relied on
-    // to clear it. On the reporter's ROCO K706 the socket close that is supposed to unblock the
-    // wait for Type 2 does not, so the coroutine never reaches its finally — three failed
-    // handshakes produced zero "BT Handshake socket closed." lines and left the old boolean true
-    // for the rest of the process. See NativeHandoffPolicy.isHandshaking.
+    // [BUG_FIX] A stamp rather than a boolean, because handleHandshake() cannot be relied on to
+    // clear it: on stacks where closing the socket does not unblock the wait for Type 2, the
+    // coroutine never reaches its finally. Seen as three failed handshakes and zero "BT Handshake
+    // socket closed." lines, with the old boolean stuck true for the rest of the process. See
+    // NativeHandoffPolicy.isHandshaking.
     @Volatile private var handshakeStartedAt = 0L
     // True for the duration of a single pokeDevice() attempt (its socket.connect() call itself
     // can fire an OS-level ACL_CONNECTED broadcast before any real handshake starts) - see
@@ -124,18 +124,16 @@ class NativeAaHandshakeManager(
     // Name of the primary Bluetooth radio we listen and poke on, captured in start(). A field
     // rather than a local so the diagnostic below can name the radio the phone is ignoring.
     @Volatile private var localRadioName: String = "?"
-    // [BUG_FIX] #706: how many wake pokes the phone has answered without ever opening the AA
-    // channel, and whether it ever has. The pair exists because "poke succeeds, nothing comes
-    // back" produced a head unit log with no sign of trouble at all — successful pokes and
-    // nothing else — while the phone was in fact reconnecting every 12 s to the head unit's own
-    // OEM Bluetooth module, which still advertises the Android Auto service record. See
-    // NativeHandoffPolicy.shouldWarnPhoneNeverCallsBack.
+    // [BUG_FIX] How many wake pokes the phone has answered without ever opening the AA channel,
+    // and whether it ever has. The pair exists because "poke succeeds, nothing comes back" makes a
+    // broken unit's log identical to a healthy one waiting for the user, while the phone is in
+    // fact reconnecting every 12 s to the unit's own OEM Bluetooth module, which advertises the
+    // same service record. See NativeHandoffPolicy.shouldWarnPhoneNeverCallsBack.
     @Volatile private var pokesSinceLastAccept = 0
     @Volatile private var everAcceptedAaConnection = false
-    // [BUG_FIX] #706: handshakes that timed out waiting for Type 2, back to back. Each one strands
-    // a Dispatchers.IO thread forever on a stack where close() does not interrupt a pending read,
-    // so this bounds how many we are willing to strand. See
-    // NativeHandoffPolicy.shouldServeHandshake.
+    // [BUG_FIX] Handshakes that timed out waiting for Type 2, back to back. Where close() does not
+    // interrupt a pending read each one strands a Dispatchers.IO thread forever, so this bounds
+    // how many we are willing to strand. See NativeHandoffPolicy.shouldServeHandshake.
     @Volatile private var consecutiveHandshakeFailures = 0
     // Whether the "not serving handshakes" warning has already been logged for the current
     // backoff, so a phone retrying every ~12 s does not repeat the long explanation each time.
@@ -177,10 +175,10 @@ class NativeAaHandshakeManager(
      * landing — the window in which it is still associating, doing WPS and getting a DHCP lease.
      *
      * [isHandshakeInFlight] deliberately goes false the instant Type 3 is written, because the
-     * *credential exchange* is done at that point. The phone's work isn't: on the #760 reporter's
-     * hardware it joined the group 0.73 s after Type 3 and was still without an IP 2.4 s later.
-     * Anything that must not disturb the phone mid-join — the wake poke, the BT auto-start
-     * re-arm, WifiDirectManager's join watchdog — has to check this, not isHandshakeInFlight().
+     * *credential exchange* is done at that point. The phone's work is not: measured joining the
+     * group 0.73 s after Type 3 and still without an IP 2.4 s later. Anything that must not disturb
+     * the phone mid-join — the wake poke, the BT auto-start re-arm, WifiDirectManager's join
+     * watchdog — has to check this, not isHandshakeInFlight().
      */
     fun isHandoffSettling(): Boolean =
         NativeHandoffPolicy.isSettling(handoffSettlingSince, SystemClock.elapsedRealtime())
@@ -276,7 +274,7 @@ class NativeAaHandshakeManager(
         // Match radios by system service name, not MAC address: BluetoothAdapter.getAddress()
         // returns the fixed placeholder "02:00:00:00:00:00" for any non-privileged app since
         // Android 6.0 (API 23), on every device - primary and secondary always look identical
-        // by address alone (see andreknieriem/headunit-revived#706).
+        // by address alone.
         val handles = try {
             BluetoothHelper.getAllBluetoothAdapterHandles(context)
         } catch (e: Exception) { emptyList() }
@@ -472,13 +470,12 @@ class NativeAaHandshakeManager(
      *
      * Never runs while a handoff is settling: AapService re-invokes this on every credential
      * re-delivery, and the phone *joining our group* is itself a P2P connection change, hence a
-     * re-delivery. That turned into a real RFCOMM connect() landing in the middle of the phone's
-     * DHCP exchange (#760).
+     * re-delivery. That put a real RFCOMM connect() in the middle of the phone's DHCP exchange.
      */
     fun triggerPoke() {
         if (isHandoffSettling()) {
-            // Info, not debug: this line is the evidence that the #760 fix is doing its job, and
-            // reporter logs default to INFO.
+            // Info, not debug: this line is the evidence the suppression is working, and reporter
+            // logs default to INFO.
             AppLog.i("NativeAA: Handoff still settling — not starting a poke that would compete with the phone's WiFi association.")
             return
         }
@@ -545,13 +542,12 @@ class NativeAaHandshakeManager(
                     pokeDevice(device, holdMs = 15000)
                 }
 
-                // [BUG_FIX] #706: say out loud that the phone is answering but never calling back.
-                // Without this the log of a head unit in that state is indistinguishable from a
-                // healthy one waiting for the user — successful pokes and nothing else — which is
-                // what let the reporter's real cause (his phone's Android Auto was bound to the
-                // head unit's own OEM Bluetooth module, still advertising the AA service record
-                // after its OEM app stopped answering) go unnoticed for weeks. Warning, not info,
-                // so it survives a reporter log exported at the default level.
+                // [BUG_FIX] Say out loud that the phone answers but never calls back. Untold, that
+                // unit's log is indistinguishable from a healthy one waiting for the user, which is
+                // what hid the real cause — Android Auto bound to the head unit's own OEM Bluetooth
+                // module, still advertising the AA service record after its OEM app stopped
+                // answering. Warning, not info, so it survives a log exported at the default
+                // level.
                 if (NativeHandoffPolicy.shouldWarnPhoneNeverCallsBack(
                         pokesSinceLastAccept, everAcceptedAaConnection
                     )
@@ -644,8 +640,8 @@ class NativeAaHandshakeManager(
 
         // The wake poke is deliberately left running here. It used to be cancelled on entry, on
         // the reasoning that a real AA_UUID connection means the poke has done its job and is now
-        // just competing for radio time — but cancelling it closes the HFP/HSP socket, and #706's
-        // phone-side Gearhead log shows the phone reacting to that within milliseconds:
+        // just competing for radio time — but cancelling it closes the HFP/HSP socket, and a
+        // phone-side Gearhead log shows the phone reacting within milliseconds:
         //   GH.BtConnectionTracker: profile connection removed
         //   GH.CurrentCarTracker:   current car bluetooth connection is lost / is gone
         //   ...WIRELESS_SETUP_CAR_BLUETOOTH_DISAPPEAR
@@ -747,14 +743,13 @@ class NativeAaHandshakeManager(
             // There is no BluetoothSocket.setSoTimeout(), so the read has to be bounded from the
             // outside. This used to be a watchdog that closed the socket to unblock readFully().
             //
-            // [BUG_FIX] #706: that only works on stacks where close() actually interrupts a
-            // pending read, and the reporter's does not — his log has three "No response from
-            // phone" lines and not one "BT Handshake socket closed.", i.e. this function never
-            // unwound. Everything downstream of it stalled with it: the wake poke stopped
-            // retrying and the P2P join watchdog deferred recovery for the rest of the session.
-            // Time out the wait instead of the socket, by running the blocking read in its own
-            // coroutine and awaiting it — that resumes on schedule whether or not the read ever
-            // returns. The close is still attempted, for the stacks where it does help.
+            // [BUG_FIX] That only works where close() actually interrupts a pending read, and on
+            // some stacks it does not: three "No response from phone" lines and not one "BT
+            // Handshake socket closed." means this function never unwound, taking the wake poke
+            // and the P2P join watchdog down with it for the rest of the session. Time out the
+            // wait instead of the socket, by running the blocking read on its own coroutine, which
+            // resumes on schedule whether or not the read returns. The close is still attempted,
+            // for the stacks where it helps.
             val reader = scope.async(Dispatchers.IO) { readProtobuf(input) }
             val response = withTimeoutOrNull(HANDSHAKE_RESPONSE_TIMEOUT_MS) { reader.await() }
             if (response == null) {
@@ -785,8 +780,8 @@ class NativeAaHandshakeManager(
                 handoffSettlingSince = SystemClock.elapsedRealtime()
                 // The phone has what it needs, so the wake poke held open since before this
                 // handshake has nothing left to wake. Release it now — it is an RFCOMM channel on
-                // the same physical radio the phone is about to associate over, and #760 is what
-                // happens when Bluetooth work overlaps the join.
+                // the radio the phone is about to associate over, and Bluetooth work across the
+                // join strands it on "Obtaining IP address".
                 pokeJob?.cancel()
 
                 // Release the Bluetooth connection once the handoff has actually happened, rather
@@ -796,13 +791,11 @@ class NativeAaHandshakeManager(
                 // it open caused the same "confusion, especially with phone calls" symptom this
                 // repo has seen reported.
                 //
-                // [BUG_FIX] #760: this used to be a flat delay(3000). That is a race, not a grace
-                // period — the phone needs however long it needs. In the reporter's logs the
-                // phone joined the group 0.73s after Type 3 and then left it 0.17s after this
-                // close fired at T+3.0s, never having got an IP; on 3.1.1, which never closed
-                // Bluetooth at all, the same phone took 21s to associate and connected fine; on
-                // 3.2.0-beta4 the TCP session landed 110ms before the close and it worked. Wait
-                // for the session instead of guessing at it.
+                // [BUG_FIX] This used to be a flat delay(3000) — a race, not a grace period, since
+                // the phone needs however long it needs. Measured: joined 0.73s after Type 3, left
+                // 0.17s after the close fired at T+3.0s, never got an IP. A build that never closed
+                // Bluetooth gave the same phone 21s and it connected fine. Wait for the session
+                // instead of guessing at it.
                 val landed = awaitWifiHandoff()
                 handoffSettlingSince = 0L
                 if (landed) {

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -468,7 +468,9 @@ class NativeAaHandshakeManager(
                     // physical radio right as the critical WifiStartRequest send is about to happen.
                     throw e
                 } catch (e: Exception) {
-                    AppLog.d("NativeAA: Poke via $uuid to ${device.name} failed: ${e.message}")
+                    // Address as well as name: getName() is null for an unbonded device, and a log line
+                    // reading "to null" names nothing at all for the reader of a bug report.
+                    AppLog.d("NativeAA: Poke via $uuid to ${device.name ?: "unnamed"} (${device.address}) failed: ${e.message}")
                 } finally {
                     try { socket?.close() } catch (e: Exception) {}
                 }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -7,7 +7,10 @@ import android.bluetooth.BluetoothServerSocket
 import android.bluetooth.BluetoothSocket
 import android.content.Context
 import com.andrerinas.openheadunit.aap.AapService
+import com.andrerinas.openheadunit.aap.NativeCredentialsPolicy
 import com.andrerinas.openheadunit.aap.NativeHandoffPolicy
+import com.andrerinas.openheadunit.aap.NativeTransport
+import com.andrerinas.openheadunit.aap.UnusableBssidAction
 import com.andrerinas.openheadunit.aap.WppAction
 import com.andrerinas.openheadunit.aap.WppEvent
 import com.andrerinas.openheadunit.aap.WppFraming
@@ -703,6 +706,8 @@ class NativeAaHandshakeManager(
         // whether this attempt counts against consecutiveHandshakeFailures.
         var spokeToPhone = false
         var abortedLocally = false
+        // Captured once, so a settings change mid-exchange cannot split it across two rulesets.
+        val transport = NativeTransport.fromSetting(settings.nativeApTransport)
         val session = WppHandshakeSession(settings.nativeWifiVersionExchange)
         // Everything the phone sends, in order. Replaces the single bounded read this used to do:
         // types 6 and 7 arrive *after* the credentials go out, so a one-shot read could never see
@@ -776,7 +781,7 @@ class NativeAaHandshakeManager(
                         AppLog.i("NativeAA: Phone ready for WiFi association. Delivering credentials...")
                         AppLog.i("NativeAA: [TX] Sending WifiInfoResponse (Type 3) with full credentials in 1000ms...")
                         delay(1000) // [FIX] Increased delay to give phone more processing time
-                        sendWifiSecurityResponse(output, credSsid, credPsk, credBssid)
+                        sendWifiSecurityResponse(output, credSsid, credPsk, credBssid, transport)
                         AppLog.i("NativeAA: Handshake completed successfully on Bluetooth side.")
                         ifOwner(socket) {
                             // The exchange is done; the phone's work is not — it still has to
@@ -948,15 +953,26 @@ class NativeAaHandshakeManager(
             credBssid = (currentBssid ?: "").uppercase()
 
             // [FIX] Ensure BSSID is uppercase and not zeroed if possible
-            if (credBssid.isEmpty() || credBssid == "00:00:00:00:00:00" || credBssid == "02:00:00:00:00:00") {
-                AppLog.e("NativeAA: BSSID is still masked/empty ($credBssid) at Type 3 time — phone WILL reject these credentials. Aborting handshake. PLEASE CHECK IF LOCATION (GPS) IS ENABLED ON THIS DEVICE!")
-                // Triggering a P2P refresh so the next attempt has a valid BSSID
-                context.triggerWifiDirectRefresh()
-                // Not fed to the session as CredentialsUnavailable: its failure reason would say
-                // the credentials never arrived, when in fact they arrived unusable, and the line
-                // above is the one the reporter needs to act on.
-                abortedLocally = true
-                return@withContext
+            if (!NativeCredentialsPolicy.isUsableBssid(credBssid)) {
+                when (NativeCredentialsPolicy.onUnusableBssid(transport)) {
+                    UnusableBssidAction.ABORT -> {
+                        AppLog.e("NativeAA: BSSID is still masked/empty ($credBssid) at Type 3 time — phone WILL reject these credentials. Aborting handshake. PLEASE CHECK IF LOCATION (GPS) IS ENABLED ON THIS DEVICE!")
+                        // Triggering a P2P refresh so the next attempt has a valid BSSID
+                        context.triggerWifiDirectRefresh()
+                        // Not fed to the session as CredentialsUnavailable: its failure reason
+                        // would say the credentials never arrived, when in fact they arrived
+                        // unusable, and the line above is the one the reporter needs to act on.
+                        abortedLocally = true
+                        return@withContext
+                    }
+                    UnusableBssidAction.OMIT_AND_CONTINUE -> {
+                        // Deliberate on this route: an ordinary AP is identified by SSID, and both
+                        // aa-proxy-rs and ZLink omit the field. Loud anyway — if the phone refuses
+                        // the credentials, this line is the first thing to look at.
+                        AppLog.w("NativeAA: No usable BSSID for this access point — sending the credentials without one. If the phone refuses to join, set a BSSID by hand in Advanced settings.")
+                        credBssid = ""
+                    }
+                }
             }
 
             AppLog.i("NativeAA: Starting Handshake Exchange:")
@@ -1076,13 +1092,27 @@ class NativeAaHandshakeManager(
         sendProtobuf(output, request.toByteArray(), WppMessageType.VERSION_REQUEST)
     }
 
-    private fun sendWifiSecurityResponse(output: OutputStream, ssid: String, key: String, bssid: String) {
+    /**
+     * Sends the credentials. A null or empty [bssid] leaves the field out of the message, as
+     * aa-proxy-rs does when it has no real address. [transport] picks the access-point type:
+     * DYNAMIC for a hotspot, STATIC for a WiFi Direct group as before.
+     */
+    private fun sendWifiSecurityResponse(
+        output: OutputStream,
+        ssid: String,
+        key: String,
+        bssid: String?,
+        transport: NativeTransport
+    ) {
         val response = Wireless.WifiInfoResponse.newBuilder()
             .setSsid(ssid)
             .setKey(key)
-            .setBssid(bssid)
             .setSecurityMode(Wireless.SecurityMode.WPA2_PERSONAL)
-            .setAccessPointType(Wireless.AccessPointType.STATIC)
+            .setAccessPointType(
+                if (transport == NativeTransport.HOTSPOT) Wireless.AccessPointType.DYNAMIC
+                else Wireless.AccessPointType.STATIC
+            )
+            .apply { if (!bssid.isNullOrEmpty()) setBssid(bssid) }
             .build()
         sendProtobuf(output, response.toByteArray(), WppMessageType.INFO_RESPONSE)
     }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -121,6 +121,11 @@ class NativeAaHandshakeManager(
     // reconnects over Bluetooth during a settle supersedes the stale one instead of running a
     // second handleHandshake() alongside it.
     @Volatile private var activeHandshakeSocket: BluetoothSocket? = null
+    // The coroutine serving [activeHandshakeSocket]. Closing a superseded handshake's socket only
+    // ends it on stacks where close() interrupts a pending read; some do not, and it runs on for
+    // minutes. Cancelling cannot break a blocking JNI read either, but it does end every real
+    // suspension point in the handshake. Do both; whichever the stack honours wins.
+    @Volatile private var activeHandshakeJob: Job? = null
     // Name of the primary Bluetooth radio we listen and poke on, captured in start(). A field
     // rather than a local so the diagnostic below can name the radio the phone is ignoring.
     @Volatile private var localRadioName: String = "?"
@@ -632,6 +637,18 @@ class NativeAaHandshakeManager(
         loggedHandshakeBackoff = false
     }
 
+    /**
+     * Runs [block] only while [socket] is still the handshake this manager is serving.
+     *
+     * Every write a handshake makes to shared manager state goes through this. Losing ownership
+     * does not stop a superseded handshake — where close() cannot interrupt a pending read it runs
+     * on for minutes — and its late writes would clear the live session's settling stamp, cancel
+     * its poke, close listeners it still needs, or wipe a backoff it had legitimately earned.
+     */
+    private inline fun ifOwner(socket: BluetoothSocket, block: () -> Unit) {
+        if (activeHandshakeSocket === socket) block()
+    }
+
     private suspend fun handleHandshake(socket: BluetoothSocket, localRadio: String? = null) = withContext(Dispatchers.IO) {
         // The phone reached us. Recorded here rather than at either accept site so both the
         // primary and the secondary-radio loops are covered by one statement.
@@ -653,17 +670,30 @@ class NativeAaHandshakeManager(
         // The listener stays open across the settling window, so the phone can reconnect over
         // Bluetooth while an earlier handoff is still settling. That reconnect means the earlier
         // one failed: retire it rather than serving both from the same manager state.
-        activeHandshakeSocket?.let { previous ->
-            if (previous !== socket) {
-                AppLog.i("NativeAA: A new handshake arrived while one was still settling — closing the previous session.")
-                handoffSettlingSince = 0L
-                try { previous.close() } catch (_: Exception) {}
-            }
-        }
+        val previousSocket = activeHandshakeSocket
+        val previousJob = activeHandshakeJob
+        // Ownership is claimed *before* the previous session is torn down, not after: cancelling
+        // it makes its finally block run on another thread at a moment we do not control, and the
+        // only thing keeping that block off this handshake's state is the ifOwner fence. Take
+        // ownership first and the fence is already closed when the old one unwinds.
         activeHandshakeSocket = socket
+        activeHandshakeJob = coroutineContext[Job]
         // Stamped after claiming ownership above, so a superseded handshake's cleanup — which
         // only fires when it still owns activeHandshakeSocket — can't wipe this one's stamp.
         handshakeStartedAt = SystemClock.elapsedRealtime()
+        if (previousSocket != null && previousSocket !== socket) {
+            AppLog.i("NativeAA: A new handshake arrived while one was still settling — closing the previous session.")
+            handoffSettlingSince = 0L
+            // Cancel *and* close, in that order: see activeHandshakeJob. Cancelling first means
+            // the old coroutine cannot mistake the close for a phone-side drop and act on it.
+            previousJob?.cancel()
+            try { previousSocket.close() } catch (_: Exception) {}
+        }
+        // Whether this handshake got as far as putting a WifiStartRequest on the wire, and whether
+        // the phone ever answered. Together they decide, once in the fenced finally below, whether
+        // this attempt counts against consecutiveHandshakeFailures.
+        var sentStartRequest = false
+        var receivedAnyMessage = false
         try {
             val device = socket.remoteDevice
             AppLog.i("NativeAA: Handling handshake for ${device.name} (${device.address}) on local radio [${localRadio ?: "?"}]")
@@ -738,6 +768,7 @@ class NativeAaHandshakeManager(
 
             AppLog.i("NativeAA: [TX] Sending WifiStartRequest (Type 1)")
             sendWifiStartRequest(output, ip, 5288)
+            sentStartRequest = true
 
             AppLog.i("NativeAA: Waiting for response from phone...")
             // There is no BluetoothSocket.setSoTimeout(), so the read has to be bounded from the
@@ -758,14 +789,16 @@ class NativeAaHandshakeManager(
                 // Best effort only: on a stack where close() does not interrupt a pending read,
                 // this cannot end `reader` — a blocking JNI read has no suspension point to
                 // cancel at — so its thread is stranded from here on. That is what
-                // consecutiveHandshakeFailures bounds; this is the one path that leaks one.
+                // consecutiveHandshakeFailures bounds (incremented in the fenced finally below,
+                // which covers this path along with every other silent ending); this is the one
+                // path that leaks one.
                 reader.cancel()
-                consecutiveHandshakeFailures++
                 return@withContext
             }
+            receivedAnyMessage = true
             // The reader returned, so nothing is stranded and the channel is carrying data in at
             // least one direction. Whatever the type turns out to be, this was not a silent unit.
-            resetHandshakeBackoff()
+            ifOwner(socket) { resetHandshakeBackoff() }
             AppLog.i("NativeAA: [RX] Received Type ${response.type} (Payload size: ${response.payload.size})")
 
             if (response.type == 2) {
@@ -774,15 +807,17 @@ class NativeAaHandshakeManager(
                 delay(1000) // [FIX] Increased delay to give phone more processing time
                 sendWifiSecurityResponse(output, ssid, psk, bssid)
                 AppLog.i("NativeAA: Handshake completed successfully on Bluetooth side.")
-                // The credential exchange is done, but the phone's work has only just started —
-                // it now has to associate, run WPS and get a DHCP lease. See isHandoffSettling().
-                handshakeStartedAt = 0L
-                handoffSettlingSince = SystemClock.elapsedRealtime()
-                // The phone has what it needs, so the wake poke held open since before this
-                // handshake has nothing left to wake. Release it now — it is an RFCOMM channel on
-                // the radio the phone is about to associate over, and Bluetooth work across the
-                // join strands it on "Obtaining IP address".
-                pokeJob?.cancel()
+                ifOwner(socket) {
+                    // The credential exchange is done, but the phone's work has only just started
+                    // — it now has to associate, run WPS and get a DHCP lease. See
+                    // isHandoffSettling().
+                    handshakeStartedAt = 0L
+                    handoffSettlingSince = SystemClock.elapsedRealtime()
+                    // The phone has what it needs, so the poke has nothing left to wake. Release
+                    // it: it is an RFCOMM channel on the radio the phone is about to associate
+                    // over, and Bluetooth work across the join strands it on "Obtaining IP".
+                    pokeJob?.cancel()
+                }
 
                 // Release the Bluetooth connection once the handoff has actually happened, rather
                 // than holding it indefinitely. The real Android Auto protocol closes Bluetooth
@@ -797,23 +832,25 @@ class NativeAaHandshakeManager(
                 // Bluetooth gave the same phone 21s and it connected fine. Wait for the session
                 // instead of guessing at it.
                 val landed = awaitWifiHandoff()
-                handoffSettlingSince = 0L
-                if (landed) {
-                    AppLog.i("NativeAA: WiFi session landed. Handshake session ending, releasing Bluetooth connection.")
-                    // Stop accepting new AA_UUID connections too, not just this socket —
-                    // otherwise the phone's immediate reconnect-retry gets accepted, bounced
-                    // (already connected), and retried again in a tight loop. See
-                    // closeAaListeners() kdoc.
-                    closeAaListeners()
-                } else {
-                    // The handoff never completed, so there is no session for a reconnect to
-                    // collide with — the reconnect storm closeAaListeners() guards against can't
-                    // happen here. Leave the listener up so the phone's own retry can be
-                    // accepted (start() early-returns while isRunning, so a close here would
-                    // strand us until AapService stopped and restarted the manager), and restart
-                    // the poke, which was cancelled once the credentials went out.
-                    AppLog.w("NativeAA: No WiFi session within ${NativeHandoffPolicy.SETTLE_TIMEOUT_MS / 1000}s of delivering credentials — keeping the AA listener open and resuming the wake poke.")
-                    triggerPoke()
+                ifOwner(socket) {
+                    handoffSettlingSince = 0L
+                    if (landed) {
+                        AppLog.i("NativeAA: WiFi session landed. Handshake session ending, releasing Bluetooth connection.")
+                        // Stop accepting new AA_UUID connections too, not just this socket —
+                        // otherwise the phone's immediate reconnect-retry gets accepted, bounced
+                        // (already connected), and retried again in a tight loop. See
+                        // closeAaListeners() kdoc.
+                        closeAaListeners()
+                    } else {
+                        // The handoff never completed, so there is no session for a reconnect to
+                        // collide with — the reconnect storm closeAaListeners() guards against
+                        // can't happen here. Leave the listener up so the phone's own retry can be
+                        // accepted (start() early-returns while isRunning, so a close here would
+                        // strand us until AapService stopped and restarted the manager), and
+                        // restart the poke, which was cancelled once the credentials went out.
+                        AppLog.w("NativeAA: No WiFi session within ${NativeHandoffPolicy.SETTLE_TIMEOUT_MS / 1000}s of delivering credentials — keeping the AA listener open and resuming the wake poke.")
+                        triggerPoke()
+                    }
                 }
             } else {
                 AppLog.w("NativeAA: Handshake failed - Unexpected response type ${response.type}. Expected Type 2.")
@@ -826,8 +863,16 @@ class NativeAaHandshakeManager(
             // has already taken over and set its own.
             if (activeHandshakeSocket === socket) {
                 activeHandshakeSocket = null
+                activeHandshakeJob = null
                 handshakeStartedAt = 0L
                 handoffSettlingSince = 0L
+                // [BUG_FIX] Every silent ending counts, not just the timeout that used to
+                // increment inline: a socket error, a swallowed write and a cancellation are one
+                // failure from the outside, and each strands an unreclaimable IO thread.
+                // Excludes our own pre-exchange aborts (no credentials, masked BSSID, USB already
+                // up) — those repeat for as long as location services are off, and backing off
+                // would bury the log line saying how to fix it.
+                if (sentStartRequest && !receivedAnyMessage) consecutiveHandshakeFailures++
             }
             try { socket.close() } catch (e: Exception) {}
             AppLog.i("NativeAA: BT Handshake socket closed.")
@@ -883,7 +928,10 @@ class NativeAaHandshakeManager(
         buffer.put(data)
         output.write(buffer.array())
         output.flush()
-        AppLog.i("NativeAA: Successfully delivered Protobuf TYPE $type (size ${data.size}) over Bluetooth!")
+        // Not "successfully delivered": write() and flush() returned, nothing more. A stack that
+        // accepts the write and puts nothing on the air logs every send exactly like this, so the
+        // old wording made a dead radio read as a textbook handshake. Proof is the phone's reply.
+        AppLog.i("NativeAA: [TX] Wrote TYPE $type (size ${data.size}) to Bluetooth (write() returned; delivery unconfirmed)")
     }
 
     private fun readProtobuf(input: DataInputStream): ProtobufMessage {
@@ -927,6 +975,10 @@ class NativeAaHandshakeManager(
         // needs.
         handshakeStartedAt = 0L
         handoffSettlingSince = 0L
+        // Cancel before dropping the reference, for the same reason a supersede does: the socket
+        // this manager just closed does not necessarily end the coroutine reading from it.
+        activeHandshakeJob?.cancel()
+        activeHandshakeJob = null
         activeHandshakeSocket = null
         // Only the per-attempt count resets: everAcceptedAaConnection is deliberately kept, so a
         // unit that has connected before is not warned just because the manager was re-armed.

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -988,11 +988,12 @@ class NativeAaHandshakeManager(
                         abortedLocally = true
                         return@withContext
                     }
-                    UnusableBssidAction.OMIT_AND_CONTINUE -> {
-                        // Deliberate on this route: an ordinary AP is identified by SSID, and both
-                        // aa-proxy-rs and ZLink omit the field. Loud anyway — if the phone refuses
-                        // the credentials, this line is the first thing to look at.
-                        AppLog.w("NativeAA: No usable BSSID for this access point — sending the credentials without one. If the phone refuses to join, set a BSSID by hand in Advanced settings.")
+                    UnusableBssidAction.SEND_WITH_EMPTY_BSSID -> {
+                        // Sending is worth a try rather than expected to work — no implementation
+                        // ships without a real BSSID, see NativeCredentialsPolicy. The point is that
+                        // a refusal is a message we can explain; this line is the first to look at
+                        // when one arrives.
+                        AppLog.w("NativeAA: No usable BSSID for this access point — sending the credentials without one, which most phones refuse. Set a BSSID by hand in Advanced settings if the phone does not join.")
                         credBssid = ""
                         bssidOmitted = true
                     }
@@ -1117,9 +1118,16 @@ class NativeAaHandshakeManager(
     }
 
     /**
-     * Sends the credentials. A null or empty [bssid] leaves the field out of the message, as
-     * aa-proxy-rs does when it has no real address. [transport] picks the access-point type:
-     * DYNAMIC for a hotspot, STATIC for a WiFi Direct group as before.
+     * Sends the credentials.
+     *
+     * All five fields go out every time, including an empty [bssid] where we have no real address:
+     * the schema the other implementations use marks bssid, security_mode and access_point_type
+     * `required`, and aa-proxy-rs sets an empty string on the one path where it has no MAC rather
+     * than dropping the field. Omitting it risks a strict parser rejecting the whole message, which
+     * would surface as silence rather than as the specific refusal an empty one produces.
+     *
+     * [transport] picks the access-point type: DYNAMIC for a hotspot, matching both reference
+     * implementations, and STATIC for a WiFi Direct group as before.
      */
     private fun sendWifiSecurityResponse(
         output: OutputStream,
@@ -1136,7 +1144,7 @@ class NativeAaHandshakeManager(
                 if (transport == NativeTransport.HOTSPOT) Wireless.AccessPointType.DYNAMIC
                 else Wireless.AccessPointType.STATIC
             )
-            .apply { if (!bssid.isNullOrEmpty()) setBssid(bssid) }
+            .setBssid(bssid.orEmpty())
             .build()
         sendProtobuf(output, response.toByteArray(), WppMessageType.INFO_RESPONSE)
     }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -8,10 +8,17 @@ import android.bluetooth.BluetoothSocket
 import android.content.Context
 import com.andrerinas.openheadunit.aap.AapService
 import com.andrerinas.openheadunit.aap.NativeHandoffPolicy
+import com.andrerinas.openheadunit.aap.WppAction
+import com.andrerinas.openheadunit.aap.WppEvent
+import com.andrerinas.openheadunit.aap.WppFraming
+import com.andrerinas.openheadunit.aap.WppHandshakeSession
+import com.andrerinas.openheadunit.aap.WppMessageType
+import com.andrerinas.openheadunit.aap.WppStage
 import com.andrerinas.openheadunit.utils.BluetoothHelper
 import com.andrerinas.openheadunit.aap.protocol.proto.Wireless
 import com.andrerinas.openheadunit.utils.AppLog
 import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
 import android.os.Build
 import android.os.SystemClock
 import android.content.pm.PackageManager
@@ -19,7 +26,6 @@ import androidx.core.content.ContextCompat
 import java.io.DataInputStream
 import java.io.IOException
 import java.io.OutputStream
-import java.nio.ByteBuffer
 import java.util.*
 
 /**
@@ -40,7 +46,10 @@ class NativeAaHandshakeManager(
         // the same pair for this exact purpose.
         private val HSP_AG_UUID = UUID.fromString("00001112-0000-1000-8000-00805f9b34fb") // Headset Profile AG
         private val HFP_AG_UUID = UUID.fromString("0000111f-0000-1000-8000-00805f9b34fb") // Hands-Free Profile AG
-        private const val HANDSHAKE_RESPONSE_TIMEOUT_MS = 15_000L
+
+        /** How long to wait for this head unit's own WiFi network to come up before giving up on
+         *  a handshake. P2P group creation is the slow case. */
+        private const val CREDENTIALS_WAIT_MS = 60_000L
 
         /** Which of [allServiceNames] are secondary Bluetooth radios, i.e. not [primaryServiceName]
          *  (dual-Bluetooth-radio head units). Pure and unit-testable: identity is by system
@@ -689,11 +698,17 @@ class NativeAaHandshakeManager(
             previousJob?.cancel()
             try { previousSocket.close() } catch (_: Exception) {}
         }
-        // Whether this handshake got as far as putting a WifiStartRequest on the wire, and whether
-        // the phone ever answered. Together they decide, once in the fenced finally below, whether
-        // this attempt counts against consecutiveHandshakeFailures.
-        var sentStartRequest = false
-        var receivedAnyMessage = false
+        // Whether this handshake put anything on the wire at all, and whether the phone answered
+        // any of it. Together with abortedLocally they decide, once in the fenced finally below,
+        // whether this attempt counts against consecutiveHandshakeFailures.
+        var spokeToPhone = false
+        var abortedLocally = false
+        val session = WppHandshakeSession(settings.nativeWifiVersionExchange)
+        // Everything the phone sends, in order. Replaces the single bounded read this used to do:
+        // types 6 and 7 arrive *after* the credentials go out, so a one-shot read could never see
+        // them, and the phone is free to interject a ping at any point in between.
+        val inbound = Channel<ProtobufMessage>(Channel.UNLIMITED)
+        var readerJob: Job? = null
         try {
             val device = socket.remoteDevice
             AppLog.i("NativeAA: Handling handshake for ${device.name} (${device.address}) on local radio [${localRadio ?: "?"}]")
@@ -701,6 +716,7 @@ class NativeAaHandshakeManager(
             if (commManager.isConnected ||
                 commManager.connectionState.value is CommManager.ConnectionState.Connecting) {
                 AppLog.i("NativeAA: USB/other session already active. Aborting BT handshake so phone does not start a parallel wireless attempt.")
+                abortedLocally = true
                 try { socket.close() } catch (_: Exception) {}
                 return@withContext
             }
@@ -717,45 +733,166 @@ class NativeAaHandshakeManager(
             val input = DataInputStream(socket.inputStream)
             val output = socket.outputStream
 
-            AppLog.i("NativeAA: Phone connected. Current credentials state: SSID=${currentSsid ?: "<null>"}, IP=${currentIp ?: "<null>"}")
-            AppLog.i("NativeAA: Waiting for WiFi credentials to be ready (Max 60s)...")
-            
-            // Wait up to 60 seconds for credentials (P2P group creation can be slow)
-            var attempts = 0
-            while ((currentSsid == null || currentIp == null) && attempts < 120 && isRunning && isActive) {
-                if (attempts % 20 == 0 && attempts > 0) {
-                    AppLog.w("NativeAA: Still waiting for credentials after ${attempts / 2}s. Requesting P2P refresh...")
-                    context.triggerWifiDirectRefresh()
-                } else if (attempts % 10 == 0 && attempts > 0) {
-                    AppLog.d("NativeAA: Still waiting... SSID=${currentSsid != null}, IP=${currentIp != null} (Attempt $attempts/120)")
+            // [BUG_FIX] There is no BluetoothSocket.setSoTimeout(), and the old workaround —
+            // close the socket to unblock readFully() — only works where close() interrupts a
+            // pending read. Where it does not, the handshake never unwinds and takes the wake poke
+            // and the P2P join watchdog down with it for the rest of the session. Time out the
+            // *wait* instead: read on a coroutine of its own and take messages from a channel,
+            // which resumes on schedule whether or not the read ever returns. The reader itself is
+            // still unreclaimable on such a stack; consecutiveHandshakeFailures bounds that.
+            readerJob = scope.launch(Dispatchers.IO + CoroutineName("NativeAa-Reader-${device.address}")) {
+                try {
+                    while (isActive) inbound.send(readProtobuf(input))
+                } catch (e: Exception) {
+                    AppLog.d("NativeAA: Bluetooth reader ended: ${e.message}")
+                } finally {
+                    inbound.close()
                 }
-                delay(500)
-                attempts++
             }
 
-            if (currentSsid == null || currentIp == null) {
-                AppLog.e("NativeAA: Handshake failed - No WiFi credentials available after 60s wait. Missing: ${if(currentSsid == null) "SSID " else ""}${if(currentIp == null) "IP" else ""}")
-                return@withContext
+            // --- everything below drives the WppHandshakeSession state machine ---
+
+            var stageEnteredAt = SystemClock.elapsedRealtime()
+            var readerClosed = false
+            // Filled in once the credentials resolve, before any action can need them.
+            var credSsid = ""
+            var credPsk = ""
+            var credIp = ""
+            var credBssid = ""
+
+            suspend fun runAction(action: WppAction, source: ProtobufMessage?) {
+                when (action) {
+                    WppAction.SendVersionRequest -> {
+                        AppLog.i("NativeAA: [TX] Sending WifiVersionRequest (Type 4) v${WppHandshakeSession.WPP_VERSION_MAJOR}.${WppHandshakeSession.WPP_VERSION_MINOR}")
+                        sendWifiVersionRequest(output)
+                        spokeToPhone = true
+                    }
+                    WppAction.SendStartRequest -> {
+                        AppLog.i("NativeAA: [TX] Sending WifiStartRequest (Type 1)")
+                        sendWifiStartRequest(output, credIp, 5288)
+                        spokeToPhone = true
+                    }
+                    WppAction.SendInfoResponse -> {
+                        AppLog.i("NativeAA: Phone ready for WiFi association. Delivering credentials...")
+                        AppLog.i("NativeAA: [TX] Sending WifiInfoResponse (Type 3) with full credentials in 1000ms...")
+                        delay(1000) // [FIX] Increased delay to give phone more processing time
+                        sendWifiSecurityResponse(output, credSsid, credPsk, credBssid)
+                        AppLog.i("NativeAA: Handshake completed successfully on Bluetooth side.")
+                        ifOwner(socket) {
+                            // The exchange is done; the phone's work is not — it still has to
+                            // associate, run WPS and get a DHCP lease. See isHandoffSettling().
+                            handshakeStartedAt = 0L
+                            handoffSettlingSince = SystemClock.elapsedRealtime()
+                            // Nothing left for the poke to wake, and it holds an RFCOMM channel on
+                            // the radio the phone is about to associate over — Bluetooth work
+                            // across the join strands it on "Obtaining IP".
+                            pokeJob?.cancel()
+                        }
+                    }
+                    WppAction.SendPingResponse -> {
+                        // Echo the request's own bytes: whatever the phone put in a keepalive,
+                        // handing it straight back cannot fail on a schema guess.
+                        AppLog.d("NativeAA: [TX] Echoing WifiPingResponse (Type 9)")
+                        sendProtobuf(output, source?.payload ?: ByteArray(0), WppMessageType.PING_RESPONSE)
+                    }
+                    WppAction.ExtendSettle -> {
+                        AppLog.i("NativeAA: Phone reports it is still joining — extending the settling window.")
+                        // Re-stamp rather than only extending our own deadline: isHandoffSettling()
+                        // is what keeps the poke off the radio during the join, and it measures
+                        // from this stamp. The session caps the total.
+                        ifOwner(socket) { handoffSettlingSince = SystemClock.elapsedRealtime() }
+                    }
+                    WppAction.CompleteSuccess -> {
+                        AppLog.i("NativeAA: WiFi session landed. Handshake session ending, releasing Bluetooth connection.")
+                        ifOwner(socket) {
+                            handoffSettlingSince = 0L
+                            // Stop accepting new AA_UUID connections too, not just this socket —
+                            // otherwise the phone's immediate reconnect-retry gets accepted,
+                            // bounced (already connected), and retried again in a tight loop. See
+                            // closeAaListeners() kdoc.
+                            closeAaListeners()
+                        }
+                    }
+                    is WppAction.Fail -> AppLog.w("NativeAA: Handshake failed — ${action.reason}.")
+                    WppAction.ResumePoke -> ifOwner(socket) {
+                        // Clear the settling stamp first: triggerPoke() refuses to start while a
+                        // handoff is settling, which is the whole point of that guard.
+                        handoffSettlingSince = 0L
+                        triggerPoke()
+                    }
+                }
             }
 
-            val ip = currentIp!!
-            val ssid = currentSsid!!
-            val psk = currentPsk ?: ""
-            var bssid = currentBssid ?: ""
-
-            // [FIX] Ensure BSSID is uppercase and not zeroed if possible
-            bssid = bssid.uppercase()
-            if (bssid.isEmpty() || bssid == "00:00:00:00:00:00" || bssid == "02:00:00:00:00:00") {
-                AppLog.e("NativeAA: BSSID is still masked/empty ($bssid) at Type 3 time — phone WILL reject these credentials. Aborting handshake. PLEASE CHECK IF LOCATION (GPS) IS ENABLED ON THIS DEVICE!")
-                // Triggering a P2P refresh so the next attempt has a valid BSSID
-                context.triggerWifiDirectRefresh()
-                return@withContext
+            suspend fun feed(event: WppEvent, source: ProtobufMessage? = null) {
+                val before = session.stage
+                val actions = session.on(event)
+                for (action in actions) runAction(action, source)
+                if (session.stage != before) {
+                    // Stamped after the actions, so the 1 s pause before Type 3 is not charged to
+                    // the settling window it opens.
+                    stageEnteredAt = SystemClock.elapsedRealtime()
+                    AppLog.d("NativeAA: Handshake stage $before -> ${session.stage}")
+                }
             }
 
-            AppLog.i("NativeAA: Starting Handshake Exchange:")
-            AppLog.i("  > Target SSID: $ssid")
-            AppLog.i("  > Target IP:   $ip:5288")
-            AppLog.i("  > BSSID:       $bssid")
+            /** Waits up to [budgetMs] for one message, then services timers. */
+            suspend fun tick(budgetMs: Long) {
+                if (readerClosed) {
+                    delay(budgetMs)
+                } else {
+                    // Polled with tryReceive() rather than awaited with a timeout around
+                    // receive(): cancelling a suspended receive can consume the element it was
+                    // about to hand over, and losing the phone's Type 2 that way would stall the
+                    // handshake until its stage deadline for no visible reason. tryReceive()
+                    // cannot lose anything; 25 ms of latency costs nothing here.
+                    val deadline = SystemClock.elapsedRealtime() + budgetMs
+                    var msg: ProtobufMessage? = null
+                    while (true) {
+                        val result = inbound.tryReceive()
+                        val received = result.getOrNull()
+                        if (received != null) { msg = received; break }
+                        if (result.isClosed) {
+                            readerClosed = true
+                            // Not a failure in itself: aa-proxy-rs treats a reset mid-bootstrap as
+                            // retriable, and a phone that has our credentials may legitimately
+                            // drop Bluetooth while it associates. Stage deadlines still bound us.
+                            AppLog.d("NativeAA: Bluetooth read channel closed by the phone or the socket.")
+                            break
+                        }
+                        if (SystemClock.elapsedRealtime() >= deadline) break
+                        delay(25)
+                    }
+                    if (msg != null) {
+                        AppLog.i("NativeAA: [RX] Received Type ${msg.type} (Payload size: ${msg.payload.size})")
+                        logReceivedDetail(msg)
+                        // The phone answered, so the channel carries data in at least one
+                        // direction. Whatever the type turns out to be, this was not a silent unit.
+                        ifOwner(socket) { resetHandshakeBackoff() }
+                        feed(WppEvent.MessageReceived(msg.type, parseStatus(msg)), msg)
+                        if (session.isTerminal()) return
+                    }
+                }
+                if (session.stage == WppStage.SETTLING &&
+                    (commManager.isConnected ||
+                        commManager.connectionState.value is CommManager.ConnectionState.Connecting)) {
+                    feed(WppEvent.TcpSessionUp)
+                    return
+                }
+                val limit = session.currentStageTimeoutMs() ?: return
+                if (SystemClock.elapsedRealtime() - stageEnteredAt < limit) return
+                if (session.stage == WppStage.SETTLING) {
+                    // The handoff never completed, so there is no session for a reconnect to
+                    // collide with — the reconnect storm closeAaListeners() guards against can't
+                    // happen here. Leave the listener up so the phone's own retry can be accepted
+                    // (start() early-returns while isRunning, so a close here would strand us
+                    // until AapService stopped and restarted the manager), and restart the poke,
+                    // which was cancelled once the credentials went out.
+                    AppLog.w("NativeAA: No WiFi session within ${limit / 1000}s of delivering credentials — keeping the AA listener open and resuming the wake poke.")
+                    feed(WppEvent.SettleTimeout)
+                } else {
+                    feed(WppEvent.StageTimeout)
+                }
+            }
 
             // Some Bluetooth stacks report the RFCOMM socket "connected" slightly before the
             // underlying channel is actually ready to carry data - writing immediately can be
@@ -766,94 +903,78 @@ class NativeAaHandshakeManager(
             // a flaky chip a moment to settle before the one message that matters most.
             delay(300)
 
-            AppLog.i("NativeAA: [TX] Sending WifiStartRequest (Type 1)")
-            sendWifiStartRequest(output, ip, 5288)
-            sentStartRequest = true
+            // The version exchange opens the conversation, *before* the wait for credentials
+            // rather than after it. The phone starts its own ~12 s first-message timer when it
+            // opens this channel, and on a cold P2P group the credential wait alone can outlast
+            // that — a head unit that has said nothing by then is a head unit that "is not
+            // present" as far as Gearhead is concerned. Saying something first costs nothing and
+            // buys the whole bring-up window.
+            feed(WppEvent.SocketReady)
 
-            AppLog.i("NativeAA: Waiting for response from phone...")
-            // There is no BluetoothSocket.setSoTimeout(), so the read has to be bounded from the
-            // outside. This used to be a watchdog that closed the socket to unblock readFully().
-            //
-            // [BUG_FIX] That only works where close() actually interrupts a pending read, and on
-            // some stacks it does not: three "No response from phone" lines and not one "BT
-            // Handshake socket closed." means this function never unwound, taking the wake poke
-            // and the P2P join watchdog down with it for the rest of the session. Time out the
-            // wait instead of the socket, by running the blocking read on its own coroutine, which
-            // resumes on schedule whether or not the read returns. The close is still attempted,
-            // for the stacks where it helps.
-            val reader = scope.async(Dispatchers.IO) { readProtobuf(input) }
-            val response = withTimeoutOrNull(HANDSHAKE_RESPONSE_TIMEOUT_MS) { reader.await() }
-            if (response == null) {
-                AppLog.e("NativeAA: Handshake failed - No response from phone ${device.name} (${device.address}) on radio [${localRadio ?: "?"}] within ${HANDSHAKE_RESPONSE_TIMEOUT_MS / 1000}s of sending WifiStartRequest. Closing socket.")
-                try { socket.close() } catch (e: Exception) {}
-                // Best effort only: on a stack where close() does not interrupt a pending read,
-                // this cannot end `reader` — a blocking JNI read has no suspension point to
-                // cancel at — so its thread is stranded from here on. That is what
-                // consecutiveHandshakeFailures bounds (incremented in the fenced finally below,
-                // which covers this path along with every other silent ending); this is the one
-                // path that leaks one.
-                reader.cancel()
+            AppLog.i("NativeAA: Phone connected. Current credentials state: SSID=${currentSsid ?: "<null>"}, IP=${currentIp ?: "<null>"}")
+            AppLog.i("NativeAA: Waiting for WiFi credentials to be ready (Max ${CREDENTIALS_WAIT_MS / 1000}s)...")
+
+            // Wait for credentials (P2P group / hotspot bring-up can be slow), servicing the
+            // phone's messages while we do: an early Type 2 or Type 5 lands here, not in the loop
+            // below.
+            val credentialsDeadline = SystemClock.elapsedRealtime() + CREDENTIALS_WAIT_MS
+            var lastRefreshAt = SystemClock.elapsedRealtime()
+            var lastProgressLogAt = SystemClock.elapsedRealtime()
+            while ((currentSsid == null || currentIp == null) && isRunning && isActive &&
+                !session.isTerminal() && SystemClock.elapsedRealtime() < credentialsDeadline) {
+                val now = SystemClock.elapsedRealtime()
+                val waitedS = (CREDENTIALS_WAIT_MS - (credentialsDeadline - now)) / 1000
+                if (now - lastRefreshAt >= 10_000) {
+                    lastRefreshAt = now
+                    AppLog.w("NativeAA: Still waiting for credentials after ${waitedS}s. Requesting WiFi refresh...")
+                    context.triggerWifiDirectRefresh()
+                } else if (now - lastProgressLogAt >= 5_000) {
+                    lastProgressLogAt = now
+                    AppLog.d("NativeAA: Still waiting... SSID=${currentSsid != null}, IP=${currentIp != null} (${waitedS}s)")
+                }
+                tick(500)
+            }
+
+            if (currentSsid == null || currentIp == null) {
+                AppLog.e("NativeAA: Handshake failed - No WiFi credentials available after ${CREDENTIALS_WAIT_MS / 1000}s wait. Missing: ${if (currentSsid == null) "SSID " else ""}${if (currentIp == null) "IP" else ""}")
+                abortedLocally = true
+                feed(WppEvent.CredentialsUnavailable)
                 return@withContext
             }
-            receivedAnyMessage = true
-            // The reader returned, so nothing is stranded and the channel is carrying data in at
-            // least one direction. Whatever the type turns out to be, this was not a silent unit.
-            ifOwner(socket) { resetHandshakeBackoff() }
-            AppLog.i("NativeAA: [RX] Received Type ${response.type} (Payload size: ${response.payload.size})")
 
-            if (response.type == 2) {
-                AppLog.i("NativeAA: Phone ready for WiFi association. Delivering credentials...")
-                AppLog.i("NativeAA: [TX] Sending WifiInfoResponse (Type 3) with full credentials in 1000ms...")
-                delay(1000) // [FIX] Increased delay to give phone more processing time
-                sendWifiSecurityResponse(output, ssid, psk, bssid)
-                AppLog.i("NativeAA: Handshake completed successfully on Bluetooth side.")
-                ifOwner(socket) {
-                    // The credential exchange is done, but the phone's work has only just started
-                    // — it now has to associate, run WPS and get a DHCP lease. See
-                    // isHandoffSettling().
-                    handshakeStartedAt = 0L
-                    handoffSettlingSince = SystemClock.elapsedRealtime()
-                    // The phone has what it needs, so the poke has nothing left to wake. Release
-                    // it: it is an RFCOMM channel on the radio the phone is about to associate
-                    // over, and Bluetooth work across the join strands it on "Obtaining IP".
-                    pokeJob?.cancel()
-                }
+            credIp = currentIp!!
+            credSsid = currentSsid!!
+            credPsk = currentPsk ?: ""
+            credBssid = (currentBssid ?: "").uppercase()
 
-                // Release the Bluetooth connection once the handoff has actually happened, rather
-                // than holding it indefinitely. The real Android Auto protocol closes Bluetooth
-                // after the WiFi credential exchange — confirmed via a reference wireless-dongle
-                // implementation (nisargjhaveri/WirelessAndroidAutoDongle#17/#18), where holding
-                // it open caused the same "confusion, especially with phone calls" symptom this
-                // repo has seen reported.
-                //
-                // [BUG_FIX] This used to be a flat delay(3000) — a race, not a grace period, since
-                // the phone needs however long it needs. Measured: joined 0.73s after Type 3, left
-                // 0.17s after the close fired at T+3.0s, never got an IP. A build that never closed
-                // Bluetooth gave the same phone 21s and it connected fine. Wait for the session
-                // instead of guessing at it.
-                val landed = awaitWifiHandoff()
-                ifOwner(socket) {
-                    handoffSettlingSince = 0L
-                    if (landed) {
-                        AppLog.i("NativeAA: WiFi session landed. Handshake session ending, releasing Bluetooth connection.")
-                        // Stop accepting new AA_UUID connections too, not just this socket —
-                        // otherwise the phone's immediate reconnect-retry gets accepted, bounced
-                        // (already connected), and retried again in a tight loop. See
-                        // closeAaListeners() kdoc.
-                        closeAaListeners()
-                    } else {
-                        // The handoff never completed, so there is no session for a reconnect to
-                        // collide with — the reconnect storm closeAaListeners() guards against
-                        // can't happen here. Leave the listener up so the phone's own retry can be
-                        // accepted (start() early-returns while isRunning, so a close here would
-                        // strand us until AapService stopped and restarted the manager), and
-                        // restart the poke, which was cancelled once the credentials went out.
-                        AppLog.w("NativeAA: No WiFi session within ${NativeHandoffPolicy.SETTLE_TIMEOUT_MS / 1000}s of delivering credentials — keeping the AA listener open and resuming the wake poke.")
-                        triggerPoke()
-                    }
-                }
-            } else {
-                AppLog.w("NativeAA: Handshake failed - Unexpected response type ${response.type}. Expected Type 2.")
+            // [FIX] Ensure BSSID is uppercase and not zeroed if possible
+            if (credBssid.isEmpty() || credBssid == "00:00:00:00:00:00" || credBssid == "02:00:00:00:00:00") {
+                AppLog.e("NativeAA: BSSID is still masked/empty ($credBssid) at Type 3 time — phone WILL reject these credentials. Aborting handshake. PLEASE CHECK IF LOCATION (GPS) IS ENABLED ON THIS DEVICE!")
+                // Triggering a P2P refresh so the next attempt has a valid BSSID
+                context.triggerWifiDirectRefresh()
+                // Not fed to the session as CredentialsUnavailable: its failure reason would say
+                // the credentials never arrived, when in fact they arrived unusable, and the line
+                // above is the one the reporter needs to act on.
+                abortedLocally = true
+                return@withContext
+            }
+
+            AppLog.i("NativeAA: Starting Handshake Exchange:")
+            AppLog.i("  > Target SSID: $credSsid")
+            AppLog.i("  > Target IP:   $credIp:5288")
+            AppLog.i("  > BSSID:       $credBssid")
+
+            feed(WppEvent.CredentialsReady)
+
+            // Runs until the session finishes: the projection session lands, the phone reports
+            // the join failed (Type 6), or a stage deadline expires.
+            //
+            // [BUG_FIX] The settle was once a flat delay(3000) before closing Bluetooth — a race,
+            // not a grace period, since the phone needs however long it needs. Association has
+            // been measured at 21 s on hardware where the 3 s close killed it dead. Wait for the
+            // session, and where the phone reports its own progress, let it.
+            while (isRunning && isActive && !session.isTerminal()) {
+                tick(250)
             }
 
         } catch (e: Exception) {
@@ -872,32 +993,63 @@ class NativeAaHandshakeManager(
                 // Excludes our own pre-exchange aborts (no credentials, masked BSSID, USB already
                 // up) — those repeat for as long as location services are off, and backing off
                 // would bury the log line saying how to fix it.
-                if (sentStartRequest && !receivedAnyMessage) consecutiveHandshakeFailures++
+                if (spokeToPhone && !abortedLocally && session.messagesReceived == 0) {
+                    consecutiveHandshakeFailures++
+                }
             }
+            // Best effort only, exactly as before: on a stack where close() does not interrupt a
+            // pending read this cannot end the reader — a blocking JNI read has no suspension
+            // point to cancel at — so its thread is stranded from here on.
+            readerJob?.cancel()
+            inbound.close()
             try { socket.close() } catch (e: Exception) {}
             AppLog.i("NativeAA: BT Handshake socket closed.")
         }
     }
 
     /**
-     * Suspends until the phone's projection session actually reaches us over WiFi, or
-     * [NativeHandoffPolicy.SETTLE_TIMEOUT_MS] elapses. Returns true if it landed.
+     * The status field of a message that carries one, or null when it has none, when the message
+     * cannot be parsed, or when the type does not have one.
      *
-     * [CommManager.isConnected] covers Connected/StartingTransport, and the Connecting state
-     * covers the moment WirelessServer hands an accepted socket over — either is proof the phone
-     * finished associating, which is the only thing we were waiting for.
+     * Null is deliberately not a failure: [WppHandshakeSession] only ever treats a non-null,
+     * non-zero status as the phone reporting trouble, so a message we fail to decode can never
+     * abort a handshake that was going fine.
      */
-    private suspend fun awaitWifiHandoff(): Boolean {
-        val deadline = SystemClock.elapsedRealtime() + NativeHandoffPolicy.SETTLE_TIMEOUT_MS
-        while (isRunning && SystemClock.elapsedRealtime() < deadline) {
-            if (commManager.isConnected ||
-                commManager.connectionState.value is CommManager.ConnectionState.Connecting) {
-                return true
-            }
-            delay(250)
+    private fun parseStatus(msg: ProtobufMessage): Int? = try {
+        when (msg.type) {
+            WppMessageType.VERSION_RESPONSE ->
+                Wireless.WifiVersionResponse.parseFrom(msg.payload).let { if (it.hasStatus()) it.status else null }
+            WppMessageType.CONNECT_STATUS ->
+                Wireless.WifiConnectStatus.parseFrom(msg.payload).let { if (it.hasStatus()) it.status else null }
+            WppMessageType.START_RESPONSE ->
+                Wireless.WifiStartResponse.parseFrom(msg.payload).let { if (it.hasStatus()) it.status else null }
+            else -> null
         }
-        return commManager.isConnected ||
-            commManager.connectionState.value is CommManager.ConnectionState.Connecting
+    } catch (e: Exception) {
+        AppLog.d("NativeAA: Could not parse Type ${msg.type} payload (${msg.payload.size} bytes): ${e.message}")
+        null
+    }
+
+    /** Says what a received message actually contained, where that is worth having in a log. */
+    private fun logReceivedDetail(msg: ProtobufMessage) {
+        try {
+            when (msg.type) {
+                WppMessageType.VERSION_RESPONSE -> {
+                    val v = Wireless.WifiVersionResponse.parseFrom(msg.payload)
+                    AppLog.i("NativeAA: [RX] WifiVersionResponse v${v.major}.${v.minor} status=${if (v.hasStatus()) v.status else "-"}")
+                }
+                WppMessageType.CONNECT_STATUS -> {
+                    val s = Wireless.WifiConnectStatus.parseFrom(msg.payload)
+                    AppLog.i("NativeAA: [RX] WifiConnectStatus status=${if (s.hasStatus()) s.status else "-"} (0 = the phone got onto our network)")
+                }
+                WppMessageType.START_RESPONSE -> {
+                    val r = Wireless.WifiStartResponse.parseFrom(msg.payload)
+                    AppLog.i("NativeAA: [RX] WifiStartResponse ip=${r.ipAddress} status=${if (r.hasStatus()) r.status else "-"}")
+                }
+            }
+        } catch (e: Exception) {
+            AppLog.d("NativeAA: Type ${msg.type} payload did not parse for logging: ${e.message}")
+        }
     }
 
     private fun sendWifiStartRequest(output: OutputStream, ip: String, port: Int) {
@@ -906,7 +1058,22 @@ class NativeAaHandshakeManager(
             .setPort(port)
             .setStatus(0)
             .build()
-        sendProtobuf(output, request.toByteArray(), 1)
+        sendProtobuf(output, request.toByteArray(), WppMessageType.START_REQUEST)
+    }
+
+    /**
+     * Declares our protocol version, opening the modern exchange. Real head units send this first
+     * — the OEM ZLink app does — while aa-proxy-rs's own dongle does not, which is why it sits
+     * behind [com.andrerinas.openheadunit.utils.Settings.nativeWifiVersionExchange].
+     *
+     * The version numbers are a guess and known to be one; see [WppHandshakeSession].
+     */
+    private fun sendWifiVersionRequest(output: OutputStream) {
+        val request = Wireless.WifiVersionRequest.newBuilder()
+            .setMajor(WppHandshakeSession.WPP_VERSION_MAJOR)
+            .setMinor(WppHandshakeSession.WPP_VERSION_MINOR)
+            .build()
+        sendProtobuf(output, request.toByteArray(), WppMessageType.VERSION_REQUEST)
     }
 
     private fun sendWifiSecurityResponse(output: OutputStream, ssid: String, key: String, bssid: String) {
@@ -917,16 +1084,11 @@ class NativeAaHandshakeManager(
             .setSecurityMode(Wireless.SecurityMode.WPA2_PERSONAL)
             .setAccessPointType(Wireless.AccessPointType.STATIC)
             .build()
-        sendProtobuf(output, response.toByteArray(), 3)
+        sendProtobuf(output, response.toByteArray(), WppMessageType.INFO_RESPONSE)
     }
 
-    private fun sendProtobuf(output: OutputStream, data: ByteArray, type: Short) {
-        val buffer = ByteBuffer.allocate(data.size + 4)
-        buffer.put((data.size shr 8).toByte())
-        buffer.put((data.size and 0xFF).toByte())
-        buffer.putShort(type)
-        buffer.put(data)
-        output.write(buffer.array())
+    private fun sendProtobuf(output: OutputStream, data: ByteArray, type: Int) {
+        output.write(WppFraming.encodeFrame(data, type))
         output.flush()
         // Not "successfully delivered": write() and flush() returned, nothing more. A stack that
         // accepts the write and puts nothing on the air logs every send exactly like this, so the
@@ -935,10 +1097,10 @@ class NativeAaHandshakeManager(
     }
 
     private fun readProtobuf(input: DataInputStream): ProtobufMessage {
-        val header = ByteArray(4)
+        val header = ByteArray(WppFraming.HEADER_SIZE)
         input.readFully(header)
-        val size = ((header[0].toInt() and 0xFF) shl 8) or (header[1].toInt() and 0xFF)
-        val type = ((header[2].toInt() and 0xFF) shl 8) or (header[3].toInt() and 0xFF)
+        val size = WppFraming.decodePayloadSize(header)
+        val type = WppFraming.decodeType(header)
         val payload = if (size > 0) {
             val p = ByteArray(size)
             input.readFully(p)

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -764,6 +764,9 @@ class NativeAaHandshakeManager(
             var credPsk = ""
             var credIp = ""
             var credBssid = ""
+            // Whether the credentials went out with no BSSID at all. A join failure means something
+            // different when they did — see the Fail action below.
+            var bssidOmitted = false
 
             suspend fun runAction(action: WppAction, source: ProtobufMessage?) {
                 when (action) {
@@ -818,7 +821,21 @@ class NativeAaHandshakeManager(
                             closeAaListeners()
                         }
                     }
-                    is WppAction.Fail -> AppLog.w("NativeAA: Handshake failed — ${action.reason}.")
+                    is WppAction.Fail -> {
+                        AppLog.w("NativeAA: Handshake failed — ${action.reason}.")
+                        // Measured against a current Gearhead: it joins with a WifiNetworkSpecifier,
+                        // which matches SSID *and* BSSID under a full ff:ff:ff:ff:ff:ff mask, and
+                        // refuses credentials carrying no BSSID outright. So on this route a join
+                        // failure right after we omitted the field is that omission, not the
+                        // network — and the retry will fail the same way until an address exists.
+                        if (bssidOmitted) {
+                            AppLog.e(
+                                "NativeAA: These credentials carried no BSSID, which this phone may " +
+                                    "have refused for that reason alone. Read the access point's MAC " +
+                                    "and set it as the static BSSID in Advanced settings."
+                            )
+                        }
+                    }
                     WppAction.ResumePoke -> ifOwner(socket) {
                         // Clear the settling stamp first: triggerPoke() refuses to start while a
                         // handoff is settling, which is the whole point of that guard.
@@ -957,6 +974,12 @@ class NativeAaHandshakeManager(
                 when (NativeCredentialsPolicy.onUnusableBssid(transport)) {
                     UnusableBssidAction.ABORT -> {
                         AppLog.e("NativeAA: BSSID is still masked/empty ($credBssid) at Type 3 time — phone WILL reject these credentials. Aborting handshake. PLEASE CHECK IF LOCATION (GPS) IS ENABLED ON THIS DEVICE!")
+                        // Location is the usual cause and the one worth naming first, but it is not
+                        // the only one: where this head unit is an ordinary phone rather than
+                        // purpose-built hardware, every source in the chain is blocked by permission
+                        // and no setting will unblock them. Say so, or the log sends the reader back
+                        // to a location toggle that is already on.
+                        AppLog.e("NativeAA: If location is already on, this device cannot read its own WiFi Direct MAC at all. Read it from the system (P2P device address) and set it as the static BSSID in Advanced settings.")
                         // Triggering a P2P refresh so the next attempt has a valid BSSID
                         context.triggerWifiDirectRefresh()
                         // Not fed to the session as CredentialsUnavailable: its failure reason
@@ -971,6 +994,7 @@ class NativeAaHandshakeManager(
                         // the credentials, this line is the first thing to look at.
                         AppLog.w("NativeAA: No usable BSSID for this access point — sending the credentials without one. If the phone refuses to join, set a BSSID by hand in Advanced settings.")
                         credBssid = ""
+                        bssidOmitted = true
                     }
                 }
             }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/SoftApCredentialsProvider.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/SoftApCredentialsProvider.kt
@@ -71,6 +71,9 @@ class SoftApCredentialsProvider(
     /** Whether *we* turned the hotspot on, and so may turn it back on if it drops. */
     @Volatile private var autoEnabled = false
 
+    /** So the once-per-second poll reports "nothing here" once, not thirty times. */
+    @Volatile private var reportedNoInterface = false
+
     private val apStateReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             if (intent.getIntExtra(EXTRA_WIFI_AP_STATE, -1) != WIFI_AP_STATE_DISABLED) return
@@ -139,6 +142,7 @@ class SoftApCredentialsProvider(
 
     private fun beginResolve() {
         resolveJob?.cancel()
+        reportedNoInterface = false
         resolveJob = scope.launch(Dispatchers.IO + CoroutineName("SoftApCredentials-Resolve")) {
             val deadline = System.currentTimeMillis() + RESOLVE_BUDGET_MS
             var triedAutoEnable = false
@@ -221,7 +225,20 @@ class SoftApCredentialsProvider(
 
         val stationIpv4 = NetworkAddresses.stationIpv4(context)
         val eligible = SoftApNetworkPolicy.eligible(candidates, stationIpv4)
-        val picked = SoftApNetworkPolicy.pickApInterface(candidates, stationIpv4) ?: return null
+        val picked = SoftApNetworkPolicy.pickApInterface(candidates, stationIpv4) ?: run {
+            // Rejecting everything is the correct answer when no hotspot is up, but saying nothing
+            // for the whole 30s budget reads as a hang. Name what was there so the reader can pick
+            // one for the override if the access point is on an interface we did not recognise.
+            if (!reportedNoInterface) {
+                reportedNoInterface = true
+                AppLog.i(
+                    "SoftApCredentials: No interface looks like an access point; waiting for one. " +
+                        "Present: " + candidates.filter { it.isUp && !it.isLoopback }
+                        .joinToString { "${it.name} (${it.siteLocalIpv4 ?: "no private address"})" }
+                )
+            }
+            return null
+        }
         if (eligible.size > 1) {
             // More than one survivor means the name decided it, which is a guess. Nothing else
             // reports having guessed, and picking wrong hands the phone an unreachable address.

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/SoftApCredentialsProvider.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/SoftApCredentialsProvider.kt
@@ -1,0 +1,296 @@
+package com.andrerinas.openheadunit.connection
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.core.content.ContextCompat
+import com.andrerinas.openheadunit.aap.ApInterfaceCandidate
+import com.andrerinas.openheadunit.aap.SoftApBssidPolicy
+import com.andrerinas.openheadunit.aap.NativeCredentialsPolicy
+import com.andrerinas.openheadunit.aap.SoftApNetworkPolicy
+import com.andrerinas.openheadunit.aap.SoftApState
+import com.andrerinas.openheadunit.utils.AppLog
+import com.andrerinas.openheadunit.utils.HotspotConfigReader
+import com.andrerinas.openheadunit.utils.HotspotManager
+import com.andrerinas.openheadunit.utils.InterfaceMacReader
+import com.andrerinas.openheadunit.utils.NetworkAddresses
+import com.andrerinas.openheadunit.utils.Settings
+import com.andrerinas.openheadunit.utils.SoftApStateReader
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.net.Inet4Address
+import java.net.NetworkInterface
+
+/**
+ * Supplies the Native AA handshake with the credentials of *this head unit's own access point*,
+ * as an alternative to [WifiDirectManager]'s P2P group.
+ *
+ * A teardown of the OEM ZLink app showed it doing wireless Android Auto over an ordinary WPA2 soft
+ * AP — same Bluetooth handshake, same UUID, no WiFi Direct — so the phone accepts a plain access
+ * point, and that route sidesteps the P2P failure modes behind most Native AA reports: group
+ * churn, the self-wake loop, phones stuck on "Obtaining IP address".
+ *
+ * It does not copy ZLink's way of *starting* the AP; that needs TETHER_PRIVILEGED and root
+ * daemons. Reading a hotspot the user configured is the load-bearing path, switching one on is
+ * best effort. Same contract as [WifiDirectManager] so a launcher can treat both transports alike.
+ */
+class SoftApCredentialsProvider(
+    private val context: Context,
+    private val scope: CoroutineScope,
+    private val settings: Settings
+) {
+
+    companion object {
+        /** How often to look for the access point while waiting for it to come up. */
+        private const val POLL_INTERVAL_MS = 1_000L
+
+        /** How long to keep looking before giving up and saying so. */
+        private const val RESOLVE_BUDGET_MS = 30_000L
+
+        /** How long to wait for a user-configured AP before trying to switch one on ourselves. */
+        private const val AUTO_ENABLE_AFTER_MS = 5_000L
+
+        /** Not in any public SDK constant: the soft AP state broadcast and its disabled state. */
+        private const val WIFI_AP_STATE_CHANGED = "android.net.wifi.WIFI_AP_STATE_CHANGED"
+        private const val EXTRA_WIFI_AP_STATE = "wifi_state"
+        private const val WIFI_AP_STATE_DISABLED = 11
+    }
+
+    private var onCredentialsReady: ((ssid: String, psk: String, ip: String, bssid: String) -> Unit)? = null
+    private var onInvalidated: (() -> Unit)? = null
+
+    private var resolveJob: Job? = null
+    @Volatile private var isRunning = false
+    @Volatile private var isReceiverRegistered = false
+    /** Whether *we* turned the hotspot on, and so may turn it back on if it drops. */
+    @Volatile private var autoEnabled = false
+
+    private val apStateReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            if (intent.getIntExtra(EXTRA_WIFI_AP_STATE, -1) != WIFI_AP_STATE_DISABLED) return
+            AppLog.w("SoftApCredentials: The hotspot went down — the credentials the phone was given are no longer valid.")
+            onInvalidated?.invoke()
+            if (autoEnabled && isRunning) {
+                AppLog.i("SoftApCredentials: Re-enabling the hotspot we started, once.")
+                autoEnabled = false
+                // Off the main thread: setHotspotEnabled waits for the access point to actually
+                // come up, and onReceive() has an ANR budget measured in seconds.
+                scope.launch(Dispatchers.IO + CoroutineName("SoftApCredentials-Reenable")) {
+                    HotspotManager.setHotspotEnabled(context, true)
+                    refresh()
+                }
+            }
+        }
+    }
+
+    fun setCredentialsListener(callback: (String, String, String, String) -> Unit) {
+        this.onCredentialsReady = callback
+    }
+
+    fun setInvalidatedListener(callback: () -> Unit) {
+        this.onInvalidated = callback
+    }
+
+    fun start() {
+        if (isRunning) {
+            refresh()
+            return
+        }
+        isRunning = true
+        if (!isReceiverRegistered) {
+            try {
+                // A system broadcast, so EXPORTED: NOT_EXPORTED silently never fires on API 34+.
+                ContextCompat.registerReceiver(
+                    context, apStateReceiver, IntentFilter(WIFI_AP_STATE_CHANGED),
+                    ContextCompat.RECEIVER_EXPORTED
+                )
+                isReceiverRegistered = true
+            } catch (e: Exception) {
+                AppLog.w("SoftApCredentials: Could not watch the hotspot state: ${e.message}")
+            }
+        }
+        beginResolve()
+    }
+
+    /** Look again, from the top. Called when the handshake has been waiting too long. */
+    fun refresh() {
+        if (!isRunning) return
+        beginResolve()
+    }
+
+    fun stop() {
+        isRunning = false
+        resolveJob?.cancel()
+        resolveJob = null
+        autoEnabled = false
+        if (isReceiverRegistered) {
+            // Reset even if unregister throws: a flag set in only one direction is how a
+            // long-lived manager ends up unable to re-arm.
+            try { context.unregisterReceiver(apStateReceiver) } catch (e: Exception) {}
+            isReceiverRegistered = false
+        }
+    }
+
+    private fun beginResolve() {
+        resolveJob?.cancel()
+        resolveJob = scope.launch(Dispatchers.IO + CoroutineName("SoftApCredentials-Resolve")) {
+            val deadline = System.currentTimeMillis() + RESOLVE_BUDGET_MS
+            var triedAutoEnable = false
+            val startedAt = System.currentTimeMillis()
+
+            while (isActive && isRunning && System.currentTimeMillis() < deadline) {
+                val chosen = pickApInterface()
+                if (chosen != null && publish(chosen)) return@launch
+
+                // Reaching here means nothing was published, whether because no interface looked
+                // like an access point or because the one that did turned out not to be running.
+                // Both are "there is no hotspot yet", which is what auto-enable is for.
+                val waited = System.currentTimeMillis() - startedAt
+                if (!triedAutoEnable && waited >= AUTO_ENABLE_AFTER_MS && settings.autoEnableHotspot) {
+                    triedAutoEnable = true
+                    AppLog.i("SoftApCredentials: No access point after ${waited / 1000}s — trying to switch this device's hotspot on.")
+                    // Best effort; most unrooted units lack the permission. Keep polling anyway,
+                    // since the user may switch it on by hand.
+                    autoEnabled = HotspotManager.setHotspotEnabled(context, true)
+                }
+                delay(POLL_INTERVAL_MS)
+            }
+
+            if (isActive && isRunning) {
+                AppLog.e(
+                    "SoftApCredentials: No usable access point after ${RESOLVE_BUDGET_MS / 1000}s. " +
+                        "Turn this device's hotspot on before connecting — 5 GHz is strongly " +
+                        "recommended, Android Auto video is poor over 2.4 GHz — or switch the " +
+                        "Android Auto network transport back to WiFi Direct."
+                )
+                onInvalidated?.invoke()
+            }
+        }
+    }
+
+    /** The interface we settled on, and whether the user named it rather than us guessing. */
+    private data class ChosenInterface(val iface: ApInterfaceCandidate, val namedByUser: Boolean)
+
+    /**
+     * The interface our access point is running on, if it is up.
+     *
+     * Every reference implementation of this protocol — aa-proxy-rs, the Raspberry Pi dongles, the
+     * OEM ZLink app — either creates the access point itself or reads the interface name from
+     * configuration; none of them infer it. We are the only one reading an access point we did not
+     * create, on hardware we do not control, which is why [Settings.hotspotInterface] comes first
+     * and the heuristic is the fallback.
+     */
+    private fun pickApInterface(): ChosenInterface? {
+        val candidates = try {
+            NetworkInterface.getNetworkInterfaces().toList().map { nif ->
+                ApInterfaceCandidate(
+                    name = nif.name,
+                    isLoopback = try { nif.isLoopback } catch (e: Exception) { false },
+                    isUp = try { nif.isUp } catch (e: Exception) { false },
+                    siteLocalIpv4 = nif.inetAddresses.toList()
+                        .filterIsInstance<Inet4Address>()
+                        .firstOrNull { it.isSiteLocalAddress }
+                        ?.hostAddress
+                )
+            }
+        } catch (e: Exception) {
+            AppLog.w("SoftApCredentials: Could not enumerate network interfaces: ${e.message}")
+            return null
+        }
+
+        val named = settings.hotspotInterface.trim()
+        if (named.isNotEmpty()) {
+            val match = candidates.firstOrNull { it.name.equals(named, ignoreCase = true) }
+            when {
+                match == null ->
+                    AppLog.w("SoftApCredentials: No interface named '$named'. Present: ${candidates.joinToString { it.name }}. Falling back to automatic selection.")
+                match.siteLocalIpv4 == null || !match.isUp ->
+                    AppLog.w("SoftApCredentials: Interface '$named' is ${if (match.isUp) "up but has no address" else "down"}. Falling back to automatic selection.")
+                else -> {
+                    AppLog.i("SoftApCredentials: Using '${match.name}' (${match.siteLocalIpv4}) as named in settings.")
+                    return ChosenInterface(match, namedByUser = true)
+                }
+            }
+        }
+
+        val stationIpv4 = NetworkAddresses.stationIpv4(context)
+        val eligible = SoftApNetworkPolicy.eligible(candidates, stationIpv4)
+        val picked = SoftApNetworkPolicy.pickApInterface(candidates, stationIpv4) ?: return null
+        if (eligible.size > 1) {
+            // More than one survivor means the name decided it, which is a guess. Nothing else
+            // reports having guessed, and picking wrong hands the phone an unreachable address.
+            AppLog.w(
+                "SoftApCredentials: More than one interface could be the access point — " +
+                    eligible.joinToString { "${it.name} (${it.siteLocalIpv4})" } +
+                    " — choosing ${picked.name} by name. Set the hotspot interface by hand if that is wrong."
+            )
+        }
+        return ChosenInterface(picked, namedByUser = false)
+    }
+
+    /** Resolves the rest of the credentials for [iface] and hands them over. True if it worked. */
+    private fun publish(chosen: ChosenInterface): Boolean {
+        val iface = chosen.iface
+        val ip = iface.siteLocalIpv4 ?: return false
+
+        // User's override first, then the system's own configuration: getSoftApConfiguration() is
+        // reflection over a non-public API and can simply refuse on a locked-down device.
+        val manualSsid = settings.hotspotSsid
+        val systemConfig = if (manualSsid.isEmpty()) HotspotConfigReader.getSystemHotspotConfig(context) else null
+        val ssid = manualSsid.ifEmpty { systemConfig?.first.orEmpty() }
+        val psk = settings.hotspotPassword.ifEmpty { systemConfig?.second.orEmpty() }
+
+        if (ssid.isEmpty()) {
+            AppLog.w(
+                "SoftApCredentials: Found an access point on ${iface.name} ($ip) but could not read " +
+                    "its name. This device does not let apps read the hotspot configuration — set " +
+                    "the name and password by hand in the Android Auto settings."
+            )
+            return false
+        }
+        if (psk.isEmpty()) {
+            AppLog.w("SoftApCredentials: No passphrase for '$ssid'. An open network will be refused by the phone; set one by hand if this fails.")
+        }
+
+        val apState = SoftApStateReader.read(context)
+        if (!NativeCredentialsPolicy.shouldPublishCredentials(apState, chosen.namedByUser)) {
+            AppLog.w(
+                "SoftApCredentials: the system reports no access point running, so ${iface.name} " +
+                    "($ip) is some other network — a modem bridge or a wired link will look just " +
+                    "like this. Not handing the phone a network that is not on air. Switch the " +
+                    "hotspot on, or name the interface by hand if you know it is up."
+            )
+            return false
+        }
+        if (apState == SoftApState.UNKNOWN) {
+            AppLog.i("SoftApCredentials: This device does not let apps read the hotspot state; proceeding without confirming the access point is up.")
+        }
+
+        val bssid = SoftApBssidPolicy.choose(
+            staticOverride = settings.staticBSSID,
+            shellMac = InterfaceMacReader.read(iface.name),
+            hardwareAddress = hardwareAddressOf(iface.name)
+        )
+        if (bssid.isEmpty()) {
+            // Not fatal on this route — see NativeCredentialsPolicy. The handshake decides.
+            AppLog.w("SoftApCredentials: Could not resolve a real BSSID for ${iface.name}; the credentials will go out without one.")
+        }
+
+        AppLog.i("SoftApCredentials: SUCCESS - Providing credentials from ${iface.name}: SSID=$ssid, IP=$ip, BSSID=${bssid.ifEmpty { "<none>" }}")
+        onCredentialsReady?.invoke(ssid, psk, ip, bssid)
+        return true
+    }
+
+    private fun hardwareAddressOf(name: String): String? = try {
+        NetworkInterface.getByName(name)?.hardwareAddress
+            ?.joinToString(":") { String.format("%02x", it) }
+    } catch (e: Exception) {
+        null
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/WifiDirectManager.kt
@@ -385,12 +385,11 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                     nativeRecreateCount = 0
                 }
                 if (hadClient && !isClientConnected) {
-                    // [BUG_FIX] #760: never rediscover on the Native AA path. We run a *quiet*
-                    // host there — the phone finds us by SSID from the credentials we handed it
-                    // over Bluetooth, never by discovery — and discoverPeers() takes the group
-                    // owner off-channel every 10s. In the reporter's logs that loop starts the
-                    // moment the phone drops mid-DHCP and then keeps every subsequent retry stuck
-                    // at "Obtaining IP address".
+                    // [BUG_FIX] Never rediscover on the Native AA path: it is a *quiet* host, the
+                    // phone finds us by SSID from the credentials handed over Bluetooth, and
+                    // discoverPeers() takes the group owner off-channel every 10 s. Starting that
+                    // loop when a phone drops mid-DHCP leaves every retry stuck at "Obtaining IP
+                    // address".
                     if (NativeHandoffPolicy.shouldRestartDiscovery(
                             nativeAaMode = isNativeAaMode(),
                             hadClient = hadClient,
@@ -1034,9 +1033,8 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
      * Tear down any current P2P group and create a fresh native quiet-host group.
      * [forceStandard] skips the 5GHz attempt, for phones that can't join a 5GHz group owner.
      *
-     * Used to also call deletePersistentGroup() here, mirroring #730's Helper-mode fix, but
-     * that's rejected outright on-device for every netId — likely a permission this app lacks.
-     * Dropped.
+     * Used to also call deletePersistentGroup() here, as the Helper mode path does, but on-device
+     * that is rejected for every netId — likely a permission this app lacks. Dropped.
      */
     @SuppressLint("MissingPermission")
     private fun recreateNativeGroup(forceStandard: Boolean) {

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -191,6 +191,13 @@ class VideoDecoder(private val settings: Settings) {
     @Volatile var lastFrameRenderedMs: Long = 0L
     private var syntheticPtsUs = 0L
 
+    // Frames rendered since whoever owns the session last zeroed this. Deliberately *not* cleared
+    // by stop(): the surface goes away and comes back within a single session (leaving projection,
+    // screen off, a config change), and lastFrameRenderedMs is zeroed every time it does. Reading
+    // that field to ask "did this session ever show video" answers no for a session that showed
+    // plenty. See CommManager.noteSessionEnded.
+    @Volatile var framesRenderedThisSession: Long = 0L
+
     // elapsedRealtime() of the last encoded video bytes received from the phone (input side),
     // as opposed to lastFrameRenderedMs (output side). Lets the projection watchdog tell a
     // phone-side pause (no input) apart from a local display stall (input flowing, nothing drawn).
@@ -560,6 +567,7 @@ class VideoDecoder(private val settings: Settings) {
 
     private fun onSoftwareFramesRendered(renderedFrames: Int) {
         lastFrameRenderedMs = SystemClock.elapsedRealtime()
+        framesRenderedThisSession++
         if (!loggedFirstSoftwareFrame) {
             loggedFirstSoftwareFrame = true
             AppLog.i("First bundled software HEVC frame rendered")
@@ -953,6 +961,7 @@ class VideoDecoder(private val settings: Settings) {
                     currentCodec.releaseOutputBuffer(outputIndex, true)
                     lastFrameRenderedMs = SystemClock.elapsedRealtime()
                     lastOutputMs = lastFrameRenderedMs
+                    framesRenderedThisSession++
                     consecutiveErrors = 0
                     onFirstFrameListener?.let { it(); onFirstFrameListener = null }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -192,10 +192,12 @@ class VideoDecoder(private val settings: Settings) {
     private var syntheticPtsUs = 0L
 
     // Frames rendered since whoever owns the session last zeroed this. Deliberately *not* cleared
-    // by stop(): the surface goes away and comes back within a single session (leaving projection,
-    // screen off, a config change), and lastFrameRenderedMs is zeroed every time it does. Reading
-    // that field to ask "did this session ever show video" answers no for a session that showed
-    // plenty. See CommManager.noteSessionEnded.
+    // by stop(), which is what separates it from framesRendered above: that one is a throughput
+    // counter and must not straddle a restart, this one must survive every restart the session
+    // contains. The surface goes away and comes back within a single session (leaving projection,
+    // screen off, a config change), and both stop() and setSurface() zero lastFrameRenderedMs when
+    // it does, so reading that to ask "did this session ever show video" answers no for a session
+    // that showed plenty. See CommManager.noteSessionEnded.
     @Volatile var framesRenderedThisSession: Long = 0L
 
     // elapsedRealtime() of the last encoded video bytes received from the phone (input side),
@@ -567,7 +569,7 @@ class VideoDecoder(private val settings: Settings) {
 
     private fun onSoftwareFramesRendered(renderedFrames: Int) {
         lastFrameRenderedMs = SystemClock.elapsedRealtime()
-        framesRenderedThisSession++
+        framesRenderedThisSession += renderedFrames
         if (!loggedFirstSoftwareFrame) {
             loggedFirstSoftwareFrame = true
             AppLog.i("First bundled software HEVC frame rendered")

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -27,13 +27,12 @@ class VideoDecoder(private val settings: Settings) {
         private const val TIMEOUT_US = 10000L
         private const val MAX_RESTARTS_WITHOUT_FRAME = 3
 
-        // sync_stall watchdog tuning (issue #742). A decoder that is merely intermittently slow
-        // (renders a frame every so often, just not within SYNC_STALL_THRESHOLD_MS) is not caught
-        // by restartsSinceLastFrame's "never produced a frame" cap, since that resets to zero the
-        // moment any frame renders. Without its own cooldown/cap this watchdog could otherwise
-        // tear the MediaCodec down and rebuild it indefinitely on marginal hardware, mirroring the
-        // same failure mode AapProjectionActivity.maybeRecoverFromDisplayStall() was hardened
-        // against for issue #650.
+        // sync_stall watchdog tuning. An intermittently slow decoder — one that renders, just not
+        // within SYNC_STALL_THRESHOLD_MS — escapes restartsSinceLastFrame's cap, which counts only
+        // restarts that produced no frame at all and resets the moment one renders. Without its own
+        // cooldown and cap this watchdog would rebuild the MediaCodec indefinitely on marginal
+        // hardware, the same failure mode
+        // AapProjectionActivity.maybeRecoverFromDisplayStall() was hardened against.
         private const val SYNC_STALL_THRESHOLD_MS = 2000L
         private const val SYNC_STALL_COOLDOWN_MS = 8000L
         private const val SYNC_STALL_RESET_MS = 60000L
@@ -161,7 +160,7 @@ class VideoDecoder(private val settings: Settings) {
     private var codecFallbackUsed = false
     private var decoderPermanentlyFailed = false
 
-    // sync_stall cooldown/cap state (issue #742) - see SYNC_STALL_* constants.
+    // sync_stall cooldown/cap state - see SYNC_STALL_* constants.
     private var syncStallRestartCount = 0
     private var lastSyncStallRestartMs = 0L
     private var lastSyncStallSuppressedLogMs = 0L
@@ -194,8 +193,7 @@ class VideoDecoder(private val settings: Settings) {
 
     // elapsedRealtime() of the last encoded video bytes received from the phone (input side),
     // as opposed to lastFrameRenderedMs (output side). Lets the projection watchdog tell a
-    // phone-side pause (no input) apart from a local display stall (input flowing, nothing
-    // drawn). See issue #650.
+    // phone-side pause (no input) apart from a local display stall (input flowing, nothing drawn).
     @Volatile var lastInputBytesReceivedMs: Long = 0L
 
     // True while the bundled software HEVC decoder is active. That path renders through the
@@ -370,11 +368,11 @@ class VideoDecoder(private val settings: Settings) {
      * Returns false when the frame was dropped because the codec's input queue was transiently
      * full, so the caller (AapVideo) can route recovery through its own throttled
      * markCorruptAndRequestRecovery() instead of every drop firing an independent, unthrottled
-     * keyframe request (issue #755 follow-up).
+     * keyframe request.
      */
     fun decode(buffer: ByteArray, offset: Int, size: Int, forceSoftware: Boolean, codecName: String): Boolean {
         synchronized(this) {
-            // Input-side liveness: bytes are arriving from the phone right now (issue #650).
+            // Input-side liveness: bytes are arriving from the phone right now.
             lastInputBytesReceivedMs = SystemClock.elapsedRealtime()
 
             // Check if a restart was requested by output thread
@@ -507,9 +505,9 @@ class VideoDecoder(private val settings: Settings) {
                     // (AapVideo.markCorruptAndRequestRecovery) decide whether/when to request a
                     // keyframe, instead of firing an unthrottled recovery here - on decoders with
                     // a small, fixed buffer count this can recur every few seconds during normal
-                    // playback and each one was an independent, unthrottled focus-cycle blink
-                    // (issue #755 follow-up). A truly stuck decoder is still caught by
-                    // outputThreadLoop's sync_stall watchdog.
+                    // playback, and each one was an independent, unthrottled focus-cycle blink. A
+                    // truly stuck decoder is still caught by outputThreadLoop's sync_stall
+                    // watchdog.
                     AppLog.w("Input buffer full. Dropping frame.")
                     framesDropped++
                     return false
@@ -991,6 +989,11 @@ class VideoDecoder(private val settings: Settings) {
                         lastOutputMs = now
                     } else {
                         // Input bytes ARE arriving, but decoder produces no output -> REAL DECODER STALL!
+                        // A device that is merely marginal — renders fine for stretches, then
+                        // stalls under load — never trips restartsSinceLastFrame's cap, since that
+                        // counts only restarts where no frame at all was rendered. Cap and cooldown
+                        // this watchdog the same way rather than rebuilding the MediaCodec every
+                        // time it fires.
                         if (syncStallRestartCount > 0 && now - lastSyncStallRestartMs > SYNC_STALL_RESET_MS) {
                             syncStallRestartCount = 0
                         }

--- a/app/src/main/java/com/andrerinas/openheadunit/main/MainActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/MainActivity.kt
@@ -121,6 +121,7 @@ class MainActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
 
         logLaunchSource()
+        clearBootLoopGuardIfOpenedByHand()
 
         // If an Android Auto session is active, bring the projection activity to front
         if (App.provide(this).commManager.isConnected && !App.isPiPActive) {
@@ -728,6 +729,21 @@ class MainActivity : BaseActivity() {
         handleLaunchIntent(intent)
     }
 
+    /**
+     * Releases the boot-loop guard, but only when a person opened the app.
+     *
+     * The distinction matters: the service launches this activity itself on every boot auto-start
+     * ([AapService] passes "Boot auto-start"), so clearing unconditionally would reset the guard on
+     * exactly the runs it exists to count. Tapping the guard's own notification does count as
+     * opening it by hand — that is a person reading the notice and acting on it.
+     */
+    private fun clearBootLoopGuardIfOpenedByHand() {
+        // No source at all is a launcher tap, which is as human as it gets.
+        val source = intent?.getStringExtra(EXTRA_LAUNCH_SOURCE) ?: ""
+        if (AUTOMATIC_LAUNCH_SOURCES.contains(source)) return
+        Settings.clearBootLoopState(this)
+    }
+
     private fun logLaunchSource() {
         val source = intent?.getStringExtra(EXTRA_LAUNCH_SOURCE)
         if (source != null) {
@@ -915,6 +931,11 @@ class MainActivity : BaseActivity() {
     companion object {
         private const val permissionRequestCode = 97
         const val EXTRA_LAUNCH_SOURCE = "launch_source"
+
+        /** Launch sources that mean the app opened itself, with nobody necessarily watching. */
+        private val AUTOMATIC_LAUNCH_SOURCES = setOf(
+            "Boot auto-start", "USB auto-start", "WiFi auto-start", "Bluetooth auto-start"
+        )
 
         /**
          * Hard upper bound for how long the auto-connect overlay may stay visible

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -71,8 +71,13 @@ class SettingsFragment : Fragment() {
     private val basicSettingIds = setOf(
         // General
         "autoOptimize", "connectionMode", "appLanguage", "uiScale",
-        // Wireless (shown in Basic only when WiFi is among the selected connection modes)
+        // Wireless (shown in Basic only when WiFi is among the selected connection modes).
+        // The hotspot entries come along with the transport choice: they only render once Hotspot
+        // is picked, and on a device that will not let an app read its hotspot configuration the
+        // manual name is the only way to finish setting the route up.
         "wifiConnectionMode",
+        "nativeApTransport", "nativeApTransportHint", "hotspotSsidOverride", "hotspotPasswordOverride",
+        "hotspotInterfaceOverride",
         // Dark mode
         "darkModeSettings",
         // Automation
@@ -130,6 +135,10 @@ class SettingsFragment : Fragment() {
     private var pendingBluetoothManagerServiceName: String? = null
     private var pendingManualSecondaryBluetoothServiceName: String? = null
     private var pendingNativeWifiVersionExchange: Boolean? = null
+    private var pendingNativeApTransport: Int? = null
+    private var pendingHotspotSsid: String? = null
+    private var pendingHotspotPassword: String? = null
+    private var pendingHotspotInterface: String? = null
 
     // Flag to determine if the projection should stretch to fill the screen
     private var pendingStretchToFill: Boolean? = null
@@ -256,6 +265,10 @@ class SettingsFragment : Fragment() {
         pendingBluetoothManagerServiceName = settings.bluetoothManagerServiceName
         pendingManualSecondaryBluetoothServiceName = settings.manualSecondaryBluetoothServiceName
         pendingNativeWifiVersionExchange = settings.nativeWifiVersionExchange
+        pendingNativeApTransport = settings.nativeApTransport
+        pendingHotspotSsid = settings.hotspotSsid
+        pendingHotspotPassword = settings.hotspotPassword
+        pendingHotspotInterface = settings.hotspotInterface
 
         pendingInsetLeft = settings.insetLeft
         pendingInsetTop = settings.insetTop
@@ -357,6 +370,10 @@ class SettingsFragment : Fragment() {
         pendingBluetoothManagerServiceName = settings.bluetoothManagerServiceName
         pendingManualSecondaryBluetoothServiceName = settings.manualSecondaryBluetoothServiceName
         pendingNativeWifiVersionExchange = settings.nativeWifiVersionExchange
+        pendingNativeApTransport = settings.nativeApTransport
+        pendingHotspotSsid = settings.hotspotSsid
+        pendingHotspotPassword = settings.hotspotPassword
+        pendingHotspotInterface = settings.hotspotInterface
         pendingInsetLeft = settings.insetLeft
         pendingInsetTop = settings.insetTop
         pendingInsetRight = settings.insetRight
@@ -487,6 +504,10 @@ class SettingsFragment : Fragment() {
         pendingBluetoothManagerServiceName?.let { settings.bluetoothManagerServiceName = it }
         pendingManualSecondaryBluetoothServiceName?.let { settings.manualSecondaryBluetoothServiceName = it }
         pendingNativeWifiVersionExchange?.let { settings.nativeWifiVersionExchange = it }
+        pendingNativeApTransport?.let { settings.nativeApTransport = it }
+        pendingHotspotSsid?.let { settings.hotspotSsid = it }
+        pendingHotspotPassword?.let { settings.hotspotPassword = it }
+        pendingHotspotInterface?.let { settings.hotspotInterface = it }
 
         pendingInsetLeft?.let { settings.insetLeft = it }
         pendingInsetTop?.let { settings.insetTop = it }
@@ -592,6 +613,10 @@ class SettingsFragment : Fragment() {
                         pendingBluetoothManagerServiceName != settings.bluetoothManagerServiceName ||
                         pendingManualSecondaryBluetoothServiceName != settings.manualSecondaryBluetoothServiceName ||
                         pendingNativeWifiVersionExchange != settings.nativeWifiVersionExchange ||
+                        pendingNativeApTransport != settings.nativeApTransport ||
+                        pendingHotspotSsid != settings.hotspotSsid ||
+                        pendingHotspotPassword != settings.hotspotPassword ||
+                        pendingHotspotInterface != settings.hotspotInterface ||
                         pendingUseLibusb != settings.useLibusb
 
         hasChanges = anyChange
@@ -797,6 +822,91 @@ class SettingsFragment : Fragment() {
         ))
 
         if (pendingWifiConnectionMode == 3) {
+            items.add(SettingItem.SegmentedButtonSettingEntry(
+                stableId = "nativeApTransport",
+                nameResId = R.string.native_ap_transport,
+                options = listOf(
+                    getString(R.string.native_ap_transport_wifi_direct),
+                    getString(R.string.native_ap_transport_hotspot)
+                ),
+                selectedIndex = if ((pendingNativeApTransport ?: 0) == 1) 1 else 0,
+                onOptionSelected = { index ->
+                    pendingNativeApTransport = index
+                    checkChanges()
+                    updateSettingsList()
+                }
+            ))
+
+            if ((pendingNativeApTransport ?: 0) == 1) {
+                items.add(SettingItem.InfoBanner(
+                    stableId = "nativeApTransportHint",
+                    textResId = R.string.native_ap_transport_hint
+                ))
+
+                // The automatic read goes through the same non-public API that a locked-down
+                // device refuses outright, so on those units this override is the only way the
+                // route can learn the network name at all.
+                val manualSsid = pendingHotspotSsid.orEmpty()
+                items.add(SettingItem.SettingEntry(
+                    stableId = "hotspotSsidOverride",
+                    nameResId = R.string.hotspot_ssid_override,
+                    value = manualSsid.ifEmpty { getString(R.string.auto) },
+                    onClick = { _ ->
+                        DialogUtils.showTextInputDialogWithMessage(
+                            requireContext(),
+                            R.string.hotspot_ssid_override,
+                            R.string.hotspot_ssid_override_message,
+                            manualSsid,
+                            { newVal ->
+                                pendingHotspotSsid = newVal.trim()
+                                checkChanges()
+                                updateSettingsList()
+                            }
+                        )
+                    }
+                ))
+
+                val manualPassword = pendingHotspotPassword.orEmpty()
+                items.add(SettingItem.SettingEntry(
+                    stableId = "hotspotPasswordOverride",
+                    nameResId = R.string.hotspot_password_override,
+                    value = if (manualPassword.isEmpty()) getString(R.string.auto) else "\u2022".repeat(manualPassword.length),
+                    onClick = { _ ->
+                        DialogUtils.showTextInputDialogWithMessage(
+                            requireContext(),
+                            R.string.hotspot_password_override,
+                            R.string.hotspot_password_override_message,
+                            manualPassword,
+                            { newVal ->
+                                pendingHotspotPassword = newVal.trim()
+                                checkChanges()
+                                updateSettingsList()
+                            }
+                        )
+                    }
+                ))
+
+                val manualInterface = pendingHotspotInterface.orEmpty()
+                items.add(SettingItem.SettingEntry(
+                    stableId = "hotspotInterfaceOverride",
+                    nameResId = R.string.hotspot_interface_override,
+                    value = manualInterface.ifEmpty { getString(R.string.auto) },
+                    onClick = { _ ->
+                        DialogUtils.showTextInputDialogWithMessage(
+                            requireContext(),
+                            R.string.hotspot_interface_override,
+                            R.string.hotspot_interface_override_message,
+                            manualInterface,
+                            { newVal ->
+                                pendingHotspotInterface = newVal.trim()
+                                checkChanges()
+                                updateSettingsList()
+                            }
+                        )
+                    }
+                ))
+            }
+
             val currentServiceName = pendingBluetoothManagerServiceName ?: "bluetooth_manager"
             items.add(SettingItem.SettingEntry(
                 stableId = "bluetoothAdapterServiceName",

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -957,7 +957,7 @@ class SettingsFragment : Fragment() {
                 stableId = "nativeWifiVersionExchange",
                 nameResId = R.string.native_wifi_version_exchange,
                 descriptionResId = R.string.native_wifi_version_exchange_description,
-                isChecked = pendingNativeWifiVersionExchange ?: true,
+                isChecked = pendingNativeWifiVersionExchange ?: false,
                 onCheckedChanged = { isChecked ->
                     pendingNativeWifiVersionExchange = isChecked
                     checkChanges()

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -129,6 +129,7 @@ class SettingsFragment : Fragment() {
     private var pendingWaitForWifiTimeout: Int? = null
     private var pendingBluetoothManagerServiceName: String? = null
     private var pendingManualSecondaryBluetoothServiceName: String? = null
+    private var pendingNativeWifiVersionExchange: Boolean? = null
 
     // Flag to determine if the projection should stretch to fill the screen
     private var pendingStretchToFill: Boolean? = null
@@ -254,6 +255,7 @@ class SettingsFragment : Fragment() {
         pendingWaitForWifiTimeout = settings.waitForWifiTimeout
         pendingBluetoothManagerServiceName = settings.bluetoothManagerServiceName
         pendingManualSecondaryBluetoothServiceName = settings.manualSecondaryBluetoothServiceName
+        pendingNativeWifiVersionExchange = settings.nativeWifiVersionExchange
 
         pendingInsetLeft = settings.insetLeft
         pendingInsetTop = settings.insetTop
@@ -354,6 +356,7 @@ class SettingsFragment : Fragment() {
         pendingWaitForWifiTimeout = settings.waitForWifiTimeout
         pendingBluetoothManagerServiceName = settings.bluetoothManagerServiceName
         pendingManualSecondaryBluetoothServiceName = settings.manualSecondaryBluetoothServiceName
+        pendingNativeWifiVersionExchange = settings.nativeWifiVersionExchange
         pendingInsetLeft = settings.insetLeft
         pendingInsetTop = settings.insetTop
         pendingInsetRight = settings.insetRight
@@ -483,6 +486,7 @@ class SettingsFragment : Fragment() {
         pendingWaitForWifiTimeout?.let { settings.waitForWifiTimeout = it }
         pendingBluetoothManagerServiceName?.let { settings.bluetoothManagerServiceName = it }
         pendingManualSecondaryBluetoothServiceName?.let { settings.manualSecondaryBluetoothServiceName = it }
+        pendingNativeWifiVersionExchange?.let { settings.nativeWifiVersionExchange = it }
 
         pendingInsetLeft?.let { settings.insetLeft = it }
         pendingInsetTop?.let { settings.insetTop = it }
@@ -587,6 +591,7 @@ class SettingsFragment : Fragment() {
                         pendingWaitForWifiTimeout != settings.waitForWifiTimeout ||
                         pendingBluetoothManagerServiceName != settings.bluetoothManagerServiceName ||
                         pendingManualSecondaryBluetoothServiceName != settings.manualSecondaryBluetoothServiceName ||
+                        pendingNativeWifiVersionExchange != settings.nativeWifiVersionExchange ||
                         pendingUseLibusb != settings.useLibusb
 
         hasChanges = anyChange
@@ -835,6 +840,18 @@ class SettingsFragment : Fragment() {
                             updateSettingsList()
                         }
                     )
+                }
+            ))
+
+            items.add(SettingItem.ToggleSettingEntry(
+                stableId = "nativeWifiVersionExchange",
+                nameResId = R.string.native_wifi_version_exchange,
+                descriptionResId = R.string.native_wifi_version_exchange_description,
+                isChecked = pendingNativeWifiVersionExchange ?: true,
+                onCheckedChanged = { isChecked ->
+                    pendingNativeWifiVersionExchange = isChecked
+                    checkChanges()
+                    updateSettingsList()
                 }
             ))
         }

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
@@ -94,8 +94,8 @@ object BluetoothHelper {
      *  user supplies a service name automatic discovery (listBluetoothServices()) didn't find.
      *  Forgiving of the AIDL interface descriptor `adb shell service list` prints in brackets
      *  (e.g. "com.qf.btsdk.IBTBinderPool") in place of the actual service name before the colon
-     *  (e.g. "btBinderPool") - confirmed via andreknieriem/headunit-revived#706 that users copy
-     *  the bracketed part since it's the more distinctive-looking of the two. */
+     *  (e.g. "btBinderPool"): users copy the bracketed part, it being the more distinctive-looking
+     *  of the two. */
     fun getAdapterHandleForService(context: Context, serviceName: String): BluetoothAdapterHandle? {
         val input = serviceName.trim().removePrefix("[").removeSuffix("]").trim()
         if (input.isEmpty()) return null

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/HotspotConfigReader.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/HotspotConfigReader.kt
@@ -1,0 +1,66 @@
+package com.andrerinas.openheadunit.utils
+
+import android.content.Context
+import android.net.wifi.WifiManager
+import android.os.Build
+
+/**
+ * Reads the SSID and passphrase of the hotspot this device is configured to run.
+ *
+ * Reflection throughout — neither `getSoftApConfiguration` nor `getWifiApConfiguration` is public
+ * API, and both can throw on a locked-down device — so callers want a manual override ahead of it.
+ * Shared by `ShareHotspotQrDialog` and the Native AA hotspot transport.
+ */
+object HotspotConfigReader {
+
+    /** The configured hotspot as (ssid, passphrase), or null if it cannot be read. */
+    fun getSystemHotspotConfig(context: Context): Pair<String, String>? {
+        try {
+            val wm = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+
+            // 1. Try modern getSoftApConfiguration (API 30+)
+            if (Build.VERSION.SDK_INT >= 30) {
+                try {
+                    val getSoftApConfigurationMethod = wm.javaClass.getMethod("getSoftApConfiguration")
+                    val softApConfig = getSoftApConfigurationMethod.invoke(wm)
+                    if (softApConfig != null) {
+                        val getSsidMethod = softApConfig.javaClass.getMethod("getSsid")
+                        val getPassphraseMethod = softApConfig.javaClass.getMethod("getPassphrase")
+                        val ssid = getSsidMethod.invoke(softApConfig) as? String ?: ""
+                        val pass = getPassphraseMethod.invoke(softApConfig) as? String ?: ""
+                        if (ssid.isNotEmpty()) {
+                            return Pair(ssid, pass)
+                        }
+                    }
+                } catch (e: Exception) {
+                    AppLog.d("HotspotConfigReader: Failed to get soft ap config via reflection: ${e.message}")
+                }
+            }
+
+            // 2. Try legacy getWifiApConfiguration (API < 30)
+            try {
+                val getWifiApConfigurationMethod = wm.javaClass.getMethod("getWifiApConfiguration")
+                val wifiConfig = getWifiApConfigurationMethod.invoke(wm)
+                if (wifiConfig != null) {
+                    val ssidField = wifiConfig.javaClass.getField("SSID")
+                    val preSharedKeyField = wifiConfig.javaClass.getField("preSharedKey")
+                    val ssid = ssidField.get(wifiConfig) as? String ?: ""
+                    val pass = preSharedKeyField.get(wifiConfig) as? String ?: ""
+
+                    // Clean SSID quotes if present
+                    val cleanSsid = if (ssid.startsWith("\"") && ssid.endsWith("\"")) {
+                        ssid.substring(1, ssid.length - 1)
+                    } else {
+                        ssid
+                    }
+                    return Pair(cleanSsid, pass)
+                }
+            } catch (e: Exception) {
+                AppLog.d("HotspotConfigReader: Failed to get wifi ap config via reflection: ${e.message}")
+            }
+        } catch (e: Exception) {
+            AppLog.e("HotspotConfigReader: Failed to access WifiManager: ${e.message}")
+        }
+        return null
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/HotspotManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/HotspotManager.kt
@@ -10,7 +10,12 @@ import android.util.Log
 import com.android.dx.DexMaker
 import com.android.dx.TypeId
 import java.lang.reflect.Method
+import java.net.Inet4Address
+import java.net.NetworkInterface
 import com.andrerinas.openheadunit.utils.SoftApConfigCompat
+import com.andrerinas.openheadunit.aap.ApInterfaceCandidate
+import com.andrerinas.openheadunit.aap.SoftApNetworkPolicy
+import com.andrerinas.openheadunit.aap.SoftApState
 
 /**
  * Manages WiFi Hotspot (tethering) using reflection + dexmaker.
@@ -19,47 +24,153 @@ object HotspotManager {
     private const val TAG = "OPENHU_WIFI"
     private const val CALLBACK_CLASS = "android.net.ConnectivityManager\$OnStartTetheringCallback"
 
+    /** How long to give the framework to actually bring an access point up. */
+    private const val AP_STATE_TIMEOUT_MS = 6_000L
+
+    /** TetheringManager.TETHERING_WIFI. */
+    private const val TETHERING_WIFI = 0
+
     private var cachedCallbackClass: Class<*>? = null
 
     fun setHotspotEnabled(context: Context, enabled: Boolean): Boolean {
         AppLog.i("HotspotManager: Setting hotspot enabled=$enabled (API ${Build.VERSION.SDK_INT}, canWriteSettings=${AppPermissions.isWriteSettingsGranted(context)})")
 
-        // On Android 8+, WiFi must be disabled before tethering can start
+        // On Android 8+, WiFi must be disabled before tethering can start. Ask, then say what
+        // actually happened: setWifiEnabled() is a no-op for apps targeting API 29+ and this app
+        // targets well past that, so on most devices the request is silently ignored and the
+        // framework drops the station itself when it needs the radio. Announcing the attempt as if
+        // it worked is how the radio state ends up being read as ours.
         if (enabled) {
             try {
                 val wm = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
                 if (wm.isWifiEnabled) {
-                    AppLog.i("HotspotManager: Disabling WiFi before enabling hotspot...")
+                    @Suppress("DEPRECATION")
                     wm.isWifiEnabled = false
                     Thread.sleep(500) // Let the radio settle
+                    if (wm.isWifiEnabled) {
+                        AppLog.i("HotspotManager: Asked to disable WiFi and the platform ignored it (expected on modern Android); the framework will take the radio itself if it needs to.")
+                    } else {
+                        AppLog.i("HotspotManager: WiFi disabled before enabling hotspot.")
+                    }
                 }
             } catch (e: Exception) {
                 AppLog.w("HotspotManager: Failed to disable WiFi: ${e.message}")
             }
         }
 
-        // Use SoftApConfiguration for Android 30+ if available
+        // [BUG_FIX] Must fall through, not return. enableHotspot() only calls
+        // setSoftApConfiguration() — it configures an access point, it does not start one — yet
+        // its `true` used to short-circuit the whole function, so on API 30+ we wrote the SSID and
+        // passphrase, reported success, and ran no start path at all. The hotspot stayed off.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            if (SoftApConfigCompat.enableHotspot(context, enabled)) return true
+            if (SoftApConfigCompat.enableHotspot(context, enabled)) {
+                AppLog.i("HotspotManager: SoftAp configuration applied; now starting the hotspot.")
+            }
         }
         // Newer API: TetheringManager (official) before ConnectivityManager fallback
+        var attempted = false
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            if (tryTetheringManager(context, enabled)) return true
+            attempted = tryTetheringManager(context, enabled) || attempted
         }
         // The remaining reflection paths (startTethering / setWifiApEnabled) require the special
         // "Modify system settings" access (WRITE_SETTINGS). Without it the framework throws a
         // SecurityException, so check first and surface a clear, actionable message instead.
         if (AppPermissions.isWriteSettingsGranted(context)) {
-            if (tryConnectivityManager(context, enabled)) return true
-            if (tryLegacyWifiManager(context, enabled)) return true
+            attempted = tryConnectivityManager(context, enabled) || attempted
+            attempted = tryLegacyWifiManager(context, enabled) || attempted
         } else {
             AppLog.w("HotspotManager: Cannot enable the hotspot without the \"Modify system settings\" permission (WRITE_SETTINGS). Grant it in the setup wizard or Settings > Permissions.")
         }
 
-        AppLog.w("HotspotManager: All hotspot attempts failed.")
-        return false
+        // [BUG_FIX] Confirm the access point instead of trusting the call that asked for it. Every
+        // start path here is reflection over an API whose real answer arrives later on a callback
+        // we cannot construct, so `invoke()` returning tells us only that the request was posted:
+        // on one head unit the framework refused it a millisecond later ("Tethering is already
+        // active or in recovering") while this method reported success and logged nothing at all.
+        // Only "an access point is up" is worth reporting as success.
+        if (!enabled) return attempted
+        val up = awaitApUp(context)
+        if (up) {
+            AppLog.i("HotspotManager: Hotspot is up.")
+        } else if (attempted) {
+            AppLog.w("HotspotManager: Every start path was tried and no access point came up within ${AP_STATE_TIMEOUT_MS / 1000}s. On a non-privileged install this usually cannot be done from an app — switch the hotspot on in system settings instead.")
+        } else {
+            AppLog.w("HotspotManager: All hotspot attempts failed.")
+        }
+        if (!up) warnIfRadioLeftDown(context)
+        return up
     }
 
+    /**
+     * Says so when a failed start has left the radio with neither a station nor an access point.
+     *
+     * The framework drops the station to free the radio for tethering; if the attempt then backs
+     * out, nothing brings it back. This app cannot: setWifiEnabled() is a no-op at its target SDK,
+     * so the only way out is the user toggling WiFi. Worth one clear line, because the symptom
+     * downstream is a WiFi Direct group that never forms and no obvious reason why.
+     */
+    private fun warnIfRadioLeftDown(context: Context) {
+        try {
+            val wm = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+            if (!wm.isWifiEnabled) {
+                AppLog.w("HotspotManager: WiFi is off and no access point came up, so this radio is now carrying neither. Nothing here can switch WiFi back on at this target SDK — toggle WiFi on the device before trying WiFi Direct, or it will not form a group.")
+            }
+        } catch (e: Exception) {
+            AppLog.d("HotspotManager: Could not read the WiFi state: ${e.message}")
+        }
+    }
+
+    /**
+     * Polls until a soft AP is up or the timeout expires.
+     *
+     * `getWifiApState()` is hidden but widely present; where it is blocked, fall back to looking
+     * for the interface, which is what a running access point is from the outside anyway.
+     */
+    private fun awaitApUp(context: Context): Boolean {
+        val deadline = System.currentTimeMillis() + AP_STATE_TIMEOUT_MS
+        while (true) {
+            if (isApUp(context)) return true
+            if (System.currentTimeMillis() >= deadline) return false
+            try { Thread.sleep(400) } catch (e: InterruptedException) { return false }
+        }
+    }
+
+    /** Whether a soft AP is running right now, by framework state or, failing that, by interface. */
+    private fun isApUp(context: Context): Boolean = when (SoftApStateReader.read(context)) {
+        SoftApState.ENABLED -> true
+        SoftApState.NOT_ENABLED -> false
+        // Nothing was learned, so fall back to what an access point looks like from outside.
+        SoftApState.UNKNOWN -> hasApInterface(context)
+    }
+
+    /**
+     * Whether any interface is one this device is hosting an access point on. Uses the same policy
+     * object SoftApCredentialsProvider uses to find the AP it will advertise, so the two cannot
+     * disagree about whether one exists.
+     */
+    private fun hasApInterface(context: Context): Boolean = try {
+        val stationIpv4 = NetworkAddresses.stationIpv4(context)
+        NetworkInterface.getNetworkInterfaces().toList().any { nif ->
+            SoftApNetworkPolicy.isApHost(
+                ApInterfaceCandidate(
+                    name = nif.name,
+                    isLoopback = try { nif.isLoopback } catch (e: Exception) { false },
+                    isUp = try { nif.isUp } catch (e: Exception) { false },
+                    siteLocalIpv4 = nif.inetAddresses.toList()
+                        .filterIsInstance<Inet4Address>()
+                        .firstOrNull { it.isSiteLocalAddress }
+                        ?.hostAddress
+                ),
+                stationIpv4
+            )
+        }
+    } catch (e: Exception) {
+        false
+    }
+
+    // The try* paths below return "the request was posted without throwing", not "the hotspot
+    // started" — the framework answers asynchronously, on a callback we cannot build. Only
+    // setHotspotEnabled() decides success, and it does so by looking for the access point.
     private fun tryConnectivityManager(context: Context, enabled: Boolean): Boolean {
         try {
             val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
@@ -78,7 +189,9 @@ object HotspotManager {
             } ?: return false
 
             startMethod.isAccessible = true
-            val callbackInst = createTetheringCallback(context)
+            // Same hazard as the TetheringManager path: the framework dispatches onto this object
+            // without a null check. If the shim could not be built, skip rather than crash.
+            val callbackInst = createTetheringCallback(context) ?: return false
             val handler = Handler(Looper.getMainLooper())
 
             return when (startMethod.parameterTypes.size) {
@@ -96,6 +209,50 @@ object HotspotManager {
             AppLog.e("HotspotManager: CM path failed", e)
             return false
         }
+    }
+
+    /**
+     * A do-nothing implementation of [type], or null if one cannot be made.
+     *
+     * `TetheringManager.StartTetheringCallback` is an interface whose methods are all default
+     * no-ops, so a [java.lang.reflect.Proxy] is enough and none of DexMaker's problems apply. If
+     * it ever turns out not to be an interface, returning null makes the caller skip the request
+     * rather than fall back to passing null and crashing again.
+     *
+     * The handler answers `hashCode`/`equals`/`toString` itself: returning null from those is its
+     * own NullPointerException the first time anything logs or hashes the object.
+     */
+    private fun noOpCallback(type: Class<*>): Any? = try {
+        if (!type.isInterface) {
+            AppLog.w("HotspotManager: ${type.name} is not an interface, so no callback can be made for it; skipping the request rather than passing null.")
+            null
+        } else {
+            java.lang.reflect.Proxy.newProxyInstance(type.classLoader, arrayOf(type)) { proxy, method, args ->
+                when (method.name) {
+                    "hashCode" -> System.identityHashCode(proxy)
+                    "equals" -> proxy === args?.getOrNull(0)
+                    "toString" -> "${type.simpleName}(no-op)"
+                    else -> null
+                }
+            }
+        }
+    } catch (e: Exception) {
+        AppLog.w("HotspotManager: Could not build a no-op ${type.simpleName}: ${e.message}")
+        null
+    }
+
+    /**
+     * A `TetheringRequest` for WiFi tethering, via its Builder, or null if it cannot be built.
+     * Only needed on platforms that dropped the plain `(int, …)` overload of startTethering.
+     */
+    private fun buildTetheringRequest(): Any? = try {
+        val builderClass = Class.forName("android.net.TetheringManager\$TetheringRequest\$Builder")
+        val builder = builderClass.getConstructor(Int::class.javaPrimitiveType)
+            .newInstance(TETHERING_WIFI)
+        builderClass.getMethod("build").invoke(builder)
+    } catch (e: Exception) {
+        AppLog.d("HotspotManager: Could not build a TetheringRequest: ${e.message}")
+        null
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -138,10 +295,28 @@ object HotspotManager {
         try {
             val tm = context.getSystemService("tethering") ?: return false
             if (enabled) {
-                val startMethod = tm.javaClass.methods.find {
+                // [BUG_FIX] Pick the overload by argument *type*, not by argument count. API 34
+                // carries two 3-arg startTethering methods — (TetheringRequest, Executor,
+                // StartTetheringCallback) and (int, Executor, StartTetheringCallback) — and
+                // find{} returned whichever the reflection order happened to yield, so passing
+                // the tethering type as an Integer threw "argument 1 has type TetheringRequest".
+                val overloads = tm.javaClass.methods.filter {
                     it.name == "startTethering" && it.parameterTypes.size == 3
-                } ?: return false
-                startMethod.invoke(tm, 0, context.mainExecutor, null)
+                }
+                val byType = overloads.find { it.parameterTypes[0] == Int::class.javaPrimitiveType }
+                val byRequest = overloads.find { it.parameterTypes[0].name.endsWith("TetheringRequest") }
+                val method = byType ?: byRequest ?: return false
+
+                // [BUG_FIX] Never pass null for the callback. The framework dispatches
+                // onTetheringStarted()/onTetheringFailed() onto it through the executor with no
+                // null check, so null crashed the app outright the moment tethering finished
+                // starting. It only shows up when the attempt gets far enough to report back — a
+                // request refused immediately never dispatches anything, which is why this hid
+                // behind an "already active" refusal the first time round.
+                val callback = noOpCallback(method.parameterTypes[2]) ?: return false
+
+                val first: Any = if (method === byType) TETHERING_WIFI else buildTetheringRequest() ?: return false
+                method.invoke(tm, first, context.mainExecutor, callback)
                 return true
             } else {
                 val stopMethod = tm.javaClass.methods.find { it.name == "stopTethering" }

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/InterfaceMacReader.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/InterfaceMacReader.kt
@@ -1,0 +1,56 @@
+package com.andrerinas.openheadunit.utils
+
+import java.io.File
+
+/**
+ * Reads an interface's MAC from outside the framework, for when
+ * `NetworkInterface.getHardwareAddress()` returns null or a placeholder — the norm for ordinary
+ * apps since Android 6.0.
+ *
+ * Separate from `WifiDirectManager.getMacFromShell()` on purpose: that one carries `[BUG_FIX]`
+ * annotations and a six-deep chain tuned against specific hardware, and sharing it would risk the
+ * WiFi Direct path to serve the hotspot one. ~30 duplicated lines, minus its leak — it never
+ * destroys the `ip link` process or closes its streams, and this runs on a poll loop.
+ */
+object InterfaceMacReader {
+
+    private val PLACEHOLDERS = setOf("00:00:00:00:00:00", "02:00:00:00:00:00")
+
+    /** The MAC of [iface] from sysfs, falling back to `ip link`, or null if neither yields a real one. */
+    fun read(iface: String): String? = fromSysfs(iface) ?: fromIpLink(iface)
+
+    /** `/sys/class/net/<iface>/address`. Readable without root on most head units. */
+    fun fromSysfs(iface: String): String? = try {
+        val file = File("/sys/class/net/$iface/address")
+        if (file.exists()) usableOrNull(file.readText()) else null
+    } catch (e: Exception) {
+        AppLog.d("InterfaceMacReader: sysfs read for $iface failed: ${e.message}")
+        null
+    }
+
+    /** `ip link show <iface>`, parsed for its `link/ether` line. */
+    fun fromIpLink(iface: String): String? {
+        var process: Process? = null
+        return try {
+            process = Runtime.getRuntime().exec(arrayOf("ip", "link", "show", iface))
+            val output = process.inputStream.bufferedReader().use { it.readText() }
+            val match = Regex("link/ether (([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2})").find(output)
+            usableOrNull(match?.groupValues?.get(1))
+        } catch (e: Exception) {
+            AppLog.d("InterfaceMacReader: 'ip link show $iface' failed: ${e.message}")
+            null
+        } finally {
+            // An undestroyed Process keeps its file descriptors, and on some ROMs its zombie,
+            // for the life of the app.
+            try { process?.errorStream?.close() } catch (e: Exception) {}
+            try { process?.outputStream?.close() } catch (e: Exception) {}
+            try { process?.destroy() } catch (e: Exception) {}
+        }
+    }
+
+    /** [mac] normalised to lower case, or null if it is blank or a masking placeholder. */
+    private fun usableOrNull(mac: String?): String? {
+        val trimmed = mac?.trim()?.lowercase().orEmpty()
+        return if (trimmed.isEmpty() || trimmed in PLACEHOLDERS) null else trimmed
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/NetworkAddresses.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/NetworkAddresses.kt
@@ -1,0 +1,64 @@
+package com.andrerinas.openheadunit.utils
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.net.wifi.WifiManager
+import android.os.Build
+import java.net.Inet4Address
+
+/**
+ * This device's own address on the WiFi network it has *joined*, as opposed to one it is hosting.
+ *
+ * Exists because those two are otherwise indistinguishable from the outside: a head unit that runs
+ * a soft AP on one radio and a station connection on another shows two `wlan*` interfaces, both up
+ * and both holding a site-local IPv4. Knowing the station's address is what lets
+ * [com.andrerinas.openheadunit.aap.SoftApNetworkPolicy] rule it out.
+ */
+object NetworkAddresses {
+
+    /** The station IPv4, or null when this device is not associated with a WiFi network. */
+    fun stationIpv4(context: Context): String? =
+        fromConnectivityManager(context) ?: fromWifiManager(context)
+
+    /**
+     * Asks for the WiFi transport specifically rather than the active network: the active one may
+     * be the VPN this app itself runs, or the AP, neither of which is the station.
+     */
+    private fun fromConnectivityManager(context: Context): String? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return null
+        return try {
+            val cm = context.applicationContext
+                .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            cm.allNetworks.asSequence()
+                .filter { network ->
+                    val caps = cm.getNetworkCapabilities(network)
+                    caps != null &&
+                        caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) &&
+                        !caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
+                }
+                .mapNotNull { network ->
+                    cm.getLinkProperties(network)?.linkAddresses
+                        ?.firstOrNull { it.address is Inet4Address }
+                        ?.address?.hostAddress
+                }
+                .firstOrNull()
+        } catch (e: Exception) {
+            AppLog.d("NetworkAddresses: ConnectivityManager lookup failed: ${e.message}")
+            null
+        }
+    }
+
+    /** Older devices, and anything the transport query could not answer. */
+    @Suppress("DEPRECATION")
+    private fun fromWifiManager(context: Context): String? = try {
+        val wm = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+        val raw = wm.connectionInfo?.ipAddress ?: 0
+        // 0 means "not associated", which is the common case while hosting an access point.
+        if (raw == 0) null else
+            "${raw and 0xFF}.${(raw shr 8) and 0xFF}.${(raw shr 16) and 0xFF}.${(raw shr 24) and 0xFF}"
+    } catch (e: Exception) {
+        AppLog.d("NetworkAddresses: WifiManager lookup failed: ${e.message}")
+        null
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -1215,12 +1215,17 @@ class Settings(private val context: Context) {
         set(value) = prefs.edit().putInt("native-ap-transport", value).apply()
 
     // Whether the Native AA handshake opens with a WifiVersionRequest (Type 4), as real head units
-    // and the OEM ZLink app do, instead of going straight to WifiStartRequest. On by default:
-    // Android Auto 17.4 broke the abbreviated exchange for several reporters, and the version
-    // exchange is the documented difference. Turning it off restores the exact wire behaviour that
-    // shipped in 3.2.1, which is the escape hatch if a unit regresses on it.
+    // and the OEM ZLink app do, instead of going straight to WifiStartRequest.
+    //
+    // Off by default, deliberately: this is the only change on this route that alters what a unit
+    // with a working setup puts on the wire, and the version it announces is a guess — no capture
+    // of a real head unit's Type 4 has been decoded. A phone under test answered that guess with
+    // status=-8 and completed the handshake anyway, so the exchange is survivable on at least one
+    // Gearhead, but "survivable on one" is not a default. Left as an opt-in until a reporter whose
+    // unit broke on Android Auto 17.4 confirms it helps, since fixing that is the only reason to
+    // send it at all.
     var nativeWifiVersionExchange: Boolean
-        get() = prefs.getBoolean("native-wifi-version-exchange", true)
+        get() = prefs.getBoolean("native-wifi-version-exchange", false)
         set(value) = prefs.edit().putBoolean("native-wifi-version-exchange", value).apply()
 
     // Manual fallback for dual-radio head units whose second radio isn't discoverable via

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -885,6 +885,69 @@ class Settings(private val context: Context) {
             }
         }
 
+        private const val KEY_BOOT_LOOP_STRIKES = "boot-loop-strikes"
+        private const val KEY_WIRELESS_PAUSED_BY_BOOT_LOOP = "wireless-paused-by-boot-loop"
+
+        /**
+         * The device-protected store, which is readable at LOCKED_BOOT_COMPLETED — before the user
+         * has unlocked, and so before ordinary preferences exist. The boot-loop counters have to
+         * live here for the same reason the auto-start flags do: they are read and written by
+         * [com.andrerinas.openheadunit.app.BootCompleteReceiver] on a device that has just booted.
+         */
+        private fun bootPrefs(context: Context) =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                context.createDeviceProtectedStorageContext()
+                    .getSharedPreferences(DEVICE_PREFS_NAME, Context.MODE_PRIVATE)
+            } else {
+                context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            }
+
+        /** Consecutive boot-started runs that did not last. See `aap/BootLoopPolicy`. */
+        fun getBootLoopStrikes(context: Context): Int = try {
+            bootPrefs(context).getInt(KEY_BOOT_LOOP_STRIKES, 0)
+        } catch (e: Exception) {
+            AppLog.d("Settings: Could not read the boot-loop strike count: ${e.message}")
+            0
+        }
+
+        fun setBootLoopStrikes(context: Context, strikes: Int) {
+            try {
+                bootPrefs(context).edit().putInt(KEY_BOOT_LOOP_STRIKES, strikes).apply()
+            } catch (e: Exception) {
+                AppLog.d("Settings: Could not store the boot-loop strike count: ${e.message}")
+            }
+        }
+
+        /**
+         * Whether wireless bring-up is currently paused because it looked like it was crashing the
+         * device. Sticky on purpose: cleared when the user opens the app, not by surviving a run,
+         * so the cycle ends outright instead of resuming every few boots.
+         */
+        fun isWirelessPausedByBootLoop(context: Context): Boolean = try {
+            bootPrefs(context).getBoolean(KEY_WIRELESS_PAUSED_BY_BOOT_LOOP, false)
+        } catch (e: Exception) {
+            AppLog.d("Settings: Could not read the boot-loop pause flag: ${e.message}")
+            false
+        }
+
+        fun setWirelessPausedByBootLoop(context: Context, paused: Boolean) {
+            try {
+                bootPrefs(context).edit()
+                    .putBoolean(KEY_WIRELESS_PAUSED_BY_BOOT_LOOP, paused)
+                    .apply()
+            } catch (e: Exception) {
+                AppLog.d("Settings: Could not store the boot-loop pause flag: ${e.message}")
+            }
+        }
+
+        /** Both counters back to their defaults, for when the user is present and can act. */
+        fun clearBootLoopState(context: Context) {
+            if (getBootLoopStrikes(context) == 0 && !isWirelessPausedByBootLoop(context)) return
+            AppLog.i("Settings: Clearing the boot-loop guard — the app was opened by hand.")
+            setBootLoopStrikes(context, 0)
+            setWirelessPausedByBootLoop(context, false)
+        }
+
         private const val KEY_AUTO_START_ON_SCREEN_ON = "auto-start-on-screen-on"
 
         /**

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -1204,6 +1204,16 @@ class Settings(private val context: Context) {
         get() = prefs.getString("bluetooth-manager-service-name", "bluetooth_manager")!!
         set(value) = prefs.edit().putString("bluetooth-manager-service-name", value).apply()
 
+    // Which network the Native AA mode (wifiConnectionMode 3) puts the phone on.
+    // 0 = WiFi Direct P2P group, 1 = this head unit's own hotspot (experimental).
+    //
+    // Deliberately not folded into helperConnectionStrategy: that setting belongs to mode 2 and
+    // means something different in every one of its five values. A wireless mode that reuses
+    // another mode's selector is how the two call sites of the old usesWifiDirect() drifted apart.
+    var nativeApTransport: Int
+        get() = prefs.getInt("native-ap-transport", 0)
+        set(value) = prefs.edit().putInt("native-ap-transport", value).apply()
+
     // Whether the Native AA handshake opens with a WifiVersionRequest (Type 4), as real head units
     // and the OEM ZLink app do, instead of going straight to WifiStartRequest. On by default:
     // Android Auto 17.4 broke the abbreviated exchange for several reporters, and the version
@@ -1219,6 +1229,19 @@ class Settings(private val context: Context) {
         get() = prefs.getString("manual-secondary-bt-service-name", "")!!
         set(value) = prefs.edit().putString("manual-secondary-bt-service-name", value).apply()
 
+    // Which interface hosts the head unit's access point. Empty = work it out from the interface
+    // list. Worth having because every other implementation of this protocol either creates the AP
+    // itself or is told the name: aa-proxy-rs has an `iface` setting, the Pi dongles pin wlan0 in
+    // hostapd.conf, and ZLink carries an ap_NIC_name field. We are the only one reading an AP we
+    // did not create, so we are the only one that has to guess.
+    var hotspotInterface: String
+        get() = prefs.getString("hotspot-interface", "")!!
+        set(value) = prefs.edit().putString("hotspot-interface", value).apply()
+
+    // Manual override for the head unit's own access point, used first by
+    // SoftApCredentialsProvider when nativeApTransport == 1. Empty = read the system's hotspot
+    // configuration instead. Worth having because getSoftApConfiguration() is reflection over a
+    // non-public API and can simply refuse on a locked-down API 30+ device.
     var hotspotSsid: String
         get() = prefs.getString("hotspot-ssid", "")!!
         set(value) = prefs.edit().putString("hotspot-ssid", value).apply()

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -1204,6 +1204,15 @@ class Settings(private val context: Context) {
         get() = prefs.getString("bluetooth-manager-service-name", "bluetooth_manager")!!
         set(value) = prefs.edit().putString("bluetooth-manager-service-name", value).apply()
 
+    // Whether the Native AA handshake opens with a WifiVersionRequest (Type 4), as real head units
+    // and the OEM ZLink app do, instead of going straight to WifiStartRequest. On by default:
+    // Android Auto 17.4 broke the abbreviated exchange for several reporters, and the version
+    // exchange is the documented difference. Turning it off restores the exact wire behaviour that
+    // shipped in 3.2.1, which is the escape hatch if a unit regresses on it.
+    var nativeWifiVersionExchange: Boolean
+        get() = prefs.getBoolean("native-wifi-version-exchange", true)
+        set(value) = prefs.edit().putBoolean("native-wifi-version-exchange", value).apply()
+
     // Manual fallback for dual-radio head units whose second radio isn't discoverable via
     // ServiceManager.listServices() at all. Empty = disabled (rely on automatic discovery only).
     var manualSecondaryBluetoothServiceName: String

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
@@ -146,6 +146,9 @@ object SettingsBackupManager {
         "wait-for-wifi-timeout" to ValueType.INT,
         "helper-connection-strategy" to ValueType.INT,
         "bluetooth-manager-service-name" to ValueType.STRING,
+        // The Native AA handshake escape hatch: a reporter who has to turn this off wants it
+        // to survive a reinstall, which is exactly when they are asked to export their settings.
+        "native-wifi-version-exchange" to ValueType.BOOLEAN,
         "use-libusb" to ValueType.BOOLEAN,
         // Custom loading screen display options. The picked image/video is copied into the app's
         // private storage, so the media path/type cannot be restored on another install and are not

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
@@ -149,6 +149,9 @@ object SettingsBackupManager {
         // The Native AA handshake escape hatch: a reporter who has to turn this off wants it
         // to survive a reinstall, which is exactly when they are asked to export their settings.
         "native-wifi-version-exchange" to ValueType.BOOLEAN,
+        // Selectable from the Android Auto mode block now that the route is wired.
+        "native-ap-transport" to ValueType.INT,
+        "hotspot-interface" to ValueType.STRING,
         "use-libusb" to ValueType.BOOLEAN,
         // Custom loading screen display options. The picked image/video is copied into the app's
         // private storage, so the media path/type cannot be restored on another install and are not

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
@@ -146,8 +146,8 @@ object SettingsBackupManager {
         "wait-for-wifi-timeout" to ValueType.INT,
         "helper-connection-strategy" to ValueType.INT,
         "bluetooth-manager-service-name" to ValueType.STRING,
-        // The Native AA handshake escape hatch: a reporter who has to turn this off wants it
-        // to survive a reinstall, which is exactly when they are asked to export their settings.
+        // The Native AA handshake opt-in: a reporter who found they need it wants it to survive a
+        // reinstall, which is exactly when they are asked to export their settings.
         "native-wifi-version-exchange" to ValueType.BOOLEAN,
         // Selectable from the Android Auto mode block now that the route is wired.
         "native-ap-transport" to ValueType.INT,

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/ShareHotspotQrDialog.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/ShareHotspotQrDialog.kt
@@ -1,8 +1,6 @@
 package com.andrerinas.openheadunit.utils
 
 import android.content.Context
-import android.net.wifi.WifiManager
-import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.view.LayoutInflater
@@ -29,7 +27,7 @@ object ShareHotspotQrDialog {
 
         fun loadAndRender() {
             if (switchShowQr == null || !switchShowQr.isChecked) return
-            val systemConfig = getSystemHotspotConfig(context)
+            val systemConfig = HotspotConfigReader.getSystemHotspotConfig(context)
             if (systemConfig != null && systemConfig.first.isNotEmpty()) {
                 val ssid = systemConfig.first
                 val pass = systemConfig.second
@@ -79,55 +77,5 @@ object ShareHotspotQrDialog {
             .setView(dialogView)
             .setPositiveButton(android.R.string.ok, null)
             .show()
-    }
-
-    private fun getSystemHotspotConfig(context: Context): Pair<String, String>? {
-        try {
-            val wm = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
-            
-            // 1. Try modern getSoftApConfiguration (API 30+)
-            if (Build.VERSION.SDK_INT >= 30) {
-                try {
-                    val getSoftApConfigurationMethod = wm.javaClass.getMethod("getSoftApConfiguration")
-                    val softApConfig = getSoftApConfigurationMethod.invoke(wm)
-                    if (softApConfig != null) {
-                        val getSsidMethod = softApConfig.javaClass.getMethod("getSsid")
-                        val getPassphraseMethod = softApConfig.javaClass.getMethod("getPassphrase")
-                        val ssid = getSsidMethod.invoke(softApConfig) as? String ?: ""
-                        val pass = getPassphraseMethod.invoke(softApConfig) as? String ?: ""
-                        if (ssid.isNotEmpty()) {
-                            return Pair(ssid, pass)
-                        }
-                    }
-                } catch (e: Exception) {
-                    AppLog.d("ShareHotspotQrDialog: Failed to get soft ap config via reflection: ${e.message}")
-                }
-            }
-            
-            // 2. Try legacy getWifiApConfiguration (API < 30)
-            try {
-                val getWifiApConfigurationMethod = wm.javaClass.getMethod("getWifiApConfiguration")
-                val wifiConfig = getWifiApConfigurationMethod.invoke(wm)
-                if (wifiConfig != null) {
-                    val ssidField = wifiConfig.javaClass.getField("SSID")
-                    val preSharedKeyField = wifiConfig.javaClass.getField("preSharedKey")
-                    val ssid = ssidField.get(wifiConfig) as? String ?: ""
-                    val pass = preSharedKeyField.get(wifiConfig) as? String ?: ""
-                    
-                    // Clean SSID quotes if present
-                    val cleanSsid = if (ssid.startsWith("\"") && ssid.endsWith("\"")) {
-                        ssid.substring(1, ssid.length - 1)
-                    } else {
-                        ssid
-                    }
-                    return Pair(cleanSsid, pass)
-                }
-            } catch (e: Exception) {
-                AppLog.d("ShareHotspotQrDialog: Failed to get wifi ap config via reflection: ${e.message}")
-            }
-        } catch (e: Exception) {
-            AppLog.e("ShareHotspotQrDialog: Failed to access WifiManager: ${e.message}")
-        }
-        return null
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SoftApStateReader.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SoftApStateReader.kt
@@ -1,0 +1,36 @@
+package com.andrerinas.openheadunit.utils
+
+import android.content.Context
+import android.net.wifi.WifiManager
+import com.andrerinas.openheadunit.aap.SoftApState
+
+/**
+ * Asks the framework whether this device is running an access point.
+ *
+ * `WifiManager.getWifiApState()` is the soft-AP counterpart to the public `getWifiState()`, but it
+ * is not public API, so it is reached by reflection and its constants are written out here. On
+ * devices where the non-SDK interface restrictions block it the call throws, which is reported as
+ * [SoftApState.UNKNOWN] rather than as "no access point" — a question we could not ask is not a
+ * question answered no, and callers treat the two very differently.
+ */
+object SoftApStateReader {
+
+    private const val WIFI_AP_STATE_ENABLED = 13
+
+    fun read(context: Context): SoftApState = try {
+        val wm = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+        when (val state = wm.javaClass.getMethod("getWifiApState").invoke(wm) as? Int) {
+            null -> SoftApState.UNKNOWN
+            WIFI_AP_STATE_ENABLED -> SoftApState.ENABLED
+            // 10 disabling, 11 disabled, 12 enabling, 14 failed. Enabling counts as not-yet:
+            // callers poll, and it resolves on a later pass.
+            else -> {
+                AppLog.d("SoftApStateReader: getWifiApState reports $state (13 = enabled).")
+                SoftApState.NOT_ENABLED
+            }
+        }
+    } catch (e: Exception) {
+        AppLog.d("SoftApStateReader: getWifiApState unavailable: ${e.message}")
+        SoftApState.UNKNOWN
+    }
+}

--- a/app/src/main/proto/wireless.proto
+++ b/app/src/main/proto/wireless.proto
@@ -61,8 +61,9 @@ message WifiInfoResponse {
 }
 
 // Type 4, head unit -> phone. Opens the modern handshake by declaring our protocol version. Real
-// head units send this first, aa-proxy-rs's dongle does not, hence the setting. Only major/minor
-// are defined — the rest is revision dependent and we never have to read one.
+// head units send this first, aa-proxy-rs's dongle does not, hence the setting — which is off by
+// default, the version below being a guess. Only major/minor are defined; the rest is revision
+// dependent and we never have to read one.
 message WifiVersionRequest {
     optional int32 major = 1;
     optional int32 minor = 2;

--- a/app/src/main/proto/wireless.proto
+++ b/app/src/main/proto/wireless.proto
@@ -2,6 +2,13 @@ syntax = "proto2";
 
 package com.andrerinas.openheadunit.aap.protocol.proto;
 
+// The Android Auto WiFi Projection Protocol, spoken over RFCOMM before the phone joins our
+// network. The "type N" in each comment is the message type from the wire header (see
+// WppFraming/WppMessageType), not a field number.
+//
+// Shapes cross-checked against aa-proxy-rs's src/bluetooth.rs and the OEM ZLink app. Fields we
+// never receive are left undefined on purpose: an absent field costs nothing, a wrong one
+// silently mis-parses.
 
 enum AccessPointType {
     STATIC = 0;
@@ -21,16 +28,78 @@ enum SecurityMode {
     WPA_WPA2_ENTERPRISE = 28;
 }
 
+// Type 1, head unit -> phone. Where to open the projection session once associated.
 message WifiStartRequest {
     required string ip_address = 1;
     required int32 port = 2;
     optional int32 status = 3;
 }
 
+// Type 2, phone -> head unit. Empty: the phone asking for the network credentials. Modelled so
+// the payload can be parsed rather than merely counted.
+message WifiInfoRequest {
+}
+
+// Type 3, head unit -> phone. The credentials themselves.
+//
+// bssid, security_mode and access_point_type were required. Optional now because a hotspot
+// cannot always resolve a real BSSID, and aa-proxy-rs omits the field outright when it has none.
+// Wire-compatible: proto2 encodes optional and required identically for a field that is set, so
+// this only drops a build()-time assertion.
 message WifiInfoResponse {
     required string ssid = 1;
     required string key = 2;
-    required string bssid = 3;
-    required SecurityMode security_mode = 4;
-    required AccessPointType access_point_type = 5;
+    optional string bssid = 3;
+    optional SecurityMode security_mode = 4;
+    optional AccessPointType access_point_type = 5;
+}
+
+// Type 4, head unit -> phone. Opens the modern handshake by declaring our protocol version. Real
+// head units send this first, aa-proxy-rs's dongle does not, hence the setting. Only major/minor
+// are defined — the rest is revision dependent and we never have to read one.
+message WifiVersionRequest {
+    optional int32 major = 1;
+    optional int32 minor = 2;
+}
+
+// Type 5, phone -> head unit. Parsed for the log only; nothing branches on it. status is int32:
+// a real phone answered -8 here, which a sint32 declaration rendered as 2147483644.
+message WifiVersionResponse {
+    optional int32 major = 1;
+    optional int32 minor = 2;
+    optional string device_serial = 3;
+    optional int32 status = 4;
+    optional int32 selected_wifi_channel_type = 5;
+}
+
+// Type 6, phone -> head unit: did it get onto our network. The only join feedback that works on
+// both transports — WiFi Direct also has the P2P client list, a hotspot has no public equivalent.
+// Observed 0 for success. Plain int32, not sint32: a capture of a real phone's type 5 carried -8,
+// which read back as 2147483644 while these were declared sint32 (zigzag). Only ==0 vs !=0 is
+// branched on either way, so that was a wrong log number rather than a wrong decision.
+message WifiConnectStatus {
+    optional int32 status = 1;
+}
+
+// Type 7, phone -> head unit. Acknowledges type 1 and reports the address it will connect from.
+// Field 2 is unclaimed on purpose — it is not observed and guessing at it would mis-parse.
+message WifiStartResponse {
+    optional string ip_address = 1;
+    optional int32 status = 3;
+}
+
+// Types 8 and 9: a keepalive the phone may interject anywhere. We answer type 8 by echoing its
+// raw payload as a type 9 without parsing, so these are for reading captures, not for the reply.
+message WifiPingRequest {
+    optional int64 timestamp = 1;
+}
+
+message WifiPingResponse {
+    optional int64 timestamp = 1;
+}
+
+// Type 11. Defined so a capture can be read; not sent.
+message WifiSetupInfo {
+    optional int32 major = 1;
+    optional int32 minor = 2;
 }

--- a/app/src/main/proto/wireless.proto
+++ b/app/src/main/proto/wireless.proto
@@ -42,10 +42,16 @@ message WifiInfoRequest {
 
 // Type 3, head unit -> phone. The credentials themselves.
 //
-// bssid, security_mode and access_point_type were required. Optional now because a hotspot
-// cannot always resolve a real BSSID, and aa-proxy-rs omits the field outright when it has none.
-// Wire-compatible: proto2 encodes optional and required identically for a field that is set, so
-// this only drops a build()-time assertion.
+// bssid, security_mode and access_point_type are `required` in the schema every other
+// implementation uses — aa-proxy-rs and WirelessAndroidAutoDongle ship byte-identical copies of it.
+// Relaxed to optional here so a truncated or future message still parses rather than throwing, and
+// that is the only reason. Wire-compatible either way: proto2 encodes optional and required
+// identically for a field that is set.
+//
+// It does not license leaving one out. Send all five, always — an empty bssid where there is no
+// real one, as aa-proxy-rs does on the one path where it has none. A field the reference schema
+// calls required is one a strict parser on the phone may refuse the whole message over, and that
+// failure would look nothing like the credentials being wrong.
 message WifiInfoResponse {
     required string ssid = 1;
     required string key = 2;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -801,6 +801,16 @@
     <string name="select_bt_adapter">Select Bluetooth Adapter</string>
     <string name="manual_secondary_bt_service_title">Manual Secondary Radio</string>
     <string name="manual_secondary_bt_service_message">Advanced: force an extra Bluetooth radio, for dual-radio units whose second radio isn\'t found automatically. Find it via \"adb shell service list\" (look for a Bluetooth-sounding entry besides bluetooth_manager) or an engineering menu, then paste either the name before the colon or the interface shown in brackets - both work. Not guaranteed to help on every unit: some head units run a customized Bluetooth stack that this can\'t bridge to no matter what you enter here. Leave blank to disable.</string>
+    <string name="native_ap_transport">Network transport</string>
+    <string name="native_ap_transport_wifi_direct">WiFi Direct</string>
+    <string name="native_ap_transport_hotspot">Hotspot</string>
+    <string name="native_ap_transport_hint">Experimental. The phone joins this device\'s own hotspot instead of a WiFi Direct group. Switch the hotspot on yourself before connecting, and set it to 5 GHz - Android Auto video is poor over 2.4 GHz. If the network name cannot be read automatically, enter it below.</string>
+    <string name="hotspot_interface_override">Hotspot network interface</string>
+    <string name="hotspot_interface_override_message">Leave blank to work it out automatically. Set this if the log says more than one interface could be the access point, or picks the wrong one. The name is the one the log reports after &quot;Providing credentials from&quot;, or the entry holding your hotspot\'s address in &quot;ip -brief addr&quot; from a shell. Common names: ap0, wlan0, wlan1, wlan2, softap0, ra0.</string>
+    <string name="hotspot_ssid_override">Hotspot name (manual)</string>
+    <string name="hotspot_ssid_override_message">Leave blank to read the name from this device\'s hotspot settings automatically. Some devices do not let apps read it - if the log says the name could not be read, type it here exactly as it appears in your hotspot settings.</string>
+    <string name="hotspot_password_override">Hotspot password (manual)</string>
+    <string name="hotspot_password_override_message">Leave blank to read the password automatically. Needed on devices that do not let apps read the hotspot configuration. The phone will be given this password to join.</string>
     <string name="native_wifi_version_exchange">Modern handshake (version exchange)</string>
     <string name="native_wifi_version_exchange_description">Opens the Bluetooth handshake by telling the phone which protocol version this head unit speaks, the way factory head units do, instead of going straight to the connection details. Leave on unless wireless worked before an update and stopped: turning it off restores the older, shorter exchange.</string>
     <!-- QR Code Generator -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -600,6 +600,9 @@
     <string name="reset_usb_option">Reset USB Connection</string>
     <string name="reset_usb_timeout">USB device not found. Please check connection.</string>
     <string name="notification_service_running">Open Headunit is running</string>
+    <string name="boot_loop_paused_title">Wireless start-up paused</string>
+    <string name="boot_loop_paused_generic">This device restarted three times in a row shortly after Open Headunit started wireless, so wireless was left off this time. USB still works. Open the app to turn it back on.</string>
+    <string name="boot_loop_paused_native_wifi_direct">This device restarted three times in a row shortly after Open Headunit started wireless, so wireless was left off this time. On some head units the WiFi chipset takes the whole system down when a phone joins a WiFi Direct network. Try switching Android Auto mode to the head unit hotspot. USB still works.</string>
     <string name="notification_projection_active">Android Auto is projected</string>
     <string name="shortcut_connect_title">Connect</string>
     <string name="shortcut_connect_desc">Auto-connect to last phone</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -804,7 +804,7 @@
     <string name="native_ap_transport">Network transport</string>
     <string name="native_ap_transport_wifi_direct">WiFi Direct</string>
     <string name="native_ap_transport_hotspot">Hotspot</string>
-    <string name="native_ap_transport_hint">Experimental. The phone joins this device\'s own hotspot instead of a WiFi Direct group. Switch the hotspot on yourself before connecting, and set it to 5 GHz - Android Auto video is poor over 2.4 GHz. If the network name cannot be read automatically, enter it below.</string>
+    <string name="native_ap_transport_hint">Experimental. The phone joins this device\'s own hotspot instead of a WiFi Direct group. Switch the hotspot on yourself before connecting, and set it to 5 GHz if you can - over 2.4 GHz the phone connects and then drops the session repeatedly without any picture, unless you lower the resolution and frame rate. If the network name cannot be read automatically, enter it below.</string>
     <string name="hotspot_interface_override">Hotspot network interface</string>
     <string name="hotspot_interface_override_message">Leave blank to work it out automatically. Set this if the log says more than one interface could be the access point, or picks the wrong one. The name is the one the log reports after &quot;Providing credentials from&quot;, or the entry holding your hotspot\'s address in &quot;ip -brief addr&quot; from a shell. Common names: ap0, wlan0, wlan1, wlan2, softap0, ra0.</string>
     <string name="hotspot_ssid_override">Hotspot name (manual)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -801,6 +801,8 @@
     <string name="select_bt_adapter">Select Bluetooth Adapter</string>
     <string name="manual_secondary_bt_service_title">Manual Secondary Radio</string>
     <string name="manual_secondary_bt_service_message">Advanced: force an extra Bluetooth radio, for dual-radio units whose second radio isn\'t found automatically. Find it via \"adb shell service list\" (look for a Bluetooth-sounding entry besides bluetooth_manager) or an engineering menu, then paste either the name before the colon or the interface shown in brackets - both work. Not guaranteed to help on every unit: some head units run a customized Bluetooth stack that this can\'t bridge to no matter what you enter here. Leave blank to disable.</string>
+    <string name="native_wifi_version_exchange">Modern handshake (version exchange)</string>
+    <string name="native_wifi_version_exchange_description">Opens the Bluetooth handshake by telling the phone which protocol version this head unit speaks, the way factory head units do, instead of going straight to the connection details. Leave on unless wireless worked before an update and stopped: turning it off restores the older, shorter exchange.</string>
     <!-- QR Code Generator -->
     <string name="share_hotspot_qr_title">Configure Wireless Helper</string>
     <string name="share_hotspot_qr_desc">Show QR Code for phone auto-connection</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -812,7 +812,7 @@
     <string name="hotspot_password_override">Hotspot password (manual)</string>
     <string name="hotspot_password_override_message">Leave blank to read the password automatically. Needed on devices that do not let apps read the hotspot configuration. The phone will be given this password to join.</string>
     <string name="native_wifi_version_exchange">Modern handshake (version exchange)</string>
-    <string name="native_wifi_version_exchange_description">Opens the Bluetooth handshake by telling the phone which protocol version this head unit speaks, the way factory head units do, instead of going straight to the connection details. Leave on unless wireless worked before an update and stopped: turning it off restores the older, shorter exchange.</string>
+    <string name="native_wifi_version_exchange_description">Opens the Bluetooth handshake by telling the phone which protocol version this head unit speaks, the way factory head units do, instead of going straight to the connection details. Off by default. Worth trying if wireless worked before an Android Auto update and has failed since; if it makes no difference, turn it back off.</string>
     <!-- QR Code Generator -->
     <string name="share_hotspot_qr_title">Configure Wireless Helper</string>
     <string name="share_hotspot_qr_desc">Show QR Code for phone auto-connection</string>

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/BootLoopPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/BootLoopPolicyTest.kt
@@ -1,0 +1,73 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BootLoopPolicyTest {
+
+    /**
+     * Replays a run of boot-started lifetimes in milliseconds and returns the strike count left
+     * behind, the way the receiver and the service between them maintain it: every boot-started run
+     * takes a strike on the way in, and clears the count if it survives long enough.
+     */
+    private fun strikesAfter(vararg runLengthsMs: Long): Int =
+        runLengthsMs.fold(0) { strikes, runMs ->
+            val taken = BootLoopPolicy.nextStrikes(strikes)
+            if (BootLoopPolicy.clearsStrikes(runMs)) 0 else taken
+        }
+
+    @Test
+    fun `strikes accumulate across runs that die young`() {
+        assertEquals(1, strikesAfter(8_000))
+        assertEquals(2, strikesAfter(8_000, 9_000))
+        assertEquals(3, strikesAfter(8_000, 9_000, 10_000))
+    }
+
+    @Test
+    fun `the third short run pauses wireless, the first two do not`() {
+        assertFalse(BootLoopPolicy.shouldPauseWireless(strikesAfter(8_000)))
+        assertFalse(BootLoopPolicy.shouldPauseWireless(strikesAfter(8_000, 9_000)))
+        assertTrue(BootLoopPolicy.shouldPauseWireless(strikesAfter(8_000, 9_000, 10_000)))
+    }
+
+    @Test
+    fun `a run that survives clears the count`() {
+        assertEquals(0, strikesAfter(8_000, 9_000, 60_000))
+        assertFalse(BootLoopPolicy.shouldPauseWireless(strikesAfter(8_000, 9_000, 60_000)))
+    }
+
+    @Test
+    fun `the healthy threshold is a floor, not a target`() {
+        assertFalse(BootLoopPolicy.clearsStrikes(BootLoopPolicy.HEALTHY_RUN_MS - 1))
+        assertTrue(BootLoopPolicy.clearsStrikes(BootLoopPolicy.HEALTHY_RUN_MS))
+    }
+
+    @Test
+    fun `the reported crash loop trips the guard`() {
+        // Process lifetimes measured from the #774 logs: the first cycle reached a full session
+        // with audio before the system died, the rest never got that far.
+        assertTrue(BootLoopPolicy.shouldPauseWireless(strikesAfter(173_000, 8_000, 9_000, 15_000)))
+        // Same unit on 3.2.1, three cycles.
+        assertTrue(BootLoopPolicy.shouldPauseWireless(strikesAfter(48_000, 10_000, 15_000)))
+    }
+
+    @Test
+    fun `an ordinary run of short trips does not trip it`() {
+        // Every trip long enough to clear on its own, however many there are.
+        assertEquals(0, strikesAfter(45_000, 90_000, 31_000, 120_000))
+    }
+
+    @Test
+    fun `a single bad boot between good ones is forgiven`() {
+        assertEquals(0, strikesAfter(60_000, 5_000, 60_000))
+        assertFalse(BootLoopPolicy.shouldPauseWireless(strikesAfter(60_000, 5_000, 60_000)))
+    }
+
+    @Test
+    fun `a corrupt or absent stored count starts a fresh run`() {
+        assertEquals(1, BootLoopPolicy.nextStrikes(-4))
+        assertEquals(1, BootLoopPolicy.nextStrikes(0))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/BootLoopPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/BootLoopPolicyTest.kt
@@ -45,12 +45,27 @@ class BootLoopPolicyTest {
     }
 
     @Test
-    fun `the reported crash loop trips the guard`() {
-        // Process lifetimes measured from the #774 logs: the first cycle reached a full session
-        // with audio before the system died, the rest never got that far.
-        assertTrue(BootLoopPolicy.shouldPauseWireless(strikesAfter(173_000, 8_000, 9_000, 15_000)))
-        // Same unit on 3.2.1, three cycles.
-        assertTrue(BootLoopPolicy.shouldPauseWireless(strikesAfter(48_000, 10_000, 15_000)))
+    fun `the reported crash loop pauses wireless on the fourth boot`() {
+        // Process lifetimes measured from HUR_Log_20260804: 173.3 s, which reached a complete
+        // projection session with audio before the system died, then 7.8 s and 9.2 s. The guard
+        // is read at the start of a run, so the fourth process is the one that comes up paused.
+        val beforeFourthBoot = strikesAfter(173_300, 7_800, 9_200)
+
+        assertEquals(2, beforeFourthBoot)
+        assertTrue(BootLoopPolicy.shouldPauseWireless(BootLoopPolicy.nextStrikes(beforeFourthBoot)))
+    }
+
+    @Test
+    fun `the 3 2 1 log ends one cycle short of the guard`() {
+        // HUR_Log_20260805, same unit: 48.1 s, 9.8 s, 15.2 s, and there the reporter stopped
+        // recording. The 48 s run clears, so the export runs out two strikes in. Recorded as
+        // measured rather than padded to a trip — the third failure is not in the log, and this
+        // test exists to replay what was observed.
+        val atEndOfLog = strikesAfter(48_100, 9_800, 15_200)
+
+        assertEquals(2, atEndOfLog)
+        assertFalse(BootLoopPolicy.shouldPauseWireless(atEndOfLog))
+        assertTrue(BootLoopPolicy.shouldPauseWireless(BootLoopPolicy.nextStrikes(atEndOfLog)))
     }
 
     @Test

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/NativeCredentialsPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/NativeCredentialsPolicyTest.kt
@@ -35,7 +35,7 @@ class NativeCredentialsPolicyTest {
         // an ordinary access point is identified by SSID. Aborting here would make the route
         // unusable on every device whose AP MAC is masked, which is most of them.
         assertEquals(
-            UnusableBssidAction.OMIT_AND_CONTINUE,
+            UnusableBssidAction.SEND_WITH_EMPTY_BSSID,
             NativeCredentialsPolicy.onUnusableBssid(NativeTransport.HOTSPOT)
         )
     }

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/NativeCredentialsPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/NativeCredentialsPolicyTest.kt
@@ -1,0 +1,79 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeCredentialsPolicyTest {
+
+    @Test
+    fun `a real address is usable and a masked or missing one is not`() {
+        assertTrue(NativeCredentialsPolicy.isUsableBssid("AA:BB:CC:DD:EE:FF"))
+        assertTrue(NativeCredentialsPolicy.isUsableBssid("02:1a:2b:3c:4d:5e"))
+
+        assertFalse(NativeCredentialsPolicy.isUsableBssid(null))
+        assertFalse(NativeCredentialsPolicy.isUsableBssid(""))
+        assertFalse(NativeCredentialsPolicy.isUsableBssid("00:00:00:00:00:00"))
+        assertFalse(NativeCredentialsPolicy.isUsableBssid("02:00:00:00:00:00"))
+    }
+
+    @Test
+    fun `WiFi Direct aborts rather than send credentials the phone will reject`() {
+        // Measured behaviour, not caution: a masked BSSID on the P2P path means the join fails
+        // anyway, and the usual cause — location services off — is something the user can fix
+        // once the log tells them to.
+        assertEquals(
+            UnusableBssidAction.ABORT,
+            NativeCredentialsPolicy.onUnusableBssid(NativeTransport.WIFI_DIRECT)
+        )
+    }
+
+    @Test
+    fun `the hotspot route sends them anyway, without the field`() {
+        // aa-proxy-rs omits the BSSID when it has none, and the OEM ZLink app ships without one:
+        // an ordinary access point is identified by SSID. Aborting here would make the route
+        // unusable on every device whose AP MAC is masked, which is most of them.
+        assertEquals(
+            UnusableBssidAction.OMIT_AND_CONTINUE,
+            NativeCredentialsPolicy.onUnusableBssid(NativeTransport.HOTSPOT)
+        )
+    }
+
+    @Test
+    fun `an interface we guessed at is not advertised when no access point is running`() {
+        // Measured on a Unisoc unit: with the real AP down, the cellular bridge seth_lte0 was the
+        // only interface up with a private address, so the right network name went out paired with
+        // an address no phone could reach — and the log said SUCCESS.
+        assertFalse(NativeCredentialsPolicy.shouldPublishCredentials(SoftApState.NOT_ENABLED, false))
+    }
+
+    @Test
+    fun `naming the interface overrides the state read`() {
+        // The escape hatch for a vendor that starts hostapd outside the framework, where the state
+        // read is silent while the access point is plainly there.
+        assertTrue(NativeCredentialsPolicy.shouldPublishCredentials(SoftApState.NOT_ENABLED, true))
+    }
+
+    @Test
+    fun `not being able to ask is never treated as an answer`() {
+        // getWifiApState is not public API and is blocked outright on some devices. Refusing there
+        // would break the route on every one of them.
+        assertTrue(NativeCredentialsPolicy.shouldPublishCredentials(SoftApState.UNKNOWN, false))
+        assertTrue(NativeCredentialsPolicy.shouldPublishCredentials(SoftApState.UNKNOWN, true))
+    }
+
+    @Test
+    fun `a running access point publishes however the interface was chosen`() {
+        assertTrue(NativeCredentialsPolicy.shouldPublishCredentials(SoftApState.ENABLED, false))
+        assertTrue(NativeCredentialsPolicy.shouldPublishCredentials(SoftApState.ENABLED, true))
+    }
+
+    @Test
+    fun `the transport setting maps over, and anything unrecognised stays on the default`() {
+        assertEquals(NativeTransport.WIFI_DIRECT, NativeTransport.fromSetting(0))
+        assertEquals(NativeTransport.HOTSPOT, NativeTransport.fromSetting(1))
+        assertEquals(NativeTransport.WIFI_DIRECT, NativeTransport.fromSetting(-1))
+        assertEquals(NativeTransport.WIFI_DIRECT, NativeTransport.fromSetting(99))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicyTest.kt
@@ -56,9 +56,9 @@ class NativeHandoffPolicyTest {
 
     @Test
     fun `handshake expires so a coroutine that never unwinds cannot latch it true`() {
-        // #706: on that head unit closing the socket does not unblock the pending read, so
-        // handleHandshake()'s cleanup never runs. Without this bound the old boolean stayed true
-        // for the life of the process, stopping the wake poke and the P2P join watchdog.
+        // Where closing the socket does not unblock the pending read, handleHandshake()'s cleanup
+        // never runs. Unbounded, the old boolean stayed true for the life of the process and took
+        // the wake poke and the P2P join watchdog down with it.
         assertFalse(
             NativeHandoffPolicy.isHandshaking(startedAtMs = 1_000L, nowMs = 1_000L + handshakeTimeout)
         )
@@ -92,8 +92,8 @@ class NativeHandoffPolicyTest {
 
     @Test
     fun `poke is blocked while a handoff is settling`() {
-        // The #760 case: the phone joining the group re-delivers credentials, which re-invokes
-        // triggerPoke() straight into the phone's DHCP exchange.
+        // The phone joining the group re-delivers credentials, which re-invokes triggerPoke()
+        // straight into the phone's DHCP exchange.
         assertFalse(
             NativeHandoffPolicy.shouldPoke(
                 settling = true, handshakeInFlight = false, sessionConnected = false

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/NativeHandoffPolicyTest.kt
@@ -1,5 +1,6 @@
 package com.andrerinas.openheadunit.aap
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -10,6 +11,20 @@ class NativeHandoffPolicyTest {
     private val handshakeTimeout = NativeHandoffPolicy.HANDSHAKE_TIMEOUT_MS
     private val silentPokeInterval = NativeHandoffPolicy.SILENT_POKE_WARN_INTERVAL
     private val maxFailures = NativeHandoffPolicy.MAX_CONSECUTIVE_HANDSHAKE_FAILURES
+
+    @Test
+    fun `the settle cap leaves room for extensions but is not open-ended`() {
+        // The phone's own progress reports (WifiConnectStatus) push the settling deadline out in
+        // SETTLE_EXTENSION_MS steps. The cap has to be reachable in whole steps from the base
+        // window — otherwise the last extension is silently refused at an arbitrary point — and it
+        // has to be finite, so a phone that keeps saying "still joining" and never arrives cannot
+        // hold Bluetooth open and the wake poke suppressed forever.
+        assertTrue(NativeHandoffPolicy.MAX_SETTLE_MS > timeout)
+        assertEquals(
+            0L,
+            (NativeHandoffPolicy.MAX_SETTLE_MS - timeout) % WppHandshakeSession.SETTLE_EXTENSION_MS
+        )
+    }
 
     @Test
     fun `no handoff is settling before any credentials go out`() {

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/SoftApBssidPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/SoftApBssidPolicyTest.kt
@@ -1,0 +1,101 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SoftApBssidPolicyTest {
+
+    @Test
+    fun `the user's own setting wins, and is normalised to upper case`() {
+        assertEquals(
+            "AA:BB:CC:DD:EE:FF",
+            SoftApBssidPolicy.choose(
+                staticOverride = " aa:bb:cc:dd:ee:ff ",
+                shellMac = "11:22:33:44:55:66",
+                hardwareAddress = "77:88:99:aa:bb:cc"
+            )
+        )
+    }
+
+    @Test
+    fun `a masked rung falls through to the next one`() {
+        assertEquals(
+            "11:22:33:44:55:66",
+            SoftApBssidPolicy.choose(
+                staticOverride = "02:00:00:00:00:00",
+                shellMac = "11:22:33:44:55:66",
+                hardwareAddress = null
+            )
+        )
+        assertEquals(
+            "77:88:99:AA:BB:CC",
+            SoftApBssidPolicy.choose(
+                staticOverride = "",
+                shellMac = "00:00:00:00:00:00",
+                hardwareAddress = "77:88:99:aa:bb:cc"
+            )
+        )
+    }
+
+    @Test
+    fun `all rungs failing yields the empty string, not a placeholder`() {
+        // Sending a placeholder is worse than sending nothing: the phone rejects it, and the
+        // hotspot route is allowed to omit the field entirely.
+        assertEquals("", SoftApBssidPolicy.choose(null, null, null))
+        assertEquals("", SoftApBssidPolicy.choose("", "  ", "02:00:00:00:00:00"))
+    }
+
+    @Test
+    fun `a randomised locally-administered address is a real address`() {
+        // Android's own soft AP routinely uses one. Rejecting everything starting with 02: would
+        // throw away the BSSID this whole chain exists to find.
+        assertTrue(SoftApBssidPolicy.isUsable("02:1A:2B:3C:4D:5E"))
+        assertEquals("02:1A:2B:3C:4D:5E", SoftApBssidPolicy.choose("02:1a:2b:3c:4d:5e", null, null))
+    }
+
+    @Test
+    fun `the settings default of "0" is not an address`() {
+        // staticBSSID stores "0" when unset. It is not MAC-shaped, so a placeholder blacklist let
+        // it through, and being first in the chain it beat the real interface MAC and went out as
+        // BSSID=0 — which the phone rejected on every retry.
+        assertFalse(SoftApBssidPolicy.isUsable("0"))
+        assertEquals(
+            "11:22:33:44:55:66",
+            SoftApBssidPolicy.choose(staticOverride = "0", shellMac = "11:22:33:44:55:66", hardwareAddress = null)
+        )
+    }
+
+    @Test
+    fun `anything that is not shaped like an address is refused`() {
+        assertFalse(SoftApBssidPolicy.isUsable("auto"))
+        assertFalse(SoftApBssidPolicy.isUsable("192.168.1.1"))
+        assertFalse(SoftApBssidPolicy.isUsable("aa:bb:cc:dd:ee"))
+        assertFalse(SoftApBssidPolicy.isUsable("aa:bb:cc:dd:ee:ff:00"))
+        assertFalse(SoftApBssidPolicy.isUsable("gg:bb:cc:dd:ee:ff"))
+        assertFalse(SoftApBssidPolicy.isUsable("aabbccddeeff"))
+    }
+
+    @Test
+    fun `a hand-typed address with dashes is accepted and normalised`() {
+        assertTrue(SoftApBssidPolicy.isUsable("aa-bb-cc-dd-ee-ff"))
+        assertEquals(
+            "AA:BB:CC:DD:EE:FF",
+            SoftApBssidPolicy.choose(staticOverride = "aa-bb-cc-dd-ee-ff", shellMac = null, hardwareAddress = null)
+        )
+        // A dash-written placeholder is still a placeholder.
+        assertFalse(SoftApBssidPolicy.isUsable("02-00-00-00-00-00"))
+    }
+
+    @Test
+    fun `the two masking placeholders and blanks are not usable`() {
+        assertFalse(SoftApBssidPolicy.isUsable(null))
+        assertFalse(SoftApBssidPolicy.isUsable(""))
+        assertFalse(SoftApBssidPolicy.isUsable("   "))
+        assertFalse(SoftApBssidPolicy.isUsable("00:00:00:00:00:00"))
+        assertFalse(SoftApBssidPolicy.isUsable("02:00:00:00:00:00"))
+        assertFalse(SoftApBssidPolicy.isUsable("02:00:00:00:00:00 "))
+        assertFalse("case must not smuggle a placeholder through", SoftApBssidPolicy.isUsable("02:00:00:00:00:00".uppercase()))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/SoftApNetworkPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/SoftApNetworkPolicyTest.kt
@@ -1,0 +1,208 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SoftApNetworkPolicyTest {
+
+    private fun iface(
+        name: String,
+        up: Boolean = true,
+        loopback: Boolean = false,
+        ipv4: String? = "192.168.43.1"
+    ) = ApInterfaceCandidate(name, isLoopback = loopback, isUp = up, siteLocalIpv4 = ipv4)
+
+    @Test
+    fun `a dedicated access point interface wins over the station one`() {
+        val picked = SoftApNetworkPolicy.pickApInterface(
+            listOf(iface("wlan0", ipv4 = "192.168.1.55"), iface("ap0"))
+        )
+
+        assertEquals("ap0", picked?.name)
+    }
+
+    @Test
+    fun `the vendor spellings are all recognised, in preference order`() {
+        assertEquals("ap0", SoftApNetworkPolicy.pickApInterface(
+            listOf(iface("wlan0"), iface("softap0"), iface("swlan0"), iface("ap0"))
+        )?.name)
+        assertEquals("swlan0", SoftApNetworkPolicy.pickApInterface(
+            listOf(iface("wlan0"), iface("softap0"), iface("swlan0"))
+        )?.name)
+        assertEquals("softap0", SoftApNetworkPolicy.pickApInterface(
+            listOf(iface("wlan0"), iface("softap0"))
+        )?.name)
+    }
+
+    @Test
+    fun `a plain wlan0 is used when it is all there is`() {
+        // The OEM ZLink head unit serves Android Auto off exactly this.
+        assertEquals("wlan0", SoftApNetworkPolicy.pickApInterface(listOf(iface("wlan0")))?.name)
+    }
+
+    @Test
+    fun `an unfamiliar name is still usable, it just loses to a familiar one`() {
+        assertEquals("eth_ap", SoftApNetworkPolicy.pickApInterface(listOf(iface("eth_ap")))?.name)
+        assertEquals(
+            "wlan0",
+            SoftApNetworkPolicy.pickApInterface(listOf(iface("eth_ap"), iface("wlan0")))?.name
+        )
+    }
+
+    @Test
+    fun `the station interface is excluded, which is what separates it from the access point`() {
+        // The shape measured on a real head unit: the soft AP runs as wlan2 holding
+        // 192.168.246.32 while wlan0 is the station. They are indistinguishable by name, and the
+        // AP's address is not a .1 gateway, so the station address is the only thing to go on.
+        val picked = SoftApNetworkPolicy.pickApInterface(
+            listOf(iface("wlan0", ipv4 = "192.168.1.55"), iface("wlan2", ipv4 = "192.168.246.32")),
+            stationIpv4 = "192.168.1.55"
+        )
+
+        assertEquals("wlan2", picked?.name)
+    }
+
+    @Test
+    fun `an access point is picked whatever address it holds`() {
+        // Not every soft AP takes the .1 of its subnet - the tested unit does not.
+        for (ip in listOf("192.168.43.1", "192.168.246.32", "10.0.0.7")) {
+            assertEquals(ip, "wlan2", SoftApNetworkPolicy.pickApInterface(listOf(iface("wlan2", ipv4 = ip)))?.name)
+        }
+    }
+
+    @Test
+    fun `with no station to exclude the name preference decides`() {
+        assertEquals(
+            "ap0",
+            SoftApNetworkPolicy.pickApInterface(
+                listOf(iface("wlan0", ipv4 = "192.168.1.55"), iface("ap0", ipv4 = "192.168.5.9"))
+            )?.name
+        )
+    }
+
+    @Test
+    fun `excluding the station cannot leave us with nothing to advertise`() {
+        // Only the station is up: there is no access point, and saying so beats handing the phone
+        // the address of a network it is already on.
+        assertNull(
+            SoftApNetworkPolicy.pickApInterface(
+                listOf(iface("wlan0", ipv4 = "192.168.1.55")),
+                stationIpv4 = "192.168.1.55"
+            )
+        )
+    }
+
+    @Test
+    fun `isApHost answers for a single interface on the same rules`() {
+        assertTrue(SoftApNetworkPolicy.isApHost(iface("wlan2", ipv4 = "192.168.246.32")))
+        assertFalse(
+            SoftApNetworkPolicy.isApHost(iface("wlan0", ipv4 = "192.168.1.55"), stationIpv4 = "192.168.1.55")
+        )
+        assertFalse(SoftApNetworkPolicy.isApHost(iface("tun0", ipv4 = "10.14.208.1")))
+        assertFalse(SoftApNetworkPolicy.isApHost(iface("wlan2", up = false)))
+    }
+
+    @Test
+    fun `a WiFi Direct group is never mistaken for our access point`() {
+        // That is the other transport, with its own credential source.
+        assertNull(SoftApNetworkPolicy.pickApInterface(listOf(iface("p2p-wlan0-7"))))
+    }
+
+    @Test
+    fun `a MediaTek AP client is a station, not an access point`() {
+        // apcli0 is the interface that joins someone else's network; ra0 is the access point. It
+        // starts with "ap", so without the exclusion it would rank best of everything.
+        assertEquals(
+            "ra0",
+            SoftApNetworkPolicy.pickApInterface(
+                listOf(iface("apcli0", ipv4 = "192.168.1.55"), iface("ra0", ipv4 = "192.168.43.1"))
+            )?.name
+        )
+        assertNull(SoftApNetworkPolicy.pickApInterface(listOf(iface("apcli0"))))
+        assertFalse(SoftApNetworkPolicy.isApHost(iface("apcli0")))
+    }
+
+    @Test
+    fun `a cellular bridge is not an access point`() {
+        // The live shape from a Unisoc head unit: the real AP (wlan2) was down, and seth_lte0 was
+        // up with a private address, so it was the only candidate and got advertised as the
+        // network the phone should join.
+        assertNull(
+            SoftApNetworkPolicy.pickApInterface(listOf(iface("seth_lte0", ipv4 = "10.72.44.51")))
+        )
+        assertEquals(
+            "wlan2",
+            SoftApNetworkPolicy.pickApInterface(
+                listOf(iface("seth_lte0", ipv4 = "10.72.44.51"), iface("wlan2", ipv4 = "192.168.246.32"))
+            )?.name
+        )
+    }
+
+    @Test
+    fun `an interface named for the station role is excluded`() {
+        assertNull(SoftApNetworkPolicy.pickApInterface(listOf(iface("sta0"))))
+        assertEquals(
+            "wlan0",
+            SoftApNetworkPolicy.pickApInterface(listOf(iface("sta0"), iface("wlan0")))?.name
+        )
+    }
+
+    @Test
+    fun `an unrecognised access point still wins once the stations are excluded`() {
+        // ra0/rai0 are deliberately not in the preferred list; they do not need to be.
+        assertEquals("ra0", SoftApNetworkPolicy.pickApInterface(listOf(iface("ra0")))?.name)
+        assertEquals("rai0", SoftApNetworkPolicy.pickApInterface(listOf(iface("rai0")))?.name)
+    }
+
+    @Test
+    fun `eligible reports what the choice was made from`() {
+        val candidates = listOf(
+            iface("wlan0", ipv4 = "192.168.1.55"),
+            iface("wlan2", ipv4 = "192.168.246.32"),
+            iface("p2p-wlan0-3"),
+            iface("lo", loopback = true)
+        )
+
+        // Two survivors means the name broke the tie, which is worth saying out loud.
+        assertEquals(2, SoftApNetworkPolicy.eligible(candidates).size)
+        assertEquals(1, SoftApNetworkPolicy.eligible(candidates, stationIpv4 = "192.168.1.55").size)
+    }
+
+    @Test
+    fun `this app's own VPN interface is not an access point`() {
+        // The github flavour parks a dummy VPN on the device. It is up and holds a site-local
+        // address, so nothing but the name excludes it.
+        assertNull(SoftApNetworkPolicy.pickApInterface(listOf(iface("tun0", ipv4 = "10.14.208.1"))))
+        assertNull(SoftApNetworkPolicy.pickApInterface(listOf(iface("dummy0", ipv4 = "10.0.0.1"))))
+        assertEquals(
+            "wlan2",
+            SoftApNetworkPolicy.pickApInterface(
+                listOf(iface("tun0", ipv4 = "10.14.208.1"), iface("wlan2", ipv4 = "192.168.43.1"))
+            )?.name
+        )
+    }
+
+    @Test
+    fun `loopback, down and address-less interfaces are all excluded`() {
+        assertNull(SoftApNetworkPolicy.pickApInterface(listOf(iface("lo", loopback = true, ipv4 = "127.0.0.1"))))
+        assertNull(SoftApNetworkPolicy.pickApInterface(listOf(iface("ap0", up = false))))
+        assertNull(SoftApNetworkPolicy.pickApInterface(listOf(iface("ap0", ipv4 = null))))
+    }
+
+    @Test
+    fun `nothing at all yields nothing`() {
+        assertNull(SoftApNetworkPolicy.pickApInterface(emptyList()))
+    }
+
+    @Test
+    fun `an excluded preferred interface does not shadow a usable unpreferred one`() {
+        val picked = SoftApNetworkPolicy.pickApInterface(
+            listOf(iface("ap0", up = false), iface("wlan0"))
+        )
+
+        assertEquals("wlan0", picked?.name)
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/VideoStarvationPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/VideoStarvationPolicyTest.kt
@@ -1,0 +1,65 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VideoStarvationPolicyTest {
+
+    private fun streakAfter(vararg sessions: Pair<Boolean, Boolean>): Int =
+        sessions.fold(0) { streak, (reachedHandshake, rendered) ->
+            VideoStarvationPolicy.nextStreak(streak, reachedHandshake, rendered)
+        }
+
+    private val starved = true to false
+    private val healthy = true to true
+    private val neverConnected = false to false
+
+    @Test
+    fun `a starved session lengthens the streak`() {
+        assertEquals(1, streakAfter(starved))
+        assertEquals(3, streakAfter(starved, starved, starved))
+    }
+
+    @Test
+    fun `one rendered frame clears it`() {
+        assertEquals(0, streakAfter(starved, starved, healthy))
+    }
+
+    @Test
+    fun `a session that never handshook neither counts nor clears`() {
+        assertEquals(2, streakAfter(starved, starved, neverConnected))
+        assertEquals(0, streakAfter(neverConnected, neverConnected))
+    }
+
+    @Test
+    fun `advises only once the run is long enough to mean something`() {
+        assertFalse(VideoStarvationPolicy.shouldAdvise(0))
+        assertFalse(VideoStarvationPolicy.shouldAdvise(1))
+        assertFalse(VideoStarvationPolicy.shouldAdvise(2))
+        assertTrue(VideoStarvationPolicy.shouldAdvise(3))
+    }
+
+    @Test
+    fun `says it once, not on every reconnect after`() {
+        // The 2.4GHz measurement produced 32 of these in under five minutes.
+        val advised = (1..32).count { VideoStarvationPolicy.shouldAdvise(it) }
+
+        assertEquals(1, advised)
+    }
+
+    @Test
+    fun `a cleared streak can advise again on the next run`() {
+        var streak = streakAfter(starved, starved, starved)
+        assertTrue(VideoStarvationPolicy.shouldAdvise(streak))
+
+        streak = VideoStarvationPolicy.nextStreak(streak, reachedHandshake = true, renderedAnyFrame = true)
+        assertEquals(0, streak)
+
+        repeat(VideoStarvationPolicy.ADVISE_AFTER_STARVED_SESSIONS) {
+            streak = VideoStarvationPolicy.nextStreak(streak, reachedHandshake = true, renderedAnyFrame = false)
+        }
+        assertTrue(VideoStarvationPolicy.shouldAdvise(streak))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/WifiModePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/WifiModePolicyTest.kt
@@ -7,10 +7,38 @@ import org.junit.Test
 class WifiModePolicyTest {
 
     @Test
-    fun `native AA mode always uses wifi direct regardless of strategy`() {
+    fun `native AA mode uses wifi direct regardless of strategy, which does not apply to it`() {
         assertTrue(WifiModePolicy.usesWifiDirect(mode = 3, strategy = 0))
         assertTrue(WifiModePolicy.usesWifiDirect(mode = 3, strategy = 1))
         assertTrue(WifiModePolicy.usesWifiDirect(mode = 3, strategy = 2))
+    }
+
+    @Test
+    fun `native AA on the hotspot transport does not use wifi direct`() {
+        // The caller force-disables the hotspot whenever this says true, so a wrong answer here
+        // tears down the access point the hotspot route is about to hand the phone.
+        assertFalse(
+            WifiModePolicy.usesWifiDirect(mode = 3, strategy = 0, transport = NativeTransport.HOTSPOT)
+        )
+        assertTrue(
+            WifiModePolicy.usesWifiDirect(mode = 3, strategy = 0, transport = NativeTransport.WIFI_DIRECT)
+        )
+    }
+
+    @Test
+    fun `the transport only applies to native AA mode`() {
+        assertTrue(
+            WifiModePolicy.usesWifiDirect(mode = 2, strategy = 1, transport = NativeTransport.HOTSPOT)
+        )
+        assertFalse(
+            WifiModePolicy.usesWifiDirect(mode = 2, strategy = 0, transport = NativeTransport.WIFI_DIRECT)
+        )
+    }
+
+    @Test
+    fun `omitting the transport keeps the pre-existing answer`() {
+        assertTrue(WifiModePolicy.usesWifiDirect(mode = 3, strategy = 0))
+        assertTrue(WifiModePolicy.usesWifiDirect(mode = 2, strategy = 1))
     }
 
     @Test

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/WppFramingTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/WppFramingTest.kt
@@ -1,0 +1,70 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WppFramingTest {
+
+    @Test
+    fun `header bytes are pinned, big-endian, for a hand-worked example`() {
+        // 0x0102 = 258 bytes of payload, message type 3 (WifiInfoResponse).
+        assertArrayEquals(
+            byteArrayOf(0x01, 0x02, 0x00, 0x03),
+            WppFraming.encodeHeader(payloadSize = 258, type = 3)
+        )
+    }
+
+    @Test
+    fun `the frame is the header followed by the payload unchanged`() {
+        val payload = byteArrayOf(0x08, 0x00, 0x7F, -0x80)
+        assertArrayEquals(
+            byteArrayOf(0x00, 0x04, 0x00, 0x06) + payload,
+            WppFraming.encodeFrame(payload, WppMessageType.CONNECT_STATUS)
+        )
+    }
+
+    @Test
+    fun `sizes round-trip through the header, including the ones that use the high byte`() {
+        // 255/256 straddle the byte boundary that a naive encoder gets wrong; 990 is a plausible
+        // real payload; 65535 is the largest the field can describe.
+        for (size in listOf(0, 1, 255, 256, 990, WppFraming.MAX_PAYLOAD_SIZE)) {
+            val header = WppFraming.encodeHeader(size, WppMessageType.START_REQUEST)
+            assertEquals("size $size", size, WppFraming.decodePayloadSize(header))
+            assertEquals("size $size", WppMessageType.START_REQUEST, WppFraming.decodeType(header))
+        }
+    }
+
+    @Test
+    fun `types round-trip through the header, including ones above one byte`() {
+        for (type in listOf(0, 1, 11, 255, 256, 0xFFFF)) {
+            val header = WppFraming.encodeHeader(payloadSize = 7, type = type)
+            assertEquals("type $type", type, WppFraming.decodeType(header))
+            assertEquals("type $type", 7, WppFraming.decodePayloadSize(header))
+        }
+    }
+
+    @Test
+    fun `decoding ignores whatever follows the header`() {
+        val frame = WppFraming.encodeFrame(ByteArray(300) { 0x41 }, WppMessageType.INFO_RESPONSE)
+        assertEquals(300, WppFraming.decodePayloadSize(frame))
+        assertEquals(WppMessageType.INFO_RESPONSE, WppFraming.decodeType(frame))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `a payload too large for the length field is refused, not truncated`() {
+        // Silently wrapping the length would put the phone permanently out of sync with the
+        // stream: every message after it is read at the wrong offset.
+        WppFraming.encodeHeader(payloadSize = WppFraming.MAX_PAYLOAD_SIZE + 1, type = 1)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `a negative payload size is refused`() {
+        WppFraming.encodeHeader(payloadSize = -1, type = 1)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `decoding refuses a short header rather than reading past it`() {
+        WppFraming.decodePayloadSize(byteArrayOf(0x00, 0x04, 0x00))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/WppHandshakeSessionTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/WppHandshakeSessionTest.kt
@@ -1,0 +1,354 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WppHandshakeSessionTest {
+
+    private fun session(versionExchange: Boolean = true) = WppHandshakeSession(versionExchange)
+
+    private fun msg(type: Int, status: Int? = null) = WppEvent.MessageReceived(type, status)
+
+    /** Drives a session to [WppStage.SETTLING] the ordinary way and returns it. */
+    private fun settledSession(versionExchange: Boolean = false): WppHandshakeSession {
+        val s = session(versionExchange)
+        s.on(WppEvent.SocketReady)
+        if (versionExchange) s.on(msg(WppMessageType.VERSION_RESPONSE))
+        s.on(WppEvent.CredentialsReady)
+        assertEquals(WppStage.AWAIT_INFO_REQUEST, s.stage)
+        assertEquals(listOf(WppAction.SendInfoResponse), s.on(msg(WppMessageType.INFO_REQUEST)))
+        assertEquals(WppStage.SETTLING, s.stage)
+        return s
+    }
+
+    // --- opening the exchange -------------------------------------------------------------
+
+    @Test
+    fun `with the version exchange off the wire behaviour is the one that shipped`() {
+        val s = session(versionExchange = false)
+
+        assertEquals(emptyList<WppAction>(), s.on(WppEvent.SocketReady))
+        assertEquals(WppStage.AWAIT_CREDENTIALS, s.stage)
+        assertEquals(listOf(WppAction.SendStartRequest), s.on(WppEvent.CredentialsReady))
+        assertEquals(listOf(WppAction.SendInfoResponse), s.on(msg(WppMessageType.INFO_REQUEST)))
+        assertEquals(WppStage.SETTLING, s.stage)
+    }
+
+    @Test
+    fun `with the version exchange on, type 4 goes out before anything else`() {
+        val s = session()
+
+        assertEquals(listOf(WppAction.SendVersionRequest), s.on(WppEvent.SocketReady))
+        assertEquals(WppStage.AWAIT_VERSION, s.stage)
+        assertEquals(emptyList<WppAction>(), s.on(msg(WppMessageType.VERSION_RESPONSE)))
+        assertEquals(WppStage.AWAIT_CREDENTIALS, s.stage)
+        assertEquals(listOf(WppAction.SendStartRequest), s.on(WppEvent.CredentialsReady))
+    }
+
+    @Test
+    fun `a phone that ignores type 4 does not fail the handshake, it just carries on`() {
+        val s = session()
+        s.on(WppEvent.SocketReady)
+
+        assertEquals(emptyList<WppAction>(), s.on(WppEvent.StageTimeout))
+
+        assertEquals(WppStage.AWAIT_CREDENTIALS, s.stage)
+        assertEquals(listOf(WppAction.SendStartRequest), s.on(WppEvent.CredentialsReady))
+    }
+
+    @Test
+    fun `credentials arriving mid-version-exchange do not jump the queue`() {
+        val s = session()
+        s.on(WppEvent.SocketReady)
+
+        // Holding them is the entire point of sending type 4 first.
+        assertEquals(emptyList<WppAction>(), s.on(WppEvent.CredentialsReady))
+        assertEquals(WppStage.AWAIT_VERSION, s.stage)
+
+        assertEquals(listOf(WppAction.SendStartRequest), s.on(msg(WppMessageType.VERSION_RESPONSE)))
+        assertEquals(WppStage.AWAIT_INFO_REQUEST, s.stage)
+    }
+
+    @Test
+    fun `credentials held across the version timeout are sent when it expires`() {
+        val s = session()
+        s.on(WppEvent.SocketReady)
+        s.on(WppEvent.CredentialsReady)
+
+        assertEquals(listOf(WppAction.SendStartRequest), s.on(WppEvent.StageTimeout))
+        assertEquals(WppStage.AWAIT_INFO_REQUEST, s.stage)
+    }
+
+    // --- the impatient phone --------------------------------------------------------------
+
+    @Test
+    fun `a phone that asks for credentials early is answered as soon as they exist`() {
+        val s = session()
+        s.on(WppEvent.SocketReady)
+
+        // Type 2 before we have anything to send: latched, not dropped and not answered yet.
+        assertEquals(emptyList<WppAction>(), s.on(msg(WppMessageType.INFO_REQUEST)))
+        assertEquals(WppStage.AWAIT_CREDENTIALS, s.stage)
+
+        assertEquals(
+            listOf(WppAction.SendStartRequest, WppAction.SendInfoResponse),
+            s.on(WppEvent.CredentialsReady)
+        )
+        assertEquals(WppStage.SETTLING, s.stage)
+    }
+
+    @Test
+    fun `an early type 2 during the credentials wait is latched too`() {
+        val s = session(versionExchange = false)
+        s.on(WppEvent.SocketReady)
+
+        assertEquals(emptyList<WppAction>(), s.on(msg(WppMessageType.INFO_REQUEST)))
+        assertEquals(
+            listOf(WppAction.SendStartRequest, WppAction.SendInfoResponse),
+            s.on(WppEvent.CredentialsReady)
+        )
+    }
+
+    // --- settling -------------------------------------------------------------------------
+
+    @Test
+    fun `the projection session landing completes the handshake`() {
+        val s = settledSession()
+
+        assertEquals(listOf(WppAction.CompleteSuccess), s.on(WppEvent.TcpSessionUp))
+        assertEquals(WppStage.DONE, s.stage)
+    }
+
+    @Test
+    fun `a phone still joining buys itself more time`() {
+        val s = settledSession()
+
+        assertEquals(listOf(WppAction.ExtendSettle), s.on(msg(WppMessageType.CONNECT_STATUS, 0)))
+        assertEquals(WppStage.SETTLING, s.stage)
+        assertEquals(
+            NativeHandoffPolicy.SETTLE_TIMEOUT_MS + WppHandshakeSession.SETTLE_EXTENSION_MS,
+            s.currentStageTimeoutMs()
+        )
+    }
+
+    @Test
+    fun `extensions stop at the cap so a phone that never arrives cannot hold us forever`() {
+        val s = settledSession()
+
+        var granted = 0
+        repeat(20) { if (s.on(msg(WppMessageType.CONNECT_STATUS, 0)).isNotEmpty()) granted++ }
+
+        assertTrue("at least one extension should be granted", granted > 0)
+        assertEquals(NativeHandoffPolicy.MAX_SETTLE_MS, s.currentStageTimeoutMs())
+        assertEquals(WppStage.SETTLING, s.stage)
+    }
+
+    @Test
+    fun `a phone reporting it could not join fails fast and lets the poke resume`() {
+        val s = settledSession()
+
+        val actions = s.on(msg(WppMessageType.CONNECT_STATUS, -1))
+
+        assertEquals(WppStage.FAILED, s.stage)
+        assertEquals(2, actions.size)
+        assertTrue(actions[0] is WppAction.Fail)
+        assertEquals(WppAction.ResumePoke, actions[1])
+    }
+
+    @Test
+    fun `a failed start response is treated the same way while settling`() {
+        val s = settledSession()
+
+        val actions = s.on(msg(WppMessageType.START_RESPONSE, 7))
+
+        assertEquals(WppStage.FAILED, s.stage)
+        assertTrue(actions[0] is WppAction.Fail)
+        assertEquals(WppAction.ResumePoke, actions[1])
+    }
+
+    @Test
+    fun `a successful start response is informational in both stages it can arrive in`() {
+        val awaiting = session(versionExchange = false)
+        awaiting.on(WppEvent.SocketReady)
+        awaiting.on(WppEvent.CredentialsReady)
+        assertEquals(emptyList<WppAction>(), awaiting.on(msg(WppMessageType.START_RESPONSE, 0)))
+        assertEquals(WppStage.AWAIT_INFO_REQUEST, awaiting.stage)
+
+        val settling = settledSession()
+        assertEquals(emptyList<WppAction>(), settling.on(msg(WppMessageType.START_RESPONSE, 0)))
+        assertEquals(WppStage.SETTLING, settling.stage)
+    }
+
+    @Test
+    fun `a start response we could not parse is never read as a failure`() {
+        val s = settledSession()
+
+        assertEquals(emptyList<WppAction>(), s.on(msg(WppMessageType.START_RESPONSE, null)))
+        assertEquals(WppStage.SETTLING, s.stage)
+    }
+
+    @Test
+    fun `a phone that asks for credentials twice gets them twice`() {
+        val s = settledSession()
+
+        assertEquals(listOf(WppAction.SendInfoResponse), s.on(msg(WppMessageType.INFO_REQUEST)))
+        assertEquals(WppStage.SETTLING, s.stage)
+    }
+
+    @Test
+    fun `the settle timeout resumes the poke and leaves the listeners alone`() {
+        val s = settledSession()
+
+        assertEquals(listOf(WppAction.ResumePoke), s.on(WppEvent.SettleTimeout))
+        assertEquals(WppStage.FAILED, s.stage)
+    }
+
+    // --- pings ----------------------------------------------------------------------------
+
+    @Test
+    fun `a ping is echoed in every live stage and never changes the stage`() {
+        val awaitVersion = session().also { it.on(WppEvent.SocketReady) }
+        val awaitCredentials = session(versionExchange = false).also { it.on(WppEvent.SocketReady) }
+        val awaitInfo = session(versionExchange = false).also {
+            it.on(WppEvent.SocketReady); it.on(WppEvent.CredentialsReady)
+        }
+        val settling = settledSession()
+
+        for (s in listOf(awaitVersion, awaitCredentials, awaitInfo, settling)) {
+            val stageBefore = s.stage
+            assertEquals(
+                "stage $stageBefore",
+                listOf(WppAction.SendPingResponse),
+                s.on(msg(WppMessageType.PING_REQUEST))
+            )
+            assertEquals(stageBefore, s.stage)
+        }
+    }
+
+    @Test
+    fun `an inbound ping response is a keepalive and is ignored`() {
+        val s = settledSession()
+
+        assertEquals(emptyList<WppAction>(), s.on(msg(WppMessageType.PING_RESPONSE)))
+        assertEquals(WppStage.SETTLING, s.stage)
+    }
+
+    @Test
+    fun `message types we do not model are ignored rather than fatal`() {
+        val s = settledSession()
+
+        assertEquals(emptyList<WppAction>(), s.on(msg(WppMessageType.SETUP_INFO)))
+        assertEquals(emptyList<WppAction>(), s.on(msg(42)))
+        assertEquals(WppStage.SETTLING, s.stage)
+    }
+
+    // --- failures and the silent-phone flag -----------------------------------------------
+
+    @Test
+    fun `a phone that never asks for credentials fails, and is recorded as silent`() {
+        val s = session(versionExchange = false)
+        s.on(WppEvent.SocketReady)
+        s.on(WppEvent.CredentialsReady)
+
+        val actions = s.on(WppEvent.StageTimeout)
+
+        assertEquals(WppStage.FAILED, s.stage)
+        val fail = actions.single() as WppAction.Fail
+        assertTrue("the phone said nothing at all", fail.phoneWasSilent)
+    }
+
+    @Test
+    fun `a phone that answered something is not recorded as silent`() {
+        val s = session()
+        s.on(WppEvent.SocketReady)
+        s.on(msg(WppMessageType.VERSION_RESPONSE))
+        s.on(WppEvent.CredentialsReady)
+
+        val fail = s.on(WppEvent.StageTimeout).single() as WppAction.Fail
+
+        // This unit's Bluetooth is carrying data, so the handshake backoff must not count it.
+        assertFalse(fail.phoneWasSilent)
+        assertEquals(1, s.messagesReceived)
+    }
+
+    @Test
+    fun `credentials that never arrive fail the handshake`() {
+        val s = session(versionExchange = false)
+        s.on(WppEvent.SocketReady)
+
+        val fail = s.on(WppEvent.CredentialsUnavailable).single() as WppAction.Fail
+
+        assertEquals(WppStage.FAILED, s.stage)
+        assertTrue(fail.phoneWasSilent)
+    }
+
+    @Test
+    fun `every message the phone sends is counted, whatever it was`() {
+        val s = settledSession()
+        s.on(msg(WppMessageType.PING_REQUEST))
+        s.on(msg(WppMessageType.PING_RESPONSE))
+        s.on(msg(999))
+
+        // 1 for the type 2 that got us to SETTLING, plus the three above.
+        assertEquals(4, s.messagesReceived)
+    }
+
+    // --- terminal behaviour ---------------------------------------------------------------
+
+    @Test
+    fun `a finished session ignores everything, repeatedly`() {
+        val s = settledSession()
+        s.on(WppEvent.TcpSessionUp)
+        assertEquals(WppStage.DONE, s.stage)
+        val countAtCompletion = s.messagesReceived
+
+        for (event in listOf(
+            WppEvent.TcpSessionUp,
+            WppEvent.SettleTimeout,
+            WppEvent.StageTimeout,
+            WppEvent.CredentialsReady,
+            WppEvent.CredentialsUnavailable,
+            msg(WppMessageType.PING_REQUEST),
+            msg(WppMessageType.CONNECT_STATUS, -1)
+        )) {
+            assertEquals(emptyList<WppAction>(), s.on(event))
+            assertEquals(WppStage.DONE, s.stage)
+        }
+        assertEquals("a terminal session counts nothing", countAtCompletion, s.messagesReceived)
+    }
+
+    @Test
+    fun `a failed session cannot be revived by a late success`() {
+        val s = settledSession()
+        s.on(WppEvent.SettleTimeout)
+
+        assertEquals(emptyList<WppAction>(), s.on(WppEvent.TcpSessionUp))
+        assertEquals(WppStage.FAILED, s.stage)
+    }
+
+    // --- stage deadlines ------------------------------------------------------------------
+
+    @Test
+    fun `each stage carries the deadline the caller should hold it to`() {
+        val s = session()
+        assertNull("nothing is out on the wire yet", s.currentStageTimeoutMs())
+
+        s.on(WppEvent.SocketReady)
+        assertEquals(WppHandshakeSession.VERSION_RESPONSE_TIMEOUT_MS, s.currentStageTimeoutMs())
+
+        s.on(WppEvent.StageTimeout)
+        assertNull("the credentials wait is bounded by the caller, not by us", s.currentStageTimeoutMs())
+
+        s.on(WppEvent.CredentialsReady)
+        assertEquals(WppHandshakeSession.INFO_REQUEST_TIMEOUT_MS, s.currentStageTimeoutMs())
+
+        s.on(msg(WppMessageType.INFO_REQUEST))
+        assertEquals(NativeHandoffPolicy.SETTLE_TIMEOUT_MS, s.currentStageTimeoutMs())
+
+        s.on(WppEvent.TcpSessionUp)
+        assertNull("a finished handshake has no deadline", s.currentStageTimeoutMs())
+    }
+}


### PR DESCRIPTION
## What this adds

A second transport for Native AA wireless (mode 3). Instead of hosting a WiFi Direct P2P group, the head unit hands the phone the credentials of its own hotspot, and the phone joins it like any other network. Same Bluetooth handshake, same UUID, no P2P anywhere in the path.

The route is selected in Android Auto mode → Transport, and defaults to WiFi Direct. Nothing changes for anyone who does not switch it.

## Why

Most Native AA bug reports are P2P failures rather than protocol failures: group churn, the self-wake loop, phones stuck on "Obtaining IP address". A teardown of the OEM ZLink app showed it doing wireless Android Auto over an ordinary WPA2 soft AP, which proves the phone accepts a plain access point and that the P2P group is a choice rather than a requirement.

It also turns out to be the fix for a specific class of hardware failure. In #774 the reporter's MT8163 unit reboots its whole Android whenever a phone joins a WiFi Direct group the app created. That unit cannot use Native AA over WiFi Direct at all. Over its own hotspot, it never touches the failing path.

## How it works

SoftApCredentialsProvider resolves the access point the device is already running: SSID and passphrase from the system hotspot configuration (with manual overrides for devices that refuse the read), the interface by elimination against the station address, and the BSSID from that interface. It watches the AP state and invalidates the credentials if it goes down. AapService routes mode 3 to it instead of WifiDirectManager when the transport is set to Hotspot, and both transports feed the same credential listener so the poke rules stay in one place.

## Also in here

The handshake is a state machine now. WppHandshakeSession owns the ordering rules and is pure; NativeAaHandshakeManager does only I/O. What this replaces sent type 1, read one message, sent type 3 and stopped listening, so types 6 and 7 (the phone's own join feedback) were never seen. That feedback is the only join signal the hotspot route can have, since a SoftAP has no equivalent of the P2P client list. It also means the AA listeners now close when the phone's session actually lands rather than on a blind 3 s timer.

The BSSID is required, and we now always send one. Our wireless.proto had relaxed bssid, security_mode and access_point_type to optional on the strength of a claim that other implementations ship without them. That claim was wrong: aa-proxy-rs and WirelessAndroidAutoDongle both declare them required and read the address from the AP interface. Measured against a current Gearhead 17.4, credentials with no BSSID are refused outright with WIFI_INVALID_BSSID. The fields stay optional locally so a truncated message still parses.

A boot crash-loop guard. Auto-start on boot turns one system-level crash into an endless cycle, measured at a 20–26 s period across seven consecutive processes. After three boot-started runs that fail to last 30 s, wireless bring-up is skipped and a notification says why. USB is unaffected, and opening the app turns it back on.

Two diagnostics for failures that previously looked like nothing. A session that reaches SSL and ends having rendered no frames, three times running, now says so and names both ways out, that shape is what a link too slow to carry the stream looks like. And a missing BSSID now explains itself instead of failing silently.

## Testing

11 runs on two devices across three rounds, on a dedicated head unit and phone-to-phone. WiFi Direct regression runs pass, so the existing route is unaffected.

The 2.4 GHz behaviour is worth knowing about: at 1080p/60 the phone connects, opens the video channel and drops the session repeatedly without a single frame arriving. On the same access point at 800x480/30 it held indefinitely, 66,137 decoded frames. It is a throughput ceiling, not a broken band. 5 GHz at full quality is clean.

## Risk

The hotspot route is inert unless selected. The one change that alters the wire for existing mode 3 users would have been the version exchange (type 4), so it is off by default, the version it announces is a guess, no capture of a real head unit's type 4 has been decoded, and turning it off is byte-identical to 3.2.1. It stays available as an opt-in for anyone whose unit broke on Android Auto 17.4, which is the only reason to send it.

Everything else is either additive, log-only, or behind the transport setting. The starvation counter is the one piece that runs on every transport including USB; it reads a frame count at disconnect and can only produce a log line.

## New Possibilites

Native now can work Phone-to-Phone, but a phone acting as head unit cannot read its own MAC, as Android hides it, it's required to get them via adb commands or a rooted phone.
Native WiFi Direct only requires manually setting BSSID and
(New) Native Hotspot requires BSSID, SSID and PASSWORD

1. Read the address (on the headunit phone)
Hotspot transport: 

The AP must be up first, the address doesn't exist otherwise:
```
adb shell cmd wifi start-softap OHU-TEST wpa2 testtest1234 -b 5
adb shell dumpsys wifi | grep -i SoftApInfo
# SoftApInfo{bssid=ff:ff:ff:ff:ff:ff, frequency=5240, bandwidth=2, ...}
```
```-b 5```  sets the band on 5 GHz which enables 1080p+ resolutions, without it the hotspot creates as 2.4 GHz

WiFi Direct transport:
```
adb shell dumpsys wifip2p | grep -A 3 mThisDevice
#  deviceAddress: aa:aa:aa:aa:aa:aa
```
2. Write the settings in the manual fields depending on the wireless method selected for Native
3. The two phones must be paired

## Known limitations

- Some devices regenerate their hotspot BSSID on every restart, which makes the static BSSID override unusable for this route on that hardware.
- The band cannot be read without NETWORK_SETTINGS, so the 2.4 GHz problem is diagnosed by symptom rather than detected.
- A device that will not let an app read its hotspot configuration needs the SSID and password entering by hand.

## APK
https://github.com/o-jcardenass/open-headunit/releases/download/v.3.2.0-fixes/Experimental_OHU3.2.2_debug.apk