### PR TITLE
Recover a dropped video frame without releasing video focus

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
@@ -129,13 +129,14 @@ class AapTransport(
         get() = pollThread?.isAlive ?: false
 
     private fun triggerFocusCycleRecovery() {
-        AppLog.w("AapTransport: Requesting recovery keyframe via focus cycle.")
-        send(com.andrerinas.openheadunit.aap.protocol.messages.VideoFocusEvent(gain = false, unsolicited = false))
-        android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
-            if (isAlive) {
-                send(com.andrerinas.openheadunit.aap.protocol.messages.VideoFocusEvent(gain = true, unsolicited = true))
-            }
-        }, 100)
+        // Ask the phone for a fresh keyframe with an unsolicited focus GAIN only, the same nudge the
+        // startup keyframe watchdog uses. We deliberately do not release focus (gain=false) first:
+        // on some head unit / phone combos, releasing video focus drops the stream to a few fps and
+        // it never recovers, so a single transient dropped frame turned into a permanent freeze
+        // (issue #755). A gain-only request still makes the phone resend a keyframe without
+        // disturbing the running stream.
+        AppLog.w("AapTransport: Requesting recovery keyframe (unsolicited focus gain).")
+        send(com.andrerinas.openheadunit.aap.protocol.messages.VideoFocusEvent(gain = true, unsolicited = true))
     }
 
     init {


### PR DESCRIPTION
On some head units the video collapses to a few fps and freezes shortly after connecting, and the last version that worked for those users is 3.2.0-beta2 (issue #755).

From @AyazIsayev's logs (clean install, H.264): the video runs fine at about 48 fps, then a transient decoder input-buffer-full drops one frame. The stream gets marked corrupt and the recovery asks for a keyframe by cycling video focus (release, then re-gain). Right after that, the phone drops to about 3 fps and never recovers, and the session ends with a "Magic Garbage detected in header" desync. beta2 does not have this recovery path, which is why it stays at full framerate there (a dropped frame just self-heals on the next keyframe).

The change: request the recovery keyframe with an unsolicited focus gain only, without releasing focus first. Releasing focus (gain=false) is what tells the phone to stop sending video, and on these units it does not come back to full rate. A gain-only request is the same nudge the startup keyframe watchdog already uses, and it still makes the phone resend a keyframe without disturbing the running stream.

This does not touch the genuine-corruption paths (fragment overflow) or the sync_stall watchdog, only how the keyframe is requested. @o-jcardenass this sits right on top of your recovery and buffer-full work, so I would appreciate your eyes on it.

I cannot reproduce this myself (I use a USB adapter, not WiFi), so it is based on the logs. A debug build is on the issue for @AyazIsayev to confirm.

Related to #755.
