### PR TITLE
Fix/video purge 738 decode regressions

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
@@ -32,6 +32,7 @@ import com.andrerinas.openheadunit.app.SurfaceActivity
 import com.andrerinas.openheadunit.connection.CommManager
 import com.andrerinas.openheadunit.contract.KeyIntent
 import kotlinx.coroutines.launch
+import com.andrerinas.openheadunit.decoder.DecoderStopPolicy
 import com.andrerinas.openheadunit.decoder.SoftwareYuvFrameSink
 import com.andrerinas.openheadunit.decoder.VideoDecoder
 import com.andrerinas.openheadunit.decoder.VideoDimensionsListener
@@ -243,7 +244,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
             val container = findViewById<FrameLayout>(R.id.container)
             if (::projectionView.isInitialized) {
                 videoDecoder.softwareYuvFrameSink = null
-                videoDecoder.stop("projectionViewRecreate")
+                videoDecoder.stop(DecoderStopPolicy.REASON_PROJECTION_VIEW_RECREATE)
                 container.removeView(projectionView as View)
             }
             isSurfaceSet = false
@@ -1317,7 +1318,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         AppLog.i("SurfaceCallback: onSurfaceDestroyed. Surface: $surface")
         isSurfaceSet = false
         commManager.send(VideoFocusEvent(gain = false, unsolicited = false))
-        videoDecoder.stop("surfaceDestroyed")
+        videoDecoder.stop(DecoderStopPolicy.REASON_SURFACE_DESTROYED)
     }
 
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapVideo.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapVideo.kt
@@ -8,13 +8,26 @@ import java.nio.ByteBuffer
 
 internal class AapVideo(private val videoDecoder: VideoDecoder, private val settings: Settings, private val onFrameCorrupted: () -> Unit) {
 
-    private val messageBuffer = ByteBuffer.allocate(
-        if (settings.videoCodec == VideoDecoder.CodecType.H265.settingsValue) {
-            Messages.DEF_BUFFER_LENGTH * 64 // ~8MB for H.265 support
-        } else {
-            Messages.DEF_BUFFER_LENGTH * 16 // ~2MB for H.264 legacy support
-        }
-    )
+    companion object {
+        /** Enough for H.264 at the resolutions most head units negotiate. ~2MB. */
+        private const val INITIAL_BUFFER_BYTES = Messages.DEF_BUFFER_LENGTH * 16
+
+        /** Ceiling for [ensureCapacity]. ~8MB, which covers H.265 at 4K. */
+        private const val MAX_BUFFER_BYTES = Messages.DEF_BUFFER_LENGTH * 64
+    }
+
+    /**
+     * Reassembly buffer for fragmented frames. Grows on demand.
+     *
+     * It used to be sized up front from settings.videoCodec, which is the user's preference and
+     * not the codec the session runs: ServiceDiscoveryResponse negotiates H.265 at 1440p and 4K
+     * whatever that setting says, and falls back to H.264 when the user asked for H.265 on a
+     * device with no HEVC decoder. Either mismatch handed an H.265 stream the 2MB H.264 buffer and
+     * turned every large frame into a fragment overflow. The real answer is also not available
+     * here - AapVideo is constructed with the transport, before the phone has negotiated anything
+     * - so start small and let a frame that does not fit be the thing that asks for more.
+     */
+    private var messageBuffer = ByteBuffer.allocate(INITIAL_BUFFER_BYTES)
     private var legacyAssembledBuffer: ByteArray? = null
     private var isFrameCorrupt = false
     private var lastKeyframeRequestMs = 0L
@@ -64,6 +77,26 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
                 }
             }
         }
+    }
+
+    /**
+     * Makes room for [additionalBytes] more of the frame being assembled, growing [messageBuffer]
+     * if it has to. Returns false only at [MAX_BUFFER_BYTES], where the frame is genuinely too
+     * large to be one we can decode and the caller should invalidate it.
+     */
+    private fun ensureCapacity(additionalBytes: Int): Boolean {
+        if (messageBuffer.remaining() >= additionalBytes) return true
+
+        val needed = messageBuffer.position() + additionalBytes
+        if (needed > MAX_BUFFER_BYTES) return false
+
+        var capacity = messageBuffer.capacity()
+        while (capacity < needed) capacity *= 2
+        val grown = ByteBuffer.allocate(capacity.coerceAtMost(MAX_BUFFER_BYTES))
+        grown.put(messageBuffer.array(), 0, messageBuffer.position())
+        messageBuffer = grown
+        AppLog.i("AapVideo: Reassembly buffer grown to ${grown.capacity() / 1024}KB")
+        return true
     }
 
     private fun findStartCode(buf: ByteArray, offset: Int): Int {
@@ -126,10 +159,10 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
                 if (isFrameCorrupt) return true // Skip fragments of an already corrupt frame
 
                 // Middle fragment - append to buffer with overflow detection
-                if (messageBuffer.remaining() >= message.size) {
+                if (ensureCapacity(message.size)) {
                     messageBuffer.put(message.data, 0, message.size)
                 } else {
-                    AppLog.e("AapVideo: Fragment overflow (Flag 8)! Size ${message.size} exceeds remaining ${messageBuffer.remaining()}. Invalidating frame.")
+                    AppLog.e("AapVideo: Fragment overflow (Flag 8)! Size ${message.size} on top of ${messageBuffer.position()} exceeds the ${MAX_BUFFER_BYTES / 1024}KB cap. Invalidating frame.")
                     markCorruptAndRequestRecovery()
                     messageBuffer.clear()
                 }
@@ -139,10 +172,10 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
                 if (isFrameCorrupt) return true // Skip fragments of an already corrupt frame
 
                 // Last fragment - append, assemble, and decode
-                if (messageBuffer.remaining() >= message.size) {
+                if (ensureCapacity(message.size)) {
                     messageBuffer.put(message.data, 0, message.size)
                 } else {
-                    AppLog.e("AapVideo: Final fragment overflow (Flag 10)! Invalidating frame.")
+                    AppLog.e("AapVideo: Final fragment overflow (Flag 10)! Frame exceeds the ${MAX_BUFFER_BYTES / 1024}KB cap. Invalidating frame.")
                     markCorruptAndRequestRecovery()
                     messageBuffer.clear()
                     return true

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapVideo.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapVideo.kt
@@ -19,101 +19,26 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
     private var isFrameCorrupt = false
     private var lastKeyframeRequestMs = 0L
     private var isAssemblingFrame = false
-    private var waitingForKeyframe = false
 
-    // Set when a P-frame lockout was armed while the throttle refused the keyframe request that
-    // ends it. See sendDeferredKeyframeRequestIfDue().
-    private var deferredKeyframeRequest = false
-
+    /**
+     * Marks the frame being assembled unusable and asks the phone for a fresh keyframe.
+     *
+     * Corruption is scoped to the current frame only: flags 8 and 10 skip the rest of it, and the
+     * next flag 9 or 11 clears the mark. There is deliberately no lockout that holds every
+     * subsequent P-frame back until a keyframe is positively identified - one existed, and because
+     * nothing could reliably tell a keyframe from a P-frame for every codec the app negotiates, it
+     * could latch for the rest of the session and freeze the picture with the connection still
+     * healthy. Dropping one frame and letting the stream heal on the phone's next keyframe is both
+     * cheaper and unable to get stuck.
+     */
     private fun markCorruptAndRequestRecovery() {
         isFrameCorrupt = true
-        waitingForKeyframe = true // Lock out P-Frames until an I-Frame arrives
         val now = android.os.SystemClock.elapsedRealtime()
         if (VideoRecoveryPolicy.canRequestKeyframe(now, lastKeyframeRequestMs)) {
             lastKeyframeRequestMs = now
-            deferredKeyframeRequest = false
             AppLog.w("AapVideo: Frame corrupted, requesting keyframe to recover stream")
             onFrameCorrupted()
-        } else {
-            // The throttle covers the request but not the lockout above, which drops every
-            // frame until a keyframe arrives. Nothing else asks for one, so the lockout would
-            // sit until the phone happens to send a keyframe on its own - the whole interval is
-            // discarded video. Record the debt and pay it in process() once the throttle allows.
-            deferredKeyframeRequest = true
         }
-    }
-
-    /**
-     * Sends a keyframe request that [markCorruptAndRequestRecovery] had to defer.
-     *
-     * Called per incoming video packet, so the request lands within a frame or two of the
-     * throttle expiring without needing a scheduler on this thread.
-     */
-    private fun sendDeferredKeyframeRequestIfDue() {
-        if (!deferredKeyframeRequest) return
-        if (!waitingForKeyframe) {
-            // The stream recovered on a keyframe the phone sent anyway; nothing left to ask for.
-            deferredKeyframeRequest = false
-            return
-        }
-        val now = android.os.SystemClock.elapsedRealtime()
-        if (!VideoRecoveryPolicy.isDeferredRequestDue(now, lastKeyframeRequestMs, true)) return
-        lastKeyframeRequestMs = now
-        deferredKeyframeRequest = false
-        AppLog.w("AapVideo: Still waiting for a keyframe, sending the deferred recovery request")
-        onFrameCorrupted()
-    }
-
-    private fun checkKeyframe(message: AapMessage): Boolean {
-        if (!waitingForKeyframe)
-            return false
-
-        val flags = message.flags.toInt()
-
-        // We need to check if this new frame is a Keyframe (SPS/PPS or IDR)
-        // Flag 11 (Single) or Flag 9 (First Fragment) indicate the start of a frame
-        // Drop middle/end fragments if it's not
-        if (flags != 11 && flags != 9)
-            return true
-
-        val buf = message.data
-        val len = message.size
-
-        // Try offset 10 first, fallback to offset 2
-        var scOffset = 10
-        var scLen = findStartCode(buf, scOffset)
-        if (scLen <= 0) {
-            scOffset = 2
-            scLen = findStartCode(buf, scOffset)
-        }
-
-        // No start code = Not a keyframe. Drop it.
-        if (scLen <= 0 || scOffset + scLen >= len)
-            return true
-
-        val nalType = if (settings.videoCodec == VideoDecoder.CodecType.H265.settingsValue) {
-            (buf[scOffset + scLen].toInt() and 0x7E) shr 1 // H.265 NAL
-        } else {
-            buf[scOffset + scLen].toInt() and 0x1F // H.264 NAL
-        }
-
-        // Check if it's an I-Frame or VPS/SPS/PPS (types that can start a clean stream)
-        val isKeyframe = if (settings.videoCodec == VideoDecoder.CodecType.H265.settingsValue) {
-            nalType in 16..21 || nalType in 32..34
-        } else {
-            nalType == 5 || nalType == 7 || nalType == 8
-        }
-
-        if (isKeyframe) {
-            AppLog.i("AapVideo: Keyframe received, resuming stream.")
-            waitingForKeyframe = false
-            isFrameCorrupt = false
-            deferredKeyframeRequest = false
-        } else {
-            return true // Drop this P-Frame, we are still waiting for a Keyframe!
-        }
-
-        return false
     }
 
     private fun checkFragmentState(message: AapMessage) {
@@ -131,8 +56,8 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
                     AppLog.e("AapVideo: Orphaned fragment (Flag $flags) detected! Frame data lost.")
                     markCorruptAndRequestRecovery()
                     messageBuffer.clear()
-                    // Still need to pass it to checkKeyframe in case it's magically valid (rare),
-                    // but usually we just drop it.
+                    // The mark makes the flag 8/10 arms below skip this fragment. It is cleared
+                    // again by the next flag 9 or 11, so the stream resumes on the frame after.
                 }
                 if (flags == 10) {
                     isAssemblingFrame = false // Assembly finished
@@ -151,11 +76,8 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
     }
 
     fun process(message: AapMessage): Boolean {
-        sendDeferredKeyframeRequestIfDue()
         // Fix smearing happening after some while
         checkFragmentState(message)
-        if (checkKeyframe(message))
-            return true
 
         val flags = message.flags.toInt()
         val buf = message.data
@@ -170,18 +92,14 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
                 // Timestamp Indication (Offset 10)
                 val sc10 = findStartCode(buf, 10)
                 if (len > 10 + sc10 && sc10 > 0) {
-                    if (!videoDecoder.decode(buf, 10, len - 10, settings.forceSoftwareDecoding, settings.videoCodec)) {
-                        markCorruptAndRequestRecovery()
-                    }
+                    videoDecoder.decode(buf, 10, len - 10, settings.forceSoftwareDecoding, settings.videoCodec)
                     return true
                 }
 
                 // Media Indication or Config (Offset 2)
                 val sc2 = findStartCode(buf, 2)
                 if (len > 2 + sc2 && sc2 > 0) {
-                    if (!videoDecoder.decode(buf, 2, len - 2, settings.forceSoftwareDecoding, settings.videoCodec)) {
-                        markCorruptAndRequestRecovery()
-                    }
+                    videoDecoder.decode(buf, 2, len - 2, settings.forceSoftwareDecoding, settings.videoCodec)
                     return true
                 }
                 AppLog.w("AapVideo: Dropped Flag 11 packet. len=$len")
@@ -233,7 +151,7 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
                 messageBuffer.flip()
                 val assembledSize = messageBuffer.limit()
 
-                val decoded = if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.LOLLIPOP) {
+                if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.LOLLIPOP) {
                     if (legacyAssembledBuffer == null || legacyAssembledBuffer!!.size < assembledSize) {
                         legacyAssembledBuffer = ByteArray(assembledSize + 1024)
                     }
@@ -241,9 +159,6 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
                     videoDecoder.decode(legacyAssembledBuffer!!, 0, assembledSize, settings.forceSoftwareDecoding, settings.videoCodec)
                 } else {
                     videoDecoder.decode(messageBuffer.array(), 0, assembledSize, settings.forceSoftwareDecoding, settings.videoCodec)
-                }
-                if (!decoded) {
-                    markCorruptAndRequestRecovery()
                 }
 
                 messageBuffer.clear()

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/VideoRecoveryPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/VideoRecoveryPolicy.kt
@@ -1,15 +1,16 @@
 package com.andrerinas.openheadunit.aap
 
 /**
- * Pacing rules for [AapVideo]'s stream recovery.
+ * Pacing rule for [AapVideo]'s stream recovery.
  *
- * Recovering from a corrupt or dropped frame means asking the phone for a fresh keyframe, which
+ * Recovering from a corrupt frame means asking the phone for a fresh keyframe, which
  * [AapTransport] implements as a video-focus loss/regain cycle. That is expensive and briefly
- * visible, so requests are rate limited. But the same recovery also locks out every P-frame until
- * a keyframe arrives, and a lockout with no request behind it can only end on the phone's own
- * keyframe cadence - seconds of discarded video. These two rules keep the throttle from stranding
- * a lockout: one decides when a request may go out, the other when a request the throttle
- * suppressed has become due.
+ * visible on screen, and the phone reacts to it by rebuilding the stream, so a burst of requests
+ * costs far more picture than the single frame that triggered the first one. Rate limit them.
+ *
+ * Suppressing a request is safe to do silently: a corrupt frame is scoped to itself and the stream
+ * resumes on the next one either way, so a suppressed request only means recovery waits for the
+ * phone's own keyframe cadence rather than being brought forward.
  */
 object VideoRecoveryPolicy {
 
@@ -19,13 +20,4 @@ object VideoRecoveryPolicy {
     /** Whether enough time has passed since [lastRequestMs] to send another keyframe request. */
     fun canRequestKeyframe(nowMs: Long, lastRequestMs: Long): Boolean =
         nowMs - lastRequestMs > KEYFRAME_REQUEST_THROTTLE_MS
-
-    /**
-     * Whether a request that [canRequestKeyframe] previously suppressed should now be sent.
-     *
-     * [deferred] is the caller's record that it armed a P-frame lockout without being allowed to
-     * ask for the keyframe that ends it.
-     */
-    fun isDeferredRequestDue(nowMs: Long, lastRequestMs: Long, deferred: Boolean): Boolean =
-        deferred && canRequestKeyframe(nowMs, lastRequestMs)
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/DecoderStopPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/DecoderStopPolicy.kt
@@ -1,0 +1,50 @@
+package com.andrerinas.openheadunit.decoder
+
+/**
+ * Decides whether a [VideoDecoder.stop] call ends the projection session or only tears the decoder
+ * down while the phone keeps streaming.
+ *
+ * The distinction matters because some of the decoder's state describes the *stream* rather than
+ * the decoder instance - the pinned codec type above all - and throwing it away while the stream is
+ * still running forces a re-detection on whatever mid-stream packet happens to arrive next. That
+ * heuristic cannot tell an ordinary H.264 P-slice header (0x41) from an HEVC VPS, so the re-detect
+ * can hand an H.264 stream an HEVC decoder.
+ *
+ * Anything not listed here ends the session, so an unrecognised reason keeps the old behaviour of
+ * resetting everything.
+ */
+object DecoderStopPolicy {
+
+    /** The projection surface went away; the AAP session is untouched. */
+    const val REASON_SURFACE_DESTROYED = "surfaceDestroyed"
+
+    /** The projection view left the window hierarchy; the AAP session is untouched. */
+    const val REASON_DETACHED_FROM_WINDOW = "onDetachedFromWindow"
+
+    /** The projection view is being swapped for another backend; the AAP session is untouched. */
+    const val REASON_PROJECTION_VIEW_RECREATE = "projectionViewRecreate"
+
+    /** A new surface replaced the old one; the AAP session is untouched. */
+    const val REASON_NEW_SURFACE = "New surface"
+
+    /** Prefix used by the decoder's own recovery restarts, which have never ended the session. */
+    private const val RESTART_PREFIX = "restart"
+
+    private val SURFACE_LIFECYCLE_REASONS = setOf(
+        REASON_SURFACE_DESTROYED,
+        REASON_DETACHED_FROM_WINDOW,
+        REASON_PROJECTION_VIEW_RECREATE,
+        REASON_NEW_SURFACE,
+    )
+
+    /** True when the decoder is tearing itself down to come straight back up. */
+    fun isDecoderRestart(reason: String): Boolean = reason.startsWith(RESTART_PREFIX)
+
+    /**
+     * True when [reason] means the phone has gone away and every piece of session state should be
+     * reset. False for the decoder's own restarts and for the surface lifecycle, where the stream
+     * outlives the decoder.
+     */
+    fun endsSession(reason: String): Boolean =
+        !isDecoderRestart(reason) && reason !in SURFACE_LIFECYCLE_REASONS
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -291,7 +291,7 @@ class VideoDecoder(private val settings: Settings) {
 
             AppLog.i("New surface set: $surface")
             if (codec != null || softwareHevcDecoder != null) {
-                stop("New surface")
+                stop(DecoderStopPolicy.REASON_NEW_SURFACE)
             }
             mSurface = surface
             lastFrameRenderedMs = 0L
@@ -333,18 +333,25 @@ class VideoDecoder(private val settings: Settings) {
             legacyFrameBuffer = null
             codecBufferInfo = null
             codecConfigured = false
-            if (!reason.startsWith("restart")) {
+            if (!DecoderStopPolicy.isDecoderRestart(reason)) {
                 vps = null
                 sps = null
                 pps = null
                 mWidth = 0
                 mHeight = 0
-                codecTypePinned = false
                 restartsSinceLastFrame = 0
                 codecFallbackUsed = false
                 decoderPermanentlyFailed = false
                 syncStallRestartCount = 0
                 lastSyncStallRestartMs = 0L
+            }
+            // The pinned codec type describes the stream, not the decoder instance, so it has to
+            // outlive a surface teardown: the phone keeps sending the same codec while the view is
+            // rebuilt, and re-detecting on whatever packet lands mid-teardown can misread an
+            // ordinary H.264 P-slice as HEVC and configure the wrong decoder for the rest of the
+            // session. Only a real disconnect can change what the phone is sending.
+            if (DecoderStopPolicy.endsSession(reason)) {
+                codecTypePinned = false
             }
             // Keep VPS/SPS/PPS cached so we can re-inject them on restart
             lastFrameRenderedMs = 0L

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -166,16 +166,24 @@ class VideoDecoder(private val settings: Settings) {
     private var lastSyncStallSuppressedLogMs = 0L
 
     // Throughput counters for the periodic telemetry tick - see THROUGHPUT_LOG_INTERVAL_MS.
-    // Session-monotonic so each has exactly one writer: framesFed/framesDropped from decode()
-    // (under this object's monitor), framesRendered from the output thread. The output thread
-    // reads all three and keeps its own last-logged snapshots to derive per-interval deltas.
+    // Session-monotonic so each has exactly one writer: framesFed/framesDropped/inputWaitMs from
+    // decode() (under this object's monitor), framesRendered from the output thread. The output
+    // thread reads them all and keeps its own last-logged snapshots to derive per-interval deltas.
     @Volatile private var framesFed = 0L
     @Volatile private var framesDropped = 0L
     @Volatile private var framesRendered = 0L
+    // Milliseconds spent waiting for a free input buffer. AapVideo.process() runs on the transport's
+    // Poll thread, which also carries audio and control, so this wait is time those cannot be
+    // dispatched - and it is otherwise invisible, since a frame that waits some of its attempts logs
+    // nothing and "Input buffer full" only fires when every attempt is exhausted. Near zero while
+    // the frame rate is low means the frames were never sent; high means the decoder is the
+    // bottleneck and the attempt budget is being paid for in audio latency.
+    @Volatile private var inputWaitMs = 0L
     private var lastThroughputLogMs = 0L
     private var lastLoggedFramesFed = 0L
     private var lastLoggedFramesDropped = 0L
     private var lastLoggedFramesRendered = 0L
+    private var lastLoggedInputWaitMs = 0L
 
     // Reuse buffers for older API levels to minimize GC pressure
     private var inputBuffers: Array<ByteBuffer>? = null
@@ -363,10 +371,12 @@ class VideoDecoder(private val settings: Settings) {
             framesFed = 0L
             framesDropped = 0L
             framesRendered = 0L
+            inputWaitMs = 0L
             lastThroughputLogMs = 0L
             lastLoggedFramesFed = 0L
             lastLoggedFramesDropped = 0L
             lastLoggedFramesRendered = 0L
+            lastLoggedInputWaitMs = 0L
             AppLog.i("Decoder stopped: $reason")
         }
     }
@@ -851,11 +861,16 @@ class VideoDecoder(private val settings: Settings) {
             // at 30ms this reported a full input queue within a second of every decoder start,
             // before the component had drained its first buffers, on hardware that then went on to
             // decode at full rate.
+            //
+            // The whole dequeue is timed, not just the retries: the first call blocks for up to
+            // TIMEOUT_US on its own, and what holds up audio behind us is the total.
+            val waitStart = SystemClock.elapsedRealtime()
             while (attempts < 30) {
                 inputIndex = currentCodec.dequeueInputBuffer(TIMEOUT_US)
                 if (inputIndex >= 0) break
                 attempts++
             }
+            inputWaitMs += SystemClock.elapsedRealtime() - waitStart
 
             if (inputIndex < 0) {
                 AppLog.e("Input buffer feed failed (full)")
@@ -927,16 +942,19 @@ class VideoDecoder(private val settings: Settings) {
         val rendered = framesRendered - lastLoggedFramesRendered
         val fed = framesFed - lastLoggedFramesFed
         val dropped = framesDropped - lastLoggedFramesDropped
+        val inputWait = inputWaitMs - lastLoggedInputWaitMs
         lastThroughputLogMs = now
         lastLoggedFramesRendered = framesRendered
         lastLoggedFramesFed = framesFed
         lastLoggedFramesDropped = framesDropped
+        lastLoggedInputWaitMs = inputWaitMs
 
         val renderedFps = rendered * 1000 / elapsed
         val fedFps = fed * 1000 / elapsed
         AppLog.i(
             "Throughput over ${elapsed}ms: rendered=$rendered (${renderedFps}fps), " +
-                "fed=$fed (${fedFps}fps), dropped=$dropped, codec=$currentCodecName"
+                "fed=$fed (${fedFps}fps), dropped=$dropped, inputWait=${inputWait}ms, " +
+                "codec=$currentCodecName"
         )
     }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -189,7 +189,6 @@ class VideoDecoder(private val settings: Settings) {
     private var loggedFirstSoftwareFrame = false
     @Volatile var onFirstFrameListener: (() -> Unit)? = null
     @Volatile var lastFrameRenderedMs: Long = 0L
-    private var syntheticPtsUs = 0L
 
     // Frames rendered since whoever owns the session last zeroed this. Deliberately *not* cleared
     // by stop(), which is what separates it from framesRendered above: that one is a throughput
@@ -349,7 +348,6 @@ class VideoDecoder(private val settings: Settings) {
             }
             // Keep VPS/SPS/PPS cached so we can re-inject them on restart
             lastFrameRenderedMs = 0L
-            syntheticPtsUs = 0L
             loggedFirstSoftwareFrame = false
             // The FPS window and the throughput counters must not straddle a restart, or the
             // first sample afterwards is averaged over the whole teardown and reads near zero.
@@ -374,12 +372,12 @@ class VideoDecoder(private val settings: Settings) {
     /**
      * Main entry point for decoding a video/control packet.
      *
-     * Returns false when the frame was dropped because the codec's input queue was transiently
-     * full, so the caller (AapVideo) can route recovery through its own throttled
-     * markCorruptAndRequestRecovery() instead of every drop firing an independent, unthrottled
-     * keyframe request.
+     * Reports nothing back to the caller. A frame this cannot place into the codec's input queue
+     * is simply lost, which the stream heals from on the phone's next keyframe; treating it as
+     * stream corruption instead put a keyframe request and a video-focus cycle behind an event
+     * that fires within a second of the decoder starting on ordinary hardware.
      */
-    fun decode(buffer: ByteArray, offset: Int, size: Int, forceSoftware: Boolean, codecName: String): Boolean {
+    fun decode(buffer: ByteArray, offset: Int, size: Int, forceSoftware: Boolean, codecName: String) {
         synchronized(this) {
             // Input-side liveness: bytes are arriving from the phone right now.
             lastInputBytesReceivedMs = SystemClock.elapsedRealtime()
@@ -424,7 +422,7 @@ class VideoDecoder(private val settings: Settings) {
                 onDecoderError?.invoke()
             }
 
-            if (decoderPermanentlyFailed) return true
+            if (decoderPermanentlyFailed) return
 
             // Buffer management for backward compatibility
             // Modern devices (API 21+) use the original buffer with offset/size to avoid GC pressure.
@@ -477,8 +475,8 @@ class VideoDecoder(private val settings: Settings) {
                     }
                 }
 
-                if (mSurface == null || !mSurface!!.isValid) return true
-                if (mWidth == 0 || mHeight == 0) return true
+                if (mSurface == null || !mSurface!!.isValid) return
+                if (mWidth == 0 || mHeight == 0) return
 
                 if (shouldUseBundledHevc(typeToUse, settings.forceSoftwareDecoding || forceSoftware)) {
                     startBundledHevc(mWidth, mHeight)
@@ -495,10 +493,10 @@ class VideoDecoder(private val settings: Settings) {
                     AppLog.e("Bundled HEVC decoder failed with code $renderedFrames")
                     scheduleRestart("software_hevc_error_$renderedFrames")
                 }
-                return true
+                return
             }
 
-            if (codec == null) return true
+            if (codec == null) return
 
             if (pendingKeyframeRequest) {
                 pendingKeyframeRequest = false
@@ -510,21 +508,20 @@ class VideoDecoder(private val settings: Settings) {
             val buf = ByteBuffer.wrap(frameData, frameOffset, size)
             while (buf.hasRemaining()) {
                 if (!feedInputBuffer(buf)) {
-                    // Input queue is transiently full. Drop this frame and let the caller
-                    // (AapVideo.markCorruptAndRequestRecovery) decide whether/when to request a
-                    // keyframe, instead of firing an unthrottled recovery here - on decoders with
-                    // a small, fixed buffer count this can recur every few seconds during normal
-                    // playback, and each one was an independent, unthrottled focus-cycle blink. A
-                    // truly stuck decoder is still caught by outputThreadLoop's sync_stall
-                    // watchdog.
+                    // The codec had no free input buffer for the whole wait. Drop what is left of
+                    // this frame and carry on: the next keyframe repairs the picture, and the
+                    // decoders this happens on are the ones least able to afford the alternative.
+                    // Routing it into the recovery path instead cost a keyframe request and a
+                    // video-focus cycle for an event that fires within a second of the decoder
+                    // starting on ordinary hardware. A decoder that is genuinely stuck rather than
+                    // busy is still caught by outputThreadLoop's sync_stall watchdog.
                     AppLog.w("Input buffer full. Dropping frame.")
                     framesDropped++
-                    return false
+                    return
                 }
             }
             framesFed++
         }
-        return true
     }
 
     private fun shouldUseBundledHevc(type: CodecType, forceSoftware: Boolean): Boolean {
@@ -713,18 +710,14 @@ class VideoDecoder(private val settings: Settings) {
 
             val format = MediaFormat.createVideoFormat(mimeType, width, height)
 
-            // Add hardware prioritization and low-latency hints
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                format.setInteger(MediaFormat.KEY_PRIORITY, 0) // 0 = Real-time priority
-                format.setInteger(MediaFormat.KEY_OPERATING_RATE, settings.fpsLimit)
-            }
-            // Some vendor decoders (e.g. MediaTek's OMX.MTK.VIDEO.DECODER.AVC) reject
-            // KEY_OPERATING_RATE outright, so also set the documented fallback frame-rate hint.
-            // KEY_FRAME_RATE predates KEY_OPERATING_RATE (API 16 vs 23), so it's unguarded.
-            format.setInteger(MediaFormat.KEY_FRAME_RATE, settings.fpsLimit)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                format.setInteger(MediaFormat.KEY_MAX_B_FRAMES, 0) // Tell codec not to hold frames -> drastically decreases latency
-            }
+            // Deliberately no KEY_PRIORITY / KEY_OPERATING_RATE / KEY_FRAME_RATE / KEY_MAX_B_FRAMES
+            // here. They were added as latency hints and measured to do nothing: the OMX components
+            // on the head units they were meant to help answer with
+            // "codec does not support config priority (err -1010)" and the same for the operating
+            // rate. The frame-rate keys are worse than inert, because the only frame rate this
+            // class knows is settings.fpsLimit - the user's cap, not the rate the phone negotiated
+            // - and KEY_MAX_B_FRAMES is an encoder key. Any replacement needs a log from a device
+            // where the codec actually accepts it.
 
             // Apply Codec Specific Data (CSD) from parsed SPS/PPS/VPS
             if (mimeType == CodecType.H265.mimeType) {
@@ -847,7 +840,11 @@ class VideoDecoder(private val settings: Settings) {
         try {
             var inputIndex = -1
             var attempts = 0
-            while (attempts < 3) { // do not set attempts to high, otherwise there is a strong hiccup
+            // ~300ms of patience. Anything much shorter gives up while the codec is merely busy:
+            // at 30ms this reported a full input queue within a second of every decoder start,
+            // before the component had drained its first buffers, on hardware that then went on to
+            // decode at full rate.
+            while (attempts < 30) {
                 inputIndex = currentCodec.dequeueInputBuffer(TIMEOUT_US)
                 if (inputIndex >= 0) break
                 attempts++
@@ -889,12 +886,7 @@ class VideoDecoder(private val settings: Settings) {
 
             inputBuffer.flip()
 
-            // Force a perfectly smooth timestamp (60 FPS = 16,666 microseconds per frame)
-            // This prevents network jitter from causing "catch-up" fast-forwards
-            if (flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG == 0) {
-                syntheticPtsUs += 1000000L/settings.fpsLimit
-            }
-            val pts = syntheticPtsUs
+            val pts = (System.nanoTime() - startTime) / 1000
 
             currentCodec.queueInputBuffer(inputIndex, 0, inputBuffer.limit(), pts, flags)
             return true

--- a/app/src/main/java/com/andrerinas/openheadunit/view/ProjectionView.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/view/ProjectionView.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.view.SurfaceHolder
 import android.view.SurfaceView
 import com.andrerinas.openheadunit.App
+import com.andrerinas.openheadunit.decoder.DecoderStopPolicy
 import com.andrerinas.openheadunit.decoder.VideoDecoder
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.HeadUnitScreenConfig
@@ -25,7 +26,7 @@ class ProjectionView @JvmOverloads constructor(
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        videoDecoder?.stop("onDetachedFromWindow")
+        videoDecoder?.stop(DecoderStopPolicy.REASON_DETACHED_FROM_WINDOW)
     }
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
@@ -46,7 +47,7 @@ class ProjectionView @JvmOverloads constructor(
 
     override fun surfaceDestroyed(holder: SurfaceHolder) {
         AppLog.i("holder $holder")
-        videoDecoder?.stop("surfaceDestroyed")
+        videoDecoder?.stop(DecoderStopPolicy.REASON_SURFACE_DESTROYED)
         callbacks.forEach { it.onSurfaceDestroyed(holder.surface) }
     }
 

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/VideoRecoveryPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/VideoRecoveryPolicyTest.kt
@@ -25,37 +25,12 @@ class VideoRecoveryPolicyTest {
     }
 
     @Test
-    fun `a deferred request stays pending until the throttle expires`() {
-        val last = 10_000L
-        assertFalse(
-            VideoRecoveryPolicy.isDeferredRequestDue(last + 500L, last, deferred = true)
-        )
-        assertTrue(
-            VideoRecoveryPolicy.isDeferredRequestDue(
-                last + KEYFRAME_REQUEST_THROTTLE_MS + 1, last, deferred = true
-            )
-        )
-    }
-
-    @Test
-    fun `nothing is due when no request was deferred`() {
-        val last = 10_000L
-        assertFalse(
-            VideoRecoveryPolicy.isDeferredRequestDue(
-                last + KEYFRAME_REQUEST_THROTTLE_MS + 1, last, deferred = false
-            )
-        )
-    }
-
-    @Test
-    fun `a deferred request never overtakes the throttle it was deferred by`() {
-        // The pairing that matters: whenever a request is suppressed, the deferred check must
-        // agree it is not yet due, so no path can send two requests inside one throttle window.
+    fun `no request is allowed anywhere inside one throttle window`() {
+        // A burst of corrupt frames must produce at most one focus cycle: the phone rebuilds the
+        // stream on each one, so several inside a second costs more picture than it recovers.
         val last = 10_000L
         for (offset in 0L..KEYFRAME_REQUEST_THROTTLE_MS) {
-            val now = last + offset
-            assertFalse(VideoRecoveryPolicy.canRequestKeyframe(now, last))
-            assertFalse(VideoRecoveryPolicy.isDeferredRequestDue(now, last, deferred = true))
+            assertFalse(VideoRecoveryPolicy.canRequestKeyframe(last + offset, last))
         }
     }
 }

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/DecoderStopPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/DecoderStopPolicyTest.kt
@@ -1,0 +1,64 @@
+package com.andrerinas.openheadunit.decoder
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The reason strings here are the ones the real call sites pass. Referencing the constants means a
+ * rename cannot silently move a stop from one category to the other.
+ */
+class DecoderStopPolicyTest {
+
+    @Test
+    fun `a surface teardown does not end the session`() {
+        assertFalse(DecoderStopPolicy.endsSession(DecoderStopPolicy.REASON_SURFACE_DESTROYED))
+        assertFalse(DecoderStopPolicy.endsSession(DecoderStopPolicy.REASON_DETACHED_FROM_WINDOW))
+        assertFalse(
+            DecoderStopPolicy.endsSession(DecoderStopPolicy.REASON_PROJECTION_VIEW_RECREATE)
+        )
+        assertFalse(DecoderStopPolicy.endsSession(DecoderStopPolicy.REASON_NEW_SURFACE))
+    }
+
+    @Test
+    fun `the decoder's own restarts do not end the session`() {
+        assertTrue(DecoderStopPolicy.isDecoderRestart("restart: sync_stall"))
+        assertTrue(DecoderStopPolicy.isDecoderRestart("restart: decoder_start_failed: timeout"))
+        assertFalse(DecoderStopPolicy.endsSession("restart: sync_stall"))
+        assertFalse(DecoderStopPolicy.endsSession("restart: decoder_start_failed: timeout"))
+    }
+
+    @Test
+    fun `a surface teardown is not mistaken for a decoder restart`() {
+        // Only a restart keeps VPS/SPS/PPS and the watchdog counters. A surface teardown must still
+        // clear those, it only keeps the pinned codec type.
+        assertFalse(DecoderStopPolicy.isDecoderRestart(DecoderStopPolicy.REASON_SURFACE_DESTROYED))
+        assertFalse(
+            DecoderStopPolicy.isDecoderRestart(DecoderStopPolicy.REASON_DETACHED_FROM_WINDOW)
+        )
+        assertFalse(
+            DecoderStopPolicy.isDecoderRestart(DecoderStopPolicy.REASON_PROJECTION_VIEW_RECREATE)
+        )
+        assertFalse(DecoderStopPolicy.isDecoderRestart(DecoderStopPolicy.REASON_NEW_SURFACE))
+    }
+
+    @Test
+    fun `a disconnect ends the session`() {
+        // These two clear the codec pin, which is what lets a reconnect renegotiate a new codec.
+        assertTrue(DecoderStopPolicy.endsSession("CommManager: doDisconnect"))
+        assertTrue(DecoderStopPolicy.endsSession("AapService::onDisconnect"))
+    }
+
+    @Test
+    fun `an unrecognised reason ends the session`() {
+        assertTrue(DecoderStopPolicy.endsSession("unknown"))
+        assertTrue(DecoderStopPolicy.endsSession(""))
+        assertTrue(DecoderStopPolicy.endsSession("something nobody has written yet"))
+    }
+
+    @Test
+    fun `matching is exact, not a prefix or a substring`() {
+        assertTrue(DecoderStopPolicy.endsSession("surfaceDestroyed unexpectedly"))
+        assertTrue(DecoderStopPolicy.endsSession("pre-surfaceDestroyed"))
+    }
+}


### PR DESCRIPTION
## Why

Eight issues since 3.2.0 report the same failure: no picture with working audio, blinking, freezing, "3 fps", general lag (#749, #755, #757, #744, #767, #771, #787, #788). Reporters keep naming 3.2.0-beta2 or beta3 as the last version whose picture was usable.

`git log v.3.2.0-beta3..v.3.2.0-beta4` over `decoder/`, `AapVideo.kt`, `AapProjectionActivity.kt` and `view/` returns seven commits, and only one changes decode behaviour: `18706589`, the video half of #738. It is in beta4 and every release since, and in no earlier tag.

Two of its changes combine badly. `feedInputBuffer`'s wait for a free input buffer went from 30 attempts to 3, so 300 ms down to 30 ms, and a failure there now marks the stream corrupt instead of being ignored. At beta3 a full input queue was a bare `return` and the picture healed on the next keyframe. After #738 it cycles video focus to beg for an IDR and arms a P-frame lockout that discards everything until a keyframe is positively identified.

The trigger fires constantly: in `HUR_Log_20260805_104127_934.txt` (#757, Intel Atom) the first `Input buffer full` lands **70 ms after `Codec initialized`**, before the component has drained its first buffers. And the lockout can fail to end, because it has no timeout, no re-request, and `checkKeyframe` parses NAL headers using `settings.videoCodec` (the user's preference, default `"Auto"`) rather than the pinned codec, while `ServiceDiscoveryResponse` enforces H.265 at 1440p regardless. Measured in `HUR_Log_20260806_214208_084.txt` (#755): `fed=0, rendered=0` for **16.5 seconds** with the phone connected and still sending. In a verbose #757 log the phone delivers **~50 frame-starts per second for 34 seconds**, all acknowledged, while the reporter watches 3 fps.

Should address #755, #757, #749 and #788. Reporter confirmation is outstanding.

## What changed

`31168026` reverts six pieces of `18706589`:

- `feedInputBuffer` waits 30 attempts again, and `decode()` returns `Unit`. A frame that cannot be placed is counted in `framesDropped` and forgotten.
- `waitingForKeyframe`, `checkKeyframe()` and the deferred-request machinery are deleted. `markCorruptAndRequestRecovery()` is self-healing again: corruption is scoped to the current frame and the next flag 9 or 11 clears it. `VideoRecoveryPolicy.isDeferredRequestDue` goes with it; the throttle stays.
- `KEY_PRIORITY`, `KEY_OPERATING_RATE`, `KEY_MAX_B_FRAMES` and the later `KEY_FRAME_RATE` are removed. The MediaTek unit in #755 answers the first two with `err -1010`, `KEY_MAX_B_FRAMES` is an encoder key, and the frame-rate keys declare `settings.fpsLimit`, the user's cap rather than the negotiated rate.
- The synthetic PTS returns to the wall clock. `releaseOutputBuffer(index, true)` ignores the timestamp, so it prevented no jitter.

`checkFragmentState()` stays: orphaned-fragment detection is the part of #738 that fixed a real defect, and with the lockout gone its recovery call is scoped to one frame.

`4bafc7fd` makes the reassembly buffer grow on demand (2 MB start, same 8 MB ceiling) instead of being sized from `settings.videoCodec`, which can disagree with the negotiated codec and is not readable at construction time anyway.

`sync_stall`, the crop-rect handling, the throughput telemetry and #754's codec pinning are untouched.

## Where to focus review

- **The 30 attempts is the one judgement call.** `AapVideo.process()` runs on `AapTransport:Handler::Poll`, which also carries audio and control, so a full input queue can block those for up to 300 ms instead of 30. beta2 and beta3 shipped 30, which is why it is 30. If it costs audio or control latency, the fix is tuning toward ~10, not restoring the coupling.
- `AapVideo.ensureCapacity()` copies `position()` bytes into the new buffer and continues writing. Worth checking the ByteBuffer mode handling.
- Removing the four `MediaFormat` keys is the only part that could be a downgrade on hardware that honours them.

## Verification

CI is the build gate. Separately, tested on a UNISOC MT50_YT610E4GFPSL_U (Android 14, 8 cores, Native AA over WiFi Direct, 1080p, `c2.unisoc.*` Codec2), baseline against this branch with settings preserved across `adb install -r`:

- Build and unit tests pass on both branches.
- 3 min at 1080p/H.264: 45 throughput samples, `fed == rendered`, `dropped=0` on every one, 49 to 60 fps. Indistinguishable from baseline.
- 30 min soak with music and navigation: 368 samples, `dropped=0` throughout, zero `sync_stall`, average 58.2 fps, no drift or judder. This tests the PTS change.
- 3 min explicit H.265: 50 samples, `dropped=0`. No buffer growth needed at 1080p, so that path is unexercised.
- Ping cadence at light load: 250 samples, gaps 0.934 s to 1.111 s, median 1.0 s. Audio continuous, confirmed by listening.
- Nine decoder restarts, all clean, no smearing.

**Gap: the cost of 300 ms of input-buffer patience under load is untested.** The stress run could not be executed. That unit hard-reboots under sustained multi-core load, confirmed by `/proc/uptime` reading 62 s on recovery, five times across 8, 6, 4 and 3 spin loops and identically on both builds, so it is that unit's margin and not either branch. Testing stopped rather than power-cycling further. The ping and audio numbers above are therefore at light load only. A thermal-throttle retry is the next step and has not been run.

Also unexercised: the codec-mismatch latch needs a 2560x1440 panel (that one caps to 1080p), and the smearing probe never hit its target window across nine restarts.

## Out of scope

- The wizard, DPI and resolution regressions behind #767, #744 and #787 landed in the same window and are partly addressed by `6c477c3d`. Kept separate so reporters test one variable.
- #789 targets the same symptom by softening the focus request. Under this change the lockout it works around is gone, and the #755 log from that build shows the gentler nudge prolonging the freeze because it does not force an IDR. Worth reconciling before either lands.
