### PR TITLE
choose log destination

### DIFF
--- a/.github/workflows/gemini-code-review.yml
+++ b/.github/workflows/gemini-code-review.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Run AI Code Review"
         uses: petarzarkov/gemini-code-review-action@latest
         with:
-          model: gemini-2.5-flash
+          model: gemini-3.5-flash-lite
           skip_draft_prs: false
           language: English
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
-### v.3.2.2-upcoming
+### v.3.2.3
+- Adding custom log location (App folder or Download folder)
+- additional fixing for the fps/freeze problems. Thanks to @o-jcardenass and @andrecuellar for helping
+
+### v.3.2.2
 - Fixing location jumping, especially on lower speeds
 - Fixing screen flicker again in video decoder
 - Fix/video throughput telemetry and keyframe lockout, thanks to @o-jcardenass

--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ adb shell am start -a android.intent.action.VIEW -d "headunit://connect?ip=192.1
 - more customization options for the UI and the app itself
 
 ## Changelog
-### v.3.2.2-upcoming
+### v.3.2.3
+- Adding custom log location (App folder or Download folder)
+- additional fixing for the fps/freeze problems. Thanks to @o-jcardenass and @andrecuellar for helping
+
+### v.3.2.2
 - Fixing location jumping, especially on lower speeds
 - Fixing screen flicker again in video decoder
 - Fix/video throughput telemetry and keyframe lockout, thanks to @o-jcardenass

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -1773,6 +1773,44 @@ class SettingsFragment : Fragment() {
             }
         ))
 
+        val logLocations = Settings.LogLocation.entries
+        val logLocationNames = logLocations.map {
+            when (it) {
+                Settings.LogLocation.DEFAULT -> getString(R.string.log_location_default)
+                Settings.LogLocation.DOWNLOADS -> getString(R.string.log_location_downloads)
+            }
+        }.toTypedArray()
+        items.add(SettingItem.SettingEntry(
+            stableId = "logLocation",
+            nameResId = R.string.log_location,
+            value = when (settings.logLocation) {
+                Settings.LogLocation.DEFAULT -> getString(R.string.log_location_default)
+                Settings.LogLocation.DOWNLOADS -> getString(R.string.log_location_downloads)
+            },
+            onClick = {
+                val currentIndex = logLocations.indexOf(settings.logLocation)
+                MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
+                    .setTitle(R.string.log_location)
+                    .setSingleChoiceItems(logLocationNames, currentIndex) { dialog, which ->
+                        val newLocation = logLocations[which]
+                        val applyLocation: () -> Unit = {
+                            settings.logLocation = newLocation
+                            if (settings.logSource == Settings.LogSource.APPLOG_FILE) {
+                                AppLog.init(settings, requireContext().applicationContext)
+                            }
+                            dialog.dismiss()
+                            updateSettingsList()
+                        }
+                        if (newLocation == Settings.LogLocation.DOWNLOADS) {
+                            runWithDownloadsStoragePermission(applyLocation)
+                        } else {
+                            applyLocation()
+                        }
+                    }
+                    .show()
+            }
+        ))
+
         items.add(SettingItem.SettingEntry(
             stableId = "captureLog",
             nameResId = if (if (settings.logSource == Settings.LogSource.APPLOG_FILE) AppLog.isCapturing else LogExporter.isCapturing) R.string.stop_log_capture else R.string.start_log_capture,

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/AppLog.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/AppLog.kt
@@ -104,7 +104,7 @@ object AppLog {
             return
         }
 
-        val logDir = LogFilesHelper.resolveLogDirectory(appContext) ?: appContext.filesDir
+        val logDir = LogFilesHelper.resolveLogDirectory(appContext, settings) ?: appContext.filesDir
         LogFilesHelper.rotateLogs(logDir)
 
         val logFile = LogFilesHelper.createTimestampedLogFile(logDir)

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/LogExporter.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/LogExporter.kt
@@ -56,7 +56,8 @@ object LogExporter {
         }
 
         stopCapture()
-        val logDir = LogFilesHelper.resolveLogDirectory(context, allowInternalFallback = false) ?: return
+        val settings = Settings(context)
+        val logDir = LogFilesHelper.resolveLogDirectory(context, settings, allowInternalFallback = false) ?: return
         LogFilesHelper.rotateLogs(logDir)
 
         val file = LogFilesHelper.createTimestampedLogFile(logDir)
@@ -123,7 +124,8 @@ object LogExporter {
                 ?.takeIf { it.exists() && it.length() > 0 }
         }
 
-        val logDir = LogFilesHelper.resolveLogDirectory(context, allowInternalFallback = false) ?: return null
+        val settings = Settings(context)
+        val logDir = LogFilesHelper.resolveLogDirectory(context, settings, allowInternalFallback = false) ?: return null
         LogFilesHelper.ensureDirectory(logDir)
 
         val source = captureFile

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/LogFilesHelper.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/LogFilesHelper.kt
@@ -1,6 +1,8 @@
 package com.andrerinas.openheadunit.utils
 
 import android.content.Context
+import android.os.Build
+import android.os.Environment
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -18,9 +20,21 @@ object LogFilesHelper {
         settings: Settings? = null,
         allowInternalFallback: Boolean = true
     ): File? {
-        val activeSettings = settings ?: try { Settings(context) } catch (_: Exception) { null }
-        if (activeSettings?.logLocation == Settings.LogLocation.DOWNLOADS) {
-            val downloadsDir = android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_DOWNLOADS)
+        val location = settings?.logLocation ?: try {
+            Settings(context).logLocation
+        } catch (_: Exception) {
+            Settings.LogLocation.DEFAULT
+        }
+
+        if (location == Settings.LogLocation.DOWNLOADS) {
+            val downloadsDir = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
+                    ?: @Suppress("DEPRECATION") Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+            } else {
+                @Suppress("DEPRECATION")
+                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+            }
+
             if (downloadsDir != null) {
                 val openHeadunitDir = File(downloadsDir, "OpenHeadunitLogs")
                 if (openHeadunitDir.exists() || openHeadunitDir.mkdirs()) {

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/LogFilesHelper.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/LogFilesHelper.kt
@@ -13,7 +13,24 @@ object LogFilesHelper {
     const val DEFAULT_MAX_LOG_FILES = 10
     const val DEFAULT_MAX_TOTAL_SIZE = 50L * 1024 * 1024 // 50 MB
 
-    fun resolveLogDirectory(context: Context, allowInternalFallback: Boolean = true): File? {
+    fun resolveLogDirectory(
+        context: Context,
+        settings: Settings? = null,
+        allowInternalFallback: Boolean = true
+    ): File? {
+        val activeSettings = settings ?: try { Settings(context) } catch (_: Exception) { null }
+        if (activeSettings?.logLocation == Settings.LogLocation.DOWNLOADS) {
+            val downloadsDir = android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_DOWNLOADS)
+            if (downloadsDir != null) {
+                val openHeadunitDir = File(downloadsDir, "OpenHeadunitLogs")
+                if (openHeadunitDir.exists() || openHeadunitDir.mkdirs()) {
+                    return openHeadunitDir
+                }
+                if (downloadsDir.exists() || downloadsDir.mkdirs()) {
+                    return downloadsDir
+                }
+            }
+        }
         return context.getExternalFilesDir(null) ?: if (allowInternalFallback) context.filesDir else null
     }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -166,9 +166,18 @@ class Settings(private val context: Context) {
         APPLOG_FILE
     }
 
+    enum class LogLocation {
+        DEFAULT,
+        DOWNLOADS
+    }
+
     var logSource: LogSource
         get() = LogSource.entries.getOrElse(prefs.getInt(KEY_LOG_SOURCE, LogSource.LOGCAT.ordinal)) { LogSource.LOGCAT }
         set(value) { prefs.edit().putInt(KEY_LOG_SOURCE, value.ordinal).apply() }
+
+    var logLocation: LogLocation
+        get() = LogLocation.entries.getOrElse(prefs.getInt(KEY_LOG_LOCATION, LogLocation.DEFAULT.ordinal)) { LogLocation.DEFAULT }
+        set(value) { prefs.edit().putInt(KEY_LOG_LOCATION, value.ordinal).apply() }
 
     /** Whether log capture should be active across restarts. Default: false (disabled). */
     var exporterCaptureEnabled: Boolean
@@ -836,6 +845,7 @@ class Settings(private val context: Context) {
         /** SharedPreferences key; also used by [AapService] for change listener. */
         const val KEY_LOG_LEVEL = "log-level"
         const val KEY_LOG_SOURCE = "log-source"
+        const val KEY_LOG_LOCATION = "log-location"
         /** Persist whether log capture should be active across restarts. */
         const val KEY_LOG_CAPTURE_ENABLED = "log-capture-enabled"
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -361,6 +361,9 @@
     <string name="log_source">مصدر السجلات</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">مباشرة إلى الملف</string>
+<string name="log_location">موقع حفظ السجلات</string>
+    <string name="log_location_default">الافتراضي (تخزين التطبيق)</string>
+    <string name="log_location_downloads">مجلد التنزيلات</string>
     <string name="start_log_capture">بدء التقاط السجل</string>
     <string name="start_log_capture_description">يبدأ تسجيل سجلات النظام في ملف.</string>
     <string name="start_log_capture_in_applog_file">تُكتب رسائل Log في ملف فقط أثناء تنشيط الالتقاط</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -361,7 +361,7 @@
     <string name="log_source">مصدر السجلات</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">مباشرة إلى الملف</string>
-<string name="log_location">موقع حفظ السجلات</string>
+    <string name="log_location">موقع حفظ السجلات</string>
     <string name="log_location_default">الافتراضي (تخزين التطبيق)</string>
     <string name="log_location_downloads">مجلد التنزيلات</string>
     <string name="start_log_capture">بدء التقاط السجل</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -361,6 +361,9 @@
     <string name="log_source">Zdroj logů</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Přímo do souboru</string>
+<string name="log_location">Uložiště protokolů</string>
+    <string name="log_location_default">Výchozí (Úložiště aplikace)</string>
+    <string name="log_location_downloads">Složka Ke stažení</string>
     <string name="start_log_capture">Spustit záznam protokolu</string>
     <string name="start_log_capture_description">Spustí nahrávání systémových protokolů do souboru.</string>
     <string name="start_log_capture_in_applog_file">Zprávy Log se zapisují do souboru pouze během aktivního záznamu</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -123,6 +123,9 @@
     <string name="log_source">Logquelle</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Direkt in Datei</string>
+    <string name="log_location">Log-Speicherort</string>
+    <string name="log_location_default">Standard (App-Speicher)</string>
+    <string name="log_location_downloads">Downloads-Ordner</string>
     <string name="start_log_capture">Log-Aufzeichnung starten</string>
     <string name="start_log_capture_description">Startet das Mitschreiben von System-Logs für Debugging</string>
     <string name="start_log_capture_in_applog_file">Log-Meldungen werden nur bei aktiver Aufzeichnung in eine Datei geschrieben</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -361,6 +361,9 @@
     <string name="log_source">Fuente de registro</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Directo a archivo</string>
+<string name="log_location">Ubicación de registros</string>
+    <string name="log_location_default">Predeterminado (Almacenamiento de app)</string>
+    <string name="log_location_downloads">Carpeta de Descargas</string>
     <string name="start_log_capture">Iniciar captura de log</string>
     <string name="start_log_capture_description">Comienza a registrar los logs del sistema en un archivo.</string>
     <string name="start_log_capture_in_applog_file">Los mensajes de Log se escriben en un archivo solo mientras la captura está activa</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -361,7 +361,7 @@
     <string name="log_source">Fuente de registro</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Directo a archivo</string>
-<string name="log_location">Ubicación de registros</string>
+    <string name="log_location">Ubicación de registros</string>
     <string name="log_location_default">Predeterminado (Almacenamiento de app)</string>
     <string name="log_location_downloads">Carpeta de Descargas</string>
     <string name="start_log_capture">Iniciar captura de log</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -361,6 +361,9 @@
     <string name="log_source">Fuente de registro</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Directo a archivo</string>
+<string name="log_location">Ubicación de registros</string>
+    <string name="log_location_default">Predeterminado (Almacenamiento de app)</string>
+    <string name="log_location_downloads">Carpeta de Descargas</string>
     <string name="start_log_capture">Iniciar captura de log</string>
     <string name="start_log_capture_description">Comienza a registrar los logs del sistema en un archivo.</string>
     <string name="start_log_capture_in_applog_file">Los mensajes de Log se escriben en un archivo solo mientras la captura está activa</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -361,7 +361,7 @@
     <string name="log_source">Fuente de registro</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Directo a archivo</string>
-<string name="log_location">Ubicación de registros</string>
+    <string name="log_location">Ubicación de registros</string>
     <string name="log_location_default">Predeterminado (Almacenamiento de app)</string>
     <string name="log_location_downloads">Carpeta de Descargas</string>
     <string name="start_log_capture">Iniciar captura de log</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -360,6 +360,9 @@
     <string name="log_source">Naplóforrás</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Közvetlenül fájlba</string>
+<string name="log_location">Napló mentési helye</string>
+    <string name="log_location_default">Alapértelmezett (Alkalmazás tárhely)</string>
+    <string name="log_location_downloads">Letöltések mappa</string>
     <string name="start_log_capture">Naplózás indítása</string>
     <string name="start_log_capture_description">Rögzíti a rendszernaplókat egy helyi fájlba a hibaelhárításhoz.</string>
     <string name="start_log_capture_in_applog_file">Az Log üzenetek csak aktív rögzítés közben íródnak fájlba</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -360,7 +360,7 @@
     <string name="log_source">Naplóforrás</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Közvetlenül fájlba</string>
-<string name="log_location">Napló mentési helye</string>
+    <string name="log_location">Napló mentési helye</string>
     <string name="log_location_default">Alapértelmezett (Alkalmazás tárhely)</string>
     <string name="log_location_downloads">Letöltések mappa</string>
     <string name="start_log_capture">Naplózás indítása</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -121,7 +121,7 @@
     <string name="log_source">Origine dei log</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Direttamente su file</string>
-<string name="log_location">Posizione file di log</string>
+    <string name="log_location">Posizione file di log</string>
     <string name="log_location_default">Predefinita (Memoria app)</string>
     <string name="log_location_downloads">Cartella Download</string>
     <string name="start_log_capture">Avvia acquisizione log</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -121,6 +121,9 @@
     <string name="log_source">Origine dei log</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Direttamente su file</string>
+<string name="log_location">Posizione file di log</string>
+    <string name="log_location_default">Predefinita (Memoria app)</string>
+    <string name="log_location_downloads">Cartella Download</string>
     <string name="start_log_capture">Avvia acquisizione log</string>
     <string name="start_log_capture_description">Inizia a registrare i log completi per il debug</string>
     <string name="start_log_capture_in_applog_file">I messaggi Log vengono scritti su file solo durante la cattura attiva</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -121,7 +121,7 @@
     <string name="log_source">ログソース</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">ファイルへ直接</string>
-<string name="log_location">ログ保存場所</string>
+    <string name="log_location">ログ保存場所</string>
     <string name="log_location_default">デフォルト (アプリ専用ストレージ)</string>
     <string name="log_location_downloads">ダウンロードフォルダ</string>
     <string name="start_log_capture">ログ取得を開始する</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -121,6 +121,9 @@
     <string name="log_source">ログソース</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">ファイルへ直接</string>
+<string name="log_location">ログ保存場所</string>
+    <string name="log_location_default">デフォルト (アプリ専用ストレージ)</string>
+    <string name="log_location_downloads">ダウンロードフォルダ</string>
     <string name="start_log_capture">ログ取得を開始する</string>
     <string name="start_log_capture_description">デバッグのためにログの記録を開始します</string>
     <string name="start_log_capture_in_applog_file">Log のメッセージはキャプチャ中のみファイルに書き込まれます</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -126,6 +126,9 @@
     <string name="log_source">ლოგის წყარო</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">პირდაპირ ფაილში</string>
+<string name="log_location">ჟურნალის შენახვის ადგილი</string>
+    <string name="log_location_default">ნაგულისხმევი (აპლიკაციის მეხსიერება)</string>
+    <string name="log_location_downloads">ჩამოტვირთვების საქაღალდე</string>
     <string name="start_log_capture">ლოგების ჩაწერის დაწყება</string>
     <string name="start_log_capture_description">გამართვისთვის სრული ლოგების ჩაწერის დაწყება</string>
     <string name="start_log_capture_in_applog_file">ლოგები იწერება ფაილში მხოლოდ მაშინ, როცა ჩაწერა აქტიურია</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -126,7 +126,7 @@
     <string name="log_source">ლოგის წყარო</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">პირდაპირ ფაილში</string>
-<string name="log_location">ჟურნალის შენახვის ადგილი</string>
+    <string name="log_location">ჟურნალის შენახვის ადგილი</string>
     <string name="log_location_default">ნაგულისხმევი (აპლიკაციის მეხსიერება)</string>
     <string name="log_location_downloads">ჩამოტვირთვების საქაღალდე</string>
     <string name="start_log_capture">ლოგების ჩაწერის დაწყება</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -125,6 +125,9 @@
     <string name="log_source">로그 수집 방식</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">앱 로그 파일</string>
+<string name="log_location">로그 저장 위치</string>
+    <string name="log_location_default">기본값 (앱 저장소)</string>
+    <string name="log_location_downloads">다운로드 폴더</string>
     <string name="start_log_capture">로그 기록 시작</string>
     <string name="start_log_capture_description">디버깅을 위해 전체 로그를 기록합니다.</string>
     <string name="start_log_capture_in_applog_file">로그 기록을 켠 동안에만 로그가 파일에 저장됩니다</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -125,7 +125,7 @@
     <string name="log_source">로그 수집 방식</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">앱 로그 파일</string>
-<string name="log_location">로그 저장 위치</string>
+    <string name="log_location">로그 저장 위치</string>
     <string name="log_location_default">기본값 (앱 저장소)</string>
     <string name="log_location_downloads">다운로드 폴더</string>
     <string name="start_log_capture">로그 기록 시작</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -358,7 +358,7 @@
     <string name="log_source">Logbron</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Rechtstreeks naar bestand</string>
-<string name="log_location">Log-opslaglocatie</string>
+    <string name="log_location">Log-opslaglocatie</string>
     <string name="log_location_default">Standaard (App-opslag)</string>
     <string name="log_location_downloads">Map Downloads</string>
     <string name="start_log_capture">Logboekregistratie starten</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -358,6 +358,9 @@
     <string name="log_source">Logbron</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Rechtstreeks naar bestand</string>
+<string name="log_location">Log-opslaglocatie</string>
+    <string name="log_location_default">Standaard (App-opslag)</string>
+    <string name="log_location_downloads">Map Downloads</string>
     <string name="start_log_capture">Logboekregistratie starten</string>
     <string name="start_log_capture_description">Begint met het opnemen van systeemlogs in een bestand.</string>
     <string name="start_log_capture_in_applog_file">Log-berichten worden alleen tijdens actieve opname naar een bestand geschreven</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -359,6 +359,9 @@
     <string name="log_source">Źródło logów</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Bezpośrednio do pliku</string>
+<string name="log_location">Lokalizacja zapisów logów</string>
+    <string name="log_location_default">Domyślna (Pamięć aplikacji)</string>
+    <string name="log_location_downloads">Folder Pobrane</string>
     <string name="start_log_capture">Rozpocznij przechwytywanie logów</string>
     <string name="start_log_capture_description">Rozpoczyna zapisywanie logów systemowych do pliku.</string>
     <string name="start_log_capture_in_applog_file">Wiadomości Log są zapisywane do pliku tylko podczas aktywnego nagrywania</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -359,7 +359,7 @@
     <string name="log_source">Źródło logów</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Bezpośrednio do pliku</string>
-<string name="log_location">Lokalizacja zapisów logów</string>
+    <string name="log_location">Lokalizacja zapisów logów</string>
     <string name="log_location_default">Domyślna (Pamięć aplikacji)</string>
     <string name="log_location_downloads">Folder Pobrane</string>
     <string name="start_log_capture">Rozpocznij przechwytywanie logów</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -359,6 +359,9 @@
     <string name="log_source">Fonte de logs</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Direto para arquivo</string>
+<string name="log_location">Local de Armazenamento de Logs</string>
+    <string name="log_location_default">Padrão (Armazenamento do App)</string>
+    <string name="log_location_downloads">Pasta Downloads</string>
     <string name="start_log_capture">Iniciar captura de log</string>
     <string name="start_log_capture_description">Começa a registrar os logs do sistema em um arquivo.</string>
     <string name="start_log_capture_in_applog_file">As mensagens do Log são gravadas em um arquivo somente enquanto a captura estiver ativa</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -359,7 +359,7 @@
     <string name="log_source">Fonte de logs</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Direto para arquivo</string>
-<string name="log_location">Local de Armazenamento de Logs</string>
+    <string name="log_location">Local de Armazenamento de Logs</string>
     <string name="log_location_default">Padrão (Armazenamento do App)</string>
     <string name="log_location_downloads">Pasta Downloads</string>
     <string name="start_log_capture">Iniciar captura de log</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -117,7 +117,7 @@
     <string name="log_source">Sursă de jurnalizare</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Direct în fișier</string>
-<string name="log_location">Locație salvare jurnale</string>
+    <string name="log_location">Locație salvare jurnale</string>
     <string name="log_location_default">Implicit (Stocare aplicație)</string>
     <string name="log_location_downloads">Dosar Descărcări</string>
     <string name="start_log_capture">Începe capturarea logurilor</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -117,6 +117,9 @@
     <string name="log_source">Sursă de jurnalizare</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Direct în fișier</string>
+<string name="log_location">Locație salvare jurnale</string>
+    <string name="log_location_default">Implicit (Stocare aplicație)</string>
+    <string name="log_location_downloads">Dosar Descărcări</string>
     <string name="start_log_capture">Începe capturarea logurilor</string>
     <string name="start_log_capture_description">Începe înregistrarea completă a logurilor pentru depanare</string>
     <string name="start_log_capture_in_applog_file">Mesajele Log sunt scrise într-un fișier doar cât timp captura este activă</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -362,7 +362,7 @@
     <string name="log_source">Источник логов</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Направить в файл</string>
-<string name="log_location">Место сохранения логов</string>
+    <string name="log_location">Место сохранения логов</string>
     <string name="log_location_default">По умолчанию (Память приложения)</string>
     <string name="log_location_downloads">Папка Загрузки</string>
     <string name="start_log_capture">Начать запись лога</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -362,6 +362,9 @@
     <string name="log_source">Источник логов</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Направить в файл</string>
+<string name="log_location">Место сохранения логов</string>
+    <string name="log_location_default">По умолчанию (Память приложения)</string>
+    <string name="log_location_downloads">Папка Загрузки</string>
     <string name="start_log_capture">Начать запись лога</string>
     <string name="start_log_capture_description">Начинает запись системных логов в файл.</string>
     <string name="start_log_capture_in_applog_file">Сообщения записываются в файл только во время активной записи</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -122,6 +122,9 @@
     <string name="log_source">Günlük kaynağı</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Doğrudan dosyaya</string>
+<string name="log_location">Log Kayıt Konumu</string>
+    <string name="log_location_default">Varsayılan (Uygulama Depolaması)</string>
+    <string name="log_location_downloads">İndirilenler Klasörü</string>
     <string name="start_log_capture">Günlük Kaydını Başlat</string>
     <string name="start_log_capture_description">Hata ayıklama için tam günlükleri kaydetmeye başla</string>
     <string name="start_log_capture_in_applog_file">Log mesajları yalnızca yakalama etkin olduğunda bir dosyaya yazılır</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -122,7 +122,7 @@
     <string name="log_source">Günlük kaynağı</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Doğrudan dosyaya</string>
-<string name="log_location">Log Kayıt Konumu</string>
+    <string name="log_location">Log Kayıt Konumu</string>
     <string name="log_location_default">Varsayılan (Uygulama Depolaması)</string>
     <string name="log_location_downloads">İndirilenler Klasörü</string>
     <string name="start_log_capture">Günlük Kaydını Başlat</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -359,6 +359,9 @@
     <string name="log_source">Джерело логів</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Безпосередньо у файл</string>
+<string name="log_location">Місце збереження логів</string>
+    <string name="log_location_default">За замовчуванням (Пам\'ять програми)</string>
+    <string name="log_location_downloads">Папка Завантаження</string>
     <string name="start_log_capture">Почати запис лога</string>
     <string name="start_log_capture_description">Починає запис системних логів у файл.</string>
     <string name="start_log_capture_in_applog_file">Повідомлення Log записуються у файл лише під час активного запису</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -359,7 +359,7 @@
     <string name="log_source">Джерело логів</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Безпосередньо у файл</string>
-<string name="log_location">Місце збереження логів</string>
+    <string name="log_location">Місце збереження логів</string>
     <string name="log_location_default">За замовчуванням (Пам\'ять програми)</string>
     <string name="log_location_downloads">Папка Завантаження</string>
     <string name="start_log_capture">Почати запис лога</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -589,6 +589,9 @@
     <string name="log_source">Nguồn nhật ký</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Trực tiếp vào tệp</string>
+<string name="log_location">Vị trí lưu nhật ký</string>
+    <string name="log_location_default">Mặc định (Bộ nhớ ứng dụng)</string>
+    <string name="log_location_downloads">Thư mục Tải về</string>
     <string name="start_log_capture_in_applog_file">Tin nhắn nhật ký chỉ được ghi vào tệp khi quá trình thu thập đang hoạt động</string>
     <!-- Native USB Driver -->
     <string name="use_libusb">Sử dụng trình điều khiển USB gốc</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -358,7 +358,7 @@
     <string name="log_source">日誌來源</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">直接寫入檔案</string>
-<string name="log_location">日誌儲存位置</string>
+    <string name="log_location">日誌儲存位置</string>
     <string name="log_location_default">預設 (應用程式儲存空間)</string>
     <string name="log_location_downloads">下載資料夾</string>
     <string name="start_log_capture">開始擷取日誌</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -358,6 +358,9 @@
     <string name="log_source">日誌來源</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">直接寫入檔案</string>
+<string name="log_location">日誌儲存位置</string>
+    <string name="log_location_default">預設 (應用程式儲存空間)</string>
+    <string name="log_location_downloads">下載資料夾</string>
     <string name="start_log_capture">開始擷取日誌</string>
     <string name="start_log_capture_description">開始將系統日誌記錄到檔案中。</string>
     <string name="start_log_capture_in_applog_file">Log 訊息僅在擷取啟用時寫入檔案</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -297,6 +297,9 @@
     <string name="log_source">Log Source</string>
     <string name="log_source_logcat">Logcat</string>
     <string name="log_source_applog_file">Direct to file</string>
+    <string name="log_location">Log Storage Location</string>
+    <string name="log_location_default">Default (App Storage)</string>
+    <string name="log_location_downloads">Downloads Folder</string>
     <string name="start_log_capture">Start Capturing Logs</string>
     <string name="start_log_capture_description">Begin recording full logs for debugging</string>
     <string name="start_log_capture_in_applog_file">Log messages are written to a file only while capture is active</string>


### PR DESCRIPTION
As asked in https://github.com/andreknieriem/open-headunit/issues/793 and somewhere a long time ago, I've added a select to the log section where you can choose the download folder instead of the application folder. 