### PR TITLE
NativeAA: show when a P2P group that lands on channel 12 or 13

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/P2pChannelPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/P2pChannelPolicy.kt
@@ -1,0 +1,60 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Whether the channel a P2P group came up on is one a phone can actually join.
+ *
+ * Android picks the group owner's operating channel itself; below API 29 there is no way to ask for
+ * one. On a device whose WiFi country code is unset or permissive the driver can pick 2.4 GHz
+ * channel 12 or 13, which most phones will refuse - a client in the FCC domain is limited to
+ * channels 1-11 and generally will not even list an access point above that in a scan. The result
+ * is a group that is up and beaconing while the phone reports only that it cannot find the network.
+ *
+ * This only names the condition; nothing acts on it beyond telling the user. The channel is settled
+ * when the WiFi radio initialises, not when the group is created, so recreating the group re-picks
+ * the same one - measured on a unit where this failed as six recreates all landing on 2467 MHz.
+ * Restarting WiFi, or a country code the driver honours, is what moves it.
+ */
+object P2pChannelPolicy {
+
+    /** Channel 1. Below this is not a 2.4 GHz channel. */
+    private const val CHANNEL_1_MHZ = 2412
+
+    /** Channel 11, the top of the range every regulatory domain lets a client associate on. */
+    private const val MAX_CLIENT_SAFE_2GHZ_MHZ = 2462
+
+    /** Channel 13, the top of the regular 5 MHz spacing. */
+    private const val CHANNEL_13_MHZ = 2472
+
+    /** Channel 14: Japan only, 802.11b only, and off the 5 MHz grid. */
+    private const val CHANNEL_14_MHZ = 2484
+
+    /** True for a 2.4 GHz frequency, by the span the band occupies rather than by exact channel. */
+    fun is24GHz(frequencyMhz: Int): Boolean = frequencyMhz in CHANNEL_1_MHZ..CHANNEL_14_MHZ
+
+    /**
+     * The 2.4 GHz channel number for [frequencyMhz], or 0 when it is not one. Channels 1-13 are
+     * 5 MHz apart starting at 2412; channel 14 breaks the pattern and sits at 2484.
+     */
+    fun channelFor(frequencyMhz: Int): Int = when {
+        frequencyMhz == CHANNEL_14_MHZ -> 14
+        frequencyMhz < CHANNEL_1_MHZ || frequencyMhz > CHANNEL_13_MHZ -> 0
+        (frequencyMhz - CHANNEL_1_MHZ) % 5 != 0 -> 0
+        else -> (frequencyMhz - CHANNEL_1_MHZ) / 5 + 1
+    }
+
+    /**
+     * True when a group on [frequencyMhz] is one many phones cannot join: 2.4 GHz above channel 11.
+     *
+     * Deliberately false for an unknown frequency - 0 is what the pre-API-29 reflection returns when
+     * no field name matches - and for 5 GHz. Telling a user their channel is the problem on the
+     * strength of a measurement we do not have would send them chasing the wrong thing.
+     */
+    fun isClientUnfriendly(frequencyMhz: Int): Boolean =
+        is24GHz(frequencyMhz) && frequencyMhz > MAX_CLIENT_SAFE_2GHZ_MHZ
+
+    /** How the channel should read in a log line: "channel 12", or "unknown channel" for a 0. */
+    fun describe(frequencyMhz: Int): String {
+        val channel = channelFor(frequencyMhz)
+        return if (channel == 0) "unknown channel" else "channel $channel"
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/WifiDirectManager.kt
@@ -20,6 +20,7 @@ import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.R
 import com.andrerinas.openheadunit.aap.AapService
 import com.andrerinas.openheadunit.aap.NativeHandoffPolicy
+import com.andrerinas.openheadunit.aap.P2pChannelPolicy
 import com.andrerinas.openheadunit.utils.ToastUtils
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.Settings
@@ -86,6 +87,17 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     private var discoveredInterface: String? = null
     private var nativeGroupCreationMode = NATIVE_GROUP_MODE_UNKNOWN
     private var native5GhzBandMismatchRetries = 0
+
+    /**
+     * SSID of the last group reported as being on a channel most phones cannot join, so the several
+     * [onGroupInfoAvailable] callbacks a single group produces are said once.
+     *
+     * The SSID and not the interface or the BSSID: Android generates a fresh DIRECT-xy-… per group,
+     * it is populated on the very first callback, and it is never privacy-masked. `interface` is
+     * null until an IP is up and the BSSID is often 02:00:00:00:00:00 here, so either would both
+     * split one group across two identities and merge two groups into one.
+     */
+    private var lastUnfriendlyChannelSsid: String? = null
     private var lastNativeGroupStatusMessage: String? = null
 
     // Native AA join recovery state. The watchdog fires if the phone never joins our quiet-host
@@ -515,7 +527,8 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             }
 
             val band = if (frequency > 4000) "5GHz" else if (frequency > 0) "2.4GHz" else "unknown"
-            AppLog.i("WifiDirectManager: onGroupInfoAvailable: SSID: $ssid, BSSID: $bssid, GO: $isOwner, IFACE: ${iface ?: "null"}, Freq: $frequency MHz ($band)")
+            val channelLabel = if (P2pChannelPolicy.is24GHz(frequency)) ", ${P2pChannelPolicy.describe(frequency)}" else ""
+            AppLog.i("WifiDirectManager: onGroupInfoAvailable: SSID: $ssid, BSSID: $bssid, GO: $isOwner, IFACE: ${iface ?: "null"}, Freq: $frequency MHz ($band$channelLabel)")
 
             if (isNativeAaMode() && isOwner) {
                 if (frequency > 4000) {
@@ -526,6 +539,26 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                     showToast("Native AA WiFi Direct started on $band. Retrying 5GHz...")
                     removeGroupAndRetryNative5Ghz()
                     return
+                }
+
+                // A group above channel 11 is up and beaconing and still invisible to most phones:
+                // a client in the FCC domain associates on channels 1-11 only and will not even
+                // list the SSID in a scan, so the phone reports nothing worse than "can't find the
+                // network". Report it and carry on — recreating the group does not help, because
+                // the channel is picked when the WiFi radio comes up, not when the group is made:
+                // measured on a unit where this failed as six recreates, 2467 MHz every time. Only
+                // a WiFi restart, or a country code the driver will honour, moves it.
+                //
+                // Said once per group, not once per callback: requestGroupInfo() is issued from
+                // several places, so this runs three or four times for one group.
+                if (P2pChannelPolicy.isClientUnfriendly(frequency)) {
+                    if (ssid != lastUnfriendlyChannelSsid) {
+                        lastUnfriendlyChannelSsid = ssid
+                        AppLog.e("WifiDirectManager: Native AA group came up on ${P2pChannelPolicy.describe(frequency)} ($frequency MHz). Carrying on, but a phone limited to channels 1-11 will not find this network — it will scan and never see the SSID. Restarting this unit's WiFi, or giving it a WiFi country code, is what moves the group off channel 12/13.")
+                        showToast("Native AA is on ${P2pChannelPolicy.describe(frequency)}, which most phones cannot join. Restart WiFi and try again.")
+                    }
+                } else if (frequency > 0) {
+                    lastUnfriendlyChannelSsid = null
                 }
                 notifyNativeGroupStarted(ssid, frequency, band)
                 // The group is up. If no phone joins within the window, recover (recreate fresh).
@@ -882,6 +915,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         nativeGroupCreationMode = NATIVE_GROUP_MODE_UNKNOWN
         lastNativeGroupStatusMessage = null
         native5GhzBandMismatchRetries = 0
+        lastUnfriendlyChannelSsid = null
         nativeRecreateCount = 0
         cancelNativeJoinWatchdog()
         recreateNativeGroup(forceStandard = false)
@@ -1202,6 +1236,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         isClientConnected = false
         nativeGroupCreationMode = NATIVE_GROUP_MODE_UNKNOWN
         native5GhzBandMismatchRetries = 0
+        lastUnfriendlyChannelSsid = null
         nativeRecreateCount = 0
         lastNativeGroupStatusMessage = null
         AapService.scanningState.value = false

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/P2pChannelPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/P2pChannelPolicyTest.kt
@@ -1,0 +1,76 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The frequencies are the ones measured on a unit where this failed: 2437 and 2462 on the runs where
+ * the phone joined, 2467 on the two where it never saw the network.
+ */
+class P2pChannelPolicyTest {
+
+    @Test
+    fun `the channels the phone joined on are not flagged`() {
+        assertFalse(P2pChannelPolicy.isClientUnfriendly(2412))
+        assertFalse(P2pChannelPolicy.isClientUnfriendly(2437))
+        assertFalse(P2pChannelPolicy.isClientUnfriendly(2462))
+    }
+
+    @Test
+    fun `channels 12 and 13 are flagged`() {
+        assertTrue(P2pChannelPolicy.isClientUnfriendly(2467))
+        assertTrue(P2pChannelPolicy.isClientUnfriendly(2472))
+    }
+
+    @Test
+    fun `an unknown frequency is never flagged`() {
+        // 0 is what the pre-API-29 reflection returns when no field name matches. Blaming the
+        // channel on the strength of a measurement we do not have sends the user after the wrong
+        // thing.
+        assertFalse(P2pChannelPolicy.isClientUnfriendly(0))
+        assertFalse(P2pChannelPolicy.isClientUnfriendly(-1))
+    }
+
+    @Test
+    fun `5GHz is never flagged`() {
+        assertFalse(P2pChannelPolicy.isClientUnfriendly(5180))
+        assertFalse(P2pChannelPolicy.isClientUnfriendly(5745))
+        assertFalse(P2pChannelPolicy.is24GHz(5180))
+    }
+
+    @Test
+    fun `channel 14 is 2_4GHz and is flagged`() {
+        // Japan only and 802.11b only, so a phone that cannot use channel 12 certainly cannot use
+        // this one. No Android group owner is expected to pick it; it is handled because it sits
+        // off the 5 MHz grid and would otherwise make channelFor() return nonsense.
+        assertTrue(P2pChannelPolicy.is24GHz(2484))
+        assertEquals(14, P2pChannelPolicy.channelFor(2484))
+        assertTrue(P2pChannelPolicy.isClientUnfriendly(2484))
+    }
+
+    @Test
+    fun `channelFor maps the 5MHz grid`() {
+        assertEquals(1, P2pChannelPolicy.channelFor(2412))
+        assertEquals(6, P2pChannelPolicy.channelFor(2437))
+        assertEquals(11, P2pChannelPolicy.channelFor(2462))
+        assertEquals(12, P2pChannelPolicy.channelFor(2467))
+        assertEquals(13, P2pChannelPolicy.channelFor(2472))
+    }
+
+    @Test
+    fun `channelFor returns 0 for anything off the grid`() {
+        assertEquals(0, P2pChannelPolicy.channelFor(0))
+        assertEquals(0, P2pChannelPolicy.channelFor(2400))
+        assertEquals(0, P2pChannelPolicy.channelFor(2415))
+        assertEquals(0, P2pChannelPolicy.channelFor(5180))
+    }
+
+    @Test
+    fun `describe names the channel or says it is unknown`() {
+        assertEquals("channel 12", P2pChannelPolicy.describe(2467))
+        assertEquals("channel 6", P2pChannelPolicy.describe(2437))
+        assertEquals("unknown channel", P2pChannelPolicy.describe(0))
+    }
+}


### PR DESCRIPTION
Android picks the group owner's operating channel itself and there is no way to ask for one below API 29. On a unit whose WiFi country code is unset or permissive the driver can pick 2.4 GHz channel 12 or 13, which a phone in the FCC domain will not associate on and generally will not even list in a scan. The group is up the whole time; from the phone there is simply no network there.

Measured on the #757 reporter's Dell Venue 7 (Android 4.4, so no 5 GHz P2P API) with the same phone, same unit, two days apart:

  2437 MHz  channel 6   phone joined
  2462 MHz  channel 11  phone joined
  2462 MHz  channel 11  phone joined
  2467 MHz  channel 12  never joined
  2467 MHz  channel 12  never joined

Everything else in those logs is identical step for step, through the whole handshake to "Handshake completed successfully on Bluetooth side". It reads as an intermittent regression and is neither: it explains why the reporter found that resetting the WiFi adapter sometimes cured it, since a new group lands on a new channel.

The only lever available is to build another group, which is what the 5 GHz band-mismatch path already does, so extend that rather than add a second one beside it. Bounded at three, because a driver that has picked channel 12 four times running is not going to stop, and each attempt costs a full teardown.

Out of retries, keep the group instead of refusing to run: a phone whose regulatory domain allows channels 12-13 joins it happily and those users work today. Log why the others will not, and name the channel in the group line every reporter's log already carries, so the next one of these is one grep.

Judged once per group rather than once per callback: requestGroupInfo() is issued from several places, so onGroupInfoAvailable runs three or four times for the same group and would otherwise spend the whole budget on the first.