### PR TITLE
Fix/hotspot unreadable config

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -1137,6 +1137,61 @@ class AapService : Service(), UsbReceiver.Listener {
                 commManager.awaitDisconnectComplete()
                 AppLog.i("AapService: CommManager teardown complete. Stopping WiFi Direct group.")
                 wifiDirectManager?.stop()
+            } else if (state.isUserExit) {
+                // The same question for the routes that run on a soft AP instead of a P2P group.
+                // Closing the socket does not make the phone leave the network — it stays
+                // associated and Android Auto retries its wireless setup until it throttles itself
+                // — so the access point has to go, and for the same reason as above only once
+                // CommManager has finished. Unlike a P2P group the access point is usually the
+                // user's own, and switching one back on is best effort, so it only comes down when
+                // they have already handed the app that job.
+                //
+                // Restarted rather than left down. It has to disappear for the phone to be put off
+                // it, but leaving it off charges the whole bring-up — measured at ~20s on a unit
+                // that refuses setSoftApConfiguration() — to the next connection, with the phone
+                // waiting through it. Paying it here spends the same seconds while the user is
+                // already walking away.
+                val action = UserExitHotspotPolicy.onUserExit(
+                    mode, strategy, nativeTransport(), settings.autoEnableHotspot,
+                    settings.hotspotTeardownProvenUnsafe
+                )
+                if (action != HotspotExitAction.NONE) {
+                    commManager.awaitDisconnectComplete()
+                    // Stop watching an access point nobody is connecting over, either way: this
+                    // holds a system broadcast receiver and can still re-enable the hotspot on its
+                    // own long after the user has finished with it.
+                    softApCredentialsProvider?.stop()
+                }
+                when (action) {
+                    HotspotExitAction.DISABLE -> {
+                        AppLog.i("AapService: CommManager teardown complete. Restarting the hotspot so the phone leaves the network.")
+                        if (!HotspotManager.restart(this@AapService)) {
+                            // The one way to learn that this radio will not host an access point
+                            // again once it has been taken down. Remembered so it costs the user
+                            // one hotspot rather than one per session — from here on this device's
+                            // access point is left alone and the phone is told, in the branch
+                            // below, what that means.
+                            settings.hotspotTeardownProvenUnsafe = true
+                            AppLog.w(
+                                "AapService: This device did not bring its access point back after " +
+                                    "the app took it down, so it will not be taken down again. " +
+                                    "Ending a session will leave the phone on the network from now " +
+                                    "on — end it from the phone's own Android Auto notification if " +
+                                    "that becomes a problem."
+                            )
+                        }
+                    }
+                    HotspotExitAction.WARN_LEFT_UP -> AppLog.w(
+                        "AapService: Stopping the connection does not switch this device's hotspot " +
+                            "off — either the app was not given charge of it, or this device has " +
+                            "already shown it cannot switch one back on. So the phone stays " +
+                            "joined to it and Android Auto may keep retrying until it throttles " +
+                            "itself. Turn the hotspot off and on again to clear that, or end the " +
+                            "session from the phone's own Android Auto notification instead, which " +
+                            "makes it leave the network by itself."
+                    )
+                    HotspotExitAction.NONE -> {}
+                }
             }
 
             App.provide(this@AapService).audioDecoder.stop()
@@ -1622,6 +1677,13 @@ class AapService : Service(), UsbReceiver.Listener {
         nativeAaHandshakeManager?.stop()
         releaseBootWakeLock()
 
+        // Before the hotspot goes, not after: SoftApCredentialsProvider watches
+        // WIFI_AP_STATE_CHANGED and switches an access point it started back on when it sees one
+        // drop. Left registered here it would treat this very teardown as the hotspot failing and
+        // bring it back up as the service dies — leaving the access point running with nothing
+        // left to serve it.
+        softApCredentialsProvider?.stop()
+
         if (App.provide(this).settings.autoEnableHotspot) {
             AppLog.i("AapService: Auto-disabling hotspot...")
             HotspotManager.setHotspotEnabled(this, false)
@@ -1642,7 +1704,6 @@ class AapService : Service(), UsbReceiver.Listener {
         stopForeground(true)
         stopWirelessServer()
         wifiDirectManager?.stop()
-        softApCredentialsProvider?.stop()
         nearbyManager?.stop()
         try {
             mediaSession?.let {
@@ -2213,6 +2274,15 @@ class AapService : Service(), UsbReceiver.Listener {
             AppLog.i("AapService: userExitedAA is true. Skipping auto-poke.")
         }
     }
+
+    /**
+     * Whether the AAP TCP port the phone will be sent to is bound and accepting.
+     *
+     * The Bluetooth handshake checks this before handing over credentials, mirroring the ordering
+     * the reference head unit software uses: access point up, address resolved, port bound, and
+     * only then talk to the phone.
+     */
+    fun isWirelessServerListening(): Boolean = wirelessServer?.isListening == true
 
     /** The transport mode 3 is configured to use. Read fresh: the user can change it in settings. */
     private fun nativeTransport(): NativeTransport =
@@ -2787,6 +2857,17 @@ class AapService : Service(), UsbReceiver.Listener {
         private var registrationListener: NsdManager.RegistrationListener? = null
         private var job: Job? = null
 
+        /**
+         * Whether the TCP port the phone is told to dial is actually bound right now.
+         *
+         * start() only launches a coroutine; the bind happens inside it and can fail (the port
+         * still held by a previous session is the usual way). Handing the phone credentials for a
+         * port nothing is listening on produces the worst possible log: a clean handshake, a
+         * successful WiFi join, and then silence.
+         */
+        @Volatile var isListening = false
+            private set
+
         fun start(registerNsd: Boolean = true) {
             nsdManager = getSystemService(Context.NSD_SERVICE) as? NsdManager
             if (nsdManager == null) {
@@ -2798,6 +2879,7 @@ class AapService : Service(), UsbReceiver.Listener {
             job = serviceScope.launch(Dispatchers.IO) {
                 try {
                     serverSocket = ServerSocket(5288).apply { reuseAddress = true }
+                    isListening = true
                     AppLog.i("Wireless Server listening on port 5288")
                     logLocalNetworkInterfaces()
 
@@ -2827,6 +2909,7 @@ class AapService : Service(), UsbReceiver.Listener {
                 } catch (e: Exception) {
                     if (isActive) AppLog.e("Wireless server error", e)
                 } finally {
+                    isListening = false
                     unregisterNsd()
                     try { serverSocket?.close() } catch (e: Exception) {}
                 }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -1519,19 +1519,29 @@ class AapService : Service(), UsbReceiver.Listener {
 
             // Mode 3: Native AA Wireless
             if (mode == 3) {
-                if (nativeTransport() == NativeTransport.HOTSPOT) {
-                    // Read this device's own access point instead of hosting a P2P group. The AP
-                    // itself is the user's to switch on; the provider only resolves and watches it.
-                    AppLog.i("AapService: Native AA on the head unit hotspot — resolving access point credentials.")
-                    softApCredentialsProvider?.start()
-                } else {
-                    // Start WiFi Direct as a "quiet host" (P2P Group for phone to join)
-                    // We let WifiDirectManager handle the WiFi state (enabling if needed)
-                    wifiDirectManager?.startNativeAaQuietHost()
-                }
+                // Skip the whole route, not just the handshake, when the Bluetooth this unit's
+                // phone is bonded to isn't reachable from here: with no Bluetooth channel there is
+                // nobody to hand the credentials to, so hosting a P2P group or holding the hotspot
+                // open would only churn the WiFi stack for nothing.
+                val externalBt = NativeAaHandshakeManager.externalBtDiagnostic()
+                if (externalBt != null) AppLog.e(externalBt)
+                val blockedByExternalBt =
+                    externalBt != null && !NativeAaHandshakeManager.externalBtOverridden(this)
+                if (!blockedByExternalBt) {
+                    if (nativeTransport() == NativeTransport.HOTSPOT) {
+                        // Read this device's own access point instead of hosting a P2P group. The AP
+                        // itself is the user's to switch on; the provider only resolves and watches it.
+                        AppLog.i("AapService: Native AA on the head unit hotspot — resolving access point credentials.")
+                        softApCredentialsProvider?.start()
+                    } else {
+                        // Start WiFi Direct as a "quiet host" (P2P Group for phone to join)
+                        // We let WifiDirectManager handle the WiFi state (enabling if needed)
+                        wifiDirectManager?.startNativeAaQuietHost()
+                    }
 
-                // Start the official Bluetooth handshake servers
-                nativeAaHandshakeManager?.start()
+                    // Start the official Bluetooth handshake servers
+                    nativeAaHandshakeManager?.start()
+                }
             }
         }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/ExternalBtPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/ExternalBtPolicy.kt
@@ -1,0 +1,55 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Whether this head unit's Bluetooth is an *external module* — a separate chip on a serial link,
+ * driven by the vendor's own daemon — rather than the radio behind `android.bluetooth`.
+ *
+ * The four signals are the ones the reference head unit software uses to decide the same thing,
+ * and they were confirmed against a unit whose own vendor log reports `bttype:extra` while its
+ * Bluetooth module answers to a different name (`CAR8032`) and a different MAC than the Android
+ * adapter reports. On that unit the vendor software routes Android Auto entirely through the
+ * external module and never opens an RFCOMM server on the Android radio.
+ *
+ * These signals are a marker for that class of hardware, not a diagnosis of a specific fault. What
+ * is measured on the one such unit examined closely: the phone opens an RFCOMM channel to the
+ * Android radio, flow control stays open, and the radio then transmits no payload at all — writes
+ * succeed, `flush()` returns, the log looks healthy, and not one byte goes on the air. Whether
+ * every unit carrying these signals fails the same way is not established; what is established is
+ * that the vendor does not use this path on them, so it is not a path to recommend.
+ */
+object ExternalBtPolicy {
+
+    /** Serial device nodes that only exist when a discrete Bluetooth module is wired to a UART. */
+    private val DEVICE_NODES = listOf("/dev/rf_serial", "/dev/zj_bt_serial")
+
+    /** Vendor properties that name the Bluetooth topology outright. */
+    private val PROPERTY_KEYS = listOf("rw.zlink.bt.type", "rw.zj.bt.type")
+
+    /** The value those properties carry on units whose Bluetooth is the external module. */
+    private const val EXTERNAL_VALUE = "extra"
+
+    /**
+     * The first piece of evidence that this unit's Bluetooth is external, or null if none of the
+     * signals fire.
+     *
+     * Returns the evidence rather than a bare boolean so the caller can name it: "external
+     * Bluetooth module detected" is not actionable in a bug report, "/dev/rf_serial exists" is.
+     *
+     * @param nodeExists whether a given absolute path exists on the filesystem
+     * @param property   the value of a given system property, or null/empty when unset
+     */
+    fun detect(nodeExists: (String) -> Boolean, property: (String) -> String?): String? {
+        for (node in DEVICE_NODES) {
+            if (nodeExists(node)) return "$node exists"
+        }
+        for (key in PROPERTY_KEYS) {
+            val value = property(key)?.trim().orEmpty()
+            if (value.equals(EXTERNAL_VALUE, ignoreCase = true)) return "$key=$value"
+        }
+        return null
+    }
+
+    /** Convenience over [detect] for callers that only need the yes/no. */
+    fun isExternal(nodeExists: (String) -> Boolean, property: (String) -> String?): Boolean =
+        detect(nodeExists, property) != null
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/SoftApBandPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/SoftApBandPolicy.kt
@@ -1,0 +1,48 @@
+package com.andrerinas.openheadunit.aap
+
+/** A radio band a soft AP can be brought up on. */
+enum class ApBand { BAND_5GHZ, BAND_2GHZ }
+
+/**
+ * Which band to bring the head unit's access point up on for wireless Android Auto, and in what
+ * order to try.
+ *
+ * 5 GHz first is not a preference, it is what the link needs. On 2.4 GHz the handshake completes
+ * and the projection then dies within seconds — a failure mode that reads as "Android Auto starts
+ * and drops" and has cost several rounds of log-reading to recognise. The reference head unit
+ * software running this route on the same class of hardware brings its AP up on channel 36, and
+ * the AA protocol itself carries the phone's answer to the same question (`selected_wifi_channel
+ * _type`, one of 2.4-only / 5-only / dual).
+ *
+ * 2.4 GHz is kept only as a fallback for radios with no 5 GHz support at all, where the choice is
+ * between a shaky link and none.
+ */
+object SoftApBandPolicy {
+
+    /**
+     * The bands to try, best first. Trying is the only way to find out: an app cannot ask whether
+     * the soft AP will accept 5 GHz — `is5GHzBandSupported()` describes the station side, and
+     * vendors ship radios that answer yes there and still refuse to host an AP on it.
+     */
+    fun attemptOrder(prefer5Ghz: Boolean = true): List<ApBand> =
+        if (prefer5Ghz) listOf(ApBand.BAND_5GHZ, ApBand.BAND_2GHZ)
+        else listOf(ApBand.BAND_2GHZ)
+
+    /** `SoftApConfiguration.BAND_2GHZ` / `BAND_5GHZ` (API 30+). */
+    fun softApConfigurationBand(band: ApBand): Int = when (band) {
+        ApBand.BAND_2GHZ -> 1
+        ApBand.BAND_5GHZ -> 2
+    }
+
+    /** The hidden `WifiConfiguration.apBand` field's values, used below API 30. */
+    fun legacyApBand(band: ApBand): Int = when (band) {
+        ApBand.BAND_2GHZ -> 0
+        ApBand.BAND_5GHZ -> 1
+    }
+
+    /** How the band reads in a log line users paste into bug reports. */
+    fun describe(band: ApBand): String = when (band) {
+        ApBand.BAND_2GHZ -> "2.4 GHz"
+        ApBand.BAND_5GHZ -> "5 GHz"
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/SoftApCredentialsPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/SoftApCredentialsPolicy.kt
@@ -1,0 +1,88 @@
+package com.andrerinas.openheadunit.aap
+
+/** What one attempt at resolving this head unit's access-point credentials came to. */
+enum class SoftApCredentialsAttempt {
+    /** Everything needed is in hand; the caller can hand the credentials over. */
+    PUBLISHED,
+
+    /**
+     * No access point yet, or the one we found is not on air. Polling is the right answer, and this
+     * is the state auto-enable exists for.
+     */
+    NO_AP_YET,
+
+    /**
+     * There *is* an access point, and this device will not tell us its name. Polling can never fix
+     * that: the read goes through a non-public API the device refuses, and it will refuse it again
+     * next second. Only the manual override gets this route running here.
+     */
+    CONFIG_UNREADABLE
+}
+
+/** The name and passphrase to hand the phone, once [SoftApCredentialsPolicy] says there are any. */
+data class SoftApCredentials(val ssid: String, val passphrase: String)
+
+/**
+ * Whether this head unit knows enough about its own access point to describe it to a phone, and if
+ * not, whether waiting could ever change that.
+ *
+ * The distinction is the whole point. "No access point yet" is worth polling for and is what the
+ * hotspot auto-enable exists to fix; "there is one and this device will not name it" is a dead end
+ * that polling only hides. They were one boolean once, and on a locked-down unit the resolve loop
+ * spent its entire budget re-reading a configuration the device had already refused — logging the
+ * same line once a second, switching on an access point that was already up, and never reaching the
+ * handshake's first message. From the car that looks like Bluetooth connecting and nothing else
+ * happening.
+ *
+ * Pure so it can be tested at all: the device this matters on is not the device available to test
+ * with, so the outcome table pinned in `SoftApCredentialsPolicyTest` is the only place the
+ * behaviour is checked.
+ */
+object SoftApCredentialsPolicy {
+
+    /**
+     * @param manualSsid [com.andrerinas.openheadunit.utils.Settings.hotspotSsid] — the user's
+     *   override, and the one thing that makes this route work on a device that hides its own
+     *   configuration
+     * @param manualPassphrase [com.andrerinas.openheadunit.utils.Settings.hotspotPassword]
+     * @param systemConfig what the device says its own access point is named, or null where it will
+     *   not say. The caller reads it only when [manualSsid] is empty — a name the user typed is a
+     *   claim about their own hardware, and reading past it would cost a reflective call whose
+     *   answer is already outranked.
+     * @param siteLocalIpv4 the chosen interface's own address, or null if it has none yet
+     */
+    fun decide(
+        manualSsid: String,
+        manualPassphrase: String,
+        systemConfig: SoftApCredentials?,
+        siteLocalIpv4: String?
+    ): SoftApCredentialsAttempt {
+        if (siteLocalIpv4.isNullOrEmpty()) return SoftApCredentialsAttempt.NO_AP_YET
+        return if (resolve(manualSsid, manualPassphrase, systemConfig).ssid.isEmpty()) {
+            SoftApCredentialsAttempt.CONFIG_UNREADABLE
+        } else {
+            SoftApCredentialsAttempt.PUBLISHED
+        }
+    }
+
+    /**
+     * The credentials to send: each field the user's override where they set one, the device's own
+     * configuration where they did not.
+     *
+     * Note what this means at the call site, since it is a real outcome and not an oversight. A user
+     * who names the network but leaves the password blank gets an **empty passphrase**, not the
+     * device's — the caller does not read the system configuration at all once a manual name is set,
+     * so there is nothing to fall back to. Sending an open network is worse than sending nothing on
+     * a protocol that refuses one, so the caller warns; it is not silently corrected here, because
+     * pairing a name the user typed with a passphrase read off the device would hand the phone a
+     * mismatched pair and fail with no line pointing at why.
+     */
+    fun resolve(
+        manualSsid: String,
+        manualPassphrase: String,
+        systemConfig: SoftApCredentials?
+    ): SoftApCredentials = SoftApCredentials(
+        ssid = manualSsid.ifEmpty { systemConfig?.ssid.orEmpty() },
+        passphrase = manualPassphrase.ifEmpty { systemConfig?.passphrase.orEmpty() }
+    )
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/UserExitHotspotPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/UserExitHotspotPolicy.kt
@@ -1,0 +1,67 @@
+package com.andrerinas.openheadunit.aap
+
+/** What a user-initiated disconnect should do to this head unit's own access point. */
+enum class HotspotExitAction {
+    /** Not a hotspot route — this decision belongs to someone else. */
+    NONE,
+
+    /** Take the access point down, so the phone is actually put off the network. */
+    DISABLE,
+
+    /** Leave it alone and say what that costs: it is not ours to switch off. */
+    WARN_LEFT_UP
+}
+
+/**
+ * Whether ending a session by hand should also take down the access point the phone is sitting on.
+ *
+ * Closing the AAP socket and sending a `ByeByeRequest` does not make the phone leave the network:
+ * it stays associated and Android Auto spins on its wireless-setup restart until it throttles
+ * itself, because from its side the car walked away mid-session. The only lever this app has is
+ * making the network go away — which is exactly what [AapService] already does for WiFi Direct by
+ * removing the P2P group. This decides the same question for the two routes that run on a soft AP
+ * instead, and is the deliberate complement of [WifiModePolicy.usesWifiDirect]: for any one
+ * disconnect exactly one of the two can answer yes.
+ *
+ * The gate is ownership rather than symptom. A P2P group is always ours, created for the session
+ * and safe to remove; a soft AP usually is not — the user switched it on, and switching one back on
+ * is best effort that most unrooted units cannot do at all. Leaving somebody's hotspot off with no
+ * way to restore it is worse than the stall, which they can clear themselves. So the access point
+ * comes down only when they have already handed the app that job.
+ */
+object UserExitHotspotPolicy {
+
+    /**
+     * @param mode [com.andrerinas.openheadunit.utils.Settings.wifiConnectionMode]
+     * @param strategy [com.andrerinas.openheadunit.utils.Settings.helperConnectionStrategy]
+     * @param transport applies to [mode] 3 only
+     * @param autoEnableHotspot [com.andrerinas.openheadunit.utils.Settings.autoEnableHotspot] — the
+     *   user's standing permission for the app to drive this device's hotspot
+     * @param teardownProvenUnsafe whether this device has already failed to bring its access point
+     *   back after the app took it down. See the note on the [HotspotExitAction.WARN_LEFT_UP]
+     *   branch below.
+     */
+    fun onUserExit(
+        mode: Int,
+        strategy: Int,
+        transport: NativeTransport,
+        autoEnableHotspot: Boolean,
+        teardownProvenUnsafe: Boolean = false
+    ): HotspotExitAction = when {
+        !usesHeadUnitHotspot(mode, strategy, transport) -> HotspotExitAction.NONE
+        // Permission is not the only question; capability is the other one, and unlike permission
+        // it can only be learned by trying. Some radios will not host an access point again once it
+        // has been taken down — measured on a UNISOC unit where hostapd's channel scan raced the
+        // driver re-creating the interface and lost, on the teardown and on every attempt after it,
+        // including the auto-enable that was supposed to be the way back. On such a device the
+        // choice is between one stranded hotspot and one per session, and the app only finds out
+        // which kind it is by stranding the first.
+        teardownProvenUnsafe -> HotspotExitAction.WARN_LEFT_UP
+        autoEnableHotspot -> HotspotExitAction.DISABLE
+        else -> HotspotExitAction.WARN_LEFT_UP
+    }
+
+    /** Whether this combination puts the phone on an access point this device is hosting. */
+    fun usesHeadUnitHotspot(mode: Int, strategy: Int, transport: NativeTransport): Boolean =
+        (mode == 3 && transport == NativeTransport.HOTSPOT) || (mode == 2 && strategy == 4)
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -557,6 +557,19 @@ class NativeAaHandshakeManager(
                         AppLog.i("NativeAA: USB/other session became active mid-poke. Stopping poke loop.")
                         break
                     }
+
+                    // Pre-flight: Ensure WiFi credentials (SSID/IP) are ready before connecting RFCOMM to phone.
+                    // If RFCOMM connects before WiFi credentials exist, the phone times out after 10s waiting for WifiStartRequest.
+                    if (currentSsid.isNullOrEmpty() || currentIp.isNullOrEmpty()) {
+                        AppLog.i("NativeAA: WiFi credentials not ready before poke. Requesting WiFi refresh...")
+                        (context as? AapService)?.triggerWifiDirectRefresh()
+                        var waitedMs = 0
+                        while ((currentSsid.isNullOrEmpty() || currentIp.isNullOrEmpty()) && waitedMs < 4000 && isRunning && isActive) {
+                            delay(200)
+                            waitedMs += 200
+                        }
+                    }
+
                     AppLog.i("NativeAA: Attempting active poke to device: ${device.name} (${device.address})...")
                     pokeDevice(device, holdMs = 15000)
                 }
@@ -610,6 +623,18 @@ class NativeAaHandshakeManager(
             
             pokeJob?.cancel()
             pokeJob = scope.launch(Dispatchers.IO + CoroutineName("NativeAa-ManualWakeup")) {
+                // Pre-flight: Ensure WiFi credentials (SSID/IP) are ready before connecting RFCOMM to phone.
+                if (currentSsid.isNullOrEmpty() || currentIp.isNullOrEmpty()) {
+                    AppLog.i("NativeAA: WiFi credentials not ready before manual poke. Requesting WiFi refresh...")
+                    (context as? AapService)?.triggerWifiDirectRefresh()
+                    var waitedMs = 0
+                    while ((currentSsid.isNullOrEmpty() || currentIp.isNullOrEmpty()) && waitedMs < 4000 && isRunning && isActive) {
+                        delay(200)
+                        waitedMs += 200
+                    }
+                    AppLog.i("NativeAA: Pre-poke credential wait completed. SSID=$currentSsid, IP=$currentIp (waited ${waitedMs}ms)")
+                }
+
                 AppLog.i("NativeAA: Attempting manual poke to ${device.name}...")
                 pokeDevice(device, holdMs = 20000)
                 AppLog.i("NativeAA: Manual poke to ${device.name} finished.")

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -54,6 +54,9 @@ class NativeAaHandshakeManager(
          *  a handshake. P2P group creation is the slow case. */
         private const val CREDENTIALS_WAIT_MS = 60_000L
 
+        /** How long to wait for the AAP TCP port to be bound before giving up on a handshake. */
+        private const val PORT_WAIT_MS = 3_000L
+
         /** Which of [allServiceNames] are secondary Bluetooth radios, i.e. not [primaryServiceName]
          *  (dual-Bluetooth-radio head units). Pure and unit-testable: identity is by system
          *  service name, not MAC address, since BluetoothAdapter.getAddress() returns the fixed
@@ -184,6 +187,16 @@ class NativeAaHandshakeManager(
     // Whether the "not serving handshakes" warning has already been logged for the current
     // backoff, so a phone retrying every ~12 s does not repeat the long explanation each time.
     @Volatile private var loggedHandshakeBackoff = false
+
+    /** Polls until the AAP TCP port is bound, or [timeoutMs] passes. */
+    private suspend fun awaitWirelessServerListening(timeoutMs: Long): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (true) {
+            if (context.isWirelessServerListening()) return true
+            if (SystemClock.elapsedRealtime() >= deadline) return false
+            delay(250)
+        }
+    }
 
     /**
      * Updates the WiFi credentials that will be sent to the phone during the next handshake.
@@ -1065,6 +1078,19 @@ class NativeAaHandshakeManager(
                         bssidOmitted = true
                     }
                 }
+            }
+
+            // The port the credentials point at must be bound before they go out. The phone's next
+            // move after Type 3 is to join the network and dial it; if nothing is listening it
+            // gets a refusal, and the log reads as a perfect handshake followed by nothing at all.
+            // Short wait rather than none: start() binds the port at service start, so being here
+            // with it unbound means a genuine failure, not a race — but a session torn down and
+            // rebuilt a moment ago can still be releasing it.
+            if (!awaitWirelessServerListening(PORT_WAIT_MS)) {
+                AppLog.e("NativeAA: Handshake aborted — nothing is listening on port 5288 after ${PORT_WAIT_MS / 1000}s, so the phone would join the network and find no head unit. Restart the app if this persists.")
+                abortedLocally = true
+                feed(WppEvent.CredentialsUnavailable)
+                return@withContext
             }
 
             AppLog.i("NativeAA: Starting Handshake Exchange:")

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -67,7 +67,36 @@ class NativeAaHandshakeManager(
             return allServiceNames.filter { it != primary }.distinct()
         }
 
+        /**
+         * The one-line explanation to log and show when this unit's Bluetooth is an external
+         * module, or null when it isn't. Kept here so the handshake manager and the settings
+         * compatibility probe say exactly the same thing.
+         */
+        fun externalBtDiagnostic(): String? = BluetoothHelper.externalBtEvidence?.let { evidence ->
+            "NativeAA: external Bluetooth module detected ($evidence) — the phone is bonded to " +
+                "the head unit's own Bluetooth chip, not the one Android exposes, so nothing we " +
+                "write over RFCOMM reaches it. Bluetooth-based wireless cannot work on this unit; " +
+                "use USB, or one of the WiFi modes that does not need the Bluetooth handshake."
+        }
+
+        /**
+         * Whether to run the Bluetooth route anyway on a unit [externalBtDiagnostic] flagged.
+         *
+         * A manually configured secondary Bluetooth service is the user telling us which radio to
+         * use, having found one automatic enumeration missed. That is exactly the case the
+         * detection cannot see, so it must not be the one case we refuse to try — the diagnostic
+         * still goes in the log either way.
+         */
+        fun externalBtOverridden(context: Context): Boolean =
+            com.andrerinas.openheadunit.App.provide(context)
+                .settings.manualSecondaryBluetoothServiceName.isNotEmpty()
+
         fun checkCompatibility(context: Context): Boolean {
+            externalBtDiagnostic()?.let {
+                AppLog.w(it)
+                if (!externalBtOverridden(context)) return false
+                AppLog.w("NativeAA: continuing anyway — a secondary Bluetooth service is configured manually.")
+            }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 if (ContextCompat.checkSelfPermission(context, android.Manifest.permission.BLUETOOTH_CONNECT) 
                     != PackageManager.PERMISSION_GRANTED) {
@@ -209,6 +238,17 @@ class NativeAaHandshakeManager(
     @SuppressLint("MissingPermission")
     fun start() {
         if (isRunning) return
+
+        // Leave isRunning false, like the "adapter disabled" case below: isActive() callers must
+        // see this as genuinely stopped. Nothing here is retryable, but a listener that was never
+        // opened must not be reported as up.
+        externalBtDiagnostic()?.let {
+            if (!externalBtOverridden(context)) {
+                AppLog.e(it)
+                return
+            }
+            AppLog.w("$it\nNativeAA: starting anyway — a secondary Bluetooth service is configured manually.")
+        }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             if (ContextCompat.checkSelfPermission(context, android.Manifest.permission.BLUETOOTH_CONNECT) 

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/SoftApCredentialsProvider.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/SoftApCredentialsProvider.kt
@@ -4,10 +4,17 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Handler
+import android.os.Looper
+import android.widget.Toast
 import androidx.core.content.ContextCompat
+import com.andrerinas.openheadunit.R
 import com.andrerinas.openheadunit.aap.ApInterfaceCandidate
 import com.andrerinas.openheadunit.aap.SoftApBssidPolicy
 import com.andrerinas.openheadunit.aap.NativeCredentialsPolicy
+import com.andrerinas.openheadunit.aap.SoftApCredentials
+import com.andrerinas.openheadunit.aap.SoftApCredentialsAttempt
+import com.andrerinas.openheadunit.aap.SoftApCredentialsPolicy
 import com.andrerinas.openheadunit.aap.SoftApNetworkPolicy
 import com.andrerinas.openheadunit.aap.SoftApState
 import com.andrerinas.openheadunit.utils.AppLog
@@ -17,6 +24,7 @@ import com.andrerinas.openheadunit.utils.InterfaceMacReader
 import com.andrerinas.openheadunit.utils.NetworkAddresses
 import com.andrerinas.openheadunit.utils.Settings
 import com.andrerinas.openheadunit.utils.SoftApStateReader
+import com.andrerinas.openheadunit.utils.ToastUtils
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -71,8 +79,40 @@ class SoftApCredentialsProvider(
     /** Whether *we* turned the hotspot on, and so may turn it back on if it drops. */
     @Volatile private var autoEnabled = false
 
+    /**
+     * Whether switching the hotspot on has already been tried since [start].
+     *
+     * A field rather than a local in [beginResolve], because [refresh] restarts that loop and the
+     * handshake calls it every time it has been waiting too long — which used to re-arm auto-enable
+     * on each one, so a slow access point got a second start sweep on top of the first, racing it
+     * band for band. One attempt per run is the whole of the best effort on offer.
+     */
+    @Volatile private var triedAutoEnable = false
+
     /** So the once-per-second poll reports "nothing here" once, not thirty times. */
     @Volatile private var reportedNoInterface = false
+
+    /**
+     * When [start] was called, so the budget below measures the run rather than one look.
+     *
+     * [beginResolve] used to stamp its own deadline, and [refresh] restarts it — which the handshake
+     * calls every ~10 s while it waits. A budget of 30 s restarted every 10 s never expires, so the
+     * line that tells the user no access point could be found was unreachable in exactly the case it
+     * was written for. Measured: an access point down for 3.5 minutes, the resolve polling the whole
+     * time, and nothing said.
+     */
+    @Volatile private var runStartedAt = 0L
+
+    /** So that budget is reported once per run, not once per [refresh]. */
+    @Volatile private var reportedBudgetExhausted = false
+
+    /**
+     * Same idea for the unreadable-configuration dead end, but latched for the whole run rather
+     * than per resolve: the handshake calls [refresh] every time it has been waiting too long, and
+     * the phone redials every few seconds, so this would otherwise be said once per attempt for as
+     * long as the user keeps trying. It is one instruction and it does not change.
+     */
+    @Volatile private var reportedConfigUnreadable = false
 
     private val apStateReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
@@ -106,6 +146,10 @@ class SoftApCredentialsProvider(
             return
         }
         isRunning = true
+        runStartedAt = System.currentTimeMillis()
+        triedAutoEnable = false
+        reportedConfigUnreadable = false
+        reportedBudgetExhausted = false
         if (!isReceiverRegistered) {
             try {
                 // A system broadcast, so EXPORTED: NOT_EXPORTED silently never fires on API 34+.
@@ -132,6 +176,9 @@ class SoftApCredentialsProvider(
         resolveJob?.cancel()
         resolveJob = null
         autoEnabled = false
+        triedAutoEnable = false
+        reportedConfigUnreadable = false
+        reportedBudgetExhausted = false
         if (isReceiverRegistered) {
             // Reset even if unregister throws: a flag set in only one direction is how a
             // long-lived manager ends up unable to re-arm.
@@ -140,42 +187,101 @@ class SoftApCredentialsProvider(
         }
     }
 
+    /**
+     * The one failure on this route the user can actually fix, so it is worth interrupting them
+     * for: without it the whole symptom is a phone that connects over Bluetooth and then does
+     * nothing, with the reason only in a log they have no reason to read.
+     *
+     * Forced past the toast preference, because a silent dead end is worse than an unwanted toast.
+     * Posted to the main thread rather than switched to it with withContext: the resolve loop is
+     * cancelled by [refresh] and by [stop], and a suspending hop would let that cancellation
+     * swallow the message after the once-per-run latch had already been set.
+     */
+    private fun showConfigUnreadableToast() {
+        Handler(Looper.getMainLooper()).post {
+            ToastUtils.showToast(
+                context,
+                R.string.hotspot_config_unreadable_toast,
+                Toast.LENGTH_LONG,
+                force = true
+            )
+        }
+    }
+
     private fun beginResolve() {
         resolveJob?.cancel()
         reportedNoInterface = false
         resolveJob = scope.launch(Dispatchers.IO + CoroutineName("SoftApCredentials-Resolve")) {
             val deadline = System.currentTimeMillis() + RESOLVE_BUDGET_MS
-            var triedAutoEnable = false
-            val startedAt = System.currentTimeMillis()
 
             while (isActive && isRunning && System.currentTimeMillis() < deadline) {
                 val chosen = pickApInterface()
-                if (chosen != null && publish(chosen)) return@launch
+                val apName = chosen?.iface?.name ?: "the access point"
+                when (if (chosen == null) SoftApCredentialsAttempt.NO_AP_YET else publish(chosen)) {
+                    SoftApCredentialsAttempt.PUBLISHED -> return@launch
 
-                // Reaching here means nothing was published, whether because no interface looked
-                // like an access point or because the one that did turned out not to be running.
-                // Both are "there is no hotspot yet", which is what auto-enable is for.
-                val waited = System.currentTimeMillis() - startedAt
-                if (!triedAutoEnable && waited >= AUTO_ENABLE_AFTER_MS && settings.autoEnableHotspot) {
-                    triedAutoEnable = true
-                    AppLog.i("SoftApCredentials: No access point after ${waited / 1000}s — trying to switch this device's hotspot on.")
-                    // Best effort; most unrooted units lack the permission. Keep polling anyway,
-                    // since the user may switch it on by hand.
-                    autoEnabled = HotspotManager.setHotspotEnabled(context, true)
+                    SoftApCredentialsAttempt.CONFIG_UNREADABLE -> {
+                        // Waiting cannot help and the budget would be spent in silence, so stop and
+                        // say the one thing that does. Observed on a unit whose hotspot was up and
+                        // found the whole time: the resolve loop read "could not read its name" as
+                        // "there is no hotspot", switched on an access point that was already on,
+                        // and repeated the same line once a second until it gave up.
+                        if (!reportedConfigUnreadable) {
+                            reportedConfigUnreadable = true
+                            AppLog.e(
+                                "SoftApCredentials: The access point on $apName is up, but this " +
+                                    "device will not let apps read its name, so there is nothing to hand the " +
+                                    "phone. Waiting will not change that. Set 'Hotspot name (manual)' and " +
+                                    "'Hotspot password (manual)' in Settings to this device's own hotspot name " +
+                                    "and password, then connect again."
+                            )
+                            showConfigUnreadableToast()
+                        }
+                        onInvalidated?.invoke()
+                        return@launch
+                    }
+
+                    SoftApCredentialsAttempt.NO_AP_YET -> {
+                        // Nothing on air yet, which is exactly what auto-enable is for. Reached only
+                        // here, so an access point that is up but unreadable never triggers it.
+                        val waited = System.currentTimeMillis() - runStartedAt
+                        reportBudgetExhaustedOnce(waited)
+                        if (!triedAutoEnable && waited >= AUTO_ENABLE_AFTER_MS && settings.autoEnableHotspot) {
+                            triedAutoEnable = true
+                            AppLog.i("SoftApCredentials: No access point after ${waited / 1000}s — trying to switch this device's hotspot on.")
+                            // Best effort; most unrooted units lack the permission. Keep polling
+                            // anyway, since the user may switch it on by hand.
+                            autoEnabled = HotspotManager.setHotspotEnabled(context, true)
+                        }
+                    }
                 }
                 delay(POLL_INTERVAL_MS)
             }
 
             if (isActive && isRunning) {
-                AppLog.e(
-                    "SoftApCredentials: No usable access point after ${RESOLVE_BUDGET_MS / 1000}s. " +
-                        "Turn this device's hotspot on before connecting — 5 GHz is strongly " +
-                        "recommended, Android Auto video is poor over 2.4 GHz — or switch the " +
-                        "Android Auto network transport back to WiFi Direct."
-                )
+                reportBudgetExhaustedOnce(System.currentTimeMillis() - runStartedAt, force = true)
                 onInvalidated?.invoke()
             }
         }
+    }
+
+    /**
+     * Says once per run that this has been going on too long to be a hotspot still coming up.
+     *
+     * Reported rather than acted on: the polling continues, because the user switching the hotspot
+     * on by hand is a real recovery and the only one left on a device where auto-enable cannot. What
+     * this replaces is silence — the old message was tied to a deadline [beginResolve] restamped on
+     * every [refresh], so on the path that needed it most it never printed at all.
+     */
+    private fun reportBudgetExhaustedOnce(waited: Long, force: Boolean = false) {
+        if (reportedBudgetExhausted || (!force && waited < RESOLVE_BUDGET_MS)) return
+        reportedBudgetExhausted = true
+        AppLog.e(
+            "SoftApCredentials: No usable access point after ${waited / 1000}s. " +
+                "Turn this device's hotspot on before connecting — 5 GHz is strongly " +
+                "recommended, Android Auto video is poor over 2.4 GHz — or switch the " +
+                "Android Auto network transport back to WiFi Direct."
+        )
     }
 
     /** The interface we settled on, and whether the user named it rather than us guessing. */
@@ -251,26 +357,25 @@ class SoftApCredentialsProvider(
         return ChosenInterface(picked, namedByUser = false)
     }
 
-    /** Resolves the rest of the credentials for [iface] and hands them over. True if it worked. */
-    private fun publish(chosen: ChosenInterface): Boolean {
+    /** Resolves the rest of the credentials for [iface] and hands them over. */
+    private fun publish(chosen: ChosenInterface): SoftApCredentialsAttempt {
         val iface = chosen.iface
-        val ip = iface.siteLocalIpv4 ?: return false
+        val ip = iface.siteLocalIpv4 ?: return SoftApCredentialsAttempt.NO_AP_YET
 
         // User's override first, then the system's own configuration: getSoftApConfiguration() is
-        // reflection over a non-public API and can simply refuse on a locked-down device.
+        // reflection over a non-public API and can simply refuse on a locked-down device. What the
+        // two of them add up to is SoftApCredentialsPolicy's question, not this method's — the
+        // device it matters on is not one we can test against, so the rule lives where a test can
+        // reach it.
         val manualSsid = settings.hotspotSsid
-        val systemConfig = if (manualSsid.isEmpty()) HotspotConfigReader.getSystemHotspotConfig(context) else null
-        val ssid = manualSsid.ifEmpty { systemConfig?.first.orEmpty() }
-        val psk = settings.hotspotPassword.ifEmpty { systemConfig?.second.orEmpty() }
+        val systemConfig = if (manualSsid.isEmpty()) {
+            HotspotConfigReader.getSystemHotspotConfig(context)?.let { SoftApCredentials(it.first, it.second) }
+        } else null
 
-        if (ssid.isEmpty()) {
-            AppLog.w(
-                "SoftApCredentials: Found an access point on ${iface.name} ($ip) but could not read " +
-                    "its name. This device does not let apps read the hotspot configuration — set " +
-                    "the name and password by hand in the Android Auto settings."
-            )
-            return false
-        }
+        val attempt = SoftApCredentialsPolicy.decide(manualSsid, settings.hotspotPassword, systemConfig, ip)
+        if (attempt != SoftApCredentialsAttempt.PUBLISHED) return attempt
+        val (ssid, psk) = SoftApCredentialsPolicy.resolve(manualSsid, settings.hotspotPassword, systemConfig)
+
         if (psk.isEmpty()) {
             AppLog.w("SoftApCredentials: No passphrase for '$ssid'. An open network will be refused by the phone; set one by hand if this fails.")
         }
@@ -283,7 +388,7 @@ class SoftApCredentialsProvider(
                     "like this. Not handing the phone a network that is not on air. Switch the " +
                     "hotspot on, or name the interface by hand if you know it is up."
             )
-            return false
+            return SoftApCredentialsAttempt.NO_AP_YET
         }
         if (apState == SoftApState.UNKNOWN) {
             AppLog.i("SoftApCredentials: This device does not let apps read the hotspot state; proceeding without confirming the access point is up.")
@@ -301,7 +406,7 @@ class SoftApCredentialsProvider(
 
         AppLog.i("SoftApCredentials: SUCCESS - Providing credentials from ${iface.name}: SSID=$ssid, IP=$ip, BSSID=${bssid.ifEmpty { "<none>" }}")
         onCredentialsReady?.invoke(ssid, psk, ip, bssid)
-        return true
+        return SoftApCredentialsAttempt.PUBLISHED
     }
 
     private fun hardwareAddressOf(name: String): String? = try {

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -187,6 +187,7 @@ class VideoDecoder(private val settings: Settings) {
     private var frameCount = 0
     private var lastFpsLogTime = 0L
     private var loggedFirstSoftwareFrame = false
+    private var loggedFirstHardwareFrame = false
     @Volatile var onFirstFrameListener: (() -> Unit)? = null
     @Volatile var lastFrameRenderedMs: Long = 0L
     private var syntheticPtsUs = 0L
@@ -351,6 +352,7 @@ class VideoDecoder(private val settings: Settings) {
             lastFrameRenderedMs = 0L
             syntheticPtsUs = 0L
             loggedFirstSoftwareFrame = false
+            loggedFirstHardwareFrame = false
             // The FPS window and the throughput counters must not straddle a restart, or the
             // first sample afterwards is averaged over the whole teardown and reads near zero.
             frameCount = 0
@@ -965,6 +967,14 @@ class VideoDecoder(private val settings: Settings) {
                     lastOutputMs = lastFrameRenderedMs
                     framesRenderedThisSession++
                     consecutiveErrors = 0
+                    // The one landmark that says video actually reached the screen on the path
+                    // almost every unit runs. Driven by its own flag rather than the listener
+                    // below, which only exists while the projection activity is up — the sessions
+                    // worth timing are exactly the ones where it might not be.
+                    if (!loggedFirstHardwareFrame) {
+                        loggedFirstHardwareFrame = true
+                        AppLog.i("First frame rendered (hardware decode)")
+                    }
                     onFirstFrameListener?.let { it(); onFirstFrameListener = null }
 
                     frameCount++

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -3188,6 +3188,27 @@ class SettingsFragment : Fragment() {
     }
 
     private fun handleNativeAaSelection() {
+        // An external Bluetooth module is not a "might not work" — the phone is bonded to a chip
+        // this app cannot write to, so say so plainly and name the evidence instead of offering
+        // the generic "try it anyway".
+        val externalBtEvidence = BluetoothHelper.externalBtEvidence
+        if (externalBtEvidence != null) {
+            MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
+                .setTitle(R.string.external_bt_nativeaa)
+                .setMessage(getString(R.string.external_bt_nativeaa_desc, externalBtEvidence))
+                // Selecting the mode is still allowed: on a unit with a second, reachable radio
+                // the user can name it under the secondary-Bluetooth setting, and Native mode
+                // will then run. Without that it stays switched off, and the log says why.
+                .setPositiveButton(android.R.string.ok) { dialog, _ ->
+                    pendingWifiConnectionMode = 3
+                    checkChanges()
+                    updateSettingsList()
+                    dialog.dismiss()
+                }
+                .setNegativeButton(android.R.string.cancel, null)
+                .show()
+            return
+        }
         if (NativeAaHandshakeManager.checkCompatibility(requireContext())) {
             MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
                 .setTitle(R.string.supported_nativeaa)

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
@@ -136,15 +136,78 @@ object BluetoothHelper {
         }
     }
 
+    /**
+     * Resolves the real Bluetooth MAC address of the headunit's Bluetooth chip.
+     * On Android 6+ (API 23+), adapter.address returns dummy "02:00:00:00:00:00".
+     * We fall back to reflection and Chinese OEM SystemProperties to find the true hardware BDADDR.
+     */
+    fun getBluetoothMacAddress(context: Context, adapter: BluetoothAdapter? = null): String? {
+        val targetAdapter = adapter ?: getBluetoothAdapter(context)
+        
+        // 1. Try standard adapter property if valid
+        try {
+            val addr = targetAdapter?.address
+            if (!addr.isNullOrEmpty() && addr != "02:00:00:00:00:00" && addr != "00:00:00:00:00:00") {
+                return addr.uppercase()
+            }
+        } catch (e: SecurityException) {
+            AppLog.w("BluetoothHelper: SecurityException reading adapter address")
+        } catch (e: Exception) {}
+
+        // 2. Try reflection via hidden getAddress() on BluetoothAdapter / IBluetooth
+        try {
+            if (targetAdapter != null) {
+                val getAddressMethod = targetAdapter.javaClass.getMethod("getAddress")
+                getAddressMethod.isAccessible = true
+                val addr = getAddressMethod.invoke(targetAdapter) as? String
+                if (!addr.isNullOrEmpty() && addr != "02:00:00:00:00:00" && addr != "00:00:00:00:00:00") {
+                    return addr.uppercase()
+                }
+            }
+        } catch (e: Exception) {}
+
+        // 3. Fallback to Chinese Headunit Vendor System Properties
+        val propKeys = arrayOf(
+            "persist.sys.bt.mac",
+            "persist.sys.btmac",
+            "persist.vendor.bt.mac",
+            "sys.bt.mac",
+            "persist.sys.bluetooth.mac",
+            "ro.boot.btmacaddr",
+            "vendor.bt.bdaddr",
+            "persist.zj.BTmac",
+            "persist.zlink.carplay.mac",
+            "sys.bt.bdaddr"
+        )
+
+        for (key in propKeys) {
+            val valStr = SystemProperties.get(key, "").trim()
+            if (valStr.isNotEmpty() && isValidMacAddress(valStr)) {
+                AppLog.i("BluetoothHelper: Resolved hardware BT MAC $valStr from property $key")
+                return valStr.uppercase()
+            }
+        }
+
+        return null
+    }
+
+    private fun isValidMacAddress(mac: String): Boolean {
+        if (mac == "02:00:00:00:00:00" || mac == "00:00:00:00:00:00") return false
+        val regex = Regex("^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$")
+        return regex.matches(mac)
+    }
+
     fun listBluetoothServices(): List<String> {
         val bluetoothServices = mutableListOf<String>()
+        val keywords = listOf("bluetooth", "bt", "syu", "hct", "mtc", "goc", "winca", "qf")
         try {
             val serviceManagerClass = Class.forName("android.os.ServiceManager")
             val listServicesMethod = serviceManagerClass.getMethod("listServices")
             val services = listServicesMethod.invoke(null) as? Array<String>
             if (services != null) {
                 for (service in services) {
-                    if (service.contains("bluetooth", ignoreCase = true)) {
+                    val lower = service.lowercase()
+                    if (keywords.any { lower.contains(it) }) {
                         bluetoothServices.add(service)
                     }
                 }
@@ -156,16 +219,16 @@ object BluetoothHelper {
         if (!bluetoothServices.contains("bluetooth_manager")) {
             bluetoothServices.add(0, "bluetooth_manager")
         }
-        return bluetoothServices
+        return bluetoothServices.distinct()
     }
 
     fun getAdapterDescription(context: Context, serviceName: String): String {
         if (serviceName == "bluetooth_manager") {
             val adapter = getDefaultAdapter(context)
             val name = try { adapter?.name } catch (e: SecurityException) { null }
-            val address = try { adapter?.address } catch (e: SecurityException) { null }
+            val address = getBluetoothMacAddress(context, adapter)
             val suffix = if (!name.isNullOrEmpty()) " ($name)" else ""
-            val addrSuffix = if (!address.isNullOrEmpty() && address != "02:00:00:00:00:00") " [$address]" else ""
+            val addrSuffix = if (!address.isNullOrEmpty()) " [$address]" else ""
             return "Default ($serviceName)$suffix$addrSuffix"
         }
 
@@ -183,9 +246,9 @@ object BluetoothHelper {
             ctor.isAccessible = true
             val adapter = ctor.newInstance(managerService) as? BluetoothAdapter
             val name = try { adapter?.name } catch (e: SecurityException) { null }
-            val address = try { adapter?.address } catch (e: SecurityException) { null }
+            val address = getBluetoothMacAddress(context, adapter)
             val suffix = if (!name.isNullOrEmpty()) " ($name)" else ""
-            val addrSuffix = if (!address.isNullOrEmpty() && address != "02:00:00:00:00:00") " [$address]" else ""
+            val addrSuffix = if (!address.isNullOrEmpty()) " [$address]" else ""
             return "Secondary ($serviceName)$suffix$addrSuffix"
         } catch (e: Exception) {
             return "Secondary ($serviceName)"

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.os.Build
 import android.os.IBinder
 import com.andrerinas.openheadunit.App
+import com.andrerinas.openheadunit.aap.ExternalBtPolicy
 import java.lang.reflect.Constructor
 
 object BluetoothHelper {
@@ -189,6 +190,22 @@ object BluetoothHelper {
         }
 
         return null
+    }
+
+    /**
+     * Evidence that this head unit's Bluetooth is an external module on a serial link rather than
+     * the radio behind `android.bluetooth`, or null when it is a normal built-in radio. See
+     * [ExternalBtPolicy] for what the evidence means and why it decides whether Bluetooth-based
+     * wireless can work here at all.
+     *
+     * Cached: the answer is a property of the hardware and cannot change within a process, and
+     * this is consulted on every handshake start.
+     */
+    val externalBtEvidence: String? by lazy {
+        ExternalBtPolicy.detect(
+            nodeExists = { path -> try { java.io.File(path).exists() } catch (e: Exception) { false } },
+            property = { key -> SystemProperties.get(key, "") }
+        )
     }
 
     private fun isValidMacAddress(mac: String): Boolean {

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/HotspotManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/HotspotManager.kt
@@ -13,7 +13,9 @@ import java.lang.reflect.Method
 import java.net.Inet4Address
 import java.net.NetworkInterface
 import com.andrerinas.openheadunit.utils.SoftApConfigCompat
+import com.andrerinas.openheadunit.aap.ApBand
 import com.andrerinas.openheadunit.aap.ApInterfaceCandidate
+import com.andrerinas.openheadunit.aap.SoftApBandPolicy
 import com.andrerinas.openheadunit.aap.SoftApNetworkPolicy
 import com.andrerinas.openheadunit.aap.SoftApState
 
@@ -27,20 +29,98 @@ object HotspotManager {
     /** How long to give the framework to actually bring an access point up. */
     private const val AP_STATE_TIMEOUT_MS = 6_000L
 
+    /** How long to leave the access point down so a joined client notices it has gone. */
+    private const val RESTART_SETTLE_MS = 2_000L
+
     /** TetheringManager.TETHERING_WIFI. */
     private const val TETHERING_WIFI = 0
 
     private var cachedCallbackClass: Class<*>? = null
 
+    /**
+     * Whether a start is already running. Bringing an access point up takes up to
+     * [AP_STATE_TIMEOUT_MS] per band, and more than one caller asks for it: the credentials
+     * provider auto-enables, and every "still waiting for credentials" refresh can ask again. Two
+     * overlapping sweeps race each other's bands and end with a log claiming the access point came
+     * up twice, on both of them.
+     */
+    @Volatile private var startInFlight = false
+
+    /**
+     * Takes the access point down and brings it straight back up.
+     *
+     * Removing the network is the only way this app can put a phone off it — nothing in the public
+     * API disconnects a client from your own access point, and the one thing that comes close,
+     * `SoftApConfiguration`'s blocked-client list, needs the same `setSoftApConfiguration()` call
+     * that head units routinely refuse outright. So the network has to go; it does not have to stay
+     * gone. Bringing it back here costs seconds nobody is waiting through, where leaving it down
+     * charges the same seconds to the next connection, with the phone waiting.
+     *
+     * Putting it back is the part that is not free, and it is asked for **once** — measured rather
+     * than assumed. Tearing an access point down and asking for it again is the sequence some
+     * drivers handle worst: hostapd begins its channel scan before the interface is back, the scan
+     * returns `ENODEV`, and it aborts instead of starting. Asking again at this layer does not beat
+     * that. Across three runs, **nine** asks spaced ~12.5 s apart failed with that same signature
+     * and not one recovered; the single bring-up that did succeed came from a start posted **127 ms**
+     * behind a failed one — 270 ms in an earlier capture — landing in a window open for a few hundred
+     * milliseconds and shut long before this layer can ask again. Where the hardware handles a
+     * stop/start cleanly one ask is all that was ever needed; where it does not, the access point
+     * stays down and the next connection's auto-enable brings it back, which is the cost this
+     * restart exists to avoid, paid only on hardware that will not cooperate — rather than that same
+     * cost plus half a minute of asking that never works.
+     *
+     * There is also a window this cannot close. Between the two calls the access point is genuinely
+     * down, and a process killed outright in that window — `am force-stop`, or the system reclaiming
+     * the app — runs none of the code below, so the hotspot stays off. Measured, and bounded rather
+     * than fixed: the next connection's `SoftApCredentialsProvider` auto-enable switches it back on,
+     * which is the same cost the restart exists to avoid paying, not a permanent break. Shrinking
+     * [RESTART_SETTLE_MS] narrows the window; nothing removes it.
+     */
+    fun restart(context: Context): Boolean {
+        AppLog.i("HotspotManager: Restarting the hotspot so any joined client is put off it.")
+        setHotspotEnabled(context, false)
+        try {
+            Thread.sleep(RESTART_SETTLE_MS)
+        } catch (e: InterruptedException) {
+            // Interrupted with the access point already down, which is the one state this method
+            // must not leave behind: switching one back on is best effort, and on a unit without
+            // WRITE_SETTINGS nothing else can. Put it back before unwinding, then restore the flag
+            // so whatever cancelled us still sees it.
+            AppLog.w("HotspotManager: Interrupted while the hotspot was down; bringing it back before giving up.")
+            val restored = setHotspotEnabled(context, true)
+            Thread.currentThread().interrupt()
+            return restored
+        }
+
+        if (setHotspotEnabled(context, true)) return true
+
+        AppLog.e("HotspotManager: The hotspot was taken down to put the phone off the network and would not come back up. It is off now, and this app cannot force it: switch it on in system settings, or just connect again — the app switches it back on itself at the start of a connection.")
+        return false
+    }
+
     fun setHotspotEnabled(context: Context, enabled: Boolean): Boolean {
         AppLog.i("HotspotManager: Setting hotspot enabled=$enabled (API ${Build.VERSION.SDK_INT}, canWriteSettings=${AppPermissions.isWriteSettingsGranted(context)})")
+
+        // Disabling has no band to choose and nothing to confirm afterwards, and never collides
+        // with a start: only one caller ever asks for it.
+        if (!enabled) return startOnBand(context, enabled = false, band = ApBand.BAND_5GHZ).attempted
+
+        // Claimed before anything slow runs, or the WiFi-disable sleep below is long enough for a
+        // second caller to walk straight past the check.
+        synchronized(this) {
+            if (startInFlight) {
+                AppLog.i("HotspotManager: A hotspot start is already running; letting it finish rather than starting a second one.")
+                return isApUp(context)
+            }
+            startInFlight = true
+        }
 
         // On Android 8+, WiFi must be disabled before tethering can start. Ask, then say what
         // actually happened: setWifiEnabled() is a no-op for apps targeting API 29+ and this app
         // targets well past that, so on most devices the request is silently ignored and the
         // framework drops the station itself when it needs the radio. Announcing the attempt as if
         // it worked is how the radio state ends up being read as ours.
-        if (enabled) {
+        try {
             try {
                 val wm = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
                 if (wm.isWifiEnabled) {
@@ -56,16 +136,82 @@ object HotspotManager {
             } catch (e: Exception) {
                 AppLog.w("HotspotManager: Failed to disable WiFi: ${e.message}")
             }
+
+            // 5 GHz first, 2.4 GHz only if the radio will not host an access point on it. See
+            // SoftApBandPolicy for why the order is not a preference.
+            var attemptedAny = false
+            for ((index, band) in SoftApBandPolicy.attemptOrder().withIndex()) {
+                if (index > 0) {
+                    AppLog.w("HotspotManager: no access point on ${SoftApBandPolicy.describe(SoftApBandPolicy.attemptOrder()[index - 1])}; retrying on ${SoftApBandPolicy.describe(band)}. Android Auto is known to drop within seconds on 2.4 GHz — if the projection dies shortly after connecting, this line is why.")
+                }
+                val outcome = startOnBand(context, enabled = true, band = band)
+                attemptedAny = attemptedAny || outcome.attempted
+                if (outcome.up) {
+                    AppLog.i(describeApUp(outcome.configured, band))
+                    return true
+                }
+                if (!outcome.configured) {
+                    // The band never reached the framework, so the next one would post the same
+                    // request against the same stored configuration and start the same access
+                    // point again. Measured on a unit that refuses setSoftApConfiguration(): three
+                    // start requests, all `channels {3=0}`, two of them tearing down an access
+                    // point the previous one had just brought up.
+                    AppLog.w("HotspotManager: This device would not take a band request, so trying ${SoftApBandPolicy.describe(SoftApBandPolicy.attemptOrder().last())} would start the same access point again. Leaving the band to the device.")
+                    break
+                }
+            }
+
+            // A request the framework accepted late still brings an access point up, after the band
+            // it belonged to has been written off. Look once more before reporting failure: saying
+            // no here is what makes a caller start a second, overlapping sweep.
+            if (attemptedAny && awaitApUp(context)) {
+                AppLog.i("HotspotManager: An access point came up after its band's window had expired; taking it. Which band it chose is not something this app can read.")
+                return true
+            }
+
+            if (attemptedAny) {
+                AppLog.w("HotspotManager: Every start path was tried on every band and no access point came up within ${AP_STATE_TIMEOUT_MS / 1000}s each. On a non-privileged install this usually cannot be done from an app — switch the hotspot on in system settings instead.")
+            } else {
+                AppLog.w("HotspotManager: All hotspot attempts failed.")
+            }
+            warnIfRadioLeftDown(context)
+            return false
+        } finally {
+            startInFlight = false
+        }
+    }
+
+    /**
+     * What one band's worth of start attempts achieved: whether anything was tried, whether an
+     * access point actually came up, and whether the band we asked for ever reached the framework.
+     */
+    private data class BandOutcome(val attempted: Boolean, val up: Boolean, val configured: Boolean)
+
+    /**
+     * What to say about an access point that is up, given whether the band request was accepted.
+     *
+     * Naming a band we only *asked* for is how a log ends up contradicting the radio. Measured on a
+     * unit that refuses `setSoftApConfiguration()`: this said 2.4 GHz while the access point that
+     * came up 8.7 s later was on 5745 MHz, so a reader with only the log would have concluded the
+     * exact opposite of what happened. The band is not readable from an ordinary app — `SoftApInfo`
+     * arrives on a callback that needs NETWORK_SETTINGS — so the honest line names what was
+     * requested and what became of the request, and nothing else.
+     */
+    private fun describeApUp(configured: Boolean, band: ApBand): String =
+        if (configured) {
+            "HotspotManager: Hotspot is up, and this device accepted the request for ${SoftApBandPolicy.describe(band)}."
+        } else {
+            "HotspotManager: Hotspot is up, but this device refused the request for ${SoftApBandPolicy.describe(band)} — the band is whatever it already had configured, which this app cannot read. If the projection dies seconds after connecting, check the hotspot's channel: Android Auto is known to drop on 2.4 GHz."
         }
 
+    private fun startOnBand(context: Context, enabled: Boolean, band: ApBand): BandOutcome {
         // [BUG_FIX] Must fall through, not return. enableHotspot() only calls
         // setSoftApConfiguration() — it configures an access point, it does not start one — yet
         // its `true` used to short-circuit the whole function, so on API 30+ we wrote the SSID and
         // passphrase, reported success, and ran no start path at all. The hotspot stayed off.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            if (SoftApConfigCompat.enableHotspot(context, enabled)) {
-                AppLog.i("HotspotManager: SoftAp configuration applied; now starting the hotspot.")
-            }
+        val configured = SoftApConfigCompat.enableHotspot(context, enabled, band)
+        if (configured) {
+            AppLog.i("HotspotManager: SoftAp configuration applied; now starting the hotspot.")
         }
         // Newer API: TetheringManager (official) before ConnectivityManager fallback
         var attempted = false
@@ -82,23 +228,15 @@ object HotspotManager {
             AppLog.w("HotspotManager: Cannot enable the hotspot without the \"Modify system settings\" permission (WRITE_SETTINGS). Grant it in the setup wizard or Settings > Permissions.")
         }
 
+        if (!enabled) return BandOutcome(attempted, up = false, configured = configured)
+
         // [BUG_FIX] Confirm the access point instead of trusting the call that asked for it. Every
         // start path here is reflection over an API whose real answer arrives later on a callback
         // we cannot construct, so `invoke()` returning tells us only that the request was posted:
         // on one head unit the framework refused it a millisecond later ("Tethering is already
         // active or in recovering") while this method reported success and logged nothing at all.
         // Only "an access point is up" is worth reporting as success.
-        if (!enabled) return attempted
-        val up = awaitApUp(context)
-        if (up) {
-            AppLog.i("HotspotManager: Hotspot is up.")
-        } else if (attempted) {
-            AppLog.w("HotspotManager: Every start path was tried and no access point came up within ${AP_STATE_TIMEOUT_MS / 1000}s. On a non-privileged install this usually cannot be done from an app — switch the hotspot on in system settings instead.")
-        } else {
-            AppLog.w("HotspotManager: All hotspot attempts failed.")
-        }
-        if (!up) warnIfRadioLeftDown(context)
-        return up
+        return BandOutcome(attempted, up = awaitApUp(context), configured = configured)
     }
 
     /**

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -1328,6 +1328,15 @@ class Settings(private val context: Context) {
         get() = prefs.getString("hotspot-password", "")!!
         set(value) = prefs.edit().putString("hotspot-password", value).apply()
 
+    // Set once this device has failed to bring its own access point back up after the app took it
+    // down, which is the only way to find out that it cannot — no API answers the question in
+    // advance. From then on a user exit leaves the hotspot alone; see UserExitHotspotPolicy.
+    // Persisted rather than kept in memory because the answer is a property of the hardware and does
+    // not change between runs, and the price of re-learning it is somebody's hotspot each time.
+    var hotspotTeardownProvenUnsafe: Boolean
+        get() = prefs.getBoolean("hotspot-teardown-proven-unsafe", false)
+        set(value) = prefs.edit().putBoolean("hotspot-teardown-proven-unsafe", value).apply()
+
     var useLibusb: Boolean
         get() = prefs.getBoolean("use-libusb", false)
         set(value) = prefs.edit().putBoolean("use-libusb", value).apply()

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SoftApConfigCompat.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SoftApConfigCompat.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.net.wifi.WifiManager
 import android.os.Build
 import com.andrerinas.openheadunit.utils.AppLog
+import com.andrerinas.openheadunit.aap.ApBand
+import com.andrerinas.openheadunit.aap.SoftApBandPolicy
 
 /**
  * Compatibility helper for Android 11+ (API 30) hotspot configuration using
@@ -18,9 +20,11 @@ object SoftApConfigCompat {
      *
      * The caller must ensure that Wi‑Fi is disabled beforehand (handled by HotspotManager).
      */
-    fun enableHotspot(context: Context, enabled: Boolean): Boolean {
+    fun enableHotspot(context: Context, enabled: Boolean, band: ApBand = ApBand.BAND_5GHZ): Boolean {
         if (!enabled) return false // disabling handled by legacy path
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return false
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            return configureLegacyBand(context, band)
+        }
 
         // Ensure location permission (required for hotspot config on API 30+)
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
@@ -37,20 +41,59 @@ object SoftApConfigCompat {
         AppLog.i("SoftApConfigCompat: enableHotspot called (API=${Build.VERSION.SDK_INT})")
         return try {
             val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+            val settings = Settings(context)
 
-            // Build SoftApConfiguration via reflection
+            // Build SoftApConfiguration via reflection, from the one already on the device where
+            // there is one. This access point is usually the user's, and it is the one whose name
+            // and passphrase have already gone out to the phone — rewriting either here renames
+            // somebody's hotspot behind their back and invalidates credentials that were correct
+            // when they were sent. The same reasoning is already spelled out on the pre-R path
+            // below; only this branch was inventing values.
             val builderClass = Class.forName("android.net.wifi.SoftApConfiguration\$Builder")
-            val builder = builderClass.getDeclaredConstructor().newInstance()
+            val existing = readSoftApConfiguration(wifiManager)
+            if (existing == null && settings.hotspotSsid.isEmpty()) {
+                // Nothing to copy and nothing the user named: an empty builder would hand the
+                // framework a configuration with no SSID at all, which is how a working access
+                // point loses its name. The caller starts the hotspot regardless of this; it only
+                // goes up on whatever band the device chooses.
+                AppLog.w("SoftApConfigCompat: cannot read this device's access point configuration and no name is set in the app, so the band cannot be requested without risking the existing one. Starting the hotspot unconfigured.")
+                return false
+            }
+            val builder = if (existing != null) {
+                builderClass
+                    .getDeclaredConstructor(Class.forName("android.net.wifi.SoftApConfiguration"))
+                    .newInstance(existing)
+            } else {
+                builderClass.getDeclaredConstructor().newInstance()
+            }
 
-            // Retrieve SSID from Settings (fallback to default)
-            val ssid = Settings(context).autoStartWifiSsid.ifEmpty { "HeadunitHotspot" }
-            builderClass.getMethod("setSsid", String::class.java).invoke(builder, ssid)
+            // The user's explicit overrides only, and nothing invented in their absence. The name
+            // and passphrase this route hands the phone are whatever the device's own access point
+            // has — SoftApCredentialsProvider reads them back rather than assuming — so a made-up
+            // pair here would rename a working hotspot to something nobody was told about.
+            // hotspotSsid, not autoStartWifiSsid: that one names the network this unit joins as a
+            // client, which has never had anything to do with the one it hosts.
+            val ssid = settings.hotspotSsid
+            if (ssid.isNotEmpty()) {
+                builderClass.getMethod("setSsid", String::class.java).invoke(builder, ssid)
+            }
+            val password = settings.hotspotPassword
+            if (password.isNotEmpty()) {
+                // 1 = SECURITY_TYPE_WPA2_PSK
+                builderClass.getMethod("setPassphrase", String::class.java, Int::class.javaPrimitiveType)
+                    .invoke(builder, password, 1)
+            }
 
-            // Retrieve password from Settings (fallback to default)
-            val password = Settings(context).hotspotPassword.ifEmpty { "12345678" }
-            // 0 = WPA2_PSK as per SoftApConfiguration constants
-            builderClass.getMethod("setPassphrase", String::class.java, Int::class.javaPrimitiveType)
-                .invoke(builder, password, 1) // 1 = WPA2_PSK
+            // Ask for the band the link needs. Not fatal if the platform refuses the call: the
+            // caller confirms the access point afterwards and retries on the other band, so a
+            // failure here just means this attempt runs on whatever the framework picks.
+            try {
+                builderClass.getMethod("setBand", Int::class.javaPrimitiveType)
+                    .invoke(builder, SoftApBandPolicy.softApConfigurationBand(band))
+                AppLog.i("SoftApConfigCompat: requesting ${SoftApBandPolicy.describe(band)} for the access point.")
+            } catch (e: Exception) {
+                AppLog.w("SoftApConfigCompat: could not request ${SoftApBandPolicy.describe(band)} (${e.message}); the framework will choose the band.")
+            }
 
             // Build the configuration object
             val buildMethod = builderClass.getMethod("build")
@@ -62,12 +105,51 @@ object SoftApConfigCompat {
                 Class.forName("android.net.wifi.SoftApConfiguration")
             )
             val result = setConfigMethod.invoke(wifiManager, softApConfig) as Boolean
-            AppLog.i("SoftApConfiguration applied (SSID=$ssid). Success=$result")
+            AppLog.i("SoftApConfiguration applied (SSID=${ssid.ifEmpty { "unchanged" }}). Success=$result")
             result
         } catch (e: Exception) {
-            // Log full exception for diagnostics
-            AppLog.e("Failed to enable hotspot via SoftApConfiguration", e)
+            // Expected on plenty of head units, which refuse setSoftApConfiguration() outright with
+            // "App not allowed to read or update stored WiFi Ap config". Not fatal and not worth an
+            // error: the caller has other start paths and confirms the access point afterwards.
+            AppLog.w("SoftApConfigCompat: could not configure the access point (${e.message}); leaving it as the device has it and starting it anyway.")
             false
         }
+    }
+
+    /** The access point this device already has configured, or null if it will not say. */
+    private fun readSoftApConfiguration(wifiManager: WifiManager): Any? = try {
+        wifiManager.javaClass.getMethod("getSoftApConfiguration").invoke(wifiManager)
+    } catch (e: Exception) {
+        AppLog.d("SoftApConfigCompat: could not read the current access point configuration: ${e.message}")
+        null
+    }
+
+    /**
+     * Sets the band on pre-Android-11 devices, where the access point is described by a
+     * `WifiConfiguration` and its band lives in the hidden `apBand` field.
+     *
+     * Reads the current configuration and writes it back with only that field changed, so the
+     * SSID and passphrase the user (or the vendor) set stay as they are — this path never owned
+     * them, and inventing values here would rename someone's hotspot behind their back.
+     */
+    private fun configureLegacyBand(context: Context, band: ApBand): Boolean = try {
+        val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+        val config = wifiManager.javaClass.getMethod("getWifiApConfiguration").invoke(wifiManager)
+        if (config == null) {
+            AppLog.w("SoftApConfigCompat: no existing AP configuration to set the band on.")
+            false
+        } else {
+            val field = config.javaClass.getField("apBand")
+            field.setInt(config, SoftApBandPolicy.legacyApBand(band))
+            val applied = wifiManager.javaClass.getMethod(
+                "setWifiApConfiguration", android.net.wifi.WifiConfiguration::class.java
+            ).invoke(wifiManager, config) as? Boolean ?: false
+            AppLog.i("SoftApConfigCompat: requested ${SoftApBandPolicy.describe(band)} via WifiConfiguration.apBand. Success=$applied")
+            applied
+        }
+    } catch (e: Exception) {
+        // Expected on plenty of ROMs — the field is hidden and some vendors drop it entirely.
+        AppLog.w("SoftApConfigCompat: could not set ${SoftApBandPolicy.describe(band)} on this API level: ${e.message}")
+        false
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -733,6 +733,8 @@
     <string name="supported_nativeaa_desc">Great news! Your device supports \"Native Wireless\" mode, which provides a more seamless Android Auto experience. \n\nTo enable this, we need to refresh your Bluetooth cache. Please: \n1. Remove the existing pairing on your phone \n2. Click OK to restart Bluetooth \n3. Re-pair your phone \n\nWould you like to switch to Native AA mode now?</string>
     <string name="not_supported_nativeaa">Native Wireless seems not supported</string>
     <string name="not_supported_nativeaa_desc">Your device might not support the required Bluetooth or Wi-Fi features for Native Wireless. You can try it anyway, but if it fails, please use the \"Wireless Helper\" or \"Auto (Headunit Server)\" mode instead.</string>
+    <string name="external_bt_nativeaa">Native Wireless cannot work on this head unit</string>
+    <string name="external_bt_nativeaa_desc">This head unit uses its own Bluetooth module (%1$s) instead of the one Android exposes to apps. Your phone pairs with that module, so anything this app sends over Bluetooth never reaches it — the connection will look like it is working and then stall.\n\nThis is a hardware limitation and cannot be worked around from the app. Please use USB, or the \"Wireless Helper\" or \"Auto (Headunit Server)\" mode, which do not need the Bluetooth handshake.</string>
 
     <string name="wait_for_wifi">Wait for WiFi before WiFi Direct</string>
     <string name="wait_for_wifi_description">On boot, wait for WiFi to connect before starting WiFi Direct. Enable this if your head unit needs a few seconds to connect to WiFi after power on.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -819,6 +819,7 @@
     <string name="hotspot_ssid_override_message">Leave blank to read the name from this device\'s hotspot settings automatically. Some devices do not let apps read it - if the log says the name could not be read, type it here exactly as it appears in your hotspot settings.</string>
     <string name="hotspot_password_override">Hotspot password (manual)</string>
     <string name="hotspot_password_override_message">Leave blank to read the password automatically. Needed on devices that do not let apps read the hotspot configuration. The phone will be given this password to join.</string>
+    <string name="hotspot_config_unreadable_toast">Can\'t read this device\'s hotspot name. Set it manually under Hotspot name/password in Settings.</string>
     <string name="native_wifi_version_exchange">Modern handshake (version exchange)</string>
     <string name="native_wifi_version_exchange_description">Opens the Bluetooth handshake by telling the phone which protocol version this head unit speaks, the way factory head units do, instead of going straight to the connection details. Off by default. Worth trying if wireless worked before an Android Auto update and has failed since; if it makes no difference, turn it back off.</string>
     <!-- QR Code Generator -->

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/ExternalBtPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/ExternalBtPolicyTest.kt
@@ -1,0 +1,84 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExternalBtPolicyTest {
+
+    private val noNodes: (String) -> Boolean = { false }
+    private val noProps: (String) -> String? = { null }
+
+    private fun nodes(vararg present: String): (String) -> Boolean =
+        { path -> present.contains(path) }
+
+    private fun props(vararg pairs: Pair<String, String>): (String) -> String? =
+        { key -> pairs.toMap()[key] }
+
+    @Test
+    fun `a unit with neither device node nor property is a normal built-in radio`() {
+        assertNull(ExternalBtPolicy.detect(noNodes, noProps))
+        assertFalse(ExternalBtPolicy.isExternal(noNodes, noProps))
+    }
+
+    @Test
+    fun `either serial device node is enough`() {
+        assertEquals("/dev/rf_serial exists", ExternalBtPolicy.detect(nodes("/dev/rf_serial"), noProps))
+        assertEquals(
+            "/dev/zj_bt_serial exists",
+            ExternalBtPolicy.detect(nodes("/dev/zj_bt_serial"), noProps)
+        )
+    }
+
+    @Test
+    fun `either vendor property set to extra is enough`() {
+        assertEquals(
+            "rw.zlink.bt.type=extra",
+            ExternalBtPolicy.detect(noNodes, props("rw.zlink.bt.type" to "extra"))
+        )
+        assertEquals(
+            "rw.zj.bt.type=extra",
+            ExternalBtPolicy.detect(noNodes, props("rw.zj.bt.type" to "extra"))
+        )
+    }
+
+    @Test
+    fun `properties naming any other topology do not fire`() {
+        // "built_in" is the value the same properties carry on units where android.bluetooth is
+        // the radio the phone is bonded to - the case this must not misreport.
+        assertNull(ExternalBtPolicy.detect(noNodes, props("rw.zlink.bt.type" to "built_in")))
+        assertNull(ExternalBtPolicy.detect(noNodes, props("rw.zj.bt.type" to "")))
+        assertNull(ExternalBtPolicy.detect(noNodes, props("rw.zj.bt.type" to "internal")))
+    }
+
+    @Test
+    fun `property values are trimmed and case-insensitive`() {
+        // getprop output arrives with whatever whitespace the vendor's init script left in it.
+        assertEquals(
+            "rw.zj.bt.type=extra",
+            ExternalBtPolicy.detect(noNodes, props("rw.zj.bt.type" to "  extra  "))
+        )
+        assertEquals(
+            "rw.zlink.bt.type=EXTRA",
+            ExternalBtPolicy.detect(noNodes, props("rw.zlink.bt.type" to "EXTRA"))
+        )
+    }
+
+    @Test
+    fun `device nodes are reported ahead of properties`() {
+        // Both signals fire on the reference unit; the device node is the more concrete evidence
+        // to put in a bug report, so it wins.
+        assertEquals(
+            "/dev/rf_serial exists",
+            ExternalBtPolicy.detect(nodes("/dev/rf_serial"), props("rw.zj.bt.type" to "extra"))
+        )
+    }
+
+    @Test
+    fun `any single signal makes the unit external`() {
+        assertTrue(ExternalBtPolicy.isExternal(nodes("/dev/zj_bt_serial"), noProps))
+        assertTrue(ExternalBtPolicy.isExternal(noNodes, props("rw.zlink.bt.type" to "extra")))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/SoftApBandPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/SoftApBandPolicyTest.kt
@@ -1,0 +1,35 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SoftApBandPolicyTest {
+
+    @Test
+    fun `5 GHz is tried first, with 2 point 4 kept only as a fallback`() {
+        assertEquals(listOf(ApBand.BAND_5GHZ, ApBand.BAND_2GHZ), SoftApBandPolicy.attemptOrder())
+    }
+
+    @Test
+    fun `opting out of 5 GHz leaves a single attempt, not a reordered pair`() {
+        // A second attempt on a band that just failed would only double the time to give up.
+        assertEquals(listOf(ApBand.BAND_2GHZ), SoftApBandPolicy.attemptOrder(prefer5Ghz = false))
+    }
+
+    @Test
+    fun `band constants match the framework's, which are not the same on both APIs`() {
+        // SoftApConfiguration: BAND_2GHZ = 1, BAND_5GHZ = 2.
+        assertEquals(1, SoftApBandPolicy.softApConfigurationBand(ApBand.BAND_2GHZ))
+        assertEquals(2, SoftApBandPolicy.softApConfigurationBand(ApBand.BAND_5GHZ))
+        // WifiConfiguration.apBand: 0 = 2.4 GHz, 1 = 5 GHz. Off by one against the above, which is
+        // the whole reason these live behind named accessors.
+        assertEquals(0, SoftApBandPolicy.legacyApBand(ApBand.BAND_2GHZ))
+        assertEquals(1, SoftApBandPolicy.legacyApBand(ApBand.BAND_5GHZ))
+    }
+
+    @Test
+    fun `bands describe themselves the way a bug report reads`() {
+        assertEquals("5 GHz", SoftApBandPolicy.describe(ApBand.BAND_5GHZ))
+        assertEquals("2.4 GHz", SoftApBandPolicy.describe(ApBand.BAND_2GHZ))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/SoftApCredentialsPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/SoftApCredentialsPolicyTest.kt
@@ -1,0 +1,102 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SoftApCredentialsPolicyTest {
+
+    private fun decide(
+        manualSsid: String = "",
+        manualPassphrase: String = "",
+        systemConfig: SoftApCredentials? = null,
+        ip: String? = "192.168.43.1"
+    ) = SoftApCredentialsPolicy.decide(manualSsid, manualPassphrase, systemConfig, ip)
+
+    @Test
+    fun `an interface with no address of its own is not an access point yet`() {
+        assertEquals(SoftApCredentialsAttempt.NO_AP_YET, decide(ip = null))
+        assertEquals(SoftApCredentialsAttempt.NO_AP_YET, decide(ip = ""))
+    }
+
+    @Test
+    fun `the device naming its own access point is enough`() {
+        assertEquals(
+            SoftApCredentialsAttempt.PUBLISHED,
+            decide(systemConfig = SoftApCredentials("AndroidAP", "swordfish"))
+        )
+    }
+
+    @Test
+    fun `a device that will not name its access point is a dead end, not a wait`() {
+        // The distinction this policy exists for. There is an access point — the interface has an
+        // address — and the read that would name it has failed. It will fail again next second, so
+        // returning NO_AP_YET here is what made the resolve loop spend its whole budget polling and
+        // switch on a hotspot that was already up.
+        assertEquals(SoftApCredentialsAttempt.CONFIG_UNREADABLE, decide(systemConfig = null))
+    }
+
+    @Test
+    fun `the manual override is the way through on a device that hides its configuration`() {
+        // What the on-screen instruction tells the user to do, so it has to be the case that does
+        // it: no system configuration available, and the route runs anyway.
+        assertEquals(
+            SoftApCredentialsAttempt.PUBLISHED,
+            decide(manualSsid = "OHU-TEST", manualPassphrase = "testtest1234", systemConfig = null)
+        )
+        assertEquals(
+            SoftApCredentials("OHU-TEST", "testtest1234"),
+            SoftApCredentialsPolicy.resolve("OHU-TEST", "testtest1234", null)
+        )
+    }
+
+    @Test
+    fun `a named network with no password goes out open, and that is the caller's warning to give`() {
+        // Not an oversight being pinned by accident. The caller does not read the system
+        // configuration at all once a manual name is set, so there is nothing to fall back to, and
+        // pairing a user-typed name with a passphrase read off the device would hand the phone a
+        // mismatched pair that fails with nothing pointing at why. The empty passphrase is the
+        // honest answer; SoftApCredentialsProvider logs it.
+        assertEquals(
+            SoftApCredentialsAttempt.PUBLISHED,
+            decide(manualSsid = "OHU-TEST", manualPassphrase = "", systemConfig = null)
+        )
+        assertEquals(
+            SoftApCredentials("OHU-TEST", ""),
+            SoftApCredentialsPolicy.resolve("OHU-TEST", "", null)
+        )
+    }
+
+    @Test
+    fun `each field takes the user's override where there is one`() {
+        // Field-by-field precedence, which is the function's own rule. Note the first case cannot
+        // arise from SoftApCredentialsProvider as it stands — it stops reading the system
+        // configuration once a manual name is set, so a manual name never meets a system
+        // passphrase. Pinned anyway, so that if a caller ever does pass both, the answer is the
+        // documented one rather than whatever falls out.
+        assertEquals(
+            SoftApCredentials("OHU-TEST", "fromTheDevice"),
+            SoftApCredentialsPolicy.resolve("OHU-TEST", "", SoftApCredentials("AndroidAP", "fromTheDevice"))
+        )
+        assertEquals(
+            SoftApCredentials("AndroidAP", "typedByHand"),
+            SoftApCredentialsPolicy.resolve("", "typedByHand", SoftApCredentials("AndroidAP", "fromTheDevice"))
+        )
+    }
+
+    @Test
+    fun `a system configuration with an empty name is no configuration at all`() {
+        // getSoftApConfiguration() can return an object whose SSID is empty rather than refusing
+        // outright; that is the same dead end and must read as one.
+        assertEquals(
+            SoftApCredentialsAttempt.CONFIG_UNREADABLE,
+            decide(systemConfig = SoftApCredentials("", ""))
+        )
+    }
+
+    @Test
+    fun `the address is checked before the name, so a missing one is never reported as unreadable`() {
+        // Ordering matters for the message the user sees: "this device will not let apps read its
+        // hotspot name" is wrong and unactionable when the truth is that no access point is up.
+        assertEquals(SoftApCredentialsAttempt.NO_AP_YET, decide(systemConfig = null, ip = null))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/UserExitHotspotPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/UserExitHotspotPolicyTest.kt
@@ -1,0 +1,149 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UserExitHotspotPolicyTest {
+
+    private fun exit(
+        mode: Int,
+        strategy: Int = 2,
+        transport: NativeTransport = NativeTransport.WIFI_DIRECT,
+        autoEnableHotspot: Boolean = true,
+        teardownProvenUnsafe: Boolean = false
+    ) = UserExitHotspotPolicy.onUserExit(
+        mode, strategy, transport, autoEnableHotspot, teardownProvenUnsafe
+    )
+
+    @Test
+    fun `native AA on this unit's own access point takes it down when the app may drive it`() {
+        assertEquals(
+            HotspotExitAction.DISABLE,
+            exit(mode = 3, transport = NativeTransport.HOTSPOT, autoEnableHotspot = true)
+        )
+    }
+
+    @Test
+    fun `the helper's head-unit-hotspot strategy is the same route by another name`() {
+        assertEquals(
+            HotspotExitAction.DISABLE,
+            exit(mode = 2, strategy = 4, autoEnableHotspot = true)
+        )
+    }
+
+    @Test
+    fun `an access point the app was never given charge of is left up, not switched off`() {
+        // Switching one back on is best effort and usually impossible without WRITE_SETTINGS, so a
+        // hotspot the user turned on by hand could be left off with nothing able to restore it.
+        assertEquals(
+            HotspotExitAction.WARN_LEFT_UP,
+            exit(mode = 3, transport = NativeTransport.HOTSPOT, autoEnableHotspot = false)
+        )
+        assertEquals(
+            HotspotExitAction.WARN_LEFT_UP,
+            exit(mode = 2, strategy = 4, autoEnableHotspot = false)
+        )
+    }
+
+    @Test
+    fun `WiFi Direct routes are never this policy's to answer`() {
+        // The caller removes the P2P group on these; both branches firing for one disconnect would
+        // tear down the group and the hotspot at once.
+        assertEquals(
+            HotspotExitAction.NONE,
+            exit(mode = 3, transport = NativeTransport.WIFI_DIRECT, autoEnableHotspot = true)
+        )
+        assertEquals(HotspotExitAction.NONE, exit(mode = 2, strategy = 1, autoEnableHotspot = true))
+    }
+
+    @Test
+    fun `the helper's other strategies and the server mode are left alone`() {
+        for (strategy in listOf(0, 2, 3)) {
+            assertEquals(
+                "helper strategy $strategy hosts no access point",
+                HotspotExitAction.NONE,
+                exit(mode = 2, strategy = strategy)
+            )
+        }
+        assertEquals(HotspotExitAction.NONE, exit(mode = 1, strategy = 0))
+    }
+
+    @Test
+    fun `the transport only speaks for native mode`() {
+        // Mode 2 keeps its own selector; reading the native transport there would make strategy 4
+        // depend on a setting that has no meaning in that mode.
+        assertEquals(
+            HotspotExitAction.DISABLE,
+            exit(mode = 2, strategy = 4, transport = NativeTransport.WIFI_DIRECT)
+        )
+        assertEquals(
+            HotspotExitAction.NONE,
+            exit(mode = 2, strategy = 0, transport = NativeTransport.HOTSPOT)
+        )
+    }
+
+    @Test
+    fun `a device that could not switch its access point back on is not asked to again`() {
+        // Learned the only way it can be — by trying once and watching it fail. From then on the
+        // hotspot is left alone even though the user gave the app charge of it, because on such a
+        // device taking it down costs them a hotspot per session and never buys the phone leaving.
+        assertEquals(
+            HotspotExitAction.WARN_LEFT_UP,
+            exit(
+                mode = 3,
+                transport = NativeTransport.HOTSPOT,
+                autoEnableHotspot = true,
+                teardownProvenUnsafe = true
+            )
+        )
+    }
+
+    @Test
+    fun `the flag does not make this policy claim a disconnect that was never its own`() {
+        // It withdraws; it never reaches. A WiFi Direct disconnect stays WiFi Direct's.
+        assertEquals(
+            HotspotExitAction.NONE,
+            exit(
+                mode = 3,
+                transport = NativeTransport.WIFI_DIRECT,
+                autoEnableHotspot = true,
+                teardownProvenUnsafe = true
+            )
+        )
+        assertEquals(
+            HotspotExitAction.NONE,
+            exit(mode = 1, autoEnableHotspot = true, teardownProvenUnsafe = true)
+        )
+    }
+
+    @Test
+    fun `an untried device is still asked, so the flag costs nothing until it is earned`() {
+        assertEquals(
+            HotspotExitAction.DISABLE,
+            exit(
+                mode = 3,
+                transport = NativeTransport.HOTSPOT,
+                autoEnableHotspot = true,
+                teardownProvenUnsafe = false
+            )
+        )
+    }
+
+    @Test
+    fun `this policy and usesWifiDirect never both claim the same disconnect`() {
+        for (mode in 1..3) {
+            for (strategy in 0..4) {
+                for (transport in NativeTransport.values()) {
+                    val hotspot = UserExitHotspotPolicy.usesHeadUnitHotspot(mode, strategy, transport)
+                    val p2p = WifiModePolicy.usesWifiDirect(mode, strategy, transport)
+                    assertFalse("mode=$mode strategy=$strategy transport=$transport", hotspot && p2p)
+                }
+            }
+        }
+        // Not vacuous: each does claim something.
+        assertTrue(UserExitHotspotPolicy.usesHeadUnitHotspot(3, 0, NativeTransport.HOTSPOT))
+        assertTrue(WifiModePolicy.usesWifiDirect(3, 0, NativeTransport.WIFI_DIRECT))
+    }
+}


### PR DESCRIPTION
## Summary

Native AA "head unit hotspot" transport: fixes to Bluetooth external-radio detection, band selection/reporting, credential resolution, and hotspot lifecycle on user exit.

- **External BT detection** (`ExternalBtPolicy`): head units whose Bluetooth is an external module are now correctly identified so mode 3 doesn't run where it can't work.
- **Band selection & honest reporting** (`SoftApBandPolicy`): requests 5 GHz, falls back only where the radio genuinely can't host an AP there. The "hotspot is up on X GHz" log now names what the device actually accepted, not just what was requested, since those can disagree on hardware that refuses `setSoftApConfiguration()`.
- **Credential dead end, made testable** (`SoftApCredentialsPolicy`): separates "no access point yet" (keep polling, auto-enable) from "there's an access point but this device won't let apps read its name" (a dead end, not a wait). The latter now surfaces a toast + log line pointing at the manual SSID/password override instead of silently burning the resolve budget.
- **User-exit hotspot handling** (`UserExitHotspotPolicy`, `HotspotManager`): takes the hotspot down on exit to force the phone off the network, then **learns, once, if this radio can't bring it back** (a real driver race on some chipsets: hostapd's channel scan can lose a race against interface teardown) and stops trying rather than repeating a doomed teardown every session.

Thanks @andreknieriem for your changes on BluetoothHelper

## Testing

Five rounds on a real head unit whose radio hits the above failure modes, not just unit tests. WiFi Direct (the default transport) verified unaffected against `main` on the same hardware. New pure-logic policy classes carry their own JVM test coverage (`ExternalBtPolicyTest`, `SoftApBandPolicyTest`, `SoftApCredentialsPolicyTest`, `UserExitHotspotPolicyTest`).