### PR TITLE
Audio focus pauses the phone over its own Bluetooth link (#744, #681)

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapAudio.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapAudio.kt
@@ -1,22 +1,26 @@
 package com.andrerinas.openheadunit.aap
 
+import android.content.Context
 import android.media.AudioAttributes
 import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import com.andrerinas.openheadunit.aap.protocol.AudioConfigs
 import com.andrerinas.openheadunit.aap.protocol.Channel
 import com.andrerinas.openheadunit.aap.protocol.proto.Control
 import com.andrerinas.openheadunit.decoder.AudioDecoder
 import com.andrerinas.openheadunit.utils.AppLog
+import com.andrerinas.openheadunit.utils.BluetoothHelper
 import com.andrerinas.openheadunit.utils.Settings
 
 internal class AapAudio(
         private val audioDecoder: AudioDecoder,
         private val audioManager: AudioManager,
-        private val settings: Settings) {
+        private val settings: Settings,
+        private val context: Context) {
 
     private val staticAudioFocus = settings.staticAudioFocus
     private val separateAudioStreams = settings.separateAudioStreams
@@ -28,6 +32,7 @@ internal class AapAudio(
     private val audioQueueCapacity = settings.audioQueueCapacity
     private val enableAudioSink = settings.enableAudioSink
     private val attachHwDspEqualizer = settings.attachHwDspEqualizer
+    private val playbackFocusMode = settings.playbackFocusMode
 
     private var audioFocusRequest: AudioFocusRequest? = null
     private var legacyFocusListener: AudioManager.OnAudioFocusChangeListener? = null
@@ -43,10 +48,23 @@ internal class AapAudio(
     // AA audio. Instead we hold system audio focus for as long as any AA audio channel is actively
     // playing and release it when the last one stops. Static mode manages focus permanently and is
     // left untouched.
+    //
+    // Whether we take it at all is PlaybackFocusPolicy's call: on a head unit that is also the
+    // phone's Bluetooth A2DP sink, the focus grab makes the sink service AVRCP-pause that same
+    // phone, silencing the stream we are playing.
     private val activeAudioChannels = mutableSetOf<Int>()
     private val playbackFocusListener = AudioManager.OnAudioFocusChangeListener {
         AppLog.i("AapAudio: playback audio focus changed: $it")
     }
+
+    @Volatile
+    private var holdingPlaybackFocus = false
+    @Volatile
+    private var focusAcquiredAtMs = 0L
+    @Volatile
+    private var selfDefeatingStops = 0
+    @Volatile
+    private var selfDefeatingLatched = false
 
     @Volatile
     private var isDucked = false
@@ -81,6 +99,44 @@ internal class AapAudio(
 
     private fun getMediaGain(): Float {
         return (1.0f + (mediaVolumeOffset / 100.0f)).coerceIn(0.0f, 2.0f)
+    }
+
+    /**
+     * Whether a focus request the phone asked for over the protocol should reach the system.
+     *
+     * [AapControl] answers every AudioFocusRequestNotification with an always-grant reply, which is
+     * what keeps AA routing audio to us; separately it asks the system for the focus the phone
+     * wanted, so other apps on the head unit duck. That second half is the same act that makes an
+     * A2DP sink AVRCP-pause the phone we project, and it honours GAIN as a *permanent* grab, so it
+     * needs the same rule as the playback path.
+     *
+     * RELEASE is never gated: abandoning focus must always work, or a grab from before the link
+     * came up would be stranded for the rest of the session.
+     *
+     * The latch does not extend here — it is armed in [onAudioPlaybackStopped], which only runs
+     * while the playback path holds focus. On a unit whose Bluetooth probe reads nothing, this path
+     * has no automatic backstop and needs the mode set to NEVER by hand.
+     */
+    fun shouldHonourProtocolFocusRequest(isRelease: Boolean): Boolean {
+        if (isRelease) return true
+
+        val btMediaLinkActive = BluetoothHelper.isA2dpMediaLinkActive(context)
+        // isAudioChannel: the notification arrives on the control channel, but the question being
+        // asked is about audio focus. The flag means "this is an audio-focus decision", not "this
+        // message came in on an audio channel".
+        val honour = PlaybackFocusPolicy.shouldAcquire(
+                mode = playbackFocusMode,
+                staticAudioFocus = staticAudioFocus,
+                audioSinkEnabled = enableAudioSink,
+                isAudioChannel = true,
+                btMediaLinkActive = btMediaLinkActive,
+                selfDefeatingLatched = selfDefeatingLatched)
+
+        if (!honour) {
+            AppLog.i("AapAudio: phone asked for audio focus - leaving system audio focus alone " +
+                    "(mode=$playbackFocusMode, bluetoothMedia=$btMediaLinkActive, latched=$selfDefeatingLatched)")
+        }
+        return honour
     }
 
     fun requestFocusChange(stream: Int, focusRequest: Int, callback: AudioManager.OnAudioFocusChangeListener): Int {
@@ -188,6 +244,12 @@ internal class AapAudio(
     fun releaseAllFocus() {
         AppLog.i("AapAudio: Releasing all audio focus.")
         synchronized(activeAudioChannels) { activeAudioChannels.clear() }
+        // The latch is a property of one connection, not of the head unit: re-arm it so a session
+        // that reconnects with Bluetooth off gets the car-radio behaviour back.
+        holdingPlaybackFocus = false
+        focusAcquiredAtMs = 0L
+        selfDefeatingStops = 0
+        selfDefeatingLatched = false
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             audioFocusRequest?.let { audioManager.abandonAudioFocusRequest(it) }
             audioFocusRequest = null
@@ -247,18 +309,41 @@ internal class AapAudio(
 
     private fun onAudioPlaybackStarted(channel: Int) {
         if (staticAudioFocus || !enableAudioSink || !Channel.isAudio(channel)) return
-        synchronized(activeAudioChannels) {
-            val wasEmpty = activeAudioChannels.isEmpty()
+
+        // Only the set mutation belongs under the lock. requestPlaybackFocus() is a binder
+        // round-trip to AudioService and the Bluetooth probe below is another, and this runs on
+        // the transport thread for every track change.
+        val wasEmpty = synchronized(activeAudioChannels) {
+            val empty = activeAudioChannels.isEmpty()
             activeAudioChannels.add(channel)
-            if (wasEmpty) {
-                // Use GAIN_TRANSIENT, not GAIN: a permanent GAIN sends other players (e.g. the car
-                // radio) a permanent AUDIOFOCUS_LOSS, so they stop and do NOT resume when we later
-                // abandon focus. TRANSIENT sends AUDIOFOCUS_LOSS_TRANSIENT so they pause and resume
-                // once AA audio stops and we release focus.
-                AppLog.i("AapAudio: AA audio started (${Channel.name(channel)}) - acquiring transient system audio focus")
-                requestPlaybackFocus()
-            }
+            empty
         }
+        if (!wasEmpty) return
+
+        val btMediaLinkActive = BluetoothHelper.isA2dpMediaLinkActive(context)
+        val acquire = PlaybackFocusPolicy.shouldAcquire(
+                mode = playbackFocusMode,
+                staticAudioFocus = staticAudioFocus,
+                audioSinkEnabled = enableAudioSink,
+                isAudioChannel = true,
+                btMediaLinkActive = btMediaLinkActive,
+                selfDefeatingLatched = selfDefeatingLatched)
+
+        if (!acquire) {
+            AppLog.i("AapAudio: AA audio started (${Channel.name(channel)}) - leaving system audio focus alone " +
+                    "(mode=$playbackFocusMode, bluetoothMedia=$btMediaLinkActive, latched=$selfDefeatingLatched)")
+            return
+        }
+
+        // Use GAIN_TRANSIENT, not GAIN: a permanent GAIN sends other players (e.g. the car
+        // radio) a permanent AUDIOFOCUS_LOSS, so they stop and do NOT resume when we later
+        // abandon focus. TRANSIENT sends AUDIOFOCUS_LOSS_TRANSIENT so they pause and resume
+        // once AA audio stops and we release focus.
+        AppLog.i("AapAudio: AA audio started (${Channel.name(channel)}) - acquiring transient system audio focus " +
+                "(mode=$playbackFocusMode, bluetoothMedia=$btMediaLinkActive)")
+        focusAcquiredAtMs = SystemClock.elapsedRealtime()
+        holdingPlaybackFocus = true
+        requestPlaybackFocus()
     }
 
     /**
@@ -267,12 +352,42 @@ internal class AapAudio(
      */
     private fun onAudioPlaybackStopped(channel: Int) {
         if (staticAudioFocus || !enableAudioSink || !Channel.isAudio(channel)) return
-        synchronized(activeAudioChannels) {
+
+        val nowEmpty = synchronized(activeAudioChannels) {
             activeAudioChannels.remove(channel)
-            if (activeAudioChannels.isEmpty()) {
-                AppLog.i("AapAudio: last AA audio channel stopped - releasing transient system audio focus")
-                releasePlaybackFocus()
-            }
+            activeAudioChannels.isEmpty()
+        }
+        if (!nowEmpty || !holdingPlaybackFocus) return
+
+        noteStopWhileHoldingFocus(channel)
+
+        AppLog.i("AapAudio: last AA audio channel stopped - releasing transient system audio focus")
+        holdingPlaybackFocus = false
+        releasePlaybackFocus()
+    }
+
+    /**
+     * Watches for the pathology the Bluetooth probe is meant to pre-empt, for the units where it
+     * cannot see the link: the media channel closing again almost as soon as we took focus, because
+     * the phone stopped its own playback in response. Two of those in a row and we stop asking for
+     * focus, so the session settles instead of cycling every few seconds.
+     */
+    private fun noteStopWhileHoldingFocus(channel: Int) {
+        if (selfDefeatingLatched || focusAcquiredAtMs == 0L) return
+
+        val elapsedMs = SystemClock.elapsedRealtime() - focusAcquiredAtMs
+        if (!PlaybackFocusPolicy.countsAsSelfDefeating(channel == Channel.ID_AUD, elapsedMs)) {
+            selfDefeatingStops = 0
+            return
+        }
+
+        selfDefeatingStops++
+        AppLog.d("AapAudio: media stopped ${elapsedMs}ms after taking audio focus " +
+                "($selfDefeatingStops/${PlaybackFocusPolicy.SELF_DEFEATING_LIMIT})")
+        if (selfDefeatingStops >= PlaybackFocusPolicy.SELF_DEFEATING_LIMIT) {
+            selfDefeatingLatched = true
+            AppLog.w("AapAudio: taking system audio focus is stopping the phone's own playback " +
+                    "(the head unit is most likely its Bluetooth audio sink) - not acquiring it again this session")
         }
     }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapControl.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapControl.kt
@@ -338,14 +338,21 @@ internal class AapControlService(
         }
 
         // Best-effort: request system audio focus to duck other apps on the headunit.
-        // The result is intentionally ignored for the protocol response above.
+        // The result is intentionally ignored for the protocol response above, which has already
+        // been sent — only the system-level grab is in question here, never the always-grant reply.
         if (settings.enableAudioSink) {
             if (settings.staticAudioFocus) {
                 AppLog.i("Static Audio Focus active - skipping dynamic system focus request to prevent routing loss")
             } else {
-                aapAudio.requestFocusChange(AudioConfigs.stream(channel, settings.separateAudioStreams), notification.request.number, AudioManager.OnAudioFocusChangeListener {
-                    AppLog.i("System audio focus changed: $it ${systemFocusName[it]}")
-                })
+                // Gated at the call site, not inside requestFocusChange: that function is also the
+                // static path's permanent grab from CommManager, where the answer is the opposite.
+                val isRelease = notification.request.number ==
+                        Control.AudioFocusRequestNotification.AudioFocusRequestType.RELEASE_VALUE
+                if (aapAudio.shouldHonourProtocolFocusRequest(isRelease)) {
+                    aapAudio.requestFocusChange(AudioConfigs.stream(channel, settings.separateAudioStreams), notification.request.number, AudioManager.OnAudioFocusChangeListener {
+                        AppLog.i("System audio focus changed: $it ${systemFocusName[it]}")
+                    })
+                }
             }
         } else {
             AppLog.i("Audio Sink disabled - skipping system audio focus request for channel ${Channel.name(channel)}")

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -827,6 +827,10 @@ class AapService : Service(), UsbReceiver.Listener {
      * (AapControl.audioFocusRequest -> AapAudio.requestFocusChange), so grabbing a
      * permanent gain here would needlessly evict other media (e.g. the car radio) the
      * moment the phone connects, before AA plays anything.
+     *
+     * Whether to take it at all is PlaybackFocusPolicy's call, the same as for the dynamic path:
+     * on a head unit that is also the phone's Bluetooth A2DP sink, evicting the sink makes it
+     * AVRCP-pause that same phone, so the session starts with the projected audio stopped.
      */
     private fun requestPermanentAudioFocus() {
         if (!settings.enableAudioSink) {
@@ -837,6 +841,22 @@ class AapService : Service(), UsbReceiver.Listener {
             AppLog.d("Static Audio Focus disabled - skipping permanent audio focus request; focus will be acquired on demand.")
             return
         }
+
+        // One probe at connect is enough: the sink only pauses on a focus-loss *event*, so a
+        // Bluetooth link that comes up later in the session never sees one.
+        val mode = settings.playbackFocusMode
+        val btMediaLinkActive = BluetoothHelper.isA2dpMediaLinkActive(this)
+        if (!PlaybackFocusPolicy.shouldAcquirePermanent(
+                mode = mode,
+                staticAudioFocus = true,
+                audioSinkEnabled = true,
+                btMediaLinkActive = btMediaLinkActive)) {
+            AppLog.i("AapService: Static Audio Focus - leaving system audio focus alone " +
+                    "(mode=$mode, bluetoothMedia=$btMediaLinkActive)")
+            return
+        }
+        AppLog.i("AapService: Static Audio Focus - acquiring permanent system audio focus " +
+                "(mode=$mode, bluetoothMedia=$btMediaLinkActive)")
 
         try {
             val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapSslContext.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapSslContext.kt
@@ -208,7 +208,12 @@ class AapSslContext(keyManager: SingleKeyKeyManager): AapSsl {
     }
 
     override fun decrypt(start: Int, length: Int, buffer: ByteArray): ByteArrayWithLimit? {
-        synchronized(this) {
+        // The status line is built under the lock but emitted outside it. encrypt() takes this same
+        // monitor, so logging in here put the whole logging pipeline — formatting, the caller-name
+        // stack walk, the file writer — between the poll thread and the send thread once per
+        // decrypted packet, which at verbose is several times per video frame.
+        var statusLine: String? = null
+        val decrypted = synchronized(this) {
             if (!::sslEngine.isInitialized || !::rxBuffer.isInitialized) {
                 AppLog.w("SSL Decrypt: Not initialized yet")
                 return null
@@ -218,15 +223,15 @@ class AapSslContext(keyManager: SingleKeyKeyManager): AapSsl {
                 val encrypted = ByteBuffer.wrap(buffer, start, length)
                 val result = sslEngine.unwrap(encrypted, rxBuffer)
                 runDelegatedTasks(result, sslEngine)
-                
+
                 if (AppLog.LOG_VERBOSE || result.bytesProduced() == 0) {
-                    AppLog.d("SSL Decrypt Status: ${result.status}, Produced: ${result.bytesProduced()}, Consumed: ${result.bytesConsumed()}")
+                    statusLine = "SSL Decrypt Status: ${result.status}, Produced: ${result.bytesProduced()}, Consumed: ${result.bytesConsumed()}"
                 }
 
                 val resultBuffer = ByteArray(result.bytesProduced())
                 rxBuffer.flip()
                 rxBuffer.get(resultBuffer)
-                return ByteArrayWithLimit(resultBuffer, resultBuffer.size)
+                ByteArrayWithLimit(resultBuffer, resultBuffer.size)
             } catch (e: Exception) {
                 // Check for Magic Garbage disconnect signal from Wireless Helper
                 if (length >= 16) {
@@ -246,9 +251,11 @@ class AapSslContext(keyManager: SingleKeyKeyManager): AapSsl {
                 if (!isUserDisconnect) {
                     AppLog.e("SSL Decrypt failed", e)
                 }
-                return null
+                null
             }
         }
+        statusLine?.let { AppLog.d(it) }
+        return decrypted
     }
 
     override fun encrypt(offset: Int, length: Int, buffer: ByteArray): ByteArrayWithLimit? {

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
@@ -141,7 +141,7 @@ class AapTransport(
 
     init {
         micRecorder.listener = this
-        aapAudio = AapAudio(audioDecoder, audioManager, settings)
+        aapAudio = AapAudio(audioDecoder, audioManager, settings, context)
         aapVideo = AapVideo(videoDecoder, settings) {
             triggerFocusCycleRecovery()
         }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/PlaybackFocusPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/PlaybackFocusPolicy.kt
@@ -1,0 +1,116 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Whether to take system audio focus away from other players on the head unit, for both routes that
+ * do it: [shouldAcquire] for the dynamic path, which holds focus while an AA audio channel plays,
+ * and [shouldAcquirePermanent] for static mode, which holds it for the whole session.
+ *
+ * Taking focus exists so a *local* player — typically the car's FM radio — pauses while AA audio
+ * plays and resumes when it stops. It backfires when the other player is the head unit's Bluetooth
+ * A2DP sink: AOSP's `A2dpSinkStreamHandler` answers the focus loss with an AVRCP passthrough PAUSE
+ * to the source device, and that source is the very phone feeding the AA stream. On the dynamic
+ * path the phone pauses, Android Auto tears the audio sink down, we release focus, the phone
+ * resumes, and the whole thing repeats every few seconds. Nothing in the focus API distinguishes
+ * the two cases, so this decides it from context instead.
+ *
+ * The two entry points are exact complements on the `staticAudioFocus` axis: whichever route is
+ * live, the other declines, so they can never both hold focus. A test asserts it.
+ *
+ * Pure and unit-tested; the I/O and the runtime bookkeeping live in [AapAudio] and [AapService].
+ */
+object PlaybackFocusPolicy {
+
+    /** User override for the automatic behaviour. Stored as an ordinal in settings. */
+    enum class Mode(val value: Int) {
+        /** Take focus only when nothing suggests it will silence the phone we are projecting. */
+        AUTO(0),
+
+        /** Always take focus. For units where the Bluetooth probe answers wrongly. */
+        ALWAYS(1),
+
+        /** Never take focus. */
+        NEVER(2);
+
+        companion object {
+            private val map = values().associateBy(Mode::value)
+            fun fromInt(value: Int): Mode = map[value] ?: AUTO
+        }
+    }
+
+    /**
+     * @param isAudioChannel   the channel is one of AUDIO / AUDIO1 / AUDIO2.
+     * @param staticAudioFocus static mode holds focus permanently and manages it elsewhere, so the
+     *                         dynamic path must keep its hands off entirely.
+     * @param btMediaLinkActive a Bluetooth media (A2DP) link to this head unit is up, so the
+     *                          "other player" we would silence is very likely the phone itself.
+     *                          Callers that cannot tell should pass `true`: a car radio playing over
+     *                          AA is an annoyance, silence is a broken app.
+     * @param selfDefeatingLatched we already observed the phone cut its own audio right after we
+     *                          took focus, more than once this session.
+     */
+    fun shouldAcquire(
+        mode: Mode,
+        staticAudioFocus: Boolean,
+        audioSinkEnabled: Boolean,
+        isAudioChannel: Boolean,
+        btMediaLinkActive: Boolean,
+        selfDefeatingLatched: Boolean
+    ): Boolean {
+        // Pre-existing gates, unchanged: these decide whether the dynamic path runs at all.
+        if (staticAudioFocus || !audioSinkEnabled || !isAudioChannel) return false
+
+        return when (mode) {
+            Mode.NEVER -> false
+            Mode.ALWAYS -> true
+            Mode.AUTO -> !btMediaLinkActive && !selfDefeatingLatched
+        }
+    }
+
+    /**
+     * The static-mode counterpart of [shouldAcquire]: whether to take the permanent
+     * `AUDIOFOCUS_GAIN` that static mode holds for a whole session, grabbed at connect time before
+     * any audio exists.
+     *
+     * Same trigger as the dynamic path — an A2DP sink answers our focus loss by pausing the phone we
+     * project — but a permanent `AUDIOFOCUS_LOSS` is not a `LOSS_TRANSIENT`: the sink pauses once and
+     * does not resume when we abandon focus, so the failure is a session that starts silent rather
+     * than one that cycles.
+     *
+     * There is no latch parameter because there is nothing here for the latch to observe. It counts
+     * media channels closing shortly after a grab, and static mode grabs once, outside any channel's
+     * lifetime. The Bluetooth probe is the only signal available on this path, which is why a unit
+     * whose probe reads nothing needs [Mode.NEVER] set by hand.
+     */
+    fun shouldAcquirePermanent(
+        mode: Mode,
+        staticAudioFocus: Boolean,
+        audioSinkEnabled: Boolean,
+        btMediaLinkActive: Boolean
+    ): Boolean {
+        // Pre-existing gates, unchanged: the permanent grab belongs to static mode alone.
+        if (!staticAudioFocus || !audioSinkEnabled) return false
+
+        return when (mode) {
+            Mode.NEVER -> false
+            Mode.ALWAYS -> true
+            Mode.AUTO -> !btMediaLinkActive
+        }
+    }
+
+    /**
+     * Whether an audio channel that stopped this soon after we took focus should count towards the
+     * latch. Measured on the reporting unit, the phone paused within 60-660 ms of the grant and
+     * Android Auto dropped the sink 3.4-4.1 s later; a track a listener actually chose to stop
+     * lasts far longer than the window.
+     *
+     * Only the media channel qualifies — speech and system-sound channels are short by nature, so
+     * counting them would latch on a single navigation prompt.
+     */
+    fun countsAsSelfDefeating(isMediaChannel: Boolean, msSinceAcquire: Long): Boolean =
+        isMediaChannel && msSinceAcquire in 0L until SELF_DEFEATING_WINDOW_MS
+
+    /** Consecutive self-defeating stops before we stop taking focus for the rest of the session. */
+    const val SELF_DEFEATING_LIMIT = 2
+
+    const val SELF_DEFEATING_WINDOW_MS = 5_000L
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
@@ -5,8 +5,10 @@ import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
 import com.andrerinas.openheadunit.aap.AapSslContext
 import com.andrerinas.openheadunit.aap.AapTransport
+import com.andrerinas.openheadunit.aap.PlaybackFocusPolicy
 import com.andrerinas.openheadunit.aap.VideoStarvationPolicy
 import com.andrerinas.openheadunit.utils.AppLog
+import com.andrerinas.openheadunit.utils.BluetoothHelper
 import com.andrerinas.openheadunit.main.BackgroundNotification
 import com.andrerinas.openheadunit.ssl.SingleKeyKeyManager
 import com.andrerinas.openheadunit.utils.Settings
@@ -378,12 +380,26 @@ class CommManager(
             // In the default (dynamic) mode focus is acquired on demand via the AA protocol, so
             // an unconditional grab here would evict other media (e.g. the car radio) the moment
             // the phone connects, before AA plays anything.
+            //
+            // And even in static mode, not when the player we would evict is the head unit's own
+            // A2DP sink: it answers by AVRCP-pausing the phone that is about to project to us.
             if (settings.enableAudioSink && settings.staticAudioFocus) {
-                transport.aapAudio?.requestFocusChange(
-                    AudioManager.STREAM_MUSIC,
-                    AudioManager.AUDIOFOCUS_GAIN,
-                    AudioManager.OnAudioFocusChangeListener { }
-                )
+                val mode = settings.playbackFocusMode
+                val btMediaLinkActive = BluetoothHelper.isA2dpMediaLinkActive(context)
+                if (PlaybackFocusPolicy.shouldAcquirePermanent(
+                        mode = mode,
+                        staticAudioFocus = true,
+                        audioSinkEnabled = true,
+                        btMediaLinkActive = btMediaLinkActive)) {
+                    transport.aapAudio?.requestFocusChange(
+                        AudioManager.STREAM_MUSIC,
+                        AudioManager.AUDIOFOCUS_GAIN,
+                        AudioManager.OnAudioFocusChangeListener { }
+                    )
+                } else {
+                    AppLog.i("CommManager: Static Audio Focus - leaving system audio focus alone " +
+                            "(mode=$mode, bluetoothMedia=$btMediaLinkActive)")
+                }
             }
             transport.startReading()
             _connectionState.emit(ConnectionState.TransportStarted)

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -25,6 +25,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.R
 import com.andrerinas.openheadunit.aap.AapService
+import com.andrerinas.openheadunit.aap.PlaybackFocusPolicy
 import com.andrerinas.openheadunit.main.settings.SettingItem
 import com.andrerinas.openheadunit.main.settings.SettingsAdapter
 import com.andrerinas.openheadunit.utils.AppLog
@@ -113,6 +114,7 @@ class SettingsFragment : Fragment() {
     private var pendingBluetoothAddress: String? = null
     private var pendingEnableAudioSink: Boolean? = null
     private var pendingStaticAudioFocus: Boolean? = null
+    private var pendingPlaybackFocusMode: PlaybackFocusPolicy.Mode? = null
     private var pendingSeparateAudioStreams: Boolean? = null
     private var pendingUseAacAudio: Boolean? = null
     private var pendingAttachHwDspEqualizer: Boolean? = null
@@ -235,6 +237,7 @@ class SettingsFragment : Fragment() {
         pendingBluetoothAddress = settings.bluetoothAddress
         pendingEnableAudioSink = settings.enableAudioSink
         pendingStaticAudioFocus = settings.staticAudioFocus
+        pendingPlaybackFocusMode = settings.playbackFocusMode
         pendingSeparateAudioStreams = settings.separateAudioStreams
         pendingUseAacAudio = settings.useAacAudio
         pendingAttachHwDspEqualizer = settings.attachHwDspEqualizer
@@ -345,6 +348,7 @@ class SettingsFragment : Fragment() {
         pendingBluetoothAddress = settings.bluetoothAddress
         pendingEnableAudioSink = settings.enableAudioSink
         pendingStaticAudioFocus = settings.staticAudioFocus
+        pendingPlaybackFocusMode = settings.playbackFocusMode
         pendingSeparateAudioStreams = settings.separateAudioStreams
         pendingUseAacAudio = settings.useAacAudio
         pendingAttachHwDspEqualizer = settings.attachHwDspEqualizer
@@ -465,6 +469,7 @@ class SettingsFragment : Fragment() {
         pendingBluetoothAddress?.let { settings.bluetoothAddress = it }
         pendingEnableAudioSink?.let { settings.enableAudioSink = it }
         pendingStaticAudioFocus?.let { settings.staticAudioFocus = it }
+        pendingPlaybackFocusMode?.let { settings.playbackFocusMode = it }
         pendingSeparateAudioStreams?.let { settings.separateAudioStreams = it }
         pendingUseAacAudio?.let { settings.useAacAudio = it }
         pendingAttachHwDspEqualizer?.let { settings.attachHwDspEqualizer = it }
@@ -581,6 +586,7 @@ class SettingsFragment : Fragment() {
                         pendingBluetoothAddress != settings.bluetoothAddress ||
                         pendingEnableAudioSink != settings.enableAudioSink ||
                         pendingStaticAudioFocus != settings.staticAudioFocus ||
+                        pendingPlaybackFocusMode != settings.playbackFocusMode ||
                         pendingSeparateAudioStreams != settings.separateAudioStreams ||
                         pendingUseAacAudio != settings.useAacAudio ||
                         pendingAttachHwDspEqualizer != settings.attachHwDspEqualizer ||
@@ -633,6 +639,7 @@ class SettingsFragment : Fragment() {
                           pendingEnableRotary != settings.enableRotary ||
                           pendingEnableAudioSink != settings.enableAudioSink ||
                           pendingStaticAudioFocus != settings.staticAudioFocus ||
+                          pendingPlaybackFocusMode != settings.playbackFocusMode ||
                           pendingSeparateAudioStreams != settings.separateAudioStreams ||
                           pendingUseAacAudio != settings.useAacAudio ||
                           pendingAttachHwDspEqualizer != settings.attachHwDspEqualizer ||
@@ -1544,6 +1551,49 @@ class SettingsFragment : Fragment() {
                     updateSettingsList()
                 }
             ))
+
+            // Applies to both focus routes: the dynamic one that runs while an AA audio channel
+            // plays, and static mode's permanent grab at connect.
+            val focusModes = listOf(
+                PlaybackFocusPolicy.Mode.AUTO,
+                PlaybackFocusPolicy.Mode.ALWAYS,
+                PlaybackFocusPolicy.Mode.NEVER
+            )
+            val currentMode = pendingPlaybackFocusMode ?: PlaybackFocusPolicy.Mode.AUTO
+            items.add(SettingItem.SegmentedButtonSettingEntry(
+                stableId = "playbackFocusMode",
+                nameResId = R.string.playback_focus_mode,
+                options = listOf(
+                    getString(R.string.playback_focus_mode_auto),
+                    getString(R.string.playback_focus_mode_always),
+                    getString(R.string.playback_focus_mode_never)
+                ),
+                selectedIndex = focusModes.indexOf(currentMode).coerceAtLeast(0),
+                onOptionSelected = { index ->
+                    pendingPlaybackFocusMode = focusModes.getOrElse(index) { PlaybackFocusPolicy.Mode.AUTO }
+                    checkChanges()
+                    updateSettingsList()
+                }
+            ))
+
+            items.add(SettingItem.InfoBanner(
+                stableId = "playbackFocusModeHint",
+                textResId = when (currentMode) {
+                    PlaybackFocusPolicy.Mode.ALWAYS -> R.string.playback_focus_mode_always_hint
+                    PlaybackFocusPolicy.Mode.NEVER -> R.string.playback_focus_mode_never_hint
+                    else -> R.string.playback_focus_mode_auto_hint
+                }
+            ))
+
+            // The hints above are written for the dynamic path, which takes focus only while
+            // audio plays. Static mode takes it for the whole session, so say so rather than
+            // maintaining a second set of three.
+            if (pendingStaticAudioFocus == true) {
+                items.add(SettingItem.InfoBanner(
+                    stableId = "playbackFocusModeStaticHint",
+                    textResId = R.string.playback_focus_mode_static_hint
+                ))
+            }
         }
 
         items.add(SettingItem.ToggleSettingEntry(

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/AppLog.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/AppLog.kt
@@ -12,6 +12,8 @@ import java.io.IOException
 import java.io.OutputStreamWriter
 import java.util.IllegalFormatException
 import java.util.Locale
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.atomic.AtomicInteger
 
 object AppLog {
 
@@ -24,60 +26,118 @@ object AppLog {
             }
         }
 
+        /**
+         * Writes to a file from one background thread fed by a bounded queue.
+         *
+         * Formatting and the write used to happen on the calling thread under a single lock shared
+         * by the AAP poll and send threads, the audio and video threads and the main thread — so at
+         * verbose, where several lines are emitted per frame, they serialised against each other and
+         * against a disk flush. Here a caller only timestamps the line and offers it to the queue.
+         *
+         * When the queue is full the oldest line is dropped rather than blocking the caller: losing
+         * log lines is always better than stalling the thread that produces them, and the count is
+         * reported so a capture never silently under-reports.
+         */
         class File(val file: IoFile) : Logger, Closeable {
-            private val lock = Any()
             private val writer = BufferedWriter(OutputStreamWriter(FileOutputStream(file, true), Charsets.UTF_8))
             private val dateFormat = java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
+            private val queue = ArrayBlockingQueue<Any>(QUEUE_CAPACITY)
+            private val dropped = AtomicInteger(0)
             @Volatile private var closed = false
 
-
-
-            override fun println(priority: Int, tag: String, msg: String) {
-                synchronized(lock) {
-                    if (closed) return
-                    try {
-                        val ts = dateFormat.format(java.util.Date())
-                        val level = when (priority) {
-                            Log.VERBOSE -> "V"
-                            Log.DEBUG -> "D"
-                            Log.INFO -> "I"
-                            Log.WARN -> "W"
-                            Log.ERROR -> "E"
-                            Log.ASSERT -> "A"
-                            else -> priority.toString()
-                        }
-                        writer.write("$ts [$tag:$level] $msg")
-                        writer.newLine()
-                    } catch (e: IOException) {
-                        Log.e(TAG, "Failed to write AppLog file ${file.absolutePath}", e)
-                    }
+            init {
+                Thread({ drainLoop() }, "AppLog-file-writer").apply {
+                    isDaemon = true
+                    priority = Thread.MIN_PRIORITY
+                    start()
                 }
             }
 
-            override fun close() {
-                synchronized(lock) {
-                    if (closed) return
-                    closed = true
-                    try {
-                        writer.flush()
-                    } catch (_: IOException) {
-                    }
-                    try {
-                        writer.close()
-                    } catch (_: IOException) {
-                    }
+            override fun println(priority: Int, tag: String, msg: String) {
+                if (closed) return
+                val level = when (priority) {
+                    Log.VERBOSE -> "V"
+                    Log.DEBUG -> "D"
+                    Log.INFO -> "I"
+                    Log.WARN -> "W"
+                    Log.ERROR -> "E"
+                    Log.ASSERT -> "A"
+                    else -> priority.toString()
                 }
+                // Timestamp here, not on the writer thread: the queue can lag, and a log whose
+                // timestamps are when a line was *written* rather than when it happened is useless
+                // for the millisecond-level causality these captures get read for.
+                val line = synchronized(dateFormat) { dateFormat.format(java.util.Date()) } +
+                        " [$tag:$level] $msg"
+                while (!queue.offer(line)) {
+                    if (queue.poll() == null) return
+                    dropped.incrementAndGet()
+                }
+            }
+
+            private fun drainLoop() {
+                try {
+                    while (true) {
+                        val item = queue.take()
+                        if (item !is String) break
+                        val line: String = item
+                        try {
+                            writer.write(line)
+                            writer.newLine()
+                            val lost = dropped.getAndSet(0)
+                            if (lost > 0) {
+                                writer.write("--- AppLog: $lost lines dropped, writer could not keep up ---")
+                                writer.newLine()
+                            }
+                            // Flush when the burst is over rather than per line, so a kill loses at
+                            // most what is still queued instead of a whole 8 KB buffer.
+                            if (queue.isEmpty()) writer.flush()
+                        } catch (e: IOException) {
+                            Log.e(TAG, "Failed to write AppLog file ${file.absolutePath}", e)
+                        }
+                    }
+                } catch (_: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                }
+                try { writer.flush() } catch (_: IOException) {}
+                try { writer.close() } catch (_: IOException) {}
+            }
+
+            /**
+             * Deliberately does not wait for the writer to finish. `close()` runs on the main thread
+             * from [AppLog.init] every time the log settings change, and joining a thread that is
+             * mid-flush to slow eMMC there is an ANR waiting to happen. The drain thread owns the
+             * writer and flushes and closes it once it sees the sentinel, so the file still ends up
+             * complete — just a moment later.
+             */
+            override fun close() {
+                if (closed) return
+                closed = true
+                // Make room for the sentinel even if producers had filled the queue.
+                while (!queue.offer(POISON)) {
+                    if (queue.poll() == null) break
+                }
+            }
+
+            private companion object {
+                const val QUEUE_CAPACITY = 4096
+
+                /** End marker; a distinct type so it can never collide with a real line. */
+                val POISON = Any()
             }
         }
     }
 
-    private var settings: Settings? = null
     @Volatile private var appLogFileLogger: Logger.File? = null
     @Volatile private var lastAppLogFile: IoFile? = null
     @Volatile private var currentLogSource: Settings.LogSource = Settings.LogSource.LOGCAT
 
     fun init(settings: Settings?, context: Context? = null) {
-        this.settings = settings
+        // Cache the level rather than resolving it per call: every call site below, and every
+        // LOG_VERBOSE/LOG_DEBUG guard, used to reach SharedPreferences.getInt() through
+        // Settings.exporterLogLevel — a lock plus a map lookup for lines that are mostly discarded.
+        // Every caller of init() is a place the level can change, so the cache cannot go stale.
+        cachedLogLevel = settings?.logLevel ?: Log.INFO
 
         val desiredSource = settings?.logSource ?: Settings.LogSource.LOGCAT
         val captureEnabled = settings?.exporterCaptureEnabled == true
@@ -122,7 +182,10 @@ object AppLog {
 
     @Volatile
     var LOGGER: Logger = Logger.Android()
-    private val LOG_LEVEL get() = settings?.logLevel ?: Log.INFO
+
+    @Volatile
+    private var cachedLogLevel: Int = Log.INFO
+    private val LOG_LEVEL get() = cachedLogLevel
 
     val logSource: Settings.LogSource get() = currentLogSource
     val currentLogFile: IoFile? get() = appLogFileLogger?.file
@@ -206,7 +269,9 @@ object AppLog {
             e("IllegalFormatException: formatString='%s' numArgs=%d", msg, array.size)
             formatted = "$msg (An error occurred while formatting the message.)"
         }
-        val stackTrace = Throwable().fillInStackTrace().stackTrace
+        // Throwable's constructor already fills in the stack trace; calling fillInStackTrace()
+        // again captured the whole thing a second time, per emitted line.
+        val stackTrace = Throwable().stackTrace
         var string = "<unknown>"
         for (i in 2 until stackTrace.size) {
             val className = stackTrace[i].className

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
@@ -2,6 +2,7 @@ package com.andrerinas.openheadunit.utils
 
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
 import android.content.Context
 import android.os.Build
 import android.os.IBinder
@@ -89,6 +90,59 @@ object BluetoothHelper {
     /** All distinct, enabled Bluetooth adapters exposed by the system. See [getAllBluetoothAdapterHandles]. */
     fun getAllBluetoothAdapters(context: Context): List<BluetoothAdapter> =
         getAllBluetoothAdapterHandles(context).map { it.adapter }
+
+    /**
+     * `BluetoothProfile.A2DP_SINK`. Hidden from the SDK, but [BluetoothAdapter.getProfileConnectionState]
+     * takes a plain profile int and answers for it, and the sink role is the one a head unit plays:
+     * the phone is the source, we render its audio.
+     */
+    private const val PROFILE_A2DP_SINK = 11
+
+    /**
+     * Whether a Bluetooth media link to this head unit is up, in either role.
+     *
+     * Used to decide against taking system audio focus for Android Auto playback: when the phone is
+     * also our A2DP source, the sink service answers our focus grab with an AVRCP pause aimed at
+     * that same phone, which stops the stream we are trying to play. Callers treat an unknown
+     * answer as "a link may be up", so this returns true when the state cannot be read — a car
+     * radio playing over AA is an annoyance, silence is a broken app.
+     */
+    fun isA2dpMediaLinkActive(context: Context): Boolean {
+        // The configured adapter only, never getAllBluetoothAdapterHandles(): this is called on the
+        // AAP transport thread every time a track starts, and enumerating the system service list
+        // by reflection there would stall video alongside audio.
+        val adapter = try {
+            getBluetoothAdapter(context)
+        } catch (e: Exception) {
+            AppLog.w("BluetoothHelper: could not resolve an adapter for the A2DP check: ${e.message}")
+            return true
+        }
+        if (adapter == null) return false
+        // An adapter that will not say whether it is on is treated as on, same as an unreadable
+        // profile state below.
+        val enabled = try { adapter.isEnabled } catch (e: Exception) { true }
+        if (!enabled) return false
+
+        var readAnyState = false
+        for (profile in intArrayOf(BluetoothProfile.A2DP, PROFILE_A2DP_SINK)) {
+            val state = try {
+                adapter.getProfileConnectionState(profile)
+            } catch (e: Exception) {
+                // SecurityException without BLUETOOTH_CONNECT, or an adapter that rejects the
+                // hidden sink profile. Try the other one before giving up.
+                continue
+            }
+            readAnyState = true
+            if (state == BluetoothProfile.STATE_CONNECTED || state == BluetoothProfile.STATE_CONNECTING) {
+                return true
+            }
+        }
+        if (!readAnyState) {
+            AppLog.w("BluetoothHelper: the adapter would not report its A2DP state; assuming a media link is up")
+            return true
+        }
+        return false
+    }
 
     /** Resolve a single, arbitrary system service name to a BluetoothAdapterHandle, if it backs a
      *  real, enabled adapter. Used for the manual secondary-radio override in Settings, where the

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/LogExporter.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/LogExporter.kt
@@ -27,6 +27,12 @@ object LogExporter {
     private var captureRestarts = 0
     private const val MAX_RESTARTS = 5
 
+    /**
+     * Ceiling for one capture file. Sits under [LogFilesHelper]'s 50 MB budget for the whole
+     * directory, so a single runaway capture cannot consume it.
+     */
+    private const val MAX_CAPTURE_BYTES = 16L * 1024 * 1024
+
     val isCapturing: Boolean get() = captureProcess != null
 
     /** Current capture verbosity while capturing, or null when no capture is active. */
@@ -80,12 +86,45 @@ object LogExporter {
             )
             captureProcess = process
             captureThread = Thread {
+                var capped = false
                 try {
                     FileOutputStream(file, true).use { out ->
-                        process.inputStream.copyTo(out)
+                        // Not copyTo(): at VERBOSE the filter is the whole system, and rotateLogs
+                        // only runs when a capture starts, so an unattended capture used to grow
+                        // until the disk did. Count what we write and stop at a bound instead.
+                        var written = file.length()
+                        val buffer = ByteArray(8 * 1024)
+                        while (true) {
+                            val read = process.inputStream.read(buffer)
+                            if (read < 0) break
+                            out.write(buffer, 0, read)
+                            written += read
+                            if (written >= MAX_CAPTURE_BYTES) {
+                                out.write(
+                                    "\n--- capture stopped: reached ${MAX_CAPTURE_BYTES / (1024 * 1024)} MB ---\n"
+                                        .toByteArray()
+                                )
+                                capped = true
+                                break
+                            }
+                        }
                     }
                 } catch (_: IOException) { }
-                // copyTo returned — logcat process died or was intentionally stopped
+
+                if (capped) {
+                    // Clear the process reference before destroying it so the restart below sees the
+                    // capture as intentionally ended. Deliberately not stopCapture(): that joins
+                    // captureThread, which is this thread.
+                    captureProcess = null
+                    process.destroy()
+                    AppLog.w(
+                        "LogExporter: capture stopped at ${MAX_CAPTURE_BYTES / (1024 * 1024)} MB. " +
+                            "Export this log and start a new capture if you still need one."
+                    )
+                    return@Thread
+                }
+
+                // the read loop ended — logcat process died or was intentionally stopped
                 if (captureProcess === process && captureRestarts < MAX_RESTARTS) {
                     captureRestarts++
                     AppLog.w("Log capture process exited, restarting (attempt $captureRestarts/$MAX_RESTARTS)")

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -7,6 +7,7 @@ import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.location.Location
 import android.os.Build
+import com.andrerinas.openheadunit.aap.PlaybackFocusPolicy
 import com.andrerinas.openheadunit.aap.protocol.proto.Control
 import com.andrerinas.openheadunit.app.UsbAttachedActivity
 import com.andrerinas.openheadunit.connection.UsbDeviceCompat
@@ -485,6 +486,16 @@ class Settings(private val context: Context) {
     var staticAudioFocus: Boolean
         get() = prefs.getBoolean("static-audio-focus", false)
         set(value) { prefs.edit().putBoolean("static-audio-focus", value).apply() }
+
+    // Whether AA playback takes system audio focus, so another local player (typically the car
+    // radio) pauses while it runs. AUTO skips it when a Bluetooth media link is up, because the
+    // A2DP sink answers our focus grab by pausing the phone that is feeding us. See
+    // PlaybackFocusPolicy for the whole story; ALWAYS and NEVER are the manual overrides.
+    var playbackFocusMode: PlaybackFocusPolicy.Mode
+        get() = PlaybackFocusPolicy.Mode.fromInt(
+            prefs.getInt("playback-focus-mode", PlaybackFocusPolicy.Mode.AUTO.value)
+        )
+        set(value) { prefs.edit().putInt("playback-focus-mode", value.value).apply() }
 
     var separateAudioStreams: Boolean
         get() = prefs.getBoolean("separate-audio-streams", false)

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
@@ -101,6 +101,9 @@ object SettingsBackupManager {
         "auto-connect-single-usb" to ValueType.BOOLEAN,
         "enable-audio-sink" to ValueType.BOOLEAN,
         "static-audio-focus" to ValueType.BOOLEAN,
+        // Enum-backed, but INT is safe: Settings.playbackFocusMode reads it through
+        // PlaybackFocusPolicy.Mode.fromInt, which falls back to AUTO for anything out of range.
+        "playback-focus-mode" to ValueType.INT,
         "separate-audio-streams" to ValueType.BOOLEAN,
         "mic-input-source" to ValueType.INT,
         "audio-latency-multiplier" to ValueType.INT,
@@ -180,6 +183,7 @@ object SettingsBackupManager {
         "enable-rotary",
         "enable-audio-sink",
         "static-audio-focus",
+        "playback-focus-mode",
         "separate-audio-streams",
         "use-aac-audio",
         "attach_hw_dsp_equalizer",

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -445,6 +445,14 @@
     <string name="enable_audio_sink_description">If disabled, the headunit will not receive audio. Sound will play from the phone.</string>
     <string name="static_audio_focus">Static Audio Focus</string>
     <string name="static_audio_focus_description">Force the phone to believe audio focus is always held, preventing audio routing losses on generic headunits. Also performs software ducking during navigation voice prompts.</string>
+    <string name="playback_focus_mode">Pause Other Audio During Playback</string>
+    <string name="playback_focus_mode_auto">Automatic</string>
+    <string name="playback_focus_mode_always">Always</string>
+    <string name="playback_focus_mode_never">Never</string>
+    <string name="playback_focus_mode_auto_hint">Pauses another player on the headunit (for example the radio) while Android Auto audio plays, but not while a Bluetooth audio link is connected — that link is usually the same phone, and pausing it would stop Android Auto\'s own sound.</string>
+    <string name="playback_focus_mode_always_hint">Always pauses other audio while Android Auto plays. If your music stops after a second or two whenever Bluetooth is on, switch back to Automatic.</string>
+    <string name="playback_focus_mode_never_hint">Never touches system audio focus. Other audio on the headunit may keep playing over Android Auto.</string>
+    <string name="playback_focus_mode_static_hint">With Static Audio Focus on, this applies from the moment the phone connects and lasts the whole session, rather than only while audio is playing.</string>
     <string name="separate_audio_streams">Separate Audio Streams</string>
     <string name="separate_audio_streams_description">Separate audio channels for music, calls, and notifications instead of a single multimedia stream (may not work correctly on some devices).</string>
     <string name="use_aac_audio">Use AAC Audio</string>

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/PlaybackFocusPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/PlaybackFocusPolicyTest.kt
@@ -1,0 +1,212 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.PlaybackFocusPolicy.Mode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaybackFocusPolicyTest {
+
+    private fun acquire(
+        mode: Mode = Mode.AUTO,
+        staticAudioFocus: Boolean = false,
+        audioSinkEnabled: Boolean = true,
+        isAudioChannel: Boolean = true,
+        btMediaLinkActive: Boolean = false,
+        selfDefeatingLatched: Boolean = false
+    ) = PlaybackFocusPolicy.shouldAcquire(
+        mode = mode,
+        staticAudioFocus = staticAudioFocus,
+        audioSinkEnabled = audioSinkEnabled,
+        isAudioChannel = isAudioChannel,
+        btMediaLinkActive = btMediaLinkActive,
+        selfDefeatingLatched = selfDefeatingLatched
+    )
+
+    // --- the pre-existing gates, which no mode may override ---
+
+    @Test
+    fun `static focus mode never uses the dynamic path`() {
+        for (mode in Mode.values()) {
+            assertFalse("mode=$mode", acquire(mode = mode, staticAudioFocus = true))
+        }
+    }
+
+    @Test
+    fun `a disabled audio sink never takes focus`() {
+        for (mode in Mode.values()) {
+            assertFalse("mode=$mode", acquire(mode = mode, audioSinkEnabled = false))
+        }
+    }
+
+    @Test
+    fun `non-audio channels never take focus`() {
+        for (mode in Mode.values()) {
+            assertFalse("mode=$mode", acquire(mode = mode, isAudioChannel = false))
+        }
+    }
+
+    // --- AUTO ---
+
+    @Test
+    fun `auto takes focus when no bluetooth media link is up`() {
+        // The car-radio case this feature was written for: nothing on Bluetooth, so the player we
+        // silence is genuinely a local one.
+        assertTrue(acquire(mode = Mode.AUTO, btMediaLinkActive = false))
+    }
+
+    @Test
+    fun `auto declines while a bluetooth media link is up`() {
+        // Taking focus here makes the A2DP sink AVRCP-pause the phone that is feeding us.
+        assertFalse(acquire(mode = Mode.AUTO, btMediaLinkActive = true))
+    }
+
+    @Test
+    fun `auto declines once the latch has tripped, even with no bluetooth link detected`() {
+        // The backstop for units where the Bluetooth probe reports nothing useful.
+        assertFalse(acquire(mode = Mode.AUTO, btMediaLinkActive = false, selfDefeatingLatched = true))
+    }
+
+    // --- ALWAYS / NEVER ---
+
+    @Test
+    fun `always keeps taking focus whatever the detection says`() {
+        assertTrue(acquire(mode = Mode.ALWAYS, btMediaLinkActive = true))
+        assertTrue(acquire(mode = Mode.ALWAYS, selfDefeatingLatched = true))
+        assertTrue(acquire(mode = Mode.ALWAYS, btMediaLinkActive = true, selfDefeatingLatched = true))
+    }
+
+    @Test
+    fun `never declines even when the detection is clean`() {
+        assertFalse(acquire(mode = Mode.NEVER, btMediaLinkActive = false, selfDefeatingLatched = false))
+    }
+
+    // --- static mode's permanent grab ---
+
+    private fun acquirePermanent(
+        mode: Mode = Mode.AUTO,
+        staticAudioFocus: Boolean = true,
+        audioSinkEnabled: Boolean = true,
+        btMediaLinkActive: Boolean = false
+    ) = PlaybackFocusPolicy.shouldAcquirePermanent(
+        mode = mode,
+        staticAudioFocus = staticAudioFocus,
+        audioSinkEnabled = audioSinkEnabled,
+        btMediaLinkActive = btMediaLinkActive
+    )
+
+    @Test
+    fun `the permanent grab belongs to static mode alone`() {
+        for (mode in Mode.values()) {
+            assertFalse("mode=$mode", acquirePermanent(mode = mode, staticAudioFocus = false))
+        }
+    }
+
+    @Test
+    fun `a disabled audio sink never takes permanent focus`() {
+        for (mode in Mode.values()) {
+            assertFalse("mode=$mode", acquirePermanent(mode = mode, audioSinkEnabled = false))
+        }
+    }
+
+    @Test
+    fun `auto takes permanent focus when no bluetooth media link is up`() {
+        // Static mode's reason for existing — a generic head unit that loses audio routing —
+        // is untouched for everyone this bug does not affect.
+        assertTrue(acquirePermanent(mode = Mode.AUTO, btMediaLinkActive = false))
+    }
+
+    @Test
+    fun `auto declines the permanent grab while a bluetooth media link is up`() {
+        assertFalse(acquirePermanent(mode = Mode.AUTO, btMediaLinkActive = true))
+    }
+
+    @Test
+    fun `always and never override the probe on the permanent path too`() {
+        assertTrue(acquirePermanent(mode = Mode.ALWAYS, btMediaLinkActive = true))
+        assertFalse(acquirePermanent(mode = Mode.NEVER, btMediaLinkActive = false))
+    }
+
+    @Test
+    fun `the two paths are exact complements and never both take focus`() {
+        // Same shape as WifiModePolicy vs UserExitHotspotPolicy: one decision, split across two
+        // functions, so the split has to be airtight rather than merely plausible.
+        for (mode in Mode.values()) {
+            for (static in listOf(false, true)) {
+                for (sink in listOf(false, true)) {
+                    for (bt in listOf(false, true)) {
+                        for (latched in listOf(false, true)) {
+                            val dynamic = PlaybackFocusPolicy.shouldAcquire(
+                                mode = mode,
+                                staticAudioFocus = static,
+                                audioSinkEnabled = sink,
+                                isAudioChannel = true,
+                                btMediaLinkActive = bt,
+                                selfDefeatingLatched = latched
+                            )
+                            val permanent = acquirePermanent(
+                                mode = mode,
+                                staticAudioFocus = static,
+                                audioSinkEnabled = sink,
+                                btMediaLinkActive = bt
+                            )
+                            assertFalse(
+                                "mode=$mode static=$static sink=$sink bt=$bt latched=$latched",
+                                dynamic && permanent
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // --- the self-defeating detector ---
+
+    @Test
+    fun `a media channel stopping inside the window counts`() {
+        assertTrue(PlaybackFocusPolicy.countsAsSelfDefeating(isMediaChannel = true, msSinceAcquire = 0L))
+        assertTrue(PlaybackFocusPolicy.countsAsSelfDefeating(isMediaChannel = true, msSinceAcquire = 3_400L))
+        assertTrue(PlaybackFocusPolicy.countsAsSelfDefeating(isMediaChannel = true, msSinceAcquire = 4_070L))
+    }
+
+    @Test
+    fun `a media channel stopping outside the window does not count`() {
+        assertFalse(
+            PlaybackFocusPolicy.countsAsSelfDefeating(
+                isMediaChannel = true,
+                msSinceAcquire = PlaybackFocusPolicy.SELF_DEFEATING_WINDOW_MS
+            )
+        )
+        assertFalse(PlaybackFocusPolicy.countsAsSelfDefeating(isMediaChannel = true, msSinceAcquire = 60_000L))
+    }
+
+    @Test
+    fun `speech and system chimes never count, however short`() {
+        // A navigation prompt is legitimately a second long; counting it would latch on one turn.
+        assertFalse(PlaybackFocusPolicy.countsAsSelfDefeating(isMediaChannel = false, msSinceAcquire = 900L))
+    }
+
+    @Test
+    fun `a negative elapsed time does not count`() {
+        // No acquire recorded yet, so there is nothing to attribute the stop to.
+        assertFalse(PlaybackFocusPolicy.countsAsSelfDefeating(isMediaChannel = true, msSinceAcquire = -1L))
+    }
+
+    // --- mode round-tripping through settings ---
+
+    @Test
+    fun `modes round-trip through their stored value and unknown values fall back to auto`() {
+        for (mode in Mode.values()) {
+            assertEquals(mode, Mode.fromInt(mode.value))
+        }
+        assertEquals(Mode.AUTO, Mode.fromInt(-1))
+        assertEquals(Mode.AUTO, Mode.fromInt(99))
+    }
+
+    @Test
+    fun `auto is the stored default so an unset preference behaves like 3 point 1 point 1 plus detection`() {
+        assertEquals(0, Mode.AUTO.value)
+    }
+}


### PR DESCRIPTION
On a head unit that's also the phone's A2DP sink, dynamic playback focus (added in v.3.2.0-beta1) makes `AudioFocusChangeListener`'s AVRCP-pause turn around and pause the same phone feeding the Android Auto stream: focus grab → phone pauses → AA drops the sink → we release focus → phone resumes → repeat every few seconds.
The screen freeze reported alongside #744 is this loop seen visually: with playback paused, AA has nothing to animate and stops sending frames.

Measured on the reporter's unit: media went PAUSED 59-661 ms after each grant, across three captures.

### Fix

`PlaybackFocusPolicy` (new, pure, unit-tested) decides whether to take system audio focus, from a Bluetooth A2DP-link probe plus a runtime latch (two media-channel cuts within 5s of a grant disables further grabs for the session). Auto/Always/Never override, exposed in Settings -> Audio -> "Pause Other Audio During Playback"; Always preserves the #658 behavior on units where the probe can't be trusted.

All three call sites that request system focus now go through the policy: the dynamic per-channel grab in `AapAudio` (confirmed cause), the permanent static-mode grab, and the protocol-requested focus in `AapControl`. Verified
on hardware for the dynamic path: forcing Always reproduces the fault on demand, Auto does not. The static and protocol paths are gated the same way but unexercised so far.

Also includes a logging-path cleanup (cached log level, off-thread file writes, no double stack capture, log rotation while a capture is running) needed to keep VERBOSE captures cheap enough to trust while debugging this.