### PR TITLE
Native AA: don't poke a phone that's no longer paired

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -587,13 +587,32 @@ class NativeAaHandshakeManager(
 
                 val lastMacs = settings.autoStartBluetoothDeviceMacs
                 val devicesToPoke = if (lastMacs.isNotEmpty()) {
-                    lastMacs.mapNotNull { mac ->
-                        try {
+                    val bonded = mutableListOf<BluetoothDevice>()
+                    val staleMacs = mutableSetOf<String>()
+                    lastMacs.forEach { mac ->
+                        val device = try {
                             adapter.getRemoteDevice(mac)
                         } catch (e: Exception) {
                             null
                         }
+                        // A poke is a raw RFCOMM connect() to a device we assume already trusts us
+                        // via classic BT pairing. Against an unbonded device, connect() makes the
+                        // OS silently kick off a *new* pairing negotiation as a side effect - the
+                        // phone unpairing us doesn't clear this list, so without this check we'd
+                        // re-solicit pairing forever every time the phone's radio comes back up.
+                        if (device != null && device.bondState == BluetoothDevice.BOND_BONDED) {
+                            bonded.add(device)
+                        } else {
+                            staleMacs.add(mac)
+                        }
                     }
+                    if (staleMacs.isNotEmpty()) {
+                        AppLog.w("NativeAA: Dropping Auto Start BT MAC(s) no longer paired: $staleMacs")
+                        val remaining = lastMacs - staleMacs
+                        settings.autoStartBluetoothDeviceMacs = remaining
+                        com.andrerinas.openheadunit.utils.Settings.syncAutoStartBtMacsToDeviceStorage(context, remaining)
+                    }
+                    bonded
                 } else {
                     AppLog.w("NativeAA: No 'Auto Start BT Device' selected in settings. Poking all paired devices as fallback...")
                     adapter.bondedDevices.toList()


### PR DESCRIPTION
triggerPoke() read the Auto Start BT MAC list and unconditionally called BluetoothSocket.connect() against it. If a device was unpaired at the OS level but its MAC was still stored (nothing pruned it), connect() against the unbonded device made Android silently start a new pairing negotiation as a side effect, surfacing to the user as a repeated, unwanted pairing request from the head unit every time the phone's radio came back up.

Skip and prune any MAC whose device isn't currently BOND_BONDED before poking, and sync the pruned list to device-protected storage so AutoStartReceiver's copy stays consistent.