### PR TITLE
Stop the setup wizard from overwriting the reported manufacturer

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/main/OnboardingActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/OnboardingActivity.kt
@@ -320,7 +320,7 @@ class OnboardingActivity : BaseActivity() {
             settings.useGpsForNavigation = checkedId == R.id.onb_gps_device
         }
 
-        // --- Car brand: a friendly identity sent to Android Auto (display name + both makes) ---
+        // --- Car brand: the display name sent to Android Auto, and the manufacturer with it ---
         bindVehicleStep()
     }
 
@@ -457,15 +457,19 @@ class OnboardingActivity : BaseActivity() {
         // Apply the display recommendation + chosen DPI on Next, so the user does not
         // have to press "Apply recommended settings" for it to take effect.
         if (step == STEP_DISPLAY || step == STEP_DPI) applyDisplaySettings()
-        // The chosen car brand fills the display name and both manufacturer fields, so it
-        // appears whichever identity field Android Auto reads.
+        // [BUG_FIX] The chosen name always becomes the display name, but only a real car brand
+        // may become the reported manufacturer. Reporting make "Google" alongside model
+        // "Desktop Head Unit" is what makes Android Auto list apps installed from outside the
+        // Play Store; sending our own app name as a manufacturer breaks that for no benefit,
+        // since the manufacturer is only read for the brand logo on Android Auto's exit button.
         if (step == STEP_VEHICLE) {
             val brand = findViewById<TextInputEditText>(R.id.onb_vehicle_input)
                 .text?.toString()?.trim().orEmpty()
             if (brand.isNotEmpty()) {
                 settings.vehicleDisplayName = brand
-                settings.vehicleMake = brand
-                settings.headUnitMake = brand
+                val make = if (brand.lowercase() in NOT_A_MANUFACTURER) DHU_MAKE else brand
+                settings.vehicleMake = make
+                settings.headUnitMake = make
             }
         }
         if (step == STEP_COUNT - 1) finishOnboarding() else goForward()
@@ -741,5 +745,11 @@ class OnboardingActivity : BaseActivity() {
         private const val STEP_VEHICLE = 8
         private const val STEP_PERMISSIONS = 9
         private const val STEP_READY = 10
+
+        // The manufacturer half of the Desktop Head Unit identity we report by default.
+        private const val DHU_MAKE = "Google"
+        // Names the car step offers that are not car brands: the head unit make itself and
+        // the app's own name. Lowercase, compared against a lowercased input.
+        private val NOT_A_MANUFACTURER = setOf("google", "open headunit")
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/main/VehicleInfoFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/VehicleInfoFragment.kt
@@ -178,7 +178,11 @@ class VehicleInfoFragment : Fragment() {
             nameResId = R.string.vehicle_make_label,
             value = pendingVehicleMake ?: "",
             onClick = {
-                showTextInputDialog(R.string.vehicle_make_label, pendingVehicleMake ?: "") { value ->
+                showTextInputDialogWithMessage(
+                    R.string.vehicle_make_label,
+                    R.string.vehicle_make_hint,
+                    pendingVehicleMake ?: ""
+                ) { value ->
                     pendingVehicleMake = value
                     checkChanges()
                     updateSettingsList()

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -326,6 +326,9 @@ class Settings(private val context: Context) {
 
     // Vehicle info settings (sent to phone during Android Auto handshake)
     var vehicleDisplayName: String
+        // Cosmetic: the phone shows this in its connection history and on the Android Auto
+        // welcome screen. It is not the reported manufacturer, which stays "Google" unless
+        // the user picks a real car brand — see the car step in OnboardingActivity.
         get() = prefs.getString("vehicle-display-name", "Open Headunit")!!
         set(value) { prefs.edit().putString("vehicle-display-name", value).apply() }
 

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -653,6 +653,12 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
+                    android:text="@string/onb_vehicle_help_sideload"
+                    android:textAppearance="?attr/textAppearanceCaption" />
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
                     android:text="@string/onb_vehicle_help_advanced"
                     android:textAppearance="?attr/textAppearanceCaption" />
             </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,7 @@
     <string name="onb_vehicle_title">Your car</string>
     <string name="onb_vehicle_input_hint">Brand or name</string>
     <string name="onb_vehicle_help_aa">This name is sent to Android Auto. It shows in your phone\'s connection history and on the Android Auto welcome screen.</string>
+    <string name="onb_vehicle_help_sideload">Picking a real car brand also shows that brand\'s logo on the Android Auto exit button, but Android Auto then stops listing apps you installed from outside the Play Store. Keep \"Google\" or \"Open Headunit\" if you use those apps.</string>
     <string name="onb_vehicle_help_advanced">You can fine-tune your vehicle details in the Advanced tab. We do not use this data; it is only sent to Android Auto because it requires it.</string>
     <string-array name="vehicle_brands">
         <item>Google</item>
@@ -715,7 +716,8 @@
     <string name="vehicle_id_description">Internal identifier only. Changing this will cause your phone to treat this as a different vehicle, resetting your Android Auto preferences for this car.</string>
     <string name="head_unit_make_label">Make</string>
     <string name="head_unit_make_description">Head unit manufacturer</string>
-    <string name="head_unit_make_hint">Your phone shows this name in Android Auto settings.</string>
+    <string name="head_unit_make_hint">Your phone shows this name in Android Auto settings.\n\nA real car brand shows that brand\'s logo on the Android Auto exit button, but Android Auto then stops listing apps installed from outside the Play Store. Set it back to \"Google\" to get those apps listed again.</string>
+    <string name="vehicle_make_hint">A real car brand shows that brand\'s logo on the Android Auto exit button, but Android Auto then stops listing apps installed from outside the Play Store. Set it back to \"Google\" to get those apps listed again.</string>
     <string name="head_unit_model_label">Model</string>
     <string name="head_unit_model_description">Head unit model</string>
     <string name="vehicle_year_error_invalid">Enter a valid year</string>


### PR DESCRIPTION
The car step wrote the chosen name into vehicleMake and headUnitMake as well as the display name. Reporting the make "Google" alongside the model "Desktop Head Unit" is what makes Android Auto list apps installed from outside the Play Store that pairing is the entire mechanism, and it is what was added when sideloaded apps were first made to work.

The wizard is shown to every upgrader, and its input is pre-filled with the stored display name, so simply pressing Next through the car step replaced "Google" with the app's own name. Everything else about the session kept working, which is why this reads as "my sideloaded apps vanished" #806 and nothing else. The values live in SharedPreferences, so it survives restarts.

Only a real car brand now becomes the reported manufacturer; the app's own name and "Google" leave it at "Google". Re-running the wizard therefore also repairs an install that has already lost it.

The manufacturer is not dead weight — it is what puts the car brand's logo on Android Auto's exit button, which is why the step wrote it in the first place. So the car step and both Make fields now say what picking a real brand costs instead of silently trading one for the other.