### PR TITLE
Native AA wake poke takes down the head unit's own hands-free link (#744)

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/BluetoothWakePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/BluetoothWakePolicy.kt
@@ -3,11 +3,12 @@ package com.andrerinas.openheadunit.aap
 import java.util.UUID
 
 /**
- * Which of the phone's Bluetooth records the Native AA wake poke may reach for, and what to call
- * them in a log.
+ * Rules for the Native AA wake poke: which of the phone's Bluetooth records it may reach for, and
+ * when it may connect at all.
  *
  * The poke raises an ACL connection so the phone notices a wireless-capable head unit. It is
- * load-bearing — some units never connect without it — so nothing here switches it off.
+ * load-bearing — some units never connect without it — so nothing here switches it off. What the
+ * rules decide is when a poke would cost more than it gains.
  *
  * Pure and unit-tested; the sockets live in `NativeAaHandshakeManager`.
  */
@@ -23,7 +24,14 @@ object BluetoothWakePolicy {
      */
     val HSP_AG_UUID: UUID = UUID.fromString("00001112-0000-1000-8000-00805f9b34fb")
 
-    /** The records a poke tries, in order — openautolink's ConnectProfile fallback chain. */
+    /**
+     * The records a poke tries, in order — openautolink's ConnectProfile fallback chain.
+     *
+     * Deliberately not a setting. A selectable HSP-AG-only mode was built and removed once the rig
+     * measured a successful HSP-AG poke leaving this unit's hands-free link down for three minutes,
+     * the same outcome as HFP-AG: a phone serves both records from one headset connection, so which
+     * one is asked for was never the lever. [shouldPoke] is.
+     */
     val POKE_TARGETS: List<UUID> = listOf(HFP_AG_UUID, HSP_AG_UUID)
 
     /** Reader-facing name for a target, so a log says what was touched rather than a UUID. */
@@ -32,4 +40,42 @@ object BluetoothWakePolicy {
         HSP_AG_UUID -> "HSP-AG"
         else -> uuid.toString()
     }
+
+    /** What this head unit's own Bluetooth stack says about its hands-free link. */
+    enum class HandsFreeLink {
+        /** A link is up. Poking would take the phone's slot away from it. */
+        CONNECTED,
+
+        /** No link. Nothing for a poke to displace. */
+        ABSENT,
+
+        /** The adapter would not say. Pokes anyway — see [shouldPoke]. */
+        UNREADABLE;
+
+        companion object {
+            /** Maps [com.andrerinas.openheadunit.utils.BluetoothHelper.handsFreeLinkState]'s
+             *  three-valued answer, so the null case is named rather than implied. */
+            fun of(connected: Boolean?): HandsFreeLink = when (connected) {
+                true -> CONNECTED
+                false -> ABSENT
+                null -> UNREADABLE
+            }
+        }
+    }
+
+    /**
+     * Whether the wake poke may run, given what this head unit's own hands-free link is doing.
+     *
+     * Measured, not theorised: a poke that connects takes the phone's single hands-free slot and
+     * this unit's own client is dropped to make room. `HfpClientConnectionService` logged its
+     * disconnect from the same peer 4 ms after `socket.connect()` returned, and the link stayed down
+     * eight minutes until a Bluetooth adapter cycle. The user sees a head unit reporting Bluetooth
+     * disconnected while the phone reports it connected, and calls coming out of the phone.
+     *
+     * Skipping costs nothing, because a live hands-free link *is* the ACL connection a poke exists
+     * to create. Units where the poke is load-bearing have no such link to read, so they keep
+     * today's behaviour — as does [HandsFreeLink.UNREADABLE], since an adapter that will not report
+     * its profiles must not silently disable a mechanism some units cannot connect without.
+     */
+    fun shouldPoke(handsFreeLink: HandsFreeLink): Boolean = handsFreeLink != HandsFreeLink.CONNECTED
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/BluetoothWakePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/BluetoothWakePolicy.kt
@@ -1,0 +1,35 @@
+package com.andrerinas.openheadunit.aap
+
+import java.util.UUID
+
+/**
+ * Which of the phone's Bluetooth records the Native AA wake poke may reach for, and what to call
+ * them in a log.
+ *
+ * The poke raises an ACL connection so the phone notices a wireless-capable head unit. It is
+ * load-bearing — some units never connect without it — so nothing here switches it off.
+ *
+ * Pure and unit-tested; the sockets live in `NativeAaHandshakeManager`.
+ */
+object BluetoothWakePolicy {
+
+    /** Handsfree Profile — Audio Gateway. The phone's hands-free side; a call rides on this. */
+    val HFP_AG_UUID: UUID = UUID.fromString("0000111f-0000-1000-8000-00805f9b34fb")
+
+    /**
+     * Headset Profile — Audio Gateway. Long stored under the name `A2DP_SOURCE_UUID`, which it never
+     * was: A2DP Source is `0000110a`. Both values are confirmed against
+     * nisargjhaveri/WirelessAndroidAutoDongle and mossyhub/openautolink.
+     */
+    val HSP_AG_UUID: UUID = UUID.fromString("00001112-0000-1000-8000-00805f9b34fb")
+
+    /** The records a poke tries, in order — openautolink's ConnectProfile fallback chain. */
+    val POKE_TARGETS: List<UUID> = listOf(HFP_AG_UUID, HSP_AG_UUID)
+
+    /** Reader-facing name for a target, so a log says what was touched rather than a UUID. */
+    fun profileName(uuid: UUID): String = when (uuid) {
+        HFP_AG_UUID -> "HFP-AG"
+        HSP_AG_UUID -> "HSP-AG"
+        else -> uuid.toString()
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/BluetoothWakePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/BluetoothWakePolicy.kt
@@ -3,8 +3,8 @@ package com.andrerinas.openheadunit.aap
 import java.util.UUID
 
 /**
- * Rules for the Native AA wake poke: which of the phone's Bluetooth records it may reach for, and
- * when it may connect at all.
+ * Rules for the Native AA wake poke: which of the phone's Bluetooth records it may reach for, when
+ * it may connect at all, and which stored MACs are worth keeping.
  *
  * The poke raises an ACL connection so the phone notices a wireless-capable head unit. It is
  * load-bearing — some units never connect without it — so nothing here switches it off. What the
@@ -78,4 +78,46 @@ object BluetoothWakePolicy {
      * its profiles must not silently disable a mechanism some units cannot connect without.
      */
     fun shouldPoke(handsFreeLink: HandsFreeLink): Boolean = handsFreeLink != HandsFreeLink.CONNECTED
+
+    /** What a stored Auto Start MAC's pairing state read as, when the poke went looking for it. */
+    enum class BondReading {
+        /** Paired. Safe to poke. */
+        BONDED,
+
+        /** A positive not-paired answer, taken from a working adapter. */
+        NOT_BONDED,
+
+        /** Not a Bluetooth address at all, so it can never become valid. */
+        MALFORMED,
+
+        /** The adapter is off, or would not answer. Says nothing about the device. */
+        UNREADABLE
+    }
+
+    /**
+     * Whether a poke may open a socket to a device in this state.
+     *
+     * Only a confirmed pairing. A poke is a raw RFCOMM `connect()` to a device we assume already
+     * trusts us; against an unpaired one the OS starts a new pairing negotiation as a side effect,
+     * which the user sees as the head unit asking to pair every time the phone's radio comes back.
+     *
+     * Strict where [shouldForget] is lenient: refusing to poke costs a retry seconds later.
+     */
+    fun mayPoke(reading: BondReading): Boolean = reading == BondReading.BONDED
+
+    /**
+     * Whether a stored MAC should be dropped from the Auto Start list.
+     *
+     * Only on evidence the device is genuinely gone. **Never on [BondReading.UNREADABLE]** —
+     * `getBondState()` answers "not bonded" when the Bluetooth service is merely unavailable, so
+     * treating that as unpaired would delete the user's configured device on any poke round that
+     * landed while the adapter was off. This head unit's Bluetooth is known to cycle itself, so that
+     * window is reachable, and the deletion is written straight through to device-protected storage
+     * where nothing would restore it.
+     *
+     * Lenient where [mayPoke] is strict: a MAC kept one round too long costs nothing, because
+     * [mayPoke] will not poke it.
+     */
+    fun shouldForget(reading: BondReading): Boolean =
+        reading == BondReading.NOT_BONDED || reading == BondReading.MALFORMED
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -511,6 +511,45 @@ class NativeAaHandshakeManager(
     }
 
     /**
+     * Read a device's pairing state, keeping "not paired" and "could not tell" apart.
+     *
+     * `getBondState()` answers `BOND_NONE` when the Bluetooth service is unavailable rather than
+     * saying it does not know, so an adapter that is off would otherwise look exactly like a phone
+     * the user unpaired. Everything that cannot be established reads as
+     * [BluetoothWakePolicy.BondReading.UNREADABLE], and the policy decides what each is worth.
+     */
+    private fun bondReadingFor(device: BluetoothDevice): BluetoothWakePolicy.BondReading {
+        val adapter = try {
+            BluetoothHelper.getBluetoothAdapter(context)
+        } catch (e: Exception) {
+            null
+        } ?: return BluetoothWakePolicy.BondReading.UNREADABLE
+        val enabled = try { adapter.isEnabled } catch (e: Exception) { false }
+        if (!enabled) return BluetoothWakePolicy.BondReading.UNREADABLE
+        val state = try {
+            device.bondState
+        } catch (e: Exception) {
+            return BluetoothWakePolicy.BondReading.UNREADABLE
+        }
+        return if (state == BluetoothDevice.BOND_BONDED) BluetoothWakePolicy.BondReading.BONDED
+        else BluetoothWakePolicy.BondReading.NOT_BONDED
+    }
+
+    /** As [bondReadingFor], for a MAC that has not been resolved to a device yet. */
+    private fun bondReadingFor(adapter: BluetoothAdapter, mac: String): BluetoothWakePolicy.BondReading {
+        val device = try {
+            adapter.getRemoteDevice(mac)
+        } catch (e: IllegalArgumentException) {
+            // Not a Bluetooth address. It can never become one, so this is the one reading that is
+            // safe to forget without the adapter having said anything.
+            return BluetoothWakePolicy.BondReading.MALFORMED
+        } catch (e: Exception) {
+            return BluetoothWakePolicy.BondReading.UNREADABLE
+        }
+        return bondReadingFor(device)
+    }
+
+    /**
      * Say once per run of skips that the poke stood down. Info first so it survives a log exported
      * at the default level, then debug: the retry loop asks again every ~30 s, and a line per
      * half-minute for a whole session buries everything around it.
@@ -529,9 +568,9 @@ class NativeAaHandshakeManager(
 
     /**
      * Tries each of [BluetoothWakePolicy.POKE_TARGETS] in turn, holding whichever connects for
-     * [holdMs]. Returns true if any of them did, false without opening anything if this unit
-     * already holds a hands-free link. Both poke entry points come through here, so one check
-     * covers the retry loop and the manual poke alike.
+     * [holdMs]. Returns true if any of them did, false without opening anything if either guard
+     * below stands the poke down. Both poke entry points come through here, so one check covers
+     * the retry loop and the manual poke alike.
      */
     private suspend fun pokeDevice(device: BluetoothDevice, holdMs: Long): Boolean {
         // A poke that connects takes the phone's single hands-free slot, and this unit's own client
@@ -542,6 +581,15 @@ class NativeAaHandshakeManager(
             return false
         }
         handsFreeSkipLogged = false
+
+        // connect() against an unpaired device makes the OS solicit pairing as a side effect, and
+        // the user meant "wake my phone", not "ask to pair with it again".
+        if (!BluetoothWakePolicy.mayPoke(bondReadingFor(device))) {
+            AppLog.w("NativeAA: Not poking ${device.name ?: "unnamed"} (${device.address}) — it is not " +
+                    "currently paired with this head unit, and connecting to an unpaired device would " +
+                    "ask the user to pair rather than wake anything.")
+            return false
+        }
 
         pokeAttemptInFlight = true
         try {
@@ -633,13 +681,25 @@ class NativeAaHandshakeManager(
 
                 val lastMacs = settings.autoStartBluetoothDeviceMacs
                 val devicesToPoke = if (lastMacs.isNotEmpty()) {
-                    lastMacs.mapNotNull { mac ->
-                        try {
-                            adapter.getRemoteDevice(mac)
-                        } catch (e: Exception) {
-                            null
+                    // Two questions, two answers. Skipping a poke is retried seconds later;
+                    // forgetting a MAC is permanent, so it needs evidence the device is really gone
+                    // rather than an adapter that happened to be off. Both rules are in the policy.
+                    val bonded = mutableListOf<BluetoothDevice>()
+                    val staleMacs = mutableSetOf<String>()
+                    lastMacs.forEach { mac ->
+                        val reading = bondReadingFor(adapter, mac)
+                        if (BluetoothWakePolicy.mayPoke(reading)) {
+                            try { bonded.add(adapter.getRemoteDevice(mac)) } catch (e: Exception) {}
                         }
+                        if (BluetoothWakePolicy.shouldForget(reading)) staleMacs.add(mac)
                     }
+                    if (staleMacs.isNotEmpty()) {
+                        AppLog.w("NativeAA: Dropping Auto Start BT MAC(s) no longer paired: $staleMacs")
+                        val remaining = lastMacs - staleMacs
+                        settings.autoStartBluetoothDeviceMacs = remaining
+                        com.andrerinas.openheadunit.utils.Settings.syncAutoStartBtMacsToDeviceStorage(context, remaining)
+                    }
+                    bonded
                 } else {
                     AppLog.w("NativeAA: No 'Auto Start BT Device' selected in settings. Poking all paired devices as fallback...")
                     adapter.bondedDevices.toList()

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -130,6 +130,10 @@ class NativeAaHandshakeManager(
     // Set by closeAaListeners() so the AA accept loops can tell "we closed this on purpose
     // after a successful handoff" apart from a real socket error, for logging only.
     @Volatile private var aaListenersClosedForSession = false
+    // Whether the "already have a hands-free link, not poking" line has been said at info level for
+    // the current run of skips. Cleared as soon as a poke does go ahead, so a later skip says so
+    // again rather than hiding behind a line from minutes earlier.
+    @Volatile private var handsFreeSkipLogged = false
 
     private var currentSsid: String? = null
     private var currentPsk: String? = null
@@ -507,10 +511,38 @@ class NativeAaHandshakeManager(
     }
 
     /**
+     * Say once per run of skips that the poke stood down. Info first so it survives a log exported
+     * at the default level, then debug: the retry loop asks again every ~30 s, and a line per
+     * half-minute for a whole session buries everything around it.
+     */
+    private fun noteHandsFreePokeSkip(device: BluetoothDevice) {
+        val message = "NativeAA: Not poking ${device.name ?: "unnamed"} (${device.address}) — this " +
+                "head unit already holds a Bluetooth hands-free link, which a poke would take over " +
+                "and leave disconnected. That link is itself the connection a poke exists to create."
+        if (!handsFreeSkipLogged) {
+            handsFreeSkipLogged = true
+            AppLog.i(message)
+        } else {
+            AppLog.d(message)
+        }
+    }
+
+    /**
      * Tries each of [BluetoothWakePolicy.POKE_TARGETS] in turn, holding whichever connects for
-     * [holdMs]. Returns true if any of them did.
+     * [holdMs]. Returns true if any of them did, false without opening anything if this unit
+     * already holds a hands-free link. Both poke entry points come through here, so one check
+     * covers the retry loop and the manual poke alike.
      */
     private suspend fun pokeDevice(device: BluetoothDevice, holdMs: Long): Boolean {
+        // A poke that connects takes the phone's single hands-free slot, and this unit's own client
+        // is dropped to make room. See BluetoothWakePolicy for the measurement.
+        val handsFreeLink = BluetoothWakePolicy.HandsFreeLink.of(BluetoothHelper.handsFreeLinkState(context))
+        if (!BluetoothWakePolicy.shouldPoke(handsFreeLink)) {
+            noteHandsFreePokeSkip(device)
+            return false
+        }
+        handsFreeSkipLogged = false
+
         pokeAttemptInFlight = true
         try {
             for (uuid in BluetoothWakePolicy.POKE_TARGETS) {

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -7,6 +7,7 @@ import android.bluetooth.BluetoothServerSocket
 import android.bluetooth.BluetoothSocket
 import android.content.Context
 import com.andrerinas.openheadunit.aap.AapService
+import com.andrerinas.openheadunit.aap.BluetoothWakePolicy
 import com.andrerinas.openheadunit.aap.NativeCredentialsPolicy
 import com.andrerinas.openheadunit.aap.NativeHandoffPolicy
 import com.andrerinas.openheadunit.aap.NativeTransport
@@ -42,13 +43,8 @@ class NativeAaHandshakeManager(
     companion object {
         private val AA_UUID = UUID.fromString("4de17a00-52cb-11e6-bdf4-0800200c9a66")
         private val HFP_UUID = UUID.fromString("0000111e-0000-1000-8000-00805f9b34fb")
-        // Phone-wake targets, tried HFP then HSP (mirrors openautolink's ConnectProfile
-        // fallback chain). HSP_AG_UUID is the old "A2DP_SOURCE_UUID" - despite that name it was
-        // never A2DP Source (real assigned number 0000110a-...); both UUIDs are confirmed
-        // against nisargjhaveri/WirelessAndroidAutoDongle and mossyhub/openautolink, which use
-        // the same pair for this exact purpose.
-        private val HSP_AG_UUID = UUID.fromString("00001112-0000-1000-8000-00805f9b34fb") // Headset Profile AG
-        private val HFP_AG_UUID = UUID.fromString("0000111f-0000-1000-8000-00805f9b34fb") // Hands-Free Profile AG
+        // The phone-wake targets, and the rules for when a poke may run at all, live in
+        // BluetoothWakePolicy — one of those records is also the one a phone call rides on.
 
         /** How long to wait for this head unit's own WiFi network to come up before giving up on
          *  a handshake. P2P group creation is the slow case. */
@@ -324,7 +320,7 @@ class NativeAaHandshakeManager(
                 while (isRunning && isActive) {
                     val socket = hfpServerSocket?.accept()
                     if (socket != null) {
-                        AppLog.i("NativeAA: HFP connection accepted from ${socket.remoteDevice.name}. Starting responder.")
+                        logHfpAccept(socket, localRadioName)
                         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-HfpResponder-${socket.remoteDevice.address}")) {
                             handleHfp(socket)
                         }
@@ -413,7 +409,7 @@ class NativeAaHandshakeManager(
                 while (isRunning && isActive) {
                     val socket = server.accept()
                     if (socket != null) {
-                        AppLog.i("NativeAA: HFP connection accepted (secondary radio '$serviceName') from ${socket.remoteDevice.name}.")
+                        logHfpAccept(socket, "$serviceName $radioName")
                         scope.launch(Dispatchers.IO + CoroutineName("NativeAa-HfpResponder-${socket.remoteDevice.address}")) {
                             handleHfp(socket)
                         }
@@ -442,6 +438,22 @@ class NativeAaHandshakeManager(
             extraAaServerSockets.forEach { try { it.close() } catch (e: Exception) {} }
             extraAaServerSockets.clear()
         }
+    }
+
+    /**
+     * Says what an accepted hands-free connection means, not only that it happened. On its own it
+     * reads like success; it is the phone attaching its hands-free link to this app rather than to
+     * the head unit's own Bluetooth stack, and the responder below can never carry call audio —
+     * it answers OK to everything and negotiates neither a codec nor a SCO link.
+     *
+     * Whether it ever fires is still open: five rig rounds and every reporter log so far, no
+     * accepts. Address as well as name, because getName() is null for an unbonded device.
+     */
+    private fun logHfpAccept(socket: BluetoothSocket, radio: String) {
+        val device = socket.remoteDevice
+        AppLog.i("NativeAA: HFP connection accepted from ${device.name ?: "unnamed"} (${device.address}) " +
+                "on radio [$radio] — the phone's hands-free link now terminates in this app, " +
+                "which cannot carry call audio. If calls are not heard on this unit, look here first.")
     }
 
     /**
@@ -495,20 +507,22 @@ class NativeAaHandshakeManager(
     }
 
     /**
-     * Tries HFP_AG_UUID first, falling back to HSP_AG_UUID, holding whichever connects for
-     * [holdMs]. Returns true if either connected. Mirrors openautolink's ConnectProfile
-     * fallback chain (HFP_AG_UUID -> HSP_AG_UUID).
+     * Tries each of [BluetoothWakePolicy.POKE_TARGETS] in turn, holding whichever connects for
+     * [holdMs]. Returns true if any of them did.
      */
     private suspend fun pokeDevice(device: BluetoothDevice, holdMs: Long): Boolean {
         pokeAttemptInFlight = true
         try {
-            for (uuid in listOf(HFP_AG_UUID, HSP_AG_UUID)) {
+            for (uuid in BluetoothWakePolicy.POKE_TARGETS) {
+                val profile = BluetoothWakePolicy.profileName(uuid)
                 var socket: BluetoothSocket? = null
                 try {
                     socket = device.createRfcommSocketToServiceRecord(uuid)
-                    AppLog.i("NativeAA: Calling socket.connect() for ${device.name} via $uuid...")
+                    AppLog.i("NativeAA: Calling socket.connect() for ${device.name} via $profile ($uuid)...")
                     socket.connect()
-                    AppLog.i("NativeAA: Successfully poked ${device.name} via $uuid. Holding ${holdMs}ms...")
+                    // Named, not just the UUID: which record we ended up on is the first thing to
+                    // check when a reporter's calls come out of the phone instead of the car.
+                    AppLog.i("NativeAA: Successfully poked ${device.name} via $profile. Holding ${holdMs}ms...")
                     // Counted before the hold, so a poke that is cancelled mid-hold still counts:
                     // the phone answered, which is the whole point of the count.
                     pokesSinceLastAccept++
@@ -523,7 +537,7 @@ class NativeAaHandshakeManager(
                 } catch (e: Exception) {
                     // Address as well as name: getName() is null for an unbonded device, and a log line
                     // reading "to null" names nothing at all for the reader of a bug report.
-                    AppLog.d("NativeAA: Poke via $uuid to ${device.name ?: "unnamed"} (${device.address}) failed: ${e.message}")
+                    AppLog.d("NativeAA: Poke via $profile to ${device.name ?: "unnamed"} (${device.address}) failed: ${e.message}")
                 } finally {
                     try { socket?.close() } catch (e: Exception) {}
                 }

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
@@ -2,6 +2,7 @@ package com.andrerinas.openheadunit.utils
 
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
 import android.content.Context
 import android.os.Build
 import android.os.IBinder
@@ -89,6 +90,56 @@ object BluetoothHelper {
     /** All distinct, enabled Bluetooth adapters exposed by the system. See [getAllBluetoothAdapterHandles]. */
     fun getAllBluetoothAdapters(context: Context): List<BluetoothAdapter> =
         getAllBluetoothAdapterHandles(context).map { it.adapter }
+
+    /**
+     * `BluetoothProfile.HEADSET_CLIENT`. Hidden from the SDK, but
+     * [BluetoothAdapter.getProfileConnectionState] takes a plain profile int and answers for it, and
+     * this is the hands-free role a head unit plays: the phone is the audio gateway, the unit is the
+     * hands-free device that carries the call.
+     */
+    private const val PROFILE_HEADSET_CLIENT = 16
+
+    /**
+     * Whether this head unit currently holds a Bluetooth hands-free link, in either role.
+     *
+     * Null when the adapter will not say. Callers must treat that as "no link known" rather than
+     * "no link", because the only decision hanging off this is whether to skip an action that is
+     * load-bearing elsewhere.
+     *
+     * Both roles are read. `HEADSET_CLIENT` is the one a head unit normally plays and the one the
+     * wake poke was measured destroying; `HEADSET` is checked too because some OEM stacks report a
+     * hands-free connection under the gateway role instead, and for this decision a false "yes" only
+     * costs a skipped poke while a false "no" costs the user their calls.
+     *
+     * Profile-wide, not per-device: `getProfileConnectionState` answers for the adapter, and the
+     * per-device equivalents are system-only. On a head unit paired with one phone that distinction
+     * does not arise; where it does, this errs toward reporting a link.
+     */
+    fun handsFreeLinkState(context: Context): Boolean? {
+        val resolved = try {
+            getBluetoothAdapter(context)
+        } catch (e: Exception) {
+            AppLog.w("BluetoothHelper: could not resolve an adapter for the hands-free check: ${e.message}")
+            return null
+        }
+        val adapter = resolved ?: return false
+        val enabled = try { adapter.isEnabled } catch (e: Exception) { null }
+        if (enabled == false) return false
+
+        var readAnyState = false
+        for (profile in intArrayOf(PROFILE_HEADSET_CLIENT, BluetoothProfile.HEADSET)) {
+            val state = try {
+                adapter.getProfileConnectionState(profile)
+            } catch (e: Exception) {
+                // SecurityException without BLUETOOTH_CONNECT, or an adapter that rejects the
+                // hidden client profile. Try the other role before giving up.
+                continue
+            }
+            readAnyState = true
+            if (state == BluetoothProfile.STATE_CONNECTED) return true
+        }
+        return if (readAnyState) false else null
+    }
 
     /** Resolve a single, arbitrary system service name to a BluetoothAdapterHandle, if it backs a
      *  real, enabled adapter. Used for the manual secondary-radio override in Settings, where the

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/BluetoothWakePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/BluetoothWakePolicyTest.kt
@@ -17,7 +17,8 @@ class BluetoothWakePolicyTest {
 
     /**
      * The poke is load-bearing on some head units — they never connect without it — so the list may
-     * never be emptied to disable it.
+     * never be emptied to disable it. Standing a poke down is [BluetoothWakePolicy.shouldPoke]'s
+     * decision, taken per attempt, and not this list's.
      */
     @Test
     fun `hands-free is tried first, headset second, and neither is ever dropped`() {
@@ -37,5 +38,44 @@ class BluetoothWakePolicyTest {
     fun `an unknown uuid still prints as itself`() {
         val other = java.util.UUID.fromString("4de17a00-52cb-11e6-bdf4-0800200c9a66")
         assertEquals(other.toString(), BluetoothWakePolicy.profileName(other))
+    }
+
+    // --- the guard: never poke a link we would destroy ---
+
+    /**
+     * The measured failure: a poke that connects takes the phone's one hands-free slot, this unit's
+     * own client is dropped 4 ms later, and it does not come back without a Bluetooth adapter cycle.
+     */
+    @Test
+    fun `a live hands-free link is never poked`() {
+        assertFalse(BluetoothWakePolicy.shouldPoke(BluetoothWakePolicy.HandsFreeLink.CONNECTED))
+    }
+
+    @Test
+    fun `no hands-free link means there is nothing to destroy, so poke`() {
+        assertTrue(BluetoothWakePolicy.shouldPoke(BluetoothWakePolicy.HandsFreeLink.ABSENT))
+    }
+
+    /**
+     * An adapter that will not report its profiles must not silently disable a mechanism some head
+     * units cannot connect without. Those units keep today's behaviour.
+     */
+    @Test
+    fun `an unreadable adapter still pokes`() {
+        assertTrue(BluetoothWakePolicy.shouldPoke(BluetoothWakePolicy.HandsFreeLink.UNREADABLE))
+    }
+
+    @Test
+    fun `the three-valued profile read maps onto the three states`() {
+        assertEquals(BluetoothWakePolicy.HandsFreeLink.CONNECTED, BluetoothWakePolicy.HandsFreeLink.of(true))
+        assertEquals(BluetoothWakePolicy.HandsFreeLink.ABSENT, BluetoothWakePolicy.HandsFreeLink.of(false))
+        assertEquals(BluetoothWakePolicy.HandsFreeLink.UNREADABLE, BluetoothWakePolicy.HandsFreeLink.of(null))
+    }
+
+    /** Exactly one state suppresses the poke; if a fourth is ever added it has to choose out loud. */
+    @Test
+    fun `only a connected link suppresses the poke`() {
+        val suppressed = BluetoothWakePolicy.HandsFreeLink.values().filterNot { BluetoothWakePolicy.shouldPoke(it) }
+        assertEquals(listOf(BluetoothWakePolicy.HandsFreeLink.CONNECTED), suppressed)
     }
 }

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/BluetoothWakePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/BluetoothWakePolicyTest.kt
@@ -78,4 +78,60 @@ class BluetoothWakePolicyTest {
         val suppressed = BluetoothWakePolicy.HandsFreeLink.values().filterNot { BluetoothWakePolicy.shouldPoke(it) }
         assertEquals(listOf(BluetoothWakePolicy.HandsFreeLink.CONNECTED), suppressed)
     }
+
+    // --- pairing: strict about poking, lenient about forgetting ---
+
+    private val BONDED = BluetoothWakePolicy.BondReading.BONDED
+    private val NOT_BONDED = BluetoothWakePolicy.BondReading.NOT_BONDED
+    private val MALFORMED = BluetoothWakePolicy.BondReading.MALFORMED
+    private val UNREADABLE = BluetoothWakePolicy.BondReading.UNREADABLE
+
+    @Test
+    fun `only a confirmed pairing may be poked`() {
+        assertTrue(BluetoothWakePolicy.mayPoke(BONDED))
+        for (reading in BluetoothWakePolicy.BondReading.values().filterNot { it == BONDED }) {
+            assertFalse("$reading should not be poked", BluetoothWakePolicy.mayPoke(reading))
+        }
+    }
+
+    /**
+     * The one that matters: `getBondState()` answers BOND_NONE when the Bluetooth service is
+     * unavailable, so an adapter that is off looks exactly like a phone the user unpaired. Forgetting
+     * is permanent and written through to device-protected storage, so it needs a real answer.
+     */
+    @Test
+    fun `an unreadable state is never forgotten`() {
+        assertFalse(BluetoothWakePolicy.shouldForget(UNREADABLE))
+    }
+
+    @Test
+    fun `a paired device is never forgotten`() {
+        assertFalse(BluetoothWakePolicy.shouldForget(BONDED))
+    }
+
+    @Test
+    fun `a positive not-paired answer is forgotten`() {
+        assertTrue(BluetoothWakePolicy.shouldForget(NOT_BONDED))
+    }
+
+    /** An address that is not a Bluetooth address can never become one. */
+    @Test
+    fun `a malformed address is forgotten`() {
+        assertTrue(BluetoothWakePolicy.shouldForget(MALFORMED))
+    }
+
+    /**
+     * The asymmetry is the design: refusing to poke costs a retry seconds later, forgetting costs
+     * the user their configured device with nothing to restore it. So nothing may ever be forgotten
+     * that was also considered pokeable, and the two rules must never both be lenient.
+     */
+    @Test
+    fun `nothing pokeable is ever forgotten`() {
+        for (reading in BluetoothWakePolicy.BondReading.values()) {
+            assertFalse(
+                "$reading was both poked and forgotten",
+                BluetoothWakePolicy.mayPoke(reading) && BluetoothWakePolicy.shouldForget(reading)
+            )
+        }
+    }
 }

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/BluetoothWakePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/BluetoothWakePolicyTest.kt
@@ -1,0 +1,41 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BluetoothWakePolicyTest {
+
+    // --- the targets themselves, pinned ---
+
+    @Test
+    fun `the poke targets are the assigned audio gateway service classes`() {
+        assertEquals("0000111f-0000-1000-8000-00805f9b34fb", BluetoothWakePolicy.HFP_AG_UUID.toString())
+        assertEquals("00001112-0000-1000-8000-00805f9b34fb", BluetoothWakePolicy.HSP_AG_UUID.toString())
+    }
+
+    /**
+     * The poke is load-bearing on some head units — they never connect without it — so the list may
+     * never be emptied to disable it.
+     */
+    @Test
+    fun `hands-free is tried first, headset second, and neither is ever dropped`() {
+        assertEquals(
+            listOf(BluetoothWakePolicy.HFP_AG_UUID, BluetoothWakePolicy.HSP_AG_UUID),
+            BluetoothWakePolicy.POKE_TARGETS
+        )
+    }
+
+    @Test
+    fun `targets are named for a log reader`() {
+        assertEquals("HFP-AG", BluetoothWakePolicy.profileName(BluetoothWakePolicy.HFP_AG_UUID))
+        assertEquals("HSP-AG", BluetoothWakePolicy.profileName(BluetoothWakePolicy.HSP_AG_UUID))
+    }
+
+    @Test
+    fun `an unknown uuid still prints as itself`() {
+        val other = java.util.UUID.fromString("4de17a00-52cb-11e6-bdf4-0800200c9a66")
+        assertEquals(other.toString(), BluetoothWakePolicy.profileName(other))
+    }
+}


### PR DESCRIPTION
Reported in #744: phone calls come out of the phone instead of the car, and the head unit shows Bluetooth disconnected while the phone shows it connected.

The Native AA wake poke connects to one of the phone's audio-gateway records to raise an ACL connection so the phone starts its wireless setup. A poke that **connects** takes the phone's single hands-free slot, and the head unit's own `HfpClientConnectionService` is dropped to make room — it logged its disconnect from the same peer 4 ms after our `socket.connect()` returned, and the link stayed down for eight minutes until a Bluetooth adapter cycle. Since v.3.2.0 the poke retries every ~30 s (`38a82373`) where v.3.1.1 tried once, so the slot is held rather than borrowed.

Reordering the targets back to v.3.1.1's is not the fix: a **successful** HSP-AG poke was measured leaving the link down for three minutes too. A phone serves HFP-AG and HSP-AG from one headset connection, so which record is asked for was never the lever.

### Fix

`BluetoothWakePolicy` (new, pure, 15 unit tests) decides when a poke may run. Three commits:

1. **Name the record in the logs.** Both UUIDs move out of `NativeAaHandshakeManager`, so a capture says `HFP-AG` rather than `0000111f-…`. One had been stored for years as `A2DP_SOURCE_UUID`, which it never was, so the values are pinned in tests. No behaviour change.
2. **Skip the poke when a hands-free link is already up** — which is also when it is pointless, that link *being* the ACL connection a poke exists to create. Units where the poke is load-bearing have no such link to read and are unaffected; an unreadable adapter still pokes, rather than silently disabling a mechanism some units cannot connect without.
3. **Don't poke an unpaired phone, and don't forget one we cannot read.** `connect()` to an unpaired device solicits pairing as a side effect. Pruning the stored Auto Start MAC gets the opposite bias: `getBondState()` answers `BOND_NONE` when the Bluetooth service is merely unavailable, so an adapter that is off looks exactly like a phone the user unpaired, and deleting on that reading is permanent.

### Verification

On hardware: the guard fires with the link up and opens no socket, Android Auto still connects in ~6.6 s with the poke suppressed, the manual poke still runs when there is no link to protect, and it refuses an unpaired device with no pairing dialog.

Unverified: the prune's adapter-off path needs the retry loop to read bond state while the adapter is genuinely disabled, and that window could not be landed. The rule is unit-tested and `isEnabled` is checked before `bondState`, so what is unconfirmed is the live race, not the decision.
