### PR TITLE
Restore the hands-free link read the wake poke checks

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
@@ -92,6 +92,56 @@ object BluetoothHelper {
         getAllBluetoothAdapterHandles(context).map { it.adapter }
 
     /**
+     * `BluetoothProfile.HEADSET_CLIENT`. Hidden from the SDK, but
+     * [BluetoothAdapter.getProfileConnectionState] takes a plain profile int and answers for it, and
+     * this is the hands-free role a head unit plays: the phone is the audio gateway, the unit is the
+     * hands-free device that carries the call.
+     */
+    private const val PROFILE_HEADSET_CLIENT = 16
+
+    /**
+     * Whether this head unit currently holds a Bluetooth hands-free link, in either role.
+     *
+     * Null when the adapter will not say. Callers must treat that as "no link known" rather than
+     * "no link", because the only decision hanging off this is whether to skip an action that is
+     * load-bearing elsewhere.
+     *
+     * Both roles are read. `HEADSET_CLIENT` is the one a head unit normally plays and the one the
+     * wake poke was measured destroying; `HEADSET` is checked too because some OEM stacks report a
+     * hands-free connection under the gateway role instead, and for this decision a false "yes" only
+     * costs a skipped poke while a false "no" costs the user their calls.
+     *
+     * Profile-wide, not per-device: `getProfileConnectionState` answers for the adapter, and the
+     * per-device equivalents are system-only. On a head unit paired with one phone that distinction
+     * does not arise; where it does, this errs toward reporting a link.
+     */
+    fun handsFreeLinkState(context: Context): Boolean? {
+        val resolved = try {
+            getBluetoothAdapter(context)
+        } catch (e: Exception) {
+            AppLog.w("BluetoothHelper: could not resolve an adapter for the hands-free check: ${e.message}")
+            return null
+        }
+        val adapter = resolved ?: return false
+        val enabled = try { adapter.isEnabled } catch (e: Exception) { null }
+        if (enabled == false) return false
+
+        var readAnyState = false
+        for (profile in intArrayOf(PROFILE_HEADSET_CLIENT, BluetoothProfile.HEADSET)) {
+            val state = try {
+                adapter.getProfileConnectionState(profile)
+            } catch (e: Exception) {
+                // SecurityException without BLUETOOTH_CONNECT, or an adapter that rejects the
+                // hidden client profile. Try the other role before giving up.
+                continue
+            }
+            readAnyState = true
+            if (state == BluetoothProfile.STATE_CONNECTED) return true
+        }
+        return if (readAnyState) false else null
+    }
+
+    /**
      * `BluetoothProfile.A2DP_SINK`. Hidden from the SDK, but [BluetoothAdapter.getProfileConnectionState]
      * takes a plain profile int and answers for it, and the sink role is the one a head unit plays:
      * the phone is the source, we render its audio.


### PR DESCRIPTION
NativeAaHandshakeManager calls BluetoothHelper.handsFreeLinkState(context) before every poke, and that function is not in the file. main does not compile: unresolved reference.

It went in with the poke's hands-free guard, together with PROFILE_HEADSET_CLIENT, and was resolved away in the merge 0b1a1c64 -- upstream had rewritten the whole of BluetoothHelper.kt in 237f94e2 for the MAC-address work, and taking that side wholesale dropped these two members while keeping the A2DP pair beside them. Nothing else was lost in that resolution: the only removals it made to this file are the two restored here.

Restored verbatim rather than rewritten. The return type is Boolean?, not Boolean, and that is the load-bearing part: null means the adapter would not say, which BluetoothWakePolicy.HandsFreeLink.of maps to UNREADABLE and pokes anyway. Collapsing it to a non-null Boolean silently disables the poke on every unit that cannot report its profiles -- which is the set of units the poke exists for.