### PR TITLE
Input: let the Bluetooth side keep the media buttons

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/AapBroadcastReceiver.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/AapBroadcastReceiver.kt
@@ -56,7 +56,9 @@ class AapBroadcastReceiver : BroadcastReceiver() {
                 intent.getParcelableExtra(KeyIntent.extraEvent)
             }
             event?.let {
-                component.commManager.sendKey(it.keyCode, it.action == KeyEvent.ACTION_DOWN)
+                component.commManager.sendKey(
+                    it.keyCode, it.action == KeyEvent.ACTION_DOWN, it.downTime, "media-key-intent"
+                )
             }
         } else if (intent.action == ProjectionActivityRequest.action){
             if (component.commManager.connectionState.value is CommManager.ConnectionState.TransportStarted) {

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
@@ -1451,7 +1451,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         // route it through CommManager so it can be remapped and sent to Android Auto.
         if (commManager.connectionState.value is CommManager.ConnectionState.TransportStarted &&
             ProjectionKeyPolicy.shouldRouteBackKeyToProjection(cachedKeyCodes, event.keyCode)) {
-            commManager.sendKey(event.keyCode, action == KeyEvent.ACTION_DOWN)
+            commManager.sendKey(event.keyCode, action == KeyEvent.ACTION_DOWN, event.downTime, "projection")
             return true
         }
 
@@ -1463,13 +1463,13 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         }
 
         // 2. Funnel all other keys to CommManager
-        commManager.sendKey(event.keyCode, event.action == KeyEvent.ACTION_DOWN)
+        commManager.sendKey(event.keyCode, event.action == KeyEvent.ACTION_DOWN, event.downTime, "projection")
         return true
     }
 
     private fun onKeyEvent(keyCode: Int, isPress: Boolean) {
         // Broadcasts (e.g. from CarKeyReceiver) still use this path.
-        commManager.sendKey(keyCode, isPress)
+        commManager.sendKey(keyCode, isPress, null, "key-broadcast")
     }
 
     private fun applyStickyOrientation() {

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -1039,8 +1039,8 @@ class AapService : Service(), UsbReceiver.Listener {
                         if (keyEvent.action == android.view.KeyEvent.ACTION_DOWN && keyEvent.repeatCount == 0) {
                             AppLog.i("MediaButtonEvent: Processing key ${keyEvent.keyCode}")
                             // Send a complete click sequence (press + release) immediately
-                            commManager.sendKey(keyEvent.keyCode, true)
-                            commManager.sendKey(keyEvent.keyCode, false)
+                            commManager.sendKey(keyEvent.keyCode, true, keyEvent.downTime, "mediasession")
+                            commManager.sendKey(keyEvent.keyCode, false, keyEvent.downTime, "mediasession")
                             return true
                         }
 
@@ -1055,32 +1055,32 @@ class AapService : Service(), UsbReceiver.Listener {
 
                 override fun onPause() {
                     AppLog.i("MediaSession: Processing transport control action = KEYCODE_MEDIA_PAUSE")
-                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PAUSE, true)
-                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PAUSE, false)
+                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PAUSE, true, null, "transport-control")
+                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PAUSE, false, null, "transport-control")
                 }
 
                 override fun onPlay() {
                     AppLog.i("MediaSession: Processing transport control action = KEYCODE_MEDIA_PLAY")
-                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PLAY, true)
-                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PLAY, false)
+                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PLAY, true, null, "transport-control")
+                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PLAY, false, null, "transport-control")
                 }
 
                 override fun onSkipToNext() {
                     AppLog.i("MediaSession: Processing transport control action = KEYCODE_MEDIA_NEXT")
-                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_NEXT, true)
-                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_NEXT, false)
+                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_NEXT, true, null, "transport-control")
+                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_NEXT, false, null, "transport-control")
                 }
 
                 override fun onSkipToPrevious() {
                     AppLog.i("MediaSession: Processing transport control action = KEYCODE_MEDIA_PREVIOUS")
-                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PREVIOUS, true)
-                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PREVIOUS, false)
+                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PREVIOUS, true, null, "transport-control")
+                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_PREVIOUS, false, null, "transport-control")
                 }
 
                 override fun onStop() {
                     AppLog.i("MediaSession: Processing transport control action = KEYCODE_MEDIA_STOP")
-                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_STOP, true)
-                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_STOP, false)
+                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_STOP, true, null, "transport-control")
+                    commManager.sendKey(android.view.KeyEvent.KEYCODE_MEDIA_STOP, false, null, "transport-control")
                 }
             })
             setPlaybackToLocal(android.media.AudioManager.STREAM_MUSIC)

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/KeyDebouncePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/KeyDebouncePolicy.kt
@@ -1,0 +1,158 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Which of the several deliveries of one physical button press actually reaches Android Auto.
+ *
+ * A single press arrives at `CommManager.sendKey` more than once: during projection the OEM hands
+ * the foreground activity a raw `KeyEvent` *and* broadcasts a media button, and the car-key
+ * receivers add their own copies on top. Every extra delivery that gets through is an extra action
+ * on the phone.
+ *
+ * The discriminator is the event's own identity. `KeyEvent.getDownTime()` is stamped when the
+ * gesture began, so every redelivery of one press carries the same value and two real presses never
+ * do — which is exact, needs no tuning, and lets a deliberate fast double-press through. The
+ * time window survives only for the proprietary OEM broadcasts that carry no `KeyEvent` at all;
+ * there, guessing from elapsed time is still all there is.
+ *
+ * Deciding a press means deciding the whole click, both edges. Releasing a key we never pressed is
+ * as wrong as pressing it twice: Android Auto reads a stray release as the end of a gesture it does
+ * not have, and a press whose release goes missing leaves the key held down forever.
+ *
+ * Pure and unit-tested; `CommManager` holds the per-key state and does the sending.
+ */
+object KeyDebouncePolicy {
+
+    /**
+     * Fallback windows for deliveries with no event identity, carried over unchanged from the
+     * original inline debounce: media keys are the ones OEM head units fan out most.
+     */
+    const val MEDIA_WINDOW_MS = 600L
+    const val DEFAULT_WINDOW_MS = 300L
+
+    /**
+     * How long a key may stay held before the next press is treated as a new one rather than a
+     * duplicate of the one still down. Without this, a delivery path that sends a press and never
+     * its release latches the key: every later press matches the held state and is dropped, and
+     * nothing clears it short of a disconnect. Long enough not to break a genuine press-and-hold,
+     * short enough that a user who presses again has their second press work.
+     */
+    const val STUCK_PRESS_MS = 2_000L
+
+    /** Per logical key. Owned by the caller, replaced wholesale by each [decide]. */
+    data class KeyState(
+        /** A press has been forwarded and its release has not. */
+        val down: Boolean = false,
+        /** When the held press was forwarded, for [STUCK_PRESS_MS]. */
+        val downAt: Long = 0L,
+        /** When the last press was forwarded, for the fallback window. Null until there is one. */
+        val lastForwardedPressAt: Long? = null,
+        /** Identity of the last forwarded press, or null if that delivery carried none. */
+        val lastForwardedDownTime: Long? = null,
+        /** The press of the click in flight was dropped, so its release must be dropped too. */
+        val pressDropped: Boolean = false
+    )
+
+    data class Result(
+        val forward: Boolean,
+        /**
+         * Send a release for the previously held press before this one. Only set for a press that
+         * arrives while a stale press is still held: the phone is owed the release of the gesture
+         * it was told about.
+         */
+        val releaseFirst: Boolean = false,
+        /** Why this delivery was dropped, for the log. Null when it was forwarded. */
+        val dropReason: String? = null,
+        val state: KeyState
+    )
+
+    fun decide(
+        state: KeyState,
+        isPress: Boolean,
+        downTime: Long?,
+        isMediaKey: Boolean,
+        now: Long
+    ): Result {
+        // A synthetic KeyEvent built from (action, code) alone carries a zero downTime, and every
+        // press would then look like a redelivery of the last one. No identity is better than a
+        // constant one.
+        val id = downTime?.takeIf { it > 0L }
+
+        return if (isPress) decidePress(state, id, isMediaKey, now) else decideRelease(state)
+    }
+
+    private fun decidePress(state: KeyState, id: Long?, isMediaKey: Boolean, now: Long): Result {
+        val last = state.lastForwardedDownTime
+        if (id != null && last != null && id == last) {
+            // Same physical press, arriving by another route. Nothing about the state changes: the
+            // release of this press still has to be able to lift the key.
+            return Result(forward = false, dropReason = "another delivery of the same key event", state = state)
+        }
+
+        // Identity settles it only when both sides have one. A press that carries identity following
+        // one that did not (or the reverse) is the same press reaching us by two different routes at
+        // least as often as it is a new one, so fall back to the window rather than assume.
+        val identityProvesNewPress = id != null && last != null
+
+        if (state.down) {
+            // A press that carries a different identity is a different press: the redelivery of the
+            // held one was already dropped above. Otherwise only time can tell a duplicate from a
+            // press whose release went missing, and a key held this long is the latter.
+            if (!identityProvesNewPress && now - state.downAt < STUCK_PRESS_MS) {
+                return Result(forward = false, dropReason = "the key is already held down", state = state)
+            }
+            // Close the held press out and let this one through, whatever the window says — the
+            // window drops duplicates, and this is not one.
+            return Result(
+                forward = true,
+                releaseFirst = true,
+                state = state.copy(
+                    down = true,
+                    downAt = now,
+                    lastForwardedPressAt = now,
+                    lastForwardedDownTime = id,
+                    pressDropped = false
+                )
+            )
+        }
+
+        val lastPressAt = state.lastForwardedPressAt
+        if (!identityProvesNewPress && lastPressAt != null) {
+            val window = if (isMediaKey) MEDIA_WINDOW_MS else DEFAULT_WINDOW_MS
+            val since = now - lastPressAt
+            if (since < window) {
+                // Drop the click as a unit. Marking the key down here — as the original code did
+                // before returning — is what put an unmatched release on the wire.
+                return Result(
+                    forward = false,
+                    dropReason = "duplicate ${since}ms after the last press, within ${window}ms",
+                    state = state.copy(pressDropped = true)
+                )
+            }
+        }
+
+        return Result(
+            forward = true,
+            state = state.copy(
+                down = true,
+                downAt = now,
+                lastForwardedPressAt = now,
+                lastForwardedDownTime = id,
+                pressDropped = false
+            )
+        )
+    }
+
+    private fun decideRelease(state: KeyState): Result {
+        if (state.pressDropped) {
+            return Result(
+                forward = false,
+                dropReason = "its press was dropped",
+                state = state.copy(pressDropped = false)
+            )
+        }
+        if (!state.down) {
+            return Result(forward = false, dropReason = "no press is outstanding", state = state)
+        }
+        return Result(forward = true, state = state.copy(down = false))
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/MediaKeyRoutingPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/MediaKeyRoutingPolicy.kt
@@ -1,0 +1,77 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Whether a physical media button should be forwarded to Android Auto, or left to the Bluetooth
+ * side that may already be acting on the same press.
+ *
+ * A head unit can end up with two consumers for one button. The OEM key handler delivers the press
+ * to us *and* the Bluetooth media stack acts on it independently: AOSP's
+ * `BluetoothMediaBrowserService` publishes a real media session whose skip-to-next issues an AVRCP
+ * passthrough FORWARD to the source device — the same phone that is projecting to us. Both
+ * consumers reach the same media app, so one press skips two tracks.
+ *
+ * Only the cumulative commands show it. Play/pause is a state-specific passthrough (PLAY or PAUSE
+ * depending on the sink's own playback state), so two consumers converge on one result and the user
+ * sees nothing wrong; next/previous add up. That asymmetry is the fingerprint of this failure, and
+ * it is what rules out "the key is sent twice" faults inside this app, which would double both.
+ *
+ * Nothing in the platform arbitrates the two: the Bluetooth profile calls that would deactivate the
+ * other consumer are `BLUETOOTH_PRIVILEGED`, aborting the broadcast does not work because the
+ * framework's media-button route is single-target rather than an ordered fan-out, and taking audio
+ * focus to deactivate the sink's session is exactly the behaviour [PlaybackFocusPolicy] exists to
+ * avoid. So the lever is which consumer *we* leave the key to.
+ *
+ * Pure and unit-tested; the Bluetooth probe and the send live in `CommManager`.
+ */
+object MediaKeyRoutingPolicy {
+
+    /** User choice for who owns the media buttons. Stored as an ordinal in settings. */
+    enum class Mode(val value: Int) {
+        /**
+         * Always forward. The value of an unset preference, so a head unit whose Bluetooth side
+         * does nothing with these buttons keeps working with no setting touched.
+         */
+        ALWAYS(0),
+
+        /**
+         * Forward unless this head unit has a Bluetooth media link of its own, in which case that
+         * link is very likely the phone we project and is already performing the action.
+         */
+        AUTO(1),
+
+        /**
+         * Never forward. For the case [AUTO] cannot see: the phone's Bluetooth link is to the car's
+         * own system rather than to this head unit, so our adapter reports nothing while the factory
+         * radio still acts on every press.
+         */
+        NEVER(2);
+
+        companion object {
+            private val map = values().associateBy(Mode::value)
+            fun fromInt(value: Int): Mode = map[value] ?: ALWAYS
+        }
+    }
+
+    /**
+     * @param isMediaKey       the key is one of the transport controls. Everything else — the rotary
+     *                         controller, D-pad, Back, Enter — is always forwarded, whatever the
+     *                         mode: those have no Bluetooth consumer competing for them, and a
+     *                         setting about media buttons that quietly disabled the controller would
+     *                         be a worse bug than the one it fixes.
+     * @param btMediaLinkActive whether a Bluetooth media (A2DP) link to this head unit is up, or
+     *                         `null` when the adapter would not say. Unknown forwards: a doubled
+     *                         skip is an annoyance, media buttons that silently do nothing read as a
+     *                         broken app. Note this is the opposite resolution to
+     *                         [PlaybackFocusPolicy], where an unreadable state means "assume a link
+     *                         is up" — there the cautious answer is to leave focus alone.
+     */
+    fun shouldForward(mode: Mode, isMediaKey: Boolean, btMediaLinkActive: Boolean?): Boolean {
+        if (!isMediaKey) return true
+
+        return when (mode) {
+            Mode.ALWAYS -> true
+            Mode.NEVER -> false
+            Mode.AUTO -> btMediaLinkActive != true
+        }
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/app/RemoteControlReceiver.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/app/RemoteControlReceiver.kt
@@ -65,32 +65,32 @@ class RemoteControlReceiver : BroadcastReceiver() {
 
             when (command) {
                 "next", "skip_next", "skip", "forward", "skip_forward" -> {
-                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_NEXT, true)
-                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_NEXT, false)
+                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_NEXT, true, null, "remote-command")
+                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_NEXT, false, null, "remote-command")
                 }
                 "previous", "skip_previous", "prev", "rewind", "back", "skip_back", "skip_backward" -> {
-                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_PREVIOUS, true)
-                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_PREVIOUS, false)
+                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_PREVIOUS, true, null, "remote-command")
+                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_PREVIOUS, false, null, "remote-command")
                 }
                 "play", "start", "resume" -> {
-                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_PLAY, true)
-                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_PLAY, false)
+                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_PLAY, true, null, "remote-command")
+                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_PLAY, false, null, "remote-command")
                 }
                 "pause", "stop" -> {
-                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_PAUSE, true)
-                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_PAUSE, false)
+                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_PAUSE, true, null, "remote-command")
+                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_PAUSE, false, null, "remote-command")
                 }
                 "togglepause", "playpause", "play_pause", "media_play_pause" -> {
-                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, true)
-                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, false)
+                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, true, null, "remote-command")
+                    commManager.sendKey(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, false, null, "remote-command")
                 }
                 "mute", "volume_mute" -> {
-                    commManager.sendKey(KeyEvent.KEYCODE_VOLUME_MUTE, true)
-                    commManager.sendKey(KeyEvent.KEYCODE_VOLUME_MUTE, false)
+                    commManager.sendKey(KeyEvent.KEYCODE_VOLUME_MUTE, true, null, "remote-command")
+                    commManager.sendKey(KeyEvent.KEYCODE_VOLUME_MUTE, false, null, "remote-command")
                 }
                 "voice", "mic", "microphone", "search" -> {
-                    commManager.sendKey(KeyEvent.KEYCODE_SEARCH, true)
-                    commManager.sendKey(KeyEvent.KEYCODE_SEARCH, false)
+                    commManager.sendKey(KeyEvent.KEYCODE_SEARCH, true, null, "remote-command")
+                    commManager.sendKey(KeyEvent.KEYCODE_SEARCH, false, null, "remote-command")
                 }
                 else -> {
                     // Some headunits send a raw keycode as an int extra
@@ -99,8 +99,8 @@ class RemoteControlReceiver : BroadcastReceiver() {
                         ?: intent.getIntExtra("key_code", -1).takeIf { it > 0 }
                     if (extraKeyCode != null) {
                         AppLog.i("RemoteControlReceiver: raw keycode=$extraKeyCode from command=$command")
-                        commManager.sendKey(extraKeyCode, true)
-                        commManager.sendKey(extraKeyCode, false)
+                        commManager.sendKey(extraKeyCode, true, null, "remote-command")
+                        commManager.sendKey(extraKeyCode, false, null, "remote-command")
                     } else {
                         AppLog.i("RemoteControlReceiver: Unknown command='$command' from action='$action'")
                     }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/CarKeyReceiver.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/CarKeyReceiver.kt
@@ -135,7 +135,7 @@ class CarKeyReceiver : BroadcastReceiver() {
                 if (isDown) KeyEvent.ACTION_DOWN else KeyEvent.ACTION_UP, keyCode
             ))
         })
-        commManager.sendKey(keyCode, isDown)
+        commManager.sendKey(keyCode, isDown, null, "carkey")
     }
 
     /** Full click (DOWN + UP) — broadcasts both events for learning AND sends to AA. */

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
@@ -5,6 +5,8 @@ import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
 import com.andrerinas.openheadunit.aap.AapSslContext
 import com.andrerinas.openheadunit.aap.AapTransport
+import com.andrerinas.openheadunit.aap.KeyDebouncePolicy
+import com.andrerinas.openheadunit.aap.MediaKeyRoutingPolicy
 import com.andrerinas.openheadunit.aap.PlaybackFocusPolicy
 import com.andrerinas.openheadunit.aap.VideoStarvationPolicy
 import com.andrerinas.openheadunit.utils.AppLog
@@ -117,7 +119,10 @@ class CommManager(
      *  failing child from cancelling the rest. */
     private val _scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    private val lastKeyEvents = mutableMapOf<Int, Long>()
+    /** Cached answer of the Bluetooth media probe used by media-key routing, and when it was taken. */
+    private var btMediaLinkCached: Boolean? = null
+    private var btMediaLinkCheckedAt: Long? = null
+    private val BT_MEDIA_LINK_CACHE_MS = 2_000L
 
     private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected())
 
@@ -446,13 +451,21 @@ class CommManager(
     // send() overloads — fire-and-forget; silently dropped if not TransportStarted
     // -----------------------------------------------------------------------------------------
 
-    private val keyStates = mutableMapOf<Int, Boolean>()
+    private val keyStates = mutableMapOf<Int, KeyDebouncePolicy.KeyState>()
 
     /**
      * Sends a key press or release event to the phone with remapping and de-duplication.
      * This is the single entry point for all key events in the application.
+     *
+     * @param downTime `KeyEvent.getDownTime()` when the caller has a real event. It identifies the
+     *                 physical press, so [KeyDebouncePolicy] can tell one press arriving by several
+     *                 routes from two presses in quick succession. Callers holding only a keycode —
+     *                 the proprietary OEM broadcasts — leave it null and get the time window.
+     * @param source   where this delivery came from, for the log. One press reaching several
+     *                 sources is the normal case on these head units, and naming them is what makes
+     *                 a user's log readable.
      */
-    fun sendKey(keyCode: Int, isPress: Boolean) {
+    fun sendKey(keyCode: Int, isPress: Boolean, downTime: Long? = null, source: String = "unknown") {
         if (_connectionState.value !is ConnectionState.TransportStarted) {
             return
         }
@@ -477,32 +490,66 @@ class CommManager(
             logicalCode = KeyEvent.KEYCODE_DPAD_CENTER
         }
 
-        // 3. State Tracking & De-duplication
-        // Prevent sending the same state twice (e.g. two consecutive DOWNs)
-        val isCurrentlyDown = keyStates[logicalCode] ?: false
-        if (isPress == isCurrentlyDown) {
-            return
-        }
-        keyStates[logicalCode] = isPress
+        val isMedia = isMediaKey(logicalCode)
 
-        // 4. Time-based Debouncing
-        val now = SystemClock.elapsedRealtime()
-        if (isPress) {
-            val lastPressTime = lastKeyEvents[logicalCode] ?: 0L
-
-            // Media keys often trigger multiple redundant intents on China headunits.
-            // Use a longer debounce (600ms) for media actions, 300ms for others.
-            val debounceMs = if (isMediaKey(logicalCode)) 600L else 300L
-
-            if (now - lastPressTime < debounceMs) {
-                AppLog.i("CommManager: Debouncing logical key $logicalCode (DOWN) - dropped duplicate trigger within ${now - lastPressTime}ms")
+        // 3. Routing: a media button the head unit's own Bluetooth side is already acting on must
+        // not be sent again, or one press performs the action twice. See MediaKeyRoutingPolicy.
+        // Only media keys can be held back, so nothing else pays for the Bluetooth probe.
+        if (isMedia) {
+            val routing = settings.mediaKeyRouting
+            if (!MediaKeyRoutingPolicy.shouldForward(routing, true, btMediaLinkForKeys())) {
+                AppLog.v("CommManager: Not sending media key $logicalCode to Android Auto " +
+                        "(routing=$routing, src=$source)")
                 return
             }
-            lastKeyEvents[logicalCode] = now
         }
 
-        AppLog.i("CommManager: TX Key -> AA=$logicalCode (isPress=$isPress)")
+        // 4. De-duplication: one press reaches us from several delivery paths at once.
+        val state = keyStates[logicalCode] ?: KeyDebouncePolicy.KeyState()
+        val decision = KeyDebouncePolicy.decide(
+            state = state,
+            isPress = isPress,
+            downTime = downTime,
+            isMediaKey = isMedia,
+            now = SystemClock.elapsedRealtime()
+        )
+        keyStates[logicalCode] = decision.state
+
+        if (!decision.forward) {
+            AppLog.v("CommManager: Dropping key $logicalCode (isPress=$isPress, src=$source) - ${decision.dropReason}")
+            return
+        }
+
+        if (decision.releaseFirst) {
+            AppLog.i("CommManager: Key $logicalCode was still held from an earlier press with no release - releasing it first")
+            _transport?.send(logicalCode, false)
+        }
+
+        AppLog.i("CommManager: TX Key -> AA=$logicalCode (isPress=$isPress) src=$source")
         _transport?.send(logicalCode, isPress)
+    }
+
+    /**
+     * Whether a Bluetooth media link is up, for [MediaKeyRoutingPolicy]. Null when the adapter would
+     * not say.
+     *
+     * Cached briefly rather than probed per press: `getProfileConnectionState` is a binder call and
+     * this runs on the main thread, from the projection activity's key dispatch. The window is short
+     * enough that toggling media audio on the phone's Bluetooth entry takes effect without
+     * reconnecting, which is how this gets tested.
+     */
+    private fun btMediaLinkForKeys(): Boolean? {
+        val now = SystemClock.elapsedRealtime()
+        // Nullable rather than a zero stamp: a head unit that starts projecting seconds after boot
+        // has an elapsedRealtime small enough to look like a fresh cache entry.
+        btMediaLinkCheckedAt?.let { if (now - it < BT_MEDIA_LINK_CACHE_MS) return btMediaLinkCached }
+        btMediaLinkCheckedAt = now
+        val state = BluetoothHelper.a2dpMediaLinkState(context)
+        if (state != btMediaLinkCached) {
+            AppLog.i("CommManager: Bluetooth media link state for key routing: $state")
+            btMediaLinkCached = state
+        }
+        return state
     }
 
     private fun isMediaKey(code: Int): Boolean {
@@ -548,14 +595,14 @@ class CommManager(
 
         // close
         if (transport.isAssistantActive) {
-            sendKey(KeyEvent.KEYCODE_BACK, true)
-            sendKey(KeyEvent.KEYCODE_BACK, false)
+            sendKey(KeyEvent.KEYCODE_BACK, true, null, "assistant")
+            sendKey(KeyEvent.KEYCODE_BACK, false, null, "assistant")
             loseFocus() // otherwise button stays marked
 
         // open
         } else {
-            sendKey(KeyEvent.KEYCODE_SEARCH, false) // up/down must be reversed
-            sendKey(KeyEvent.KEYCODE_SEARCH, true)
+            sendKey(KeyEvent.KEYCODE_SEARCH, false, null, "assistant") // up/down must be reversed
+            sendKey(KeyEvent.KEYCODE_SEARCH, true, null, "assistant")
         }
     }
 
@@ -660,8 +707,9 @@ class CommManager(
         val connection = _connection
         _transport = null
         _connection = null
-        lastKeyEvents.clear()
         keyStates.clear()
+        btMediaLinkCached = null
+        btMediaLinkCheckedAt = null
         // Counts frames over the whole session rather than reading lastFrameRenderedMs, which the
         // decoder zeroes every time the projection surface goes away — leaving projection before
         // disconnecting is normal, and would otherwise make every such session look starved.

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/carkey/CarKeyReceiver.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/carkey/CarKeyReceiver.kt
@@ -47,7 +47,7 @@ interface CarKeyReceiver {
                 )
             },
         )
-        commManager.sendKey(keyCode, isDown)
+        commManager.sendKey(keyCode, isDown, null, "carkey")
     }
 
     fun handleKey(context: Context, keyCode: Int, isDown: Boolean) {

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -25,6 +25,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.R
 import com.andrerinas.openheadunit.aap.AapService
+import com.andrerinas.openheadunit.aap.MediaKeyRoutingPolicy
 import com.andrerinas.openheadunit.aap.PlaybackFocusPolicy
 import com.andrerinas.openheadunit.main.settings.SettingItem
 import com.andrerinas.openheadunit.main.settings.SettingsAdapter
@@ -120,6 +121,7 @@ class SettingsFragment : Fragment() {
     private var pendingAttachHwDspEqualizer: Boolean? = null
     private var pendingMicInputSource: Int? = null
     private var pendingEnableRotary: Boolean? = null
+    private var pendingMediaKeyRouting: MediaKeyRoutingPolicy.Mode? = null
     private var pendingAudioLatencyMultiplier: Int? = null
     private var pendingUseLibusb: Boolean? = null
     private var pendingAudioQueueCapacity: Int? = null
@@ -243,6 +245,7 @@ class SettingsFragment : Fragment() {
         pendingAttachHwDspEqualizer = settings.attachHwDspEqualizer
         pendingMicInputSource = settings.micInputSource
         pendingEnableRotary = settings.enableRotary
+        pendingMediaKeyRouting = settings.mediaKeyRouting
         pendingAudioLatencyMultiplier = settings.audioLatencyMultiplier
         pendingAudioQueueCapacity = settings.audioQueueCapacity
         pendingShowFpsCounter = settings.showFpsCounter
@@ -353,6 +356,7 @@ class SettingsFragment : Fragment() {
         pendingUseAacAudio = settings.useAacAudio
         pendingAttachHwDspEqualizer = settings.attachHwDspEqualizer
         pendingEnableRotary = settings.enableRotary
+        pendingMediaKeyRouting = settings.mediaKeyRouting
         pendingAudioLatencyMultiplier = settings.audioLatencyMultiplier
         pendingAudioQueueCapacity = settings.audioQueueCapacity
         pendingShowFpsCounter = settings.showFpsCounter
@@ -475,6 +479,7 @@ class SettingsFragment : Fragment() {
         pendingAttachHwDspEqualizer?.let { settings.attachHwDspEqualizer = it }
         pendingMicInputSource?.let { settings.micInputSource = it }
         pendingEnableRotary?.let { settings.enableRotary = it }
+        pendingMediaKeyRouting?.let { settings.mediaKeyRouting = it }
         pendingAudioLatencyMultiplier?.let { settings.audioLatencyMultiplier = it }
         pendingAudioQueueCapacity?.let { settings.audioQueueCapacity = it }
         pendingShowFpsCounter?.let { settings.showFpsCounter = it }
@@ -592,6 +597,7 @@ class SettingsFragment : Fragment() {
                         pendingAttachHwDspEqualizer != settings.attachHwDspEqualizer ||
                         pendingMicInputSource != settings.micInputSource ||
                         pendingEnableRotary != settings.enableRotary ||
+                        pendingMediaKeyRouting != settings.mediaKeyRouting ||
                         pendingAudioLatencyMultiplier != settings.audioLatencyMultiplier ||
                         pendingAudioQueueCapacity != settings.audioQueueCapacity ||
                         pendingShowFpsCounter != settings.showFpsCounter ||
@@ -1523,6 +1529,49 @@ class SettingsFragment : Fragment() {
                 updateSettingsList()
             }
         ))
+
+        // Media buttons only. The rotary controller, D-pad and the rest are never affected by this,
+        // which is the point: the head unit's Bluetooth side competes for the transport controls
+        // and for nothing else.
+        val mediaKeyModes = listOf(
+            MediaKeyRoutingPolicy.Mode.ALWAYS,
+            MediaKeyRoutingPolicy.Mode.AUTO,
+            MediaKeyRoutingPolicy.Mode.NEVER
+        )
+        val currentMediaKeyMode = pendingMediaKeyRouting ?: MediaKeyRoutingPolicy.Mode.ALWAYS
+        items.add(SettingItem.SegmentedButtonSettingEntry(
+            stableId = "mediaKeyRouting",
+            nameResId = R.string.media_key_routing,
+            options = listOf(
+                getString(R.string.media_key_routing_always),
+                getString(R.string.media_key_routing_auto),
+                getString(R.string.media_key_routing_never)
+            ),
+            selectedIndex = mediaKeyModes.indexOf(currentMediaKeyMode).coerceAtLeast(0),
+            onOptionSelected = { index ->
+                pendingMediaKeyRouting = mediaKeyModes.getOrElse(index) { MediaKeyRoutingPolicy.Mode.ALWAYS }
+                checkChanges()
+                updateSettingsList()
+            }
+        ))
+
+        items.add(SettingItem.InfoBanner(
+            stableId = "mediaKeyRoutingHint",
+            textResId = when (currentMediaKeyMode) {
+                MediaKeyRoutingPolicy.Mode.AUTO -> R.string.media_key_routing_auto_hint
+                MediaKeyRoutingPolicy.Mode.NEVER -> R.string.media_key_routing_never_hint
+                else -> R.string.media_key_routing_always_hint
+            }
+        ))
+
+        // Only worth saying once the setting is actually holding something back: the reason to reach
+        // for this is a doubled track skip, and the fear it raises is losing the rotary with it.
+        if (currentMediaKeyMode != MediaKeyRoutingPolicy.Mode.ALWAYS) {
+            items.add(SettingItem.InfoBanner(
+                stableId = "mediaKeyRoutingScopeHint",
+                textResId = R.string.media_key_routing_hint_common
+            ))
+        }
 
         // --- Audio Settings ---
         items.add(SettingItem.CategoryHeader("audio", R.string.category_audio))

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/BluetoothHelper.kt
@@ -157,7 +157,19 @@ object BluetoothHelper {
      * answer as "a link may be up", so this returns true when the state cannot be read — a car
      * radio playing over AA is an annoyance, silence is a broken app.
      */
-    fun isA2dpMediaLinkActive(context: Context): Boolean {
+    fun isA2dpMediaLinkActive(context: Context): Boolean = a2dpMediaLinkState(context) ?: true
+
+    /**
+     * The same probe as [isA2dpMediaLinkActive], but saying so when it does not know: null means no
+     * profile state could be read at all, rather than "no link".
+     *
+     * The two callers want opposite things from that answer. Audio focus treats unknown as a link
+     * being up, because a car radio playing over Android Auto is an annoyance and silence is a
+     * broken app. Media-key routing treats unknown as no link, because a doubled track skip is an
+     * annoyance and buttons that quietly do nothing are a broken app. Neither default is right for
+     * both, so the resolution belongs to the caller.
+     */
+    fun a2dpMediaLinkState(context: Context): Boolean? {
         // The configured adapter only, never getAllBluetoothAdapterHandles(): this is called on the
         // AAP transport thread every time a track starts, and enumerating the system service list
         // by reflection there would stall video alongside audio.
@@ -165,11 +177,11 @@ object BluetoothHelper {
             getBluetoothAdapter(context)
         } catch (e: Exception) {
             AppLog.w("BluetoothHelper: could not resolve an adapter for the A2DP check: ${e.message}")
-            return true
+            return null
         }
         if (adapter == null) return false
-        // An adapter that will not say whether it is on is treated as on, same as an unreadable
-        // profile state below.
+        // An adapter that will not say whether it is on is treated as on, and left to the profile
+        // probe below to decide.
         val enabled = try { adapter.isEnabled } catch (e: Exception) { true }
         if (!enabled) return false
 
@@ -188,8 +200,8 @@ object BluetoothHelper {
             }
         }
         if (!readAnyState) {
-            AppLog.w("BluetoothHelper: the adapter would not report its A2DP state; assuming a media link is up")
-            return true
+            AppLog.w("BluetoothHelper: the adapter would not report its A2DP state")
+            return null
         }
         return false
     }

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -7,6 +7,7 @@ import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.location.Location
 import android.os.Build
+import com.andrerinas.openheadunit.aap.MediaKeyRoutingPolicy
 import com.andrerinas.openheadunit.aap.PlaybackFocusPolicy
 import com.andrerinas.openheadunit.aap.protocol.proto.Control
 import com.andrerinas.openheadunit.app.UsbAttachedActivity
@@ -499,6 +500,16 @@ class Settings(private val context: Context) {
             prefs.getInt("playback-focus-mode", PlaybackFocusPolicy.Mode.AUTO.value)
         )
         set(value) { prefs.edit().putInt("playback-focus-mode", value.value).apply() }
+
+    // Whether the physical media buttons reach Android Auto, or are left to the Bluetooth side that
+    // may already act on the same press — two consumers of one button skip two tracks. See
+    // MediaKeyRoutingPolicy. ALWAYS is the stored zero value so an unset preference keeps the
+    // behaviour every existing install has.
+    var mediaKeyRouting: MediaKeyRoutingPolicy.Mode
+        get() = MediaKeyRoutingPolicy.Mode.fromInt(
+            prefs.getInt("media-key-routing", MediaKeyRoutingPolicy.Mode.ALWAYS.value)
+        )
+        set(value) { prefs.edit().putInt("media-key-routing", value.value).apply() }
 
     var separateAudioStreams: Boolean
         get() = prefs.getBoolean("separate-audio-streams", false)

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/SettingsBackupManager.kt
@@ -104,6 +104,9 @@ object SettingsBackupManager {
         // Enum-backed, but INT is safe: Settings.playbackFocusMode reads it through
         // PlaybackFocusPolicy.Mode.fromInt, which falls back to AUTO for anything out of range.
         "playback-focus-mode" to ValueType.INT,
+        // Same reasoning: read through MediaKeyRoutingPolicy.Mode.fromInt, which falls back to
+        // ALWAYS for anything out of range.
+        "media-key-routing" to ValueType.INT,
         "separate-audio-streams" to ValueType.BOOLEAN,
         "mic-input-source" to ValueType.INT,
         "audio-latency-multiplier" to ValueType.INT,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -446,6 +446,14 @@
     <string name="enable_audio_sink_description">If disabled, the headunit will not receive audio. Sound will play from the phone.</string>
     <string name="static_audio_focus">Static Audio Focus</string>
     <string name="static_audio_focus_description">Force the phone to believe audio focus is always held, preventing audio routing losses on generic headunits. Also performs software ducking during navigation voice prompts.</string>
+    <string name="media_key_routing">Send Media Buttons To Android Auto</string>
+    <string name="media_key_routing_always">Always</string>
+    <string name="media_key_routing_auto">Automatic</string>
+    <string name="media_key_routing_never">Never</string>
+    <string name="media_key_routing_always_hint">Next, previous and play/pause are always sent to Android Auto. Use this unless one press skips two tracks.</string>
+    <string name="media_key_routing_auto_hint">Stops sending them while this headunit has a Bluetooth media connection to the phone, because that connection already performs the action. Choose this if one press skips two tracks and your phone is paired to this headunit.</string>
+    <string name="media_key_routing_never_hint">Never sends them, leaving the buttons to Bluetooth. Choose this if one press skips two tracks and your phone is paired to the car\'s own system rather than to this headunit — Automatic cannot detect that connection.</string>
+    <string name="media_key_routing_hint_common">Only the media buttons are affected. Rotary controllers, D-pad, Back and Enter always reach Android Auto.</string>
     <string name="playback_focus_mode">Pause Other Audio During Playback</string>
     <string name="playback_focus_mode_auto">Automatic</string>
     <string name="playback_focus_mode_always">Always</string>

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/KeyDebouncePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/KeyDebouncePolicyTest.kt
@@ -1,0 +1,177 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.KeyDebouncePolicy.KeyState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KeyDebouncePolicyTest {
+
+    /**
+     * Feeds deliveries through the policy the way CommManager does, and records what would have
+     * reached the phone. A "delivery" is one call to sendKey.
+     */
+    private class Key(private val isMediaKey: Boolean = true) {
+        var state = KeyState()
+        val sent = mutableListOf<Pair<Boolean, Long>>()
+
+        fun deliver(isPress: Boolean, now: Long, downTime: Long? = null) {
+            val result = KeyDebouncePolicy.decide(state, isPress, downTime, isMediaKey, now)
+            state = result.state
+            if (result.releaseFirst) sent.add(false to now)
+            if (result.forward) sent.add(isPress to now)
+        }
+
+        /** The press/release sequence that reached the phone. */
+        fun edges(): List<Boolean> = sent.map { it.first }
+    }
+
+    @Test
+    fun `one press one click`() {
+        val key = Key()
+        key.deliver(isPress = true, now = 0, downTime = 100)
+        key.deliver(isPress = false, now = 60, downTime = 100)
+        assertEquals(listOf(true, false), key.edges())
+    }
+
+    @Test
+    fun `the same key event arriving twice is one click - activity first`() {
+        // The ordering seen in the reporter's logs: the foreground activity gets the raw KeyEvent,
+        // the media button broadcast follows a few milliseconds later.
+        val key = Key()
+        key.deliver(isPress = true, now = 0, downTime = 500)     // activity DOWN
+        key.deliver(isPress = true, now = 4, downTime = 500)     // media session DOWN
+        key.deliver(isPress = false, now = 4, downTime = 500)    // media session UP
+        key.deliver(isPress = false, now = 6, downTime = 500)    // activity UP
+        assertEquals(listOf(true, false), key.edges())
+    }
+
+    @Test
+    fun `the same key event arriving twice is one click - broadcast first`() {
+        // The same press with the two paths swapped. Under the old code this ordering produced a
+        // stray extra release; it must produce the same single click as the other one.
+        val key = Key()
+        key.deliver(isPress = true, now = 0, downTime = 500)     // media session DOWN
+        key.deliver(isPress = false, now = 0, downTime = 500)    // media session UP
+        key.deliver(isPress = true, now = 2, downTime = 500)     // activity DOWN
+        key.deliver(isPress = false, now = 8, downTime = 500)    // activity UP
+        assertEquals(listOf(true, false), key.edges())
+    }
+
+    @Test
+    fun `two deliberate presses inside the old window both get through when they carry identity`() {
+        // 200 ms apart is well inside the 600 ms media window that used to merge them into one.
+        val key = Key()
+        key.deliver(isPress = true, now = 0, downTime = 100)
+        key.deliver(isPress = false, now = 50, downTime = 100)
+        key.deliver(isPress = true, now = 200, downTime = 300)
+        key.deliver(isPress = false, now = 250, downTime = 300)
+        assertEquals(listOf(true, false, true, false), key.edges())
+    }
+
+    @Test
+    fun `a duplicate with no identity is still dropped by the window`() {
+        // The proprietary OEM broadcasts carry no KeyEvent, so elapsed time is all there is.
+        val key = Key()
+        key.deliver(isPress = true, now = 0)
+        key.deliver(isPress = false, now = 20)
+        key.deliver(isPress = true, now = 30)
+        key.deliver(isPress = false, now = 40)
+        assertEquals(listOf(true, false), key.edges())
+    }
+
+    @Test
+    fun `a dropped press drops its release too`() {
+        // The defect this replaces: the old code marked the key down before returning, so the
+        // release of a dropped press was transmitted and Android Auto saw DOWN, UP, UP.
+        val key = Key()
+        key.deliver(isPress = true, now = 0)
+        key.deliver(isPress = false, now = 20)
+        key.deliver(isPress = true, now = 30)     // duplicate press, dropped
+        key.deliver(isPress = false, now = 34)    // its release must go too
+        assertEquals(listOf(true, false), key.edges())
+        assertFalse(key.state.down)
+    }
+
+    @Test
+    fun `a release with no outstanding press is never sent`() {
+        val key = Key()
+        key.deliver(isPress = false, now = 0, downTime = 100)
+        assertTrue(key.edges().isEmpty())
+    }
+
+    @Test
+    fun `a press whose release never arrives does not swallow the next press`() {
+        // A delivery path that sends a press and no release used to latch the key: every later
+        // press matched the held state and was dropped in silence until the next disconnect.
+        val key = Key()
+        key.deliver(isPress = true, now = 0)
+        key.deliver(isPress = true, now = KeyDebouncePolicy.STUCK_PRESS_MS)
+        key.deliver(isPress = false, now = KeyDebouncePolicy.STUCK_PRESS_MS + 50)
+        // The stale press is closed out before the new one, so the phone is never left holding a
+        // key it was told about.
+        assertEquals(listOf(true, false, true, false), key.edges())
+        assertFalse(key.state.down)
+    }
+
+    @Test
+    fun `a genuine press and hold is not broken up`() {
+        val key = Key()
+        key.deliver(isPress = true, now = 0, downTime = 100)
+        // Auto-repeat redeliveries of the same gesture, well past the window.
+        key.deliver(isPress = true, now = 1_000, downTime = 100)
+        key.deliver(isPress = false, now = 1_500, downTime = 100)
+        assertEquals(listOf(true, false), key.edges())
+    }
+
+    @Test
+    fun `identity is ignored when it cannot be trusted`() {
+        // A synthetic KeyEvent built from an action and a keycode alone carries downTime 0. Treating
+        // that as an identity would make every press look like a redelivery of the last one.
+        val key = Key()
+        key.deliver(isPress = true, now = 0, downTime = 0)
+        key.deliver(isPress = false, now = 20, downTime = 0)
+        key.deliver(isPress = true, now = 900, downTime = 0)
+        key.deliver(isPress = false, now = 950, downTime = 0)
+        assertEquals(listOf(true, false, true, false), key.edges())
+    }
+
+    @Test
+    fun `a press with identity following one without falls back to the window`() {
+        // One press reaching us by two routes, only one of which carries a KeyEvent. Identity
+        // cannot prove these are different presses, so the window has to decide.
+        val key = Key()
+        key.deliver(isPress = true, now = 0)                   // no identity
+        key.deliver(isPress = true, now = 5, downTime = 700)   // same press, with identity
+        key.deliver(isPress = false, now = 10, downTime = 700)
+        key.deliver(isPress = false, now = 12)
+        assertEquals(listOf(true, false), key.edges())
+    }
+
+    @Test
+    fun `non-media keys use the shorter window`() {
+        val key = Key(isMediaKey = false)
+        key.deliver(isPress = true, now = 0)
+        key.deliver(isPress = false, now = 20)
+        // 400 ms is inside the media window but outside the 300 ms one, so this is a second press.
+        key.deliver(isPress = true, now = 400)
+        key.deliver(isPress = false, now = 420)
+        assertEquals(listOf(true, false, true, false), key.edges())
+
+        val media = Key(isMediaKey = true)
+        media.deliver(isPress = true, now = 0)
+        media.deliver(isPress = false, now = 20)
+        media.deliver(isPress = true, now = 400)
+        media.deliver(isPress = false, now = 420)
+        assertEquals(listOf(true, false), media.edges())
+    }
+
+    @Test
+    fun `the very first press is never treated as a duplicate`() {
+        // Elapsed-time state starts at zero, and "now" can legitimately be small.
+        val key = Key()
+        key.deliver(isPress = true, now = 5)
+        assertEquals(listOf(true), key.edges())
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/MediaKeyRoutingPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/MediaKeyRoutingPolicyTest.kt
@@ -1,0 +1,58 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.MediaKeyRoutingPolicy.Mode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MediaKeyRoutingPolicyTest {
+
+    private fun forward(mode: Mode, isMediaKey: Boolean = true, bt: Boolean? = null) =
+        MediaKeyRoutingPolicy.shouldForward(mode, isMediaKey, bt)
+
+    @Test
+    fun `everything that is not a media button is always forwarded`() {
+        for (mode in Mode.values()) {
+            for (bt in listOf(true, false, null)) {
+                assertTrue("mode=$mode bt=$bt", forward(mode, isMediaKey = false, bt = bt))
+            }
+        }
+    }
+
+    @Test
+    fun `always forwards whatever bluetooth is doing`() {
+        for (bt in listOf(true, false, null)) {
+            assertTrue("bt=$bt", forward(Mode.ALWAYS, bt = bt))
+        }
+    }
+
+    @Test
+    fun `never suppresses whatever bluetooth is doing`() {
+        for (bt in listOf(true, false, null)) {
+            assertFalse("bt=$bt", forward(Mode.NEVER, bt = bt))
+        }
+    }
+
+    @Test
+    fun `auto suppresses only while a bluetooth media link is up`() {
+        assertFalse(forward(Mode.AUTO, bt = true))
+        assertTrue(forward(Mode.AUTO, bt = false))
+    }
+
+    @Test
+    fun `auto forwards when the bluetooth state cannot be read`() {
+        // The opposite resolution to PlaybackFocusPolicy's unknown case, on purpose: a doubled skip
+        // is an annoyance, media buttons that silently do nothing read as a broken app.
+        assertTrue(forward(Mode.AUTO, bt = null))
+    }
+
+    @Test
+    fun `an unset or damaged preference means always`() {
+        assertEquals(Mode.ALWAYS, Mode.fromInt(0))
+        assertEquals(Mode.ALWAYS, Mode.fromInt(-1))
+        assertEquals(Mode.ALWAYS, Mode.fromInt(99))
+        assertEquals(Mode.AUTO, Mode.fromInt(1))
+        assertEquals(Mode.NEVER, Mode.fromInt(2))
+    }
+}


### PR DESCRIPTION
## What

Settings -> Input -> **Send Media Buttons To Android Auto** (Always / Automatic / Never), plus a rewrite of the key de-duplication in `CommManager.sendKey` as a pure, tested policy object.

Addresses #803, and the steering-wheel double-skip reported by email against a BMW F30.

## Why

One press of Next skipping two tracks is **two consumers acting on one button**, not one key sent twice.

The reporter settled it by toggling "Media audio" for the phone inside a single live projection session, both directions: A2DP on -> two skips, A2DP off -> one. Their logs show exactly one `AA=87` press/release pair per press in *both* states, so the second skip was never ours to debounce. AOSP's `BluetoothMediaBrowserService` publishes a media session whose skip-to-next issues an AVRCP passthrough FORWARD at the source device -- the phone we are projecting -- the same head-unit-as-A2DP-sink topology `d2dff1df` measured for the audio-focus pause loop.

Play/pause never doubles for the same reporter, which corroborates it: passthrough PLAY/PAUSE are state-specific and converge, FORWARD adds up. A fault inside this app would double both.

Nothing arbitrates the two consumers for us: `setConnectionPolicy`/`setActiveDevice` are `BLUETOOTH_PRIVILEGED`, `abortBroadcast()` cannot reach the framework's media-button route (single target, not an ordered fan-out), and taking audio focus to deactivate the sink's session is precisely what `d2dff1df` removed. So the lever is which consumer we leave the key to.

## The setting

| Mode | For |
|---|---|
| **Always** (default, stored `0`) | today's behaviour -- an unset preference is unchanged |
| **Automatic** | phone paired to *this* head unit: suppresses media keys while A2DP is up |
| **Never** | phone paired to the *car's own* system (the BMW case): our adapter sees no link, so Automatic is structurally blind to it |

Non-media keys are never held back in any mode. That is the BMW reporter's actual ask -- keep the iDrive controller, drop the media buttons.

Defaulting to Automatic would silently disable media keys for everyone whose phone is merely paired for calls on a unit whose Bluetooth side never touches these buttons, hence Always as the zero value.

## Also fixed, independent of #803

Three defects in `sendKey`, all reachable on `main` today:

1. `keyStates` was latched **before** the debounce returned, so a dropped press still marked the key down and its release was transmitted -- `DOWN, UP, UP` on the wire, present in the reporter's own logs.
2. A press whose release never arrived latched the key: every later press matched the held state and returned in silence until the next disconnect. This is the shape of the long-standing "steering keys stop working until I restart" reports.
3. Deliveries now dedupe on `KeyEvent.getDownTime()` where the caller has a real event, instead of guessing from elapsed time. Two deliberate presses inside 600 ms used to merge into one; they no longer do. The 600/300 ms windows survive only for the proprietary OEM broadcasts that carry no `KeyEvent`.

`sendKey` also takes a source label and every call site names itself, so a log shows how many *distinct physical presses* there were rather than how many deliveries.

