### PR TITLE
Fix black screen after backgrounding, and the washed-out picture a dropped frame leaves (#822, #830)

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
@@ -94,6 +94,10 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
     private var fpsTextView: TextView? = null
     private var touchOverlayView: OverlayTouchView? = null
     private var currentFps: Int? = null
+
+    // Named rather than inline so onDestroy can tell this instance's listener apart from a
+    // relaunched instance's before clearing it - lambdas have no usable identity across instances.
+    private val fpsListener: (Int) -> Unit = { fps -> currentFps = fps }
     private val performanceHandler = android.os.Handler(android.os.Looper.getMainLooper())
     private val performanceSampler = PerformanceSampler()
     private val performanceExecutor = Executors.newSingleThreadExecutor { runnable ->
@@ -127,6 +131,9 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
                 }
 
                 AppLog.w("Watchdog: No video received yet. Requesting Keyframe (Unsolicited Focus)...")
+                // Shares one throttle clock with the reconnecting watchdog's mid-session
+                // re-request, so the two never double-fire across the overlay transition.
+                lastVideoFocusRequestMs = SystemClock.elapsedRealtime()
                 commManager.send(VideoFocusEvent(gain = true, unsolicited = true))
                 watchdogHandler.postDelayed(this, 1500)
             }
@@ -134,8 +141,12 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
     }
     private val reconnectingWatchdog = object : Runnable {
         override fun run() {
-            // Only run watchdog if we are actually supposed to be connected
-            if (commManager.connectionState.value !is CommManager.ConnectionState.HandshakeComplete) {
+            // Bail without re-posting only when the session is genuinely over; onResume re-arms
+            // on the next entry. The steady state during projection is TransportStarted, and
+            // checking only HandshakeComplete here killed this watchdog on its first tick of
+            // every session - which is why a video stream that died mid-session stayed black
+            // with nothing ever asking for it back.
+            if (!ProjectionWatchdogPolicy.isSessionLive(commManager.connectionState.value)) {
                 return
             }
             val lastFrame = videoDecoder.lastFrameRenderedMs
@@ -155,8 +166,29 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
                 // Decoder producing but display possibly frozen (issue #650).
                 maybeRecoverFromDisplayStall()
             }
+            maybeRequestVideoFocus()
             watchdogHandler.postDelayed(this, 2000)
         }
+    }
+
+    private var lastVideoFocusRequestMs = 0L
+
+    /**
+     * Mid-session recovery: the connection is proven live (the state check above) but no frame
+     * has arrived for long enough that the reconnecting overlay is up, so ask the phone for
+     * video again. Without this, the one unsolicited focus gain sent when a surface appears was
+     * the only request in the whole session - if the stream stopped after that, nothing ever
+     * asked for it back and the screen stayed black until the app was killed.
+     */
+    private fun maybeRequestVideoFocus() {
+        val now = SystemClock.elapsedRealtime()
+        if (!ProjectionWatchdogPolicy.shouldRequestVideoFocus(
+                overlayState == OverlayState.RECONNECTING, now, lastVideoFocusRequestMs
+            )
+        ) return
+        lastVideoFocusRequestMs = now
+        AppLog.w("AapProjectionActivity: connected but no frames - requesting video focus (unsolicited)")
+        commManager.send(VideoFocusEvent(gain = true, unsolicited = true))
     }
     private val exitRunnable = Runnable {
         if (commManager.connectionState.value is CommManager.ConnectionState.Disconnected) {
@@ -243,6 +275,11 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
             AppLog.i("Recreating projection view due to settings change...")
             val container = findViewById<FrameLayout>(R.id.container)
             if (::projectionView.isInitialized) {
+                // Deregister before discarding the view: the GLES backend posts its
+                // onSurfaceDestroyed to the main looper, so a still-registered callback from the
+                // discarded view would land after the replacement's onSurfaceChanged and release
+                // video focus for the new view's running stream.
+                projectionView.removeCallback(this)
                 videoDecoder.softwareYuvFrameSink = null
                 videoDecoder.stop(DecoderStopPolicy.REASON_PROJECTION_VIEW_RECREATE)
                 container.removeView(projectionView as View)
@@ -1315,10 +1352,20 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
     }
 
     override fun onSurfaceDestroyed(surface: android.view.Surface) {
+        // A relaunched instance may already own the decoder: on a singleTask relaunch the old
+        // instance's surface teardown is framework-ordered after its onDestroy, and for the GLES
+        // backend one main-looper post later still, so it lands after the new instance's
+        // setSurface. Acting on it then would release video focus for a stream the new instance
+        // is rendering and stop a decoder that was just rebuilt. All surface ownership changes
+        // happen on the main thread, so this read cannot race the send below.
+        if (!videoDecoder.isCurrentSurface(surface)) {
+            AppLog.i("SurfaceCallback: onSurfaceDestroyed for a stale surface - ignoring. Surface: $surface")
+            return
+        }
         AppLog.i("SurfaceCallback: onSurfaceDestroyed. Surface: $surface")
         isSurfaceSet = false
         commManager.send(VideoFocusEvent(gain = false, unsolicited = false))
-        videoDecoder.stop(DecoderStopPolicy.REASON_SURFACE_DESTROYED)
+        videoDecoder.stopIfCurrentSurface(surface, DecoderStopPolicy.REASON_SURFACE_DESTROYED)
     }
 
 
@@ -1506,9 +1553,17 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         performanceExecutor.shutdownNow()
         AppLog.i("AapProjectionActivity.onDestroy called. isFinishing=$isFinishing")
         App.isPiPActive = false
-        videoDecoder.onFpsChanged = null
-        videoDecoder.softwareYuvFrameSink = null
-        videoDecoder.dimensionsListener = null
+        // On a singleTask relaunch the new instance's onCreate runs before this old instance's
+        // onDestroy, so it has already registered its own view callback and decoder listeners.
+        // Deregister only what still belongs to this instance, or the teardown of the old
+        // instance strips the live one: its view callback stays armed to fire a stale
+        // surface-destroy, and its listeners get nulled out from under it.
+        if (::projectionView.isInitialized) projectionView.removeCallback(this)
+        if (videoDecoder.onFpsChanged === fpsListener) videoDecoder.onFpsChanged = null
+        (if (::projectionView.isInitialized) projectionView as? SoftwareYuvFrameSink else null)?.let {
+            if (videoDecoder.softwareYuvFrameSink === it) videoDecoder.softwareYuvFrameSink = null
+        }
+        if (videoDecoder.dimensionsListener === this) videoDecoder.dimensionsListener = null
     }
 
     companion object {
@@ -1625,9 +1680,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         }
         container.addView(fpsTextView, params)
 
-        videoDecoder.onFpsChanged = { fps ->
-            currentFps = fps
-        }
+        videoDecoder.onFpsChanged = fpsListener
         startPerformanceOverlayUpdates()
     }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
@@ -154,6 +154,10 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
                 // First frame hasn't arrived yet — handled by the starting overlay. If the phone is
                 // streaming video but nothing draws, offer to switch renderer (issue #767).
                 maybeOfferRendererConfirm()
+                // A relaunch lands here too, and used to get nothing else: the overlay is already
+                // hidden (the previous instance had rendered), so its keyframe watchdog never
+                // re-arms, and maybeRequestVideoFocus below is never reached.
+                maybeRecoverWarmRelaunch()
                 watchdogHandler.postDelayed(this, 2000)
                 return
             }
@@ -172,6 +176,96 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
     }
 
     private var lastVideoFocusRequestMs = 0L
+
+    // Age and escalation state of the surface the decoder currently renders to. Reset together in
+    // onSurfaceChanged, so each relaunch gets exactly one focus cycle.
+    private var lastSurfaceSetMs = 0L
+    private var warmRelaunchCycleSpent = false
+
+    /**
+     * A relaunch handed the decoder a fresh surface and no picture has followed it.
+     *
+     * The phone is the bottleneck here, not the rebuild: measured across ten TextureView/GLES
+     * returns, the relaunch took 384-507 ms and codec creation 49-308 ms, while waiting for a
+     * decodable picture afterwards took 6.3-115.9 s - 97-99% of the whole return. On the SurfaceView
+     * backend, whose teardown releases video focus and so makes the phone re-run sink setup, the
+     * same wait was 42-96 ms.
+     *
+     * Repeating the unsolicited gain does not close that gap; dozens go out per slow return and none
+     * is ever followed by a picture. [WarmRelaunchKeyframePolicy] decides when to escalate to the
+     * release/regain cycle instead, and why each gate is there.
+     */
+    private fun maybeRecoverWarmRelaunch() {
+        if (lastSurfaceSetMs == 0L) return
+        val now = SystemClock.elapsedRealtime()
+        val action = WarmRelaunchKeyframePolicy.decide(
+            sessionHasRendered = videoDecoder.hasRenderedThisSession,
+            renderedSinceSurfaceSet = videoDecoder.lastFrameRenderedMs != 0L,
+            transportStarted = commManager.connectionState.value is CommManager.ConnectionState.TransportStarted,
+            msSinceSurfaceSet = now - lastSurfaceSetMs,
+            msSincePhoneBytes = now - videoDecoder.lastInputBytesReceivedMs,
+            phoneAliveThresholdMs = phoneAliveThresholdMs,
+            cycleAlreadySpent = warmRelaunchCycleSpent,
+            msSinceLastRequest = now - lastVideoFocusRequestMs
+        )
+        when (action) {
+            WarmRelaunchKeyframePolicy.Action.NONE -> return
+            WarmRelaunchKeyframePolicy.Action.NUDGE -> {
+                lastVideoFocusRequestMs = now
+                AppLog.w("AapProjectionActivity: relaunched surface still has no picture - requesting video focus (unsolicited)")
+                commManager.send(VideoFocusEvent(gain = true, unsolicited = true))
+            }
+            WarmRelaunchKeyframePolicy.Action.CYCLE_FOCUS -> {
+                warmRelaunchCycleSpent = true
+                lastVideoFocusRequestMs = now
+                AppLog.w("AapProjectionActivity: relaunched surface has no picture after ${now - lastSurfaceSetMs}ms - cycling video focus")
+                commManager.releaseVideoFocusForKeyframe()
+                focusCycleGainPending = true
+                watchdogHandler.removeCallbacks(focusCycleGainRunnable)
+                watchdogHandler.postDelayed(
+                    focusCycleGainRunnable,
+                    WarmRelaunchKeyframePolicy.FOCUS_CYCLE_GAP_MS
+                )
+            }
+        }
+    }
+
+    /**
+     * Runs the escalation check one window after a surface is claimed, instead of waiting for the
+     * reconnecting watchdog to reach it.
+     *
+     * That watchdog is the backstop, not the trigger: it first ticks 5 s after onResume and every
+     * 2 s after that, so leaving the escalation to it would put a floor under the recovery well
+     * above the window the policy actually specifies. Driving it from the surface keeps the cost at
+     * the window itself.
+     */
+    private val warmRelaunchCheckRunnable = Runnable { maybeRecoverWarmRelaunch() }
+
+    private var focusCycleGainPending = false
+
+    /**
+     * Second half of the focus cycle - see [WarmRelaunchKeyframePolicy.FOCUS_CYCLE_GAP_MS] for why
+     * it is not sent with the release.
+     */
+    private val focusCycleGainRunnable = Runnable {
+        focusCycleGainPending = false
+        AppLog.w("AapProjectionActivity: retaking video focus to complete the keyframe cycle")
+        commManager.send(VideoFocusEvent(gain = true, unsolicited = true))
+    }
+
+    /**
+     * Completes a focus cycle early rather than dropping it.
+     *
+     * The release and the gain are one operation split across a delay, so anything that cancels the
+     * pending half has to send it instead of forgetting it. Left released, the phone stops the video
+     * sink and nothing ever asks for it back - a permanent black screen with audio still playing,
+     * which is a worse outcome than the slow return the cycle exists to fix.
+     */
+    private fun settleFocusCycle() {
+        if (!focusCycleGainPending) return
+        watchdogHandler.removeCallbacks(focusCycleGainRunnable)
+        focusCycleGainRunnable.run()
+    }
 
     /**
      * Mid-session recovery: the connection is proven live (the state check above) but no frame
@@ -724,6 +818,9 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         // Clear any activity-local fullscreen override when leaving the Activity so
         // the stored settings remain authoritative on next resume.
         activityFullscreenOverride = null
+        // Before the handler is cleared below, and never after it.
+        settleFocusCycle()
+        watchdogHandler.removeCallbacks(warmRelaunchCheckRunnable)
         watchdogHandler.removeCallbacks(watchdogRunnable)
         watchdogHandler.removeCallbacks(videoWatchdogRunnable)
         watchdogHandler.removeCallbacks(reconnectingWatchdog)
@@ -1285,6 +1382,15 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         isSurfaceSet = true
 
         videoDecoder.setSurface(surface)
+        // A surface arriving inside a cycle's own gap must not strand the pending gain.
+        settleFocusCycle()
+        lastSurfaceSetMs = SystemClock.elapsedRealtime()
+        warmRelaunchCycleSpent = false
+        watchdogHandler.removeCallbacks(warmRelaunchCheckRunnable)
+        watchdogHandler.postDelayed(
+            warmRelaunchCheckRunnable,
+            WarmRelaunchKeyframePolicy.ESCALATE_AFTER_SURFACE_MS
+        )
 
         // --- Surface Mismatch Detection ---
         // Compare actual surface dimensions with what HeadUnitScreenConfig negotiated.

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
@@ -17,6 +17,7 @@ import com.andrerinas.openheadunit.aap.protocol.messages.MediaAck
 import com.andrerinas.openheadunit.aap.protocol.messages.Messages
 import com.andrerinas.openheadunit.aap.protocol.messages.ScrollWheelEvent
 import com.andrerinas.openheadunit.aap.protocol.messages.SensorEvent
+import com.andrerinas.openheadunit.aap.protocol.messages.VideoFocusEvent
 import com.andrerinas.openheadunit.utils.LegacyOptimizer
 import com.andrerinas.openheadunit.connection.AccessoryConnection
 import com.andrerinas.openheadunit.connection.SocketAccessoryConnection
@@ -128,26 +129,155 @@ class AapTransport(
     val isAlive: Boolean
         get() = pollThread?.isAlive ?: false
 
-    private fun triggerFocusCycleRecovery() {
-        // Ask the phone for a fresh keyframe with an unsolicited focus GAIN only, the same nudge the
-        // startup keyframe watchdog uses. We deliberately do not release focus (gain=false) first:
-        // on some head unit / phone combos, releasing video focus drops the stream to a few fps and
-        // it never recovers, so a single transient dropped frame turned into a permanent freeze
-        // (issue #755). A gain-only request still makes the phone resend a keyframe without
-        // disturbing the running stream.
+    // Escalation state for KeyframeCycleEscalationPolicy - see triggerFocusCycleRecovery().
+    // unrepairedSinceMs is when the picture was last known good: set by a shed reference frame,
+    // cleared when a keyframe reaches the codec. Zero means nothing is broken.
+    private var unrepairedSinceMs = 0L
+    private var focusCyclesUsedThisSession = 0
+    private var lastFocusCycleMs = 0L
+
+    /** Second half of an escalated focus cycle - see [WarmRelaunchKeyframePolicy.FOCUS_CYCLE_GAP_MS]. */
+    private val focusCycleGainRunnable = Runnable {
+        AppLog.w("AapTransport: retaking video focus to complete the keyframe cycle")
+        send(VideoFocusEvent(gain = true, unsolicited = true))
+    }
+
+    /**
+     * Armed by the first shed frame of an unrepaired stretch, cancelled by the keyframe that repairs
+     * it. This is what makes the escalation reachable at all: recovery requests are throttled to one
+     * a second, so a single dropped frame produces exactly one call into
+     * [triggerFocusCycleRecovery] - anything that escalated on a *count* of calls could never fire
+     * for the one-lost-frame case the fix exists for.
+     */
+    private val unrepairedCheckRunnable = Runnable { escalateIfStillUnrepaired() }
+
+    /**
+     * Asks the phone for a fresh keyframe with a gain-only nudge, and starts the clock that decides
+     * whether the nudge was enough.
+     *
+     * The nudge is measured inert across three hardware rounds - see [KeyframeCycleEscalationPolicy]
+     * for the numbers - but it costs one message, does not disturb the running stream the way a
+     * release can, and has only ever been tested against one phone. It stays the first response.
+     *
+     * @param escalatable whether this caller's stream is live enough to earn a focus release if the
+     *   nudge goes unanswered. Only the dropped-frame path passes true: it is already gated on the
+     *   decoder having rendered, so the picture provably exists. A decoder error fires while the
+     *   codec is being rebuilt, which is [WarmRelaunchKeyframePolicy]'s window, and pointing a second
+     *   decider at the same lever there is how two escalations end up racing. Frame corruption on a
+     *   live stream would qualify on merit, but [AapVideo] has no rendered-frame signal to gate on.
+     */
+    @Synchronized
+    private fun triggerFocusCycleRecovery(escalatable: Boolean) {
         AppLog.w("AapTransport: Requesting recovery keyframe (unsolicited focus gain).")
-        send(com.andrerinas.openheadunit.aap.protocol.messages.VideoFocusEvent(gain = true, unsolicited = true))
+        send(VideoFocusEvent(gain = true, unsolicited = true))
+
+        if (!escalatable || unrepairedSinceMs != 0L) return
+        // Stamped only once the check is actually armed. Setting it without a handler to run the
+        // check on would latch the clock with nothing able to clear it but a keyframe, and every
+        // later drop would return early on it - the stuck-latch failure this design exists to avoid.
+        val handler = sendHandler ?: return
+        unrepairedSinceMs = SystemClock.elapsedRealtime()
+        handler.removeCallbacks(unrepairedCheckRunnable)
+        handler.postDelayed(
+            unrepairedCheckRunnable,
+            KeyframeCycleEscalationPolicy.ESCALATE_AFTER_UNREPAIRED_MS
+        )
+    }
+
+    /**
+     * The picture has been broken for [KeyframeCycleEscalationPolicy.ESCALATE_AFTER_UNREPAIRED_MS]
+     * and no keyframe has arrived to repair it. Spend a cycle if the budget allows.
+     */
+    @Synchronized
+    private fun escalateIfStillUnrepaired() {
+        val since = unrepairedSinceMs
+        if (since == 0L) return
+
+        val now = SystemClock.elapsedRealtime()
+        val spent = "$focusCyclesUsedThisSession/${KeyframeCycleEscalationPolicy.MAX_CYCLES_PER_SESSION}"
+
+        when (KeyframeCycleEscalationPolicy.decide(now, since, focusCyclesUsedThisSession, lastFocusCycleMs)) {
+            KeyframeCycleEscalationPolicy.Action.NUDGE -> AppLog.w(
+                "AapTransport: picture unrepaired for ${now - since}ms, no cycle available now " +
+                    "($spent spent) - waiting for the phone's own keyframe"
+            )
+
+            KeyframeCycleEscalationPolicy.Action.CYCLE_FOCUS -> {
+                focusCyclesUsedThisSession++
+                lastFocusCycleMs = now
+                AppLog.w(
+                    "AapTransport: picture unrepaired for ${now - since}ms - cycling video focus " +
+                        "($focusCyclesUsedThisSession/${KeyframeCycleEscalationPolicy.MAX_CYCLES_PER_SESSION})"
+                )
+                ignoreNextStopRequest = true
+                send(VideoFocusEvent(gain = false, unsolicited = false))
+                // One shared regain runnable, replaced rather than tracked per cycle. Sound because
+                // CYCLE_COOLDOWN_MS keeps two cycles sixty seconds apart against a 400ms regain gap,
+                // so two can never be in flight together - see that constant before shortening it.
+                sendHandler?.removeCallbacks(focusCycleGainRunnable)
+                sendHandler?.postDelayed(focusCycleGainRunnable, WarmRelaunchKeyframePolicy.FOCUS_CYCLE_GAP_MS)
+            }
+        }
+
+        // Look again after the cooldown while the picture is still broken and the budget still has
+        // something in it. Without this, a cycle the cooldown refused - or one that fired and did not
+        // work - would be the end of it for the session, because a drop arriving while the clock is
+        // already running deliberately does not re-arm anything. Once the budget is gone nothing is
+        // re-armed and the line above has said so.
+        if (focusCyclesUsedThisSession < KeyframeCycleEscalationPolicy.MAX_CYCLES_PER_SESSION) {
+            sendHandler?.removeCallbacks(unrepairedCheckRunnable)
+            sendHandler?.postDelayed(unrepairedCheckRunnable, KeyframeCycleEscalationPolicy.CYCLE_COOLDOWN_MS)
+        }
+    }
+
+    /**
+     * A keyframe reached the codec, so whatever was broken is repaired. Stops the clock and disarms
+     * the escalation.
+     *
+     * Runs on the decoder's feed thread. Everything it touches is this object's own state and it
+     * never waits on the decoder, which is what keeps it clear of [VideoDecoder.stop] - that holds
+     * the decoder's monitor while joining the very thread this runs on.
+     */
+    @Synchronized
+    private fun onKeyframeRepairedPicture() {
+        if (unrepairedSinceMs == 0L) return
+        unrepairedSinceMs = 0L
+        sendHandler?.removeCallbacks(unrepairedCheckRunnable)
+    }
+
+    /**
+     * Drops the escalation clock without treating the picture as repaired.
+     *
+     * Called when the decoder is being rebuilt. Whatever was corrupt belongs to a codec that no
+     * longer exists, and the window that follows is [WarmRelaunchKeyframePolicy]'s - if the clock
+     * were left running it could spend a cycle in the middle of that policy's own escalation, which
+     * is two deciders reaching for the same lever. The next shed frame after the new codec renders
+     * starts a fresh clock.
+     */
+    @Synchronized
+    private fun abandonUnrepairedClock() {
+        unrepairedSinceMs = 0L
+        sendHandler?.removeCallbacks(unrepairedCheckRunnable)
     }
 
     init {
         micRecorder.listener = this
         aapAudio = AapAudio(audioDecoder, audioManager, settings, context)
         aapVideo = AapVideo(videoDecoder, settings) {
-            triggerFocusCycleRecovery()
+            triggerFocusCycleRecovery(escalatable = false)
         }
 
         videoDecoder.onDecoderError = {
-            triggerFocusCycleRecovery()
+            abandonUnrepairedClock()
+            triggerFocusCycleRecovery(escalatable = false)
+        }
+
+        videoDecoder.onFrameDropped = {
+            triggerFocusCycleRecovery(escalatable = true)
+        }
+
+        videoDecoder.onKeyframeObserved = {
+            onKeyframeRepairedPicture()
         }
     }
 
@@ -192,12 +322,16 @@ class AapTransport(
         cb.invoke(clean)
         micRecorder.stop()
         micRecorder.listener = null
+        sendHandler?.removeCallbacks(focusCycleGainRunnable)
+        sendHandler?.removeCallbacks(unrepairedCheckRunnable)
         pollThread?.quit()
         sendThread?.quit()
         aapAudio.releaseAllFocus()
         aapVideo.release()
 
         videoDecoder.onDecoderError = null
+        videoDecoder.onFrameDropped = null
+        videoDecoder.onKeyframeObserved = null
 
         try {            // Don't join the poll thread from within itself — it would block for the full
             // timeout since the thread can't finish while it's waiting for itself to finish.

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicy.kt
@@ -1,0 +1,136 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Decides when a dropped reference frame has gone unrepaired long enough to earn a real focus
+ * release/regain cycle instead of the gain-only nudge [AapTransport] normally sends.
+ *
+ * ### Why the nudge is not enough
+ *
+ * The gain-only unsolicited [com.andrerinas.openheadunit.aap.protocol.messages.VideoFocusEvent] is
+ * measured inert, three times over. Dropped-frame-keyframe rounds 1 and 2 fired it 419 times under
+ * sustained drops and the keyframes that followed arrived on the phone's own cadence, not sooner;
+ * round 4 reproduced that on a clean stream. In every round the median wait came out at half the
+ * natural keyframe interval, which is the wait a *random* observer of a periodic process gets - the
+ * arithmetic of no causal link. It is kept as the first response because it costs one message and
+ * one phone is not the fleet, not because it is expected to work.
+ *
+ * Round 4 also ruled out every cheaper alternative in the protocol. AAP has no keyframe-request
+ * message at all; an `UpdateUiConfigRequest` is acknowledged by the phone and changes nothing about
+ * the video (16 of 16); and `VIDEO_FOCUS_NATIVE_TRANSIENT`, which should in principle let the phone
+ * hold its session, produced a full sink stop and a new session on all five attempts - it costs
+ * exactly what a `VIDEO_FOCUS_NATIVE` release costs. **The release/regain cycle is the only lever
+ * that exists**, and it produces a keyframe 0.52-0.78s after the release.
+ *
+ * ### Why the trigger is "unrepaired" rather than "sustained"
+ *
+ * The first version of this policy escalated after a drop *episode* had run unbroken for 150s. That
+ * can never fire for the fault it was written for: the phone emits keyframes on a fixed ~69s GOP
+ * (round 4: eight gaps, median 69.4s, spread under 2s), so a single shed reference frame leaves the
+ * picture washed for an average of ~35s and then heals on its own. That is one drop, not 150s of
+ * them - an episode of length zero.
+ *
+ * So the clock here measures how long the picture has been *unrepaired*: it starts at the first drop
+ * and stops when a keyframe reaches the codec ([VideoKeyframeScanner]). Escalating after
+ * [ESCALATE_AFTER_UNREPAIRED_MS] trades ~2.5s of corruption for the ~35s average of waiting the GOP
+ * out.
+ *
+ * ### Why the gates are still reluctant
+ *
+ * Releasing focus across a healthy, rendering stream is the precondition of issue #755, where one
+ * dropped frame turned into a permanent few-fps freeze on some head unit / phone combinations. That
+ * has not reappeared - round 3 measured one cycle clean, and round 4 put seven real sink-stop/start
+ * cycles through this rig in under five minutes with fps recovering every time and the codec
+ * component never re-initialised - but that is one rig and one phone. Hence a budget rather than a
+ * free hand: [MAX_CYCLES_PER_SESSION] in total, no two closer together than [CYCLE_COOLDOWN_MS].
+ *
+ * Deliberately blind to everything except its own timeline and the keyframe signal. An earlier
+ * attempt (commit 66e59b2c) latched on a `waitingForKeyframe` flag that gated the *feed*, and could
+ * stick for a whole session with no timeout. Nothing here can stick: the clock clears on a keyframe,
+ * the budget is a hard ceiling, and frames keep flowing regardless of what this decides.
+ */
+object KeyframeCycleEscalationPolicy {
+
+    /**
+     * Fastest isolated keyframe gap ever measured, in milliseconds.
+     *
+     * Nothing reads this at runtime; it is here because it is the number
+     * [ESCALATE_AFTER_UNREPAIRED_MS] is chosen against, and a test holds the two in the ratio the
+     * choice assumed. It bounds how quickly the phone has ever been seen to repair a stream unaided,
+     * and it comes from rounds 1 and 2's forced-software-decoding path rather than a healthy one -
+     * continuous drops pull the cadence around, which is why it sits so far below the ~69s the clean
+     * path runs at.
+     */
+    const val NATURAL_CADENCE_MIN_OBSERVED_MS = 7_467L
+
+    /**
+     * How long the picture must stay unrepaired before the cycle is spent on it.
+     *
+     * Bounded from both sides by measurement. Below, it must clear two throttle windows so at least
+     * one nudge has demonstrably gone unanswered before anything more expensive happens - see
+     * [VideoRecoveryPolicy.KEYFRAME_REQUEST_THROTTLE_MS]. Above, it must stay well under
+     * [NATURAL_CADENCE_MIN_OBSERVED_MS]: past a third of the fastest unaided repair ever measured,
+     * the phone's own cadence would often beat the escalation and the disturbance buys nothing.
+     *
+     * Widening it is cheap and safe; narrowing it means firing a focus release closer to every
+     * transient drop, which is what the #755 gates exist to avoid.
+     */
+    const val ESCALATE_AFTER_UNREPAIRED_MS = 2_000L
+
+    /**
+     * Minimum spacing between two focus cycles in one session.
+     *
+     * This is the decay on the budget: the picture has to have been healthy for a stretch before
+     * another cycle is earned, so a stream that is failing continuously cannot spend the whole
+     * allowance inside one bad minute.
+     *
+     * It also carries a second job. The regain half of a cycle is a single shared runnable on the
+     * send handler, replaced rather than tracked per cycle, which is only sound if two cycles can
+     * never be in flight together. At sixty seconds against
+     * [WarmRelaunchKeyframePolicy.FOCUS_CYCLE_GAP_MS]'s 400ms that is not close, and a test pins the
+     * ratio. Shortening this without giving each release its own pending
+     * regain would let a second release silently strand the first one's.
+     */
+    const val CYCLE_COOLDOWN_MS = 60_000L
+
+    /**
+     * Hard cap on focus cycles per session, ever.
+     *
+     * Was 1, chosen when the only evidence was round 3's single forced cycle. Round 4 put seven real
+     * sink-stop/start cycles through this rig in under five minutes - more disruption in less time,
+     * on the same mechanism - with fps recovering every time, `dropped=0` throughout, and the decoder
+     * component never re-initialised. Three, with [CYCLE_COOLDOWN_MS] between them, stays well inside
+     * what has been measured while covering a drive that hits more than one bad patch.
+     *
+     * Still a cap rather than a free hand: this releases focus across a stream that *is* rendering,
+     * the exact precondition of #755, and seven clean cycles on one rig with one phone is evidence,
+     * not proof.
+     */
+    const val MAX_CYCLES_PER_SESSION = 3
+
+    enum class Action {
+        /** Send the unsolicited focus gain, the existing behaviour. */
+        NUDGE,
+
+        /** Release video focus and take it back, so the phone rebuilds the stream. */
+        CYCLE_FOCUS,
+    }
+
+    /**
+     * @param unrepairedSinceMs when the picture was last known good - the first drop with no keyframe
+     *   since. Zero means nothing is broken, and nothing is escalated.
+     * @param cyclesUsedThisSession how many [Action.CYCLE_FOCUS] escalations this session has spent.
+     * @param lastCycleMs when the last one fired, or zero if none has.
+     */
+    fun decide(
+        nowMs: Long,
+        unrepairedSinceMs: Long,
+        cyclesUsedThisSession: Int,
+        lastCycleMs: Long,
+    ): Action {
+        if (unrepairedSinceMs == 0L) return Action.NUDGE
+        if (nowMs - unrepairedSinceMs < ESCALATE_AFTER_UNREPAIRED_MS) return Action.NUDGE
+        if (cyclesUsedThisSession >= MAX_CYCLES_PER_SESSION) return Action.NUDGE
+        if (lastCycleMs != 0L && nowMs - lastCycleMs < CYCLE_COOLDOWN_MS) return Action.NUDGE
+        return Action.CYCLE_FOCUS
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/ProjectionWatchdogPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/ProjectionWatchdogPolicy.kt
@@ -1,0 +1,39 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.connection.CommManager
+
+/**
+ * Decides when the projection activity's recovery watchdog keeps running and when a black
+ * mid-session picture warrants asking the phone for video again.
+ *
+ * Extracted because the previous inline check cost the watchdog its life on the first tick of
+ * every session: it accepted only [CommManager.ConnectionState.HandshakeComplete], but that state
+ * is a brief window before video starts - the steady state for the whole drive is
+ * [CommManager.ConnectionState.TransportStarted] - and the runnable returned without re-posting
+ * itself. Everything hanging off it (the reconnecting overlay, display-stall recovery, the
+ * renderer-confirm offer) was unreachable in a normal session, so a video stream that died
+ * mid-session stayed black with nothing ever asking for it back.
+ */
+object ProjectionWatchdogPolicy {
+
+    /**
+     * True while the projection session is live: [CommManager.ConnectionState.HandshakeComplete]
+     * is the brief window before video starts, [CommManager.ConnectionState.TransportStarted] the
+     * steady state after. The watchdog must keep ticking through both.
+     */
+    fun isSessionLive(state: CommManager.ConnectionState): Boolean =
+        state is CommManager.ConnectionState.HandshakeComplete ||
+            state is CommManager.ConnectionState.TransportStarted
+
+    /**
+     * Whether a black mid-session picture warrants asking the phone for video focus again.
+     * Gated on the reconnecting overlay being up, which the watchdog only shows after a 10s
+     * frame gap on a live connection, and paced by [VideoRecoveryPolicy] so a stuck session
+     * asks about once per throttle window rather than on every tick.
+     */
+    fun shouldRequestVideoFocus(
+        reconnectingOverlayShown: Boolean,
+        nowMs: Long,
+        lastRequestMs: Long
+    ): Boolean = reconnectingOverlayShown && VideoRecoveryPolicy.canRequestKeyframe(nowMs, lastRequestMs)
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/VideoKeyframeScanner.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/VideoKeyframeScanner.kt
@@ -1,0 +1,90 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Answers one question about an access unit: does it carry a keyframe the decoder can start from?
+ *
+ * Recovery from a shed reference frame is only over when a keyframe actually reaches the codec, and
+ * nothing else in the app can tell. Frame size is the closest thing - the hardware rounds identified
+ * keyframes as assembled frames above a threshold - and it does not hold up: round 4 measured a
+ * healthy stream whose true keyframes were 67-78KB against a 1.5KB median, with a scatter of 5-18KB
+ * single-message frames in between that no threshold separates. Only the fragmentation pattern told
+ * those apart, and only because that capture happened to have one. Reading the NAL type is exact.
+ *
+ * Round 4 checked this against the size method over an undisturbed session and the two agreed on all
+ * three keyframes: same count, within 21ms on timing, within 10 bytes on size.
+ *
+ * ### Why this is safe when the last attempt was not
+ *
+ * Commit 66e59b2c removed a `waitingForKeyframe` latch that read NAL headers and held **every
+ * subsequent P-frame back** until it was satisfied. It read them against the user's codec
+ * *preference* rather than the type the decoder actually pinned, so on a mismatched stream it never
+ * saw its keyframe, latched for the session and froze the picture with the connection healthy.
+ *
+ * Two things differ here. The caller passes the pinned type, not a preference. And nothing gates on
+ * the answer: this only ever decides whether to stop *asking* for a keyframe, so a missed one costs
+ * one extra request and a false positive costs one request not sent. Neither can stick, and frames
+ * keep flowing either way.
+ */
+object VideoKeyframeScanner {
+
+    /** H.264: coded slice of an IDR picture. */
+    private const val AVC_NAL_IDR = 5
+
+    /** H.265 IRAP range - BLA_W_LP (16) through CRA_NUT (21). Any of them is a decoder entry point. */
+    private val HEVC_IRAP_RANGE = 16..21
+
+    /**
+     * How many NAL headers to look at before giving up.
+     *
+     * A keyframe access unit leads with its parameter sets - SPS/PPS then the IDR slice on H.264,
+     * VPS/SPS/PPS then the slice on H.265 - so the interesting NAL is never deep. Bounding the walk
+     * keeps this off the profile on a path that runs per frame at 60fps.
+     */
+    private const val MAX_NAL_HEADERS_SCANNED = 8
+
+    /**
+     * Whether the access unit in [data] between [offset] and [offset] + [size] contains a keyframe.
+     *
+     * @param isHevc the codec the decoder has **pinned** for this session, never a user preference.
+     */
+    fun containsKeyframe(data: ByteArray, offset: Int, size: Int, isHevc: Boolean): Boolean {
+        if (size < 4) return false
+        val end = (offset + size).coerceAtMost(data.size)
+        var i = offset
+        var headersSeen = 0
+
+        while (i + 3 < end && headersSeen < MAX_NAL_HEADERS_SCANNED) {
+            val headerPos = startCodeHeaderPos(data, i, end)
+            if (headerPos < 0) {
+                i++
+                continue
+            }
+            headersSeen++
+            val b = data[headerPos].toInt()
+            val isKeyframe = if (isHevc) {
+                ((b and 0x7E) shr 1) in HEVC_IRAP_RANGE
+            } else {
+                (b and 0x1F) == AVC_NAL_IDR
+            }
+            if (isKeyframe) return true
+            i = headerPos + 1
+        }
+        return false
+    }
+
+    /**
+     * Position of the NAL header byte if a 3- or 4-byte start code begins at [i], else -1.
+     *
+     * Same shape as VideoDecoder.isCodecConfigData's walk, kept separate because that one answers a
+     * different question about the first NAL only.
+     */
+    private fun startCodeHeaderPos(data: ByteArray, i: Int, end: Int): Int {
+        if (data[i].toInt() != 0 || data[i + 1].toInt() != 0) return -1
+        val headerPos = when {
+            data[i + 2].toInt() == 1 -> i + 3
+            data[i + 2].toInt() == 0 && i + 3 < end && data[i + 3].toInt() == 1 -> i + 4
+            else -> return -1
+        }
+        return if (headerPos < end) headerPos else -1
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/VideoRecoveryPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/VideoRecoveryPolicy.kt
@@ -4,9 +4,11 @@ package com.andrerinas.openheadunit.aap
  * Pacing rule for [AapVideo]'s stream recovery.
  *
  * Recovering from a corrupt frame means asking the phone for a fresh keyframe, which
- * [AapTransport] implements as a video-focus loss/regain cycle. That is expensive and briefly
- * visible on screen, and the phone reacts to it by rebuilding the stream, so a burst of requests
- * costs far more picture than the single frame that triggered the first one. Rate limit them.
+ * [AapTransport] implements as a gain-only unsolicited focus nudge by default, escalating to a real
+ * focus loss/regain cycle only per [KeyframeCycleEscalationPolicy]'s much stricter gates. Either one
+ * is expensive and briefly visible on screen, and the phone reacts to it by rebuilding the stream,
+ * so a burst of requests costs far more picture than the single frame that triggered the first one.
+ * Rate limit them.
  *
  * Suppressing a request is safe to do silently: a corrupt frame is scoped to itself and the stream
  * resumes on the next one either way, so a suppressed request only means recovery waits for the
@@ -20,4 +22,21 @@ object VideoRecoveryPolicy {
     /** Whether enough time has passed since [lastRequestMs] to send another keyframe request. */
     fun canRequestKeyframe(nowMs: Long, lastRequestMs: Long): Boolean =
         nowMs - lastRequestMs > KEYFRAME_REQUEST_THROTTLE_MS
+
+    /**
+     * Whether the decoder shedding a frame warrants asking the phone for a keyframe.
+     *
+     * A shed frame is a reference some later frame predicts from, so the picture drifts
+     * washed-out and blocky until a keyframe arrives - and on an idle stream the phone's own
+     * cadence can leave that on screen for a minute. The ask is the same throttled gain-only
+     * nudge as corrupt-frame recovery.
+     *
+     * Gated on [hasRendered] because before the first rendered frame the drop means something
+     * else entirely: a codec still draining its first buffers sheds frames while perfectly
+     * healthy, the nudge is measured to do nothing before the phone has started its video sink,
+     * and the not-yet-rendering window already has its own escalation
+     * ([WarmRelaunchKeyframePolicy]).
+     */
+    fun shouldRequestOnDroppedFrame(hasRendered: Boolean, nowMs: Long, lastRequestMs: Long): Boolean =
+        hasRendered && canRequestKeyframe(nowMs, lastRequestMs)
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/WarmRelaunchKeyframePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/WarmRelaunchKeyframePolicy.kt
@@ -1,0 +1,149 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Decides how hard to ask the phone for a picture when the projection surface has been replaced on a
+ * session that was already rendering.
+ *
+ * The projection activity is destroyed and recreated whenever the main screen comes forward - the
+ * launcher icon, a deep link - so a live session routinely rebuilds its decoder against a fresh
+ * surface. Whether the picture comes straight back then depends on something that is not obvious
+ * from the head unit's side: whether the *phone* was told to restart the video sink.
+ *
+ * Measured across twelve returns on a UNISOC MT50 (video-black rounds 5 and 6):
+ *
+ *  - The SurfaceView backend has its surface destroyed by the cover, so the teardown releases video
+ *    focus, the phone answers with a sink stop, and on return the focus gain makes it re-run sink
+ *    setup. `Media Start Request VIDEO` landed after 4 of 4 returns, and the picture followed
+ *    42-96 ms after the codec was configured.
+ *  - The TextureView and GLES backends never destroy their surface, so focus is never released and
+ *    the phone is never told anything. `Media Start Request VIDEO` landed after 0 of 10 returns, and
+ *    the picture took 6.3-115.9 s after the codec was configured - 97-99% of the whole return.
+ *
+ * The relaunch itself is not the cost and never was: it ran in 384-507 ms on every backend, and
+ * codec creation in 49-308 ms.
+ *
+ * What does *not* work is asking again with the same message. An unsolicited focus gain sent while
+ * the phone still believes the head unit holds focus is not a state change, and dozens of them go
+ * out per slow return - one every 1.5 s from the overlay watchdog, one per decoder restart from the
+ * transport - without one of them ever being followed by a picture. Only a real release/regain
+ * cycle, the one the SurfaceView teardown performs by accident, moves the phone.
+ *
+ * So this policy escalates rather than repeats: a warm relaunch gets the cycle, once, and the
+ * gain-only nudge is what remains for everything else.
+ *
+ * Round 7 then measured it against a same-day build of its own parent on the same rig. The four GLES
+ * holds went from 30.8 s, 74.8 s, one cycle that never rendered at all, and 49.3 s to a flat
+ * 3.04-3.20 s; TextureView the same. The cycle fired and `Media Start Request VIDEO` followed it on
+ * fourteen of fourteen returns, and the SurfaceView backend - whose teardown already does all of this
+ * - fired the policy zero times, which is the regression guard this is meant to pass.
+ *
+ * ### Why the cycle is gated rather than always sent
+ *
+ * Releasing video focus across a healthy, rendering stream is exactly the regression that made a
+ * single dropped frame turn into a permanent few-fps freeze on some head unit / phone combinations,
+ * which is why AapTransport's own recovery deliberately sends a gain only. Every gate
+ * here requires the opposite situation: a decoder rebuilt under a surface that has never shown a
+ * frame, on a session that has already proven itself. There is no picture to lose at that point,
+ * and the once-per-surface cap bounds the cost if the phone answers badly anyway.
+ */
+object WarmRelaunchKeyframePolicy {
+
+    /**
+     * How long a freshly claimed surface is given to produce a picture on its own before the cycle
+     * is spent on it.
+     *
+     * This is measured against the healthy path rather than guessed. The slowest a surface has been
+     * seen to render unaided, across every capture of rounds 5-7, is **404 ms** from `New surface
+     * set:` - a SurfaceView return whose codec creation took 308 ms and whose first frame followed
+     * 96 ms later. See [HEALTHY_FIRST_FRAME_CEILING_MS], which the tests hold this above.
+     *
+     * It started at 2000 ms, chosen before any of this code had run and with no measurement of what
+     * it needed to clear. That cost every return 1.2 s it did not need: round 7 measured the whole
+     * escalation at a flat 3.0-3.2 s, of which this constant was the largest single term, and found
+     * no case across fourteen cycles where a surface would have rendered on its own inside it.
+     *
+     * 850 ms is twice the ceiling, with the 42 ms over a round 800 deliberate: doubling the measured
+     * worst case is the rule, and a rounder number that quietly sits under it is how a margin stops
+     * meaning anything. It is still a rounding error against the 6.3-115.9 s this exists to prevent.
+     *
+     * Widening it is cheap and safe; narrowing it is what needs evidence, because the cost of firing
+     * on a surface that was about to render is a focus release across a live stream - see the class
+     * comment on why that is the one thing this must not do.
+     */
+    const val ESCALATE_AFTER_SURFACE_MS = 850L
+
+    /**
+     * The slowest unaided `New surface set:` → first frame ever measured, in milliseconds.
+     *
+     * Not used at runtime. It is the number [ESCALATE_AFTER_SURFACE_MS] is chosen against, recorded
+     * here so a future change to that constant fails a test that explains itself rather than silently
+     * moving under the healthy path.
+     */
+    const val HEALTHY_FIRST_FRAME_CEILING_MS = 404L
+
+    /** Minimum spacing between two nudges, shared with the other keyframe requesters. */
+    const val NUDGE_THROTTLE_MS = VideoRecoveryPolicy.KEYFRAME_REQUEST_THROTTLE_MS
+
+    /**
+     * Gap between the release and the gain that make up the cycle.
+     *
+     * The pair has to read as two events to the phone, not one. On the SurfaceView backend, where
+     * this sequence happens by accident, the two are seconds apart - the cover and the return - and
+     * the phone acts on each. Sent back to back they would very likely be coalesced: the phone would
+     * see focus land back on PROJECTED before it had acted on the loss, and do nothing, which is the
+     * failure this whole policy exists to avoid. 400 ms is far above the send path's own latency,
+     * short enough that the two halves stay inside one watchdog tick, and a rounding error against
+     * the 6.3-115.9 s wait it replaces.
+     */
+    const val FOCUS_CYCLE_GAP_MS = 400L
+
+    enum class Action {
+        /** Ask for nothing; something else already has this covered. */
+        NONE,
+
+        /** Send the unsolicited focus gain, the existing behaviour. */
+        NUDGE,
+
+        /** Release video focus and take it back, so the phone re-runs sink setup. */
+        CYCLE_FOCUS,
+    }
+
+    /**
+     * @param sessionHasRendered whether any frame of this session ever reached the screen. False on
+     *   a cold start, where the phone is already running sink setup of its own accord and a focus
+     *   cycle would interrupt it.
+     * @param renderedSinceSurfaceSet whether the current surface has shown a frame yet.
+     * @param transportStarted whether the AAP session is in its steady state. Nothing can be sent
+     *   otherwise, and a handshake in progress will produce sink setup on its own.
+     * @param msSinceSurfaceSet age of the current surface.
+     * @param msSincePhoneBytes age of the last video bytes from the phone. A phone that has stopped
+     *   sending has paused the stream deliberately; the reconnecting overlay owns that case.
+     * @param phoneAliveThresholdMs how recent [msSincePhoneBytes] must be to count as streaming.
+     * @param cycleAlreadySpent whether this surface has already had its one focus cycle.
+     * @param msSinceLastRequest age of the last keyframe request of any kind.
+     */
+    fun decide(
+        sessionHasRendered: Boolean,
+        renderedSinceSurfaceSet: Boolean,
+        transportStarted: Boolean,
+        msSinceSurfaceSet: Long,
+        msSincePhoneBytes: Long,
+        phoneAliveThresholdMs: Long,
+        cycleAlreadySpent: Boolean,
+        msSinceLastRequest: Long
+    ): Action {
+        if (!transportStarted) return Action.NONE
+        // A picture is on screen. Nothing to ask for, and asking is what costs a stream.
+        if (renderedSinceSurfaceSet) return Action.NONE
+        // A cold start has never rendered, so there is no "was working a moment ago" to restore.
+        if (!sessionHasRendered) return Action.NONE
+        // The phone has stopped sending. A focus cycle cannot fix a stream that is paused upstream.
+        if (msSincePhoneBytes > phoneAliveThresholdMs) return Action.NONE
+        // Give the surface the healthy path's own worst case before escalating.
+        if (msSinceSurfaceSet < ESCALATE_AFTER_SURFACE_MS) return Action.NONE
+
+        if (!cycleAlreadySpent) return Action.CYCLE_FOCUS
+        if (msSinceLastRequest >= NUDGE_THROTTLE_MS) return Action.NUDGE
+        return Action.NONE
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
@@ -626,6 +626,27 @@ class CommManager(
         send(com.andrerinas.openheadunit.aap.protocol.messages.VideoFocusEvent(gain = true, unsolicited = true))
     }
 
+    /**
+     * First half of a video-focus cycle: release focus so the phone tears its video sink down and
+     * has to set it up again, which is what makes it start the next stream with a keyframe. The
+     * caller sends the matching gain after a gap.
+     *
+     * The release makes the phone answer with a video sink stop. [AapTransport.ignoreNextStopRequest]
+     * marks that one as ours, so it stays distinguishable in the log from a sink stop nobody asked
+     * for - which is what a video-black failure looks like, and has been the decisive line in four
+     * rounds of hardware testing.
+     *
+     * Only WarmRelaunchKeyframePolicy should be deciding when this is warranted: releasing focus
+     * across a stream that is rendering is a known way to lose one permanently.
+     */
+    fun releaseVideoFocusForKeyframe() {
+        if (_connectionState.value !is ConnectionState.TransportStarted) return
+        val transport = _transport ?: return
+        transport.ignoreNextStopRequest = true
+        AppLog.i("CommManager: releasing video focus to force a keyframe")
+        transport.send(com.andrerinas.openheadunit.aap.protocol.messages.VideoFocusEvent(gain = false, unsolicited = false))
+    }
+
     fun updateAudioGains() {
         _transport?.aapAudio?.updateGains()
     }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
@@ -621,8 +621,11 @@ class CommManager(
         val request = com.andrerinas.openheadunit.aap.protocol.messages.UpdateUiConfigRequest(left, top, right, bottom)
         AppLog.i("[UI_DEBUG_FIX] TX UpdateUiConfigRequest: L=$left T=$top R=$right B=$bottom")
         send(request)
-        // Always sends VideoFocusNotification(PROJECTED, unsolicited=true) after
-        // updating the UI config. This triggers a keyframe from the phone.
+        // The trailing gain-only notification does *not* bring a keyframe forward, whatever this
+        // comment used to claim. Dropped-frame-keyframe round 4 fired sixteen of these config
+        // requests on a live stream: the phone acknowledged every one and its keyframe cadence never
+        // moved off its fixed ~69s period. Kept because it costs one message and nothing has measured
+        // the surface-mismatch path this serves without it.
         send(com.andrerinas.openheadunit.aap.protocol.messages.VideoFocusEvent(gain = true, unsolicited = true))
     }
 
@@ -636,8 +639,12 @@ class CommManager(
      * for - which is what a video-black failure looks like, and has been the decisive line in four
      * rounds of hardware testing.
      *
-     * Only WarmRelaunchKeyframePolicy should be deciding when this is warranted: releasing focus
-     * across a stream that is rendering is a known way to lose one permanently.
+     * Two policies decide when this is warranted, and nothing else should: [WarmRelaunchKeyframePolicy]
+     * for a surface that has never shown a frame, and [KeyframeCycleEscalationPolicy] for a picture
+     * left corrupt by a shed reference frame. The latter sends its own release from [AapTransport]
+     * rather than calling here, because it has to pair the release with a regain on the send handler.
+     * Releasing focus across a stream that is rendering is a known way to lose one permanently, which
+     * is why both sets of gates are as reluctant as they are.
      */
     fun releaseVideoFocusForKeyframe() {
         if (_connectionState.value !is ConnectionState.TransportStarted) return

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/DecoderRestartPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/DecoderRestartPolicy.kt
@@ -1,0 +1,29 @@
+package com.andrerinas.openheadunit.decoder
+
+/**
+ * Decides whether a decoder restart counts toward the codec-type flip and the permanent-failure
+ * latch.
+ *
+ * The escalation ladder exists for one case: a hardware component that cannot decode this codec
+ * type at all, which would otherwise restart forever. The evidence for that case is a session in
+ * which *nothing has ever rendered*. The counter used to test only "no frame since the last
+ * start" - but every surface swap stops the decoder and zeroes that timestamp, so a stream that
+ * had been rendering for an hour looked identical to one that never worked, and a few slow
+ * warm-ups after a relaunch walked it through the flip (to a codec type guaranteed wrong for the
+ * running stream) and into the latch. Measured on hardware: first frame after a mid-session
+ * reconfigure takes up to ~8s on some SoCs against a 2s stall window, so the ladder climbed on
+ * healthy sessions.
+ */
+object DecoderRestartPolicy {
+
+    /**
+     * True when this restart is evidence against the pinned codec type. [renderedThisSession]
+     * being true proves the codec type decodes this stream, so no number of warm-up restarts
+     * after that is reason to flip or to give up.
+     */
+    fun countsTowardFailure(
+        codecTypePinned: Boolean,
+        renderedSinceLastStart: Boolean,
+        renderedThisSession: Boolean
+    ): Boolean = codecTypePinned && !renderedSinceLastStart && !renderedThisSession
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -1032,6 +1032,20 @@ class VideoDecoder(private val settings: Settings) {
             // leaked one makes every later create fail until the process dies.
             try { codec?.release() } catch (ignore: Exception) {}
             codec = null; running = false
+            // The surface died between decode()'s validity check and this configure - the framework
+            // tears it down on the main thread and no lock of ours covers that window. Restarting
+            // would only fail here again, and every attempt reaches onDecoderError, which asks the
+            // phone for a keyframe: measured once on hardware, that provoked an unsolicited video
+            // sink start while no surface existed at all, and the session's next real relaunch
+            // needed a focus cycle to recover from the state it left behind.
+            //
+            // So do not schedule anything. decode()'s own surface guard idles this path until
+            // setSurface() arrives with a replacement, which rebuilds from there - the same route
+            // every ordinary surface swap already takes.
+            if (mSurface?.isValid != true) {
+                AppLog.w("Decoder start aborted: the surface went away mid-configure. Waiting for a new one.")
+                return
+            }
             scheduleRestart("decoder_start_failed: ${e.message}")
         }
     }

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -27,10 +27,6 @@ interface VideoDimensionsListener {
 class VideoDecoder(private val settings: Settings) {
     companion object {
         private const val TIMEOUT_US = 10000L
-        // How long feedInputBuffer waits for a free codec input buffer, total. Measured: 30ms
-        // reported a full queue within a second of every start on hardware that then decoded at
-        // full rate. The wait also aborts as soon as running clears - see the loop.
-        private const val INPUT_DEQUEUE_PATIENCE_MS = 300L
         private const val MAX_RESTARTS_WITHOUT_FRAME = 3
 
         // sync_stall watchdog tuning. An intermittently slow decoder — one that renders, just not
@@ -65,11 +61,9 @@ class VideoDecoder(private val settings: Settings) {
         // handing back a long backlog cannot hold the loop away from its stall checks.
         private const val MAX_CATCHUP_SKIPS = 8
 
-        // Frames that may wait between the transport and the codec. Deep enough to absorb the
-        // arrival burst that follows a few hundred milliseconds of wireless silence, around
-        // 200ms of video at the rates this negotiates, and no deeper, because everything sitting
-        // here is latency between a touch and the picture answering it.
-        private const val FRAME_QUEUE_CAPACITY = 12
+        // How deep the queue between the transport and the codec is, and how long the feed thread
+        // waits for the codec, both live in VideoFeedQueuePolicy - they are one decision and
+        // drifting apart is what cost #830 its reference frames.
         private const val FEED_POLL_MS = 200L
         // Floor for pooled frame buffers, so the pool settles at a reusable size instead of
         // reallocating around whatever the first few frames happened to measure.
@@ -236,8 +230,11 @@ class VideoDecoder(private val settings: Settings) {
     // undrained, which turned a busy decoder into stalled audio and late keepalives. Frames are
     // copied on the way in because the transport reuses the buffer it hands us.
     private class PendingFrame(var data: ByteArray, var size: Int, var arrivalNanos: Long)
-    private val frameQueue = ArrayBlockingQueue<PendingFrame>(FRAME_QUEUE_CAPACITY)
-    private val framePool = ArrayBlockingQueue<PendingFrame>(FRAME_QUEUE_CAPACITY + 2)
+    // Derived once per decoder rather than per session: the queue is allocated here, and fpsLimit
+    // only changes when the user changes it, which restarts the service that owns this object.
+    private val frameQueueCapacity = VideoFeedQueuePolicy.capacityFor(settings.fpsLimit)
+    private val frameQueue = ArrayBlockingQueue<PendingFrame>(frameQueueCapacity)
+    private val framePool = ArrayBlockingQueue<PendingFrame>(frameQueueCapacity + 2)
     // Volatile and identity-checked by the loop itself: interrupt() does not abort a MediaCodec
     // call, so a feed thread parked in dequeueInputBuffer can outlive the join() below. If it
     // does, stop() goes on to release the codec and a later start() sets running back to true -
@@ -696,7 +693,10 @@ class VideoDecoder(private val settings: Settings) {
      * instead - read [codec] once, and let stop() clear [running] and interrupt before releasing.
      */
     private fun feedThreadLoop() {
-        AppLog.i("Feed thread started")
+        AppLog.i(
+            "Feed thread started (queue holds $frameQueueCapacity frames, " +
+                "${VideoFeedQueuePolicy.heldMsAt(settings.fpsLimit)}ms at ${settings.fpsLimit}fps)"
+        )
         val self = Thread.currentThread()
         while (running && feedThread === self) {
             val frame = try {
@@ -708,30 +708,24 @@ class VideoDecoder(private val settings: Settings) {
             try {
                 if (!running || feedThread !== self || codec == null) continue
                 val buf = ByteBuffer.wrap(frame.data, 0, frame.size)
-                var fed = true
-                while (buf.hasRemaining()) {
-                    if (!feedInputBuffer(buf, frame.arrivalNanos)) {
-                        // A teardown that lands mid-frame fails the same way a full queue does.
-                        // Say nothing in that case: the frame is moot and the log line would
-                        // appear on every ordinary stop.
-                        if (!running || feedThread !== self || codec == null) {
-                            fed = false
-                            break
+                when (feedInputBuffer(buf, frame.arrivalNanos)) {
+                    FeedResult.FED -> framesFed++
+                    // Counted and answered where the real buffer capacity is known.
+                    FeedResult.DROPPED_TOO_LARGE -> {}
+                    FeedResult.NO_INPUT_BUFFER -> {
+                        // A teardown fails the same way a full queue does. Say nothing in that
+                        // case: the frame is moot and the log line would appear on every
+                        // ordinary stop.
+                        if (running && feedThread === self && codec != null) {
+                            // The codec had no free input buffer for the whole wait. Drop the
+                            // frame and carry on: the next keyframe repairs the picture, and a
+                            // decoder that is genuinely stuck rather than busy is still caught by
+                            // the sync_stall watchdog.
+                            AppLog.w("Input buffer full. Dropping frame.")
+                            framesDropped++
                         }
-                        // The codec had no free input buffer for the whole wait. Drop what is left
-                        // of this frame and carry on: the next keyframe repairs the picture, and
-                        // the decoders this happens on are the ones least able to afford the
-                        // alternative. Routing it into the recovery path instead cost a keyframe
-                        // request and a video-focus cycle for an event that fires within a second
-                        // of the decoder starting on ordinary hardware. A decoder that is genuinely
-                        // stuck rather than busy is still caught by the sync_stall watchdog.
-                        AppLog.w("Input buffer full. Dropping frame.")
-                        framesDropped++
-                        fed = false
-                        break
                     }
                 }
-                if (fed) framesFed++
             } catch (e: Exception) {
                 AppLog.w("Feed thread error: ${e.message}")
             } finally {
@@ -1087,11 +1081,28 @@ class VideoDecoder(private val settings: Settings) {
         return false
     }
 
+    /** Outcome of [feedInputBuffer] for one frame. */
+    private enum class FeedResult {
+        /** The whole frame was queued into the codec. */
+        FED,
+
+        /** No free input buffer inside the patience window; nothing was queued. */
+        NO_INPUT_BUFFER,
+
+        /** Frame exceeds the codec's input buffer; dropped and accounted for inside. */
+        DROPPED_TOO_LARGE,
+    }
+
     /**
-     * Feeds the raw byte stream into the decoder buffer.
+     * Queues one whole frame into the codec, or nothing at all.
+     *
+     * A frame is never split across input buffers: each queued buffer is parsed as a complete
+     * access unit (this API range has no partial-frame flag), so a piece fed on its own reaches
+     * the codec as a frame of its own and corrupts the picture as surely as the loss it was
+     * trying to avoid - that is what the old truncate-and-feed path did.
      */
-    private fun feedInputBuffer(buffer: ByteBuffer, arrivalNanos: Long): Boolean {
-        val currentCodec = codec ?: return false
+    private fun feedInputBuffer(buffer: ByteBuffer, arrivalNanos: Long): FeedResult {
+        val currentCodec = codec ?: return FeedResult.NO_INPUT_BUFFER
         try {
             var inputIndex = -1
             // ~300ms of patience. Anything much shorter gives up while the codec is merely busy:
@@ -1107,7 +1118,7 @@ class VideoDecoder(private val settings: Settings) {
             // the time a stopping decoder waits on us to one dequeue rather than the full budget -
             // which is what lets stop()'s join reliably win before it releases the codec.
             val waitStart = SystemClock.elapsedRealtime()
-            while (running && SystemClock.elapsedRealtime() - waitStart < INPUT_DEQUEUE_PATIENCE_MS) {
+            while (running && SystemClock.elapsedRealtime() - waitStart < VideoFeedQueuePolicy.INPUT_DEQUEUE_PATIENCE_MS) {
                 inputIndex = currentCodec.dequeueInputBuffer(TIMEOUT_US)
                 if (inputIndex >= 0) break
             }
@@ -1117,7 +1128,7 @@ class VideoDecoder(private val settings: Settings) {
                 // Silent when the wait was cut short by a teardown: that exit is ordinary and the
                 // frame is moot, while "full" would blame the codec on every stop.
                 if (running) AppLog.e("Input buffer feed failed (full)")
-                return false
+                return FeedResult.NO_INPUT_BUFFER
             }
 
             val inputBuffer = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -1126,7 +1137,7 @@ class VideoDecoder(private val settings: Settings) {
                 @Suppress("DEPRECATION") inputBuffers?.get(inputIndex)
             }
 
-            if (inputBuffer == null) return false
+            if (inputBuffer == null) return FeedResult.NO_INPUT_BUFFER
             inputBuffer.clear()
 
             val capacity = inputBuffer.capacity()
@@ -1139,25 +1150,27 @@ class VideoDecoder(private val settings: Settings) {
                 MediaCodec.BUFFER_FLAG_CODEC_CONFIG
             } else 0
 
-            if (buffer.remaining() <= capacity) {
-                inputBuffer.put(buffer)
-            } else {
-                AppLog.w("Frame too large: ${buffer.remaining()} > $capacity. Truncating!")
-                val limit = buffer.limit()
-                buffer.limit(buffer.position() + capacity)
-                inputBuffer.put(buffer)
-                buffer.limit(limit)
+            if (buffer.remaining() > capacity) {
+                // Handled here rather than in the caller because this is the only place the real
+                // buffer capacity is known - codecs are free to allocate more or less than the
+                // KEY_MAX_INPUT_SIZE the format asked for. The dequeued buffer goes straight back
+                // empty so the codec's pool is not depleted by the drop.
+                AppLog.w("Frame larger than the codec input buffer: ${buffer.remaining()} > $capacity bytes. Dropping frame.")
+                currentCodec.queueInputBuffer(inputIndex, 0, 0, 0, 0)
+                framesDropped++
+                return FeedResult.DROPPED_TOO_LARGE
             }
 
+            inputBuffer.put(buffer)
             inputBuffer.flip()
 
             val pts = ((if (arrivalNanos > 0L) arrivalNanos else System.nanoTime()) - startTime) / 1000
 
             currentCodec.queueInputBuffer(inputIndex, 0, inputBuffer.limit(), pts, flags)
-            return true
+            return FeedResult.FED
         } catch (e: Exception) {
             AppLog.e("Error feeding input buffer", e)
-            return false
+            return FeedResult.NO_INPUT_BUFFER
         }
     }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -6,6 +6,8 @@ import android.media.MediaCodecList
 import android.media.MediaFormat
 import android.os.Build
 import android.view.Surface
+import com.andrerinas.openheadunit.aap.VideoKeyframeScanner
+import com.andrerinas.openheadunit.aap.VideoRecoveryPolicy
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.Settings
 import com.andrerinas.openheadunit.utils.HeadUnitScreenConfig
@@ -284,6 +286,20 @@ class VideoDecoder(private val settings: Settings) {
     // Callback for transport layer integration
     var onDecoderError: (() -> Unit)? = null
 
+    // Fired, throttled, when a frame is shed with the picture live - see notifyFrameDropped().
+    // The transport wires it to the same gain-only keyframe nudge corrupt-frame recovery uses.
+    var onFrameDropped: (() -> Unit)? = null
+
+    // Fired when a keyframe is handed to the codec, which is the only evidence a shed reference
+    // frame has been repaired. Read where the frame is fed rather than where it arrives: a keyframe
+    // the queue sheds never reaches the picture, so it repairs nothing and must not count.
+    var onKeyframeObserved: (() -> Unit)? = null
+
+    // Throttle stamp for onFrameDropped. Both drop sites feed it: the transport read thread on
+    // queue overflow and the feed thread on input-buffer exhaustion. A race between them costs
+    // at most one extra nudge, so a volatile check-then-set is enough.
+    @Volatile private var lastDropKeyframeRequestMs = 0L
+
     val videoWidth: Int get() = mWidth
     val videoHeight: Int get() = mHeight
 
@@ -498,6 +514,7 @@ class VideoDecoder(private val settings: Settings) {
             framesRendered = 0L
             framesSkippedAtRender = 0L
             inputWaitMs = 0L
+            lastDropKeyframeRequestMs = 0L
             lastThroughputLogMs = 0L
             lastLoggedFramesFed = 0L
             lastLoggedFramesDropped = 0L
@@ -517,9 +534,9 @@ class VideoDecoder(private val settings: Settings) {
      * Main entry point for decoding a video/control packet.
      *
      * Reports nothing back to the caller. A frame this cannot place into the codec's input queue
-     * is simply lost, which the stream heals from on the phone's next keyframe; treating it as
-     * stream corruption instead put a keyframe request and a video-focus cycle behind an event
-     * that fires within a second of the decoder starting on ordinary hardware.
+     * is lost here, and once the picture is live the loss asks the phone for a keyframe - see
+     * [notifyFrameDropped] for the shape of that ask and why it stays silent before the first
+     * rendered frame.
      */
     fun decode(buffer: ByteArray, offset: Int, size: Int, forceSoftware: Boolean, codecName: String) {
         synchronized(this) {
@@ -680,10 +697,41 @@ class VideoDecoder(private val settings: Settings) {
             // The codec has not taken a frame for as long as this queue holds. Drop the one that
             // just arrived rather than something already queued: the older frames are what
             // everything after them is decoded against, so dropping forward costs one frame while
-            // dropping backward corrupts every frame that referenced it until the next keyframe -
-            // and on this protocol those are seconds apart and cannot be asked for cheaply.
+            // dropping backward corrupts every frame that referenced it until the next keyframe.
+            // The frame shed here is still a reference for what follows it, though, so ask for
+            // that keyframe rather than waiting out the phone's own cadence - see
+            // notifyFrameDropped().
             framePool.offer(frame)
-            framesDropped++
+            notifyFrameDropped()
+        }
+    }
+
+    /**
+     * Counts a shed frame and, with the picture live, asks the phone for the keyframe that
+     * repairs what the loss costs.
+     *
+     * Every frame shed here is a reference some later frame predicts from, so the picture drifts
+     * washed-out and blocky until a keyframe arrives - and the phone runs a fixed keyframe period
+     * measured at ~69s, so waiting that out costs an average of ~35s of corruption on screen.
+     *
+     * The transport answers with the gain-only unsolicited focus nudge first, throttled so a
+     * sustained backlog costs one request a second rather than one per frame, and starts a clock
+     * that [com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy] uses to decide whether
+     * that was enough. There is still no P-frame latch here and never will be: gating the feed on
+     * keyframe detection is what once made recovering from a drop more expensive than the drop.
+     *
+     * Before the first rendered frame this stays silent - a warming codec sheds frames while
+     * perfectly healthy, and that window belongs to
+     * [com.andrerinas.openheadunit.aap.WarmRelaunchKeyframePolicy], which must not have a second
+     * decider reaching for the same lever underneath it.
+     */
+    private fun notifyFrameDropped() {
+        framesDropped++
+        val now = SystemClock.elapsedRealtime()
+        if (VideoRecoveryPolicy.shouldRequestOnDroppedFrame(lastFrameRenderedMs != 0L, now, lastDropKeyframeRequestMs)) {
+            lastDropKeyframeRequestMs = now
+            AppLog.w("VideoDecoder: dropped a reference frame, requesting keyframe")
+            onFrameDropped?.invoke()
         }
     }
 
@@ -718,11 +766,14 @@ class VideoDecoder(private val settings: Settings) {
                         // ordinary stop.
                         if (running && feedThread === self && codec != null) {
                             // The codec had no free input buffer for the whole wait. Drop the
-                            // frame and carry on: the next keyframe repairs the picture, and a
-                            // decoder that is genuinely stuck rather than busy is still caught by
-                            // the sync_stall watchdog.
+                            // frame and carry on, asking for the keyframe that repairs the
+                            // picture - see notifyFrameDropped(), whose rendered-frame gate keeps
+                            // this quiet in the window where it used to misfire: within a second
+                            // of the decoder starting, while the component is merely draining its
+                            // first buffers. A decoder that is genuinely stuck rather than busy
+                            // is still caught by the sync_stall watchdog.
                             AppLog.w("Input buffer full. Dropping frame.")
-                            framesDropped++
+                            notifyFrameDropped()
                         }
                     }
                 }
@@ -1146,6 +1197,9 @@ class VideoDecoder(private val settings: Settings) {
             // Some decoders (Rockchip/Allwinner) require this flag for every config packet
             // even after the stream has already started.
             val isConfig = buffer.hasArray() && isCodecConfigData(buffer.array(), buffer.position(), buffer.remaining())
+            val isKeyframe = buffer.hasArray() && VideoKeyframeScanner.containsKeyframe(
+                buffer.array(), buffer.position(), buffer.remaining(), currentCodecType == CodecType.H265
+            )
             val flags = if (isConfig && (shouldAlwaysFlagConfig() || !codecConfigured)) {
                 MediaCodec.BUFFER_FLAG_CODEC_CONFIG
             } else 0
@@ -1157,7 +1211,7 @@ class VideoDecoder(private val settings: Settings) {
                 // empty so the codec's pool is not depleted by the drop.
                 AppLog.w("Frame larger than the codec input buffer: ${buffer.remaining()} > $capacity bytes. Dropping frame.")
                 currentCodec.queueInputBuffer(inputIndex, 0, 0, 0, 0)
-                framesDropped++
+                notifyFrameDropped()
                 return FeedResult.DROPPED_TOO_LARGE
             }
 
@@ -1167,6 +1221,10 @@ class VideoDecoder(private val settings: Settings) {
             val pts = ((if (arrivalNanos > 0L) arrivalNanos else System.nanoTime()) - startTime) / 1000
 
             currentCodec.queueInputBuffer(inputIndex, 0, inputBuffer.limit(), pts, flags)
+            if (isKeyframe) {
+                AppLog.i("VideoDecoder: keyframe reached the codec (${inputBuffer.limit()} bytes)")
+                onKeyframeObserved?.invoke()
+            }
             return FeedResult.FED
         } catch (e: Exception) {
             AppLog.e("Error feeding input buffer", e)

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -354,6 +354,32 @@ class VideoDecoder(private val settings: Settings) {
     }
 
     /**
+     * True when [surface] is the surface this decoder currently renders to.
+     *
+     * Identity comparison is deliberate: every teardown path hands back the exact Surface object
+     * it created, so `===` distinguishes a live owner from a torn-down view whose callback is
+     * arriving late.
+     */
+    fun isCurrentSurface(surface: Surface): Boolean = synchronized(this) { mSurface === surface }
+
+    /**
+     * Stops the decoder only if [surface] still owns it. Compare-and-stop is atomic under the
+     * same monitor [setSurface] and [stop] already hold, so a stale teardown from a torn-down
+     * view can never stop a decoder that a newer surface has since claimed. [mSurface] is left
+     * as it is either way — [stop] never cleared it, and [decode] guards on validity.
+     *
+     * @return whether the decoder was actually stopped.
+     */
+    fun stopIfCurrentSurface(surface: Surface, reason: String): Boolean = synchronized(this) {
+        if (mSurface !== surface) {
+            AppLog.i("Decoder stop ($reason) skipped: surface is no longer current")
+            return false
+        }
+        stop(reason)
+        true
+    }
+
+    /**
      * Stops the decoder, terminates the output thread, and releases hardware resources.
      */
     fun stop(reason: String = "unknown") {

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -27,6 +27,10 @@ interface VideoDimensionsListener {
 class VideoDecoder(private val settings: Settings) {
     companion object {
         private const val TIMEOUT_US = 10000L
+        // How long feedInputBuffer waits for a free codec input buffer, total. Measured: 30ms
+        // reported a full queue within a second of every start on hardware that then decoded at
+        // full rate. The wait also aborts as soon as running clears - see the loop.
+        private const val INPUT_DEQUEUE_PATIENCE_MS = 300L
         private const val MAX_RESTARTS_WITHOUT_FRAME = 3
 
         // sync_stall watchdog tuning. An intermittently slow decoder — one that renders, just not
@@ -39,6 +43,14 @@ class VideoDecoder(private val settings: Settings) {
         private const val SYNC_STALL_COOLDOWN_MS = 8000L
         private const val SYNC_STALL_RESET_MS = 60000L
         private const val MAX_SYNC_STALL_RESTARTS = 4
+        // First-frame window for a codec rebuilt mid-session. Measured on a UNISOC MT50: up to
+        // ~8s from a mid-session reconfigure to the first frame on a session that then ran at
+        // 50fps, so the 2s window above restarted codecs that were merely warming up - and each
+        // restart resets the warm-up, which is how a healthy relaunch cascaded into the restart
+        // budget. Applies only while the session has already rendered (the codec type is proven,
+        // patience is cheap); a cold start keeps the 2s window so a genuinely dead component
+        // still fails fast.
+        private const val WARM_RECONFIGURE_FIRST_FRAME_GRACE_MS = 10000L
 
         // Interval of the decode/render throughput summary. This exists because a slow picture
         // is otherwise unattributable from a user-submitted log: the only rendered-frame count
@@ -177,6 +189,12 @@ class VideoDecoder(private val settings: Settings) {
     private var restartsSinceLastFrame = 0
     private var codecFallbackUsed = false
     private var decoderPermanentlyFailed = false
+    // True once any frame of this session has rendered. Session-scoped where lastFrameRenderedMs
+    // is start-scoped: every stop() zeroes that timestamp, so after a surface swap a stream that
+    // had rendered for an hour looks identical to one that never worked. This flag is what lets
+    // the restart ladder tell them apart, and it clears only when the session itself ends.
+    // Written by the output thread and the software render path, read on the transport thread.
+    @Volatile private var renderedThisSession = false
 
     // sync_stall cooldown/cap state - see SYNC_STALL_* constants.
     private var syncStallRestartCount = 0
@@ -265,13 +283,19 @@ class VideoDecoder(private val settings: Settings) {
 
     @Volatile private var decoderNeedsRestart = false
     @Volatile private var decoderRestartReason: String? = null
-    @Volatile private var pendingKeyframeRequest = false
 
     // Callback for transport layer integration
     var onDecoderError: (() -> Unit)? = null
 
     val videoWidth: Int get() = mWidth
     val videoHeight: Int get() = mHeight
+
+    /**
+     * Whether any frame of the current session has rendered. Distinguishes a decoder rebuilt under a
+     * live, proven stream from one that has never worked, which [lastFrameRenderedMs] cannot: every
+     * stop() zeroes that timestamp.
+     */
+    val hasRenderedThisSession: Boolean get() = renderedThisSession
 
     enum class CodecType(val mimeType: String, val displayName: String, val settingsValue: String) {
         H264("video/avc", "H.264/AVC", "H.264"),
@@ -345,9 +369,13 @@ class VideoDecoder(private val settings: Settings) {
             if (mSurface === surface) return
 
             AppLog.i("New surface set: $surface")
-            if (codec != null || softwareHevcDecoder != null) {
-                stop(DecoderStopPolicy.REASON_NEW_SURFACE)
-            }
+            // Unconditional, not gated on a live codec: stop() is where the failure state
+            // (decoderPermanentlyFailed, the restart counters, the one-time fallback) is reset,
+            // and the failure paths release the codec on their way down - so gating this on
+            // codec != null made a latched failure permanent for the rest of the session, with a
+            // fresh surface arriving and nothing ever clearing the flag that blocks decode().
+            // stop() is idempotent when nothing is running.
+            stop(DecoderStopPolicy.REASON_NEW_SURFACE)
             mSurface = surface
             lastFrameRenderedMs = 0L
         }
@@ -394,14 +422,18 @@ class VideoDecoder(private val settings: Settings) {
             } catch (e: Exception) {}
             outputThread = null
 
-            // Shorter than the output thread's join because overrunning it is safe here: the loop
-            // checks its own identity against feedThread, so once this clears it a thread still
-            // parked in MediaCodec can only exit. Kept short because stop() holds this object's
-            // monitor and setSurface() reaches it from the main thread.
+            // The join budget must exceed the longest MediaCodec call the feed thread can be
+            // inside, or this falls through to codec.release() while the thread is still in the
+            // codec - interrupt() does not abort a MediaCodec call, and calling into a released
+            // codec wedges some vendor components until the process dies. The feed loop checks
+            // running (cleared above) on every 10ms dequeue, so in practice it exits within one
+            // dequeue; 500ms covers the worst case with margin. The identity check against
+            // feedThread remains the backstop for a thread that overruns even this: it can only
+            // exit, never feed the next session's codec.
             try {
                 if (feedThread != null && feedThread != Thread.currentThread()) {
                     feedThread?.interrupt()
-                    feedThread?.join(200)
+                    feedThread?.join(500)
                 }
             } catch (e: Exception) {}
             feedThread = null
@@ -429,28 +461,34 @@ class VideoDecoder(private val settings: Settings) {
             inputBuffers = null
             legacyFrameBuffer = null
             codecBufferInfo = null
-            codecConfigured = false
             if (!DecoderStopPolicy.isDecoderRestart(reason)) {
-                vps = null
-                sps = null
-                pps = null
-                mWidth = 0
-                mHeight = 0
                 restartsSinceLastFrame = 0
                 codecFallbackUsed = false
                 decoderPermanentlyFailed = false
                 syncStallRestartCount = 0
                 lastSyncStallRestartMs = 0L
             }
-            // The pinned codec type describes the stream, not the decoder instance, so it has to
-            // outlive a surface teardown: the phone keeps sending the same codec while the view is
-            // rebuilt, and re-detecting on whatever packet lands mid-teardown can misread an
-            // ordinary H.264 P-slice as HEVC and configure the wrong decoder for the rest of the
-            // session. Only a real disconnect can change what the phone is sending.
+            // Everything that describes the *stream* rather than this decoder instance survives
+            // anything short of the session ending, and only a real disconnect can change what the
+            // phone is sending.
+            //
+            // The pinned codec type has to outlive a surface teardown because re-detecting on
+            // whatever packet lands mid-teardown can misread an ordinary H.264 P-slice as HEVC and
+            // configure the wrong decoder for the rest of the session. The parameter sets and the
+            // dimensions parsed out of them are the same kind of fact: dropping them left the
+            // rebuilt codec configured from HeadUnitScreenConfig's negotiated size with no csd-0 at
+            // all, which is what the "Fallback to negotiated dimensions" line reports - measured
+            // once per relaunch, on every backend, in every capture of the video-black round 6.
             if (DecoderStopPolicy.endsSession(reason)) {
                 codecTypePinned = false
+                renderedThisSession = false
+                vps = null
+                sps = null
+                pps = null
+                mWidth = 0
+                mHeight = 0
+                codecConfigured = false
             }
-            // Keep VPS/SPS/PPS cached so we can re-inject them on restart
             lastFrameRenderedMs = 0L
             loggedFirstSoftwareFrame = false
             loggedFirstHardwareFrame = false
@@ -497,8 +535,16 @@ class VideoDecoder(private val settings: Settings) {
 
                 // Track restarts that never produced a single frame for the currently pinned
                 // codec type. A genuinely broken hardware decoder (e.g. an MTK HEVC component
-                // that can't configure at all) will keep failing here forever otherwise.
-                if (codecTypePinned && lastFrameRenderedMs == 0L) {
+                // that can't configure at all) will keep failing here forever otherwise. A
+                // session that has already rendered is excluded: the codec type is proven for
+                // this stream, so restarts after a surface swap are warm-up churn, and counting
+                // them walked healthy sessions through the flip and into the permanent latch.
+                if (DecoderRestartPolicy.countsTowardFailure(
+                        codecTypePinned,
+                        renderedSinceLastStart = lastFrameRenderedMs != 0L,
+                        renderedThisSession = renderedThisSession
+                    )
+                ) {
                     restartsSinceLastFrame++
                     if (restartsSinceLastFrame >= MAX_RESTARTS_WITHOUT_FRAME) {
                         if (!codecFallbackUsed) {
@@ -520,8 +566,9 @@ class VideoDecoder(private val settings: Settings) {
                             decoderPermanentlyFailed = true
                         }
                     }
-                } else if (lastFrameRenderedMs != 0L) {
-                    // Decoder was healthy before this restart; don't count it against the pin.
+                } else if (lastFrameRenderedMs != 0L || renderedThisSession) {
+                    // Decoder was healthy before this restart, or the session has already proven
+                    // the codec type; don't count it against the pin.
                     restartsSinceLastFrame = 0
                 }
 
@@ -606,12 +653,6 @@ class VideoDecoder(private val settings: Settings) {
             }
 
             if (codec == null) return
-
-            if (pendingKeyframeRequest) {
-                pendingKeyframeRequest = false
-                AppLog.i("Decoder restarted and ready. Invoking error callback to request keyframe.")
-                onDecoderError?.invoke()
-            }
 
             enqueueForFeed(frameData, frameOffset, size)
         }
@@ -750,6 +791,7 @@ class VideoDecoder(private val settings: Settings) {
 
     private fun onSoftwareFramesRendered(renderedFrames: Int) {
         lastFrameRenderedMs = SystemClock.elapsedRealtime()
+        renderedThisSession = true
         framesRenderedThisSession += renderedFrames
         if (!loggedFirstSoftwareFrame) {
             loggedFirstSoftwareFrame = true
@@ -970,15 +1012,25 @@ class VideoDecoder(private val settings: Settings) {
                 LegacyOptimizer.setHighPriority()
                 outputThreadLoop()
             }.apply { name = "VideoDecoder-Output"; start() }
-            feedThread = Thread {
+            // Published before start(): the loop's guard reads this field to prove its own
+            // identity, and a thread that starts before the assignment lands can read the null a
+            // prior stop() left and exit at birth - after which every frame queues into a feed
+            // queue nobody drains.
+            val newFeedThread = Thread {
                 android.os.Process.setThreadPriority(android.os.Process.THREAD_PRIORITY_DISPLAY)
                 feedThreadLoop()
-            }.apply { name = "VideoDecoder-Feed"; start() }
+            }.apply { name = "VideoDecoder-Feed" }
+            feedThread = newFeedThread
+            newFeedThread.start()
 
             codecTypePinned = true
             AppLog.i("Codec initialized: $bestCodec")
         } catch (e: Exception) {
             AppLog.e("Failed to start decoder", e)
+            // Release, not just null: a component created but never released survives the
+            // reference drop, and on head units with a single hardware decoder instance each
+            // leaked one makes every later create fail until the process dies.
+            try { codec?.release() } catch (ignore: Exception) {}
             codec = null; running = false
             scheduleRestart("decoder_start_failed: ${e.message}")
         }
@@ -1028,7 +1080,6 @@ class VideoDecoder(private val settings: Settings) {
         val currentCodec = codec ?: return false
         try {
             var inputIndex = -1
-            var attempts = 0
             // ~300ms of patience. Anything much shorter gives up while the codec is merely busy:
             // at 30ms this reported a full input queue within a second of every decoder start,
             // before the component had drained its first buffers, on hardware that then went on to
@@ -1036,16 +1087,22 @@ class VideoDecoder(private val settings: Settings) {
             //
             // The whole dequeue is timed, not just the retries: the first call blocks for up to
             // TIMEOUT_US on its own, and what holds up audio behind us is the total.
+            //
+            // running is checked every iteration because interrupt() cannot abort a MediaCodec
+            // call: stop() clears running before it joins this thread, so checking it here bounds
+            // the time a stopping decoder waits on us to one dequeue rather than the full budget -
+            // which is what lets stop()'s join reliably win before it releases the codec.
             val waitStart = SystemClock.elapsedRealtime()
-            while (attempts < 30) {
+            while (running && SystemClock.elapsedRealtime() - waitStart < INPUT_DEQUEUE_PATIENCE_MS) {
                 inputIndex = currentCodec.dequeueInputBuffer(TIMEOUT_US)
                 if (inputIndex >= 0) break
-                attempts++
             }
             inputWaitMs += SystemClock.elapsedRealtime() - waitStart
 
             if (inputIndex < 0) {
-                AppLog.e("Input buffer feed failed (full)")
+                // Silent when the wait was cut short by a teardown: that exit is ordinary and the
+                // frame is moot, while "full" would blame the codec on every stop.
+                if (running) AppLog.e("Input buffer feed failed (full)")
                 return false
             }
 
@@ -1208,6 +1265,7 @@ class VideoDecoder(private val settings: Settings) {
 
                     currentCodec.releaseOutputBuffer(renderIndex, true)
                     lastFrameRenderedMs = SystemClock.elapsedRealtime()
+                    renderedThisSession = true
                     lastOutputMs = lastFrameRenderedMs
                     framesRenderedThisSession++
                     consecutiveErrors = 0
@@ -1247,10 +1305,21 @@ class VideoDecoder(private val settings: Settings) {
                 // we update lastOutputMs to prevent false-positive restarts and screen flickering.
                 val now = SystemClock.elapsedRealtime()
                 val stallGap = now - lastOutputMs
-                if (stallGap > SYNC_STALL_THRESHOLD_MS) {
+                // A rebuilt codec that has not yet produced its first frame gets the longer
+                // warm-up window when this session has already rendered - see the constant.
+                val stallThreshold = if (lastFrameRenderedMs == 0L && renderedThisSession) {
+                    WARM_RECONFIGURE_FIRST_FRAME_GRACE_MS
+                } else {
+                    SYNC_STALL_THRESHOLD_MS
+                }
+                if (stallGap > stallThreshold) {
                     val inputIdleGap = now - lastInputBytesReceivedMs
                     if (inputIdleGap > SYNC_STALL_THRESHOLD_MS) {
                         // Stream is idle on the phone side (no new video frames arriving).
+                        // Deliberately silent: this branch used to fall through to the
+                        // "restart suppressed" line below, which read as a decoder fault for a
+                        // phone that had simply stopped sending, and misled a whole hardware
+                        // round with "0/4 used" printed every 10s for an idle stream.
                         lastOutputMs = now
                     } else {
                         // Input bytes ARE arriving, but decoder produces no output -> REAL DECODER STALL!
@@ -1270,14 +1339,14 @@ class VideoDecoder(private val settings: Settings) {
                             scheduleRestart("sync_stall")
                             break
                         }
-                    }
-                    // Suppressed by the cooldown or the cap. Report it, throttled: the branch
-                    // above is the only thing that ever mentions a stall, so once it stops
-                    // firing a decoder that has exhausted its restart budget keeps stalling
-                    // with an entirely clean log and reads as healthy.
-                    if (now - lastSyncStallSuppressedLogMs >= SYNC_STALL_SUPPRESSED_LOG_INTERVAL_MS) {
-                        lastSyncStallSuppressedLogMs = now
-                        AppLog.w("Decoder stall detected (no output for ${stallGap}ms) but restart suppressed ($syncStallRestartCount/$MAX_SYNC_STALL_RESTARTS used, ${SYNC_STALL_COOLDOWN_MS}ms cooldown). Still spinning on output.")
+                        // Suppressed by the cooldown or the cap. Report it, throttled: the branch
+                        // above is the only thing that ever mentions a stall, so once it stops
+                        // firing a decoder that has exhausted its restart budget keeps stalling
+                        // with an entirely clean log and reads as healthy.
+                        if (now - lastSyncStallSuppressedLogMs >= SYNC_STALL_SUPPRESSED_LOG_INTERVAL_MS) {
+                            lastSyncStallSuppressedLogMs = now
+                            AppLog.w("Decoder stall detected (no output for ${stallGap}ms) but restart suppressed ($syncStallRestartCount/$MAX_SYNC_STALL_RESTARTS used, ${SYNC_STALL_COOLDOWN_MS}ms cooldown). Still spinning on output.")
+                        }
                     }
                 }
             } catch (e: Exception) {

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoFeedQueuePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoFeedQueuePolicy.kt
@@ -1,0 +1,85 @@
+package com.andrerinas.openheadunit.decoder
+
+/**
+ * How much video may wait between the transport and the codec, and how long the feed thread waits
+ * for the codec to take it.
+ *
+ * These two numbers are one decision and are kept together because separating them is what caused
+ * issue #830. [VideoDecoder] used to hold a flat twelve frames - "around 200ms" by its own comment -
+ * in front of a feed thread that would wait [INPUT_DEQUEUE_PATIENCE_MS], a third of a second, for a
+ * free input buffer. So on any codec stall between those two figures the queue was shedding frames
+ * while the thread in front of it was still deliberately being patient. The 200ms had been chosen
+ * against touch latency and the 300ms against codec behaviour, and nothing reconciled them.
+ *
+ * A shed frame is not a dropped frame in the harmless sense: everything after it predicts from it,
+ * so the picture drifts washed-out and blocky until a keyframe arrives, and the phone sends those on
+ * a fixed period measured at ~69s. Roughly 35 seconds of visible corruption, on average, for a stall
+ * of a couple of hundred milliseconds.
+ *
+ * ### Why depth is cheaper than it looks
+ *
+ * The instinct that a deep queue is latency is right for most pipelines and wrong for this one. A
+ * backlog here drains in milliseconds once the codec unblocks, and the output thread then discards
+ * everything but the newest decoded frame on the way to the surface. So the cost is one catch-up
+ * jump, not lasting lag - and a discarded *decoded* frame breaks no prediction, which is the whole
+ * point. That is the model the protocol layer already describes: bound the backlog where it costs
+ * nothing rather than by having the phone send less.
+ *
+ * The exception is a decoder persistently slower than the stream, where nothing ever drains and the
+ * depth is real latency. That is the forced software-decoding path, which is already a deliberate
+ * choice by someone whose hardware decoder does not work.
+ */
+object VideoFeedQueuePolicy {
+
+    /**
+     * How long the feed thread waits, in total, for the codec to free an input buffer before giving
+     * up on a frame.
+     *
+     * Measured: 30ms reported a full queue within a second of every start on hardware that then
+     * decoded at full rate. The wait also aborts as soon as the decoder stops.
+     */
+    const val INPUT_DEQUEUE_PATIENCE_MS = 300L
+
+    /**
+     * How much video the queue holds, in milliseconds.
+     *
+     * Has to clear [INPUT_DEQUEUE_PATIENCE_MS], or the queue sheds frames the feed thread has not
+     * given up on yet. 500ms is that plus margin. Widening it costs memory and, on a decoder that
+     * never catches up, latency; narrowing it below the patience reopens #830.
+     */
+    const val FRAME_QUEUE_MS = 500
+
+    /**
+     * Floor on the derived depth.
+     *
+     * `fpsLimit` is the user's cap, not a rate negotiated with the phone - the decoder has no access
+     * to the real one - so it can understate what is actually arriving. The floor means a low cap
+     * cannot produce a queue too shallow to hold the patience regardless.
+     */
+    const val MIN_CAPACITY = 15
+
+    /**
+     * Ceiling on the derived depth.
+     *
+     * Every slot carries a pooled buffer that grows to the largest frame it has held, so a queue
+     * full of oversized keyframes is the worst case worth bounding. It also bounds the guarantee
+     * below: past about 133fps this ceiling, not [FRAME_QUEUE_MS], decides the depth, and the queue
+     * would no longer cover the patience. Android Auto negotiates 30 or 60.
+     */
+    const val MAX_CAPACITY = 40
+
+    /** Frames the queue holds at [fpsLimit], clamped to [MIN_CAPACITY]..[MAX_CAPACITY]. */
+    fun capacityFor(fpsLimit: Int): Int =
+        (safeRate(fpsLimit) * FRAME_QUEUE_MS / 1000).coerceIn(MIN_CAPACITY, MAX_CAPACITY)
+
+    /** How much video [capacityFor] holds at [fpsLimit], in milliseconds. */
+    fun heldMsAt(fpsLimit: Int): Long =
+        capacityFor(fpsLimit) * 1000L / safeRate(fpsLimit)
+
+    /**
+     * [fpsLimit] comes from stored settings, so nothing structurally stops it being zero or
+     * negative - and this runs on the feed thread's start path, where an arithmetic exception would
+     * take the decoder down rather than degrade it. A nonsense rate falls back to the floor.
+     */
+    private fun safeRate(fpsLimit: Int): Int = if (fpsLimit > 0) fpsLimit else MIN_CAPACITY
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/main/MainActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/MainActivity.kt
@@ -126,12 +126,8 @@ class MainActivity : BaseActivity() {
         // If an Android Auto session is active, bring the projection activity to front
         if (App.provide(this).commManager.isConnected && !App.isPiPActive) {
             AppLog.i("MainActivity: Active session detected in onCreate, bringing projection to front")
-            val aapIntent = AapProjectionActivity.intent(this).apply {
-                putExtra(AapProjectionActivity.EXTRA_FOCUS, true)
-                addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_SINGLE_TOP)
-            }
-            startActivity(aapIntent)
-            
+            bringProjectionToFront()
+
             // If we are auto-forwarding, hide the splash immediately to avoid flashing it twice
             if (savedInstanceState == null) {
                 findViewById<View>(R.id.splash_overlay)?.visibility = View.GONE
@@ -383,11 +379,7 @@ class MainActivity : BaseActivity() {
             // mediaSinkSetupRequest, which can lag well behind HandshakeComplete -
             // during that gap this overlay had already hidden itself, leaving the
             // user stuck on HomeFragment with only a relabeled button to notice.
-            val aapIntent = AapProjectionActivity.intent(this).apply {
-                putExtra(AapProjectionActivity.EXTRA_FOCUS, true)
-                addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_SINGLE_TOP)
-            }
-            startActivity(aapIntent)
+            bringProjectionToFront()
             // Hiding without an animation avoids the fade competing with the
             // activity transition.
             findViewById<View>(R.id.auto_connect_loading_overlay)?.visibility = View.GONE
@@ -861,12 +853,24 @@ class MainActivity : BaseActivity() {
         // If an Android Auto session is active, bring the projection activity to front
         if (App.provide(this).commManager.isConnected && !App.isPiPActive && !AapProjectionActivity.isForeground) {
             AppLog.i("MainActivity: Active session detected, bringing projection to front")
-            val aapIntent = AapProjectionActivity.intent(this).apply {
-                putExtra(AapProjectionActivity.EXTRA_FOCUS, true)
-                addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_SINGLE_TOP)
-            }
-            startActivity(aapIntent)
+            bringProjectionToFront()
         }
+    }
+
+    /**
+     * The one place the projection relaunch intent is built. The guards stay at the call sites
+     * on purpose - they differ (post-connect must launch unconditionally, onResume checks
+     * foreground) - but the flag recipe must not drift between copies: this launch is what
+     * rebuilds the projection after singleTask semantics tore it down, and the torn-down
+     * instance's late surface callback is exactly the stale-owner case the decoder's ownership
+     * gate exists for.
+     */
+    private fun bringProjectionToFront() {
+        val aapIntent = AapProjectionActivity.intent(this).apply {
+            putExtra(AapProjectionActivity.EXTRA_FOCUS, true)
+            addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        }
+        startActivity(aapIntent)
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/andrerinas/openheadunit/view/ProjectionView.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/view/ProjectionView.kt
@@ -26,7 +26,9 @@ class ProjectionView @JvmOverloads constructor(
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        videoDecoder?.stop(DecoderStopPolicy.REASON_DETACHED_FROM_WINDOW)
+        // The decoder is a singleton and this view may be a discarded instance detaching after a
+        // replacement already claimed it, so only stop the decoder if this surface still owns it.
+        videoDecoder?.stopIfCurrentSurface(holder.surface, DecoderStopPolicy.REASON_DETACHED_FROM_WINDOW)
     }
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
@@ -47,7 +49,7 @@ class ProjectionView @JvmOverloads constructor(
 
     override fun surfaceDestroyed(holder: SurfaceHolder) {
         AppLog.i("holder $holder")
-        videoDecoder?.stop(DecoderStopPolicy.REASON_SURFACE_DESTROYED)
+        videoDecoder?.stopIfCurrentSurface(holder.surface, DecoderStopPolicy.REASON_SURFACE_DESTROYED)
         callbacks.forEach { it.onSurfaceDestroyed(holder.surface) }
     }
 

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicyTest.kt
@@ -1,0 +1,164 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.Action
+import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.CYCLE_COOLDOWN_MS
+import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.ESCALATE_AFTER_UNREPAIRED_MS
+import com.andrerinas.openheadunit.aap.WarmRelaunchKeyframePolicy.FOCUS_CYCLE_GAP_MS
+import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.MAX_CYCLES_PER_SESSION
+import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.NATURAL_CADENCE_MIN_OBSERVED_MS
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * A focus release across a stream that is rendering is the precondition of issue #755, so escalation
+ * past the gain-only nudge has to be earned: the picture has to have stayed broken past the point
+ * where the phone would plausibly have repaired it, and the cycles are a decaying budget rather than
+ * something a bad minute can spend all at once.
+ */
+class KeyframeCycleEscalationPolicyTest {
+
+    private fun decide(
+        nowMs: Long,
+        unrepairedSinceMs: Long,
+        cyclesUsedThisSession: Int = 0,
+        lastCycleMs: Long = 0L,
+    ) = KeyframeCycleEscalationPolicy.decide(nowMs, unrepairedSinceMs, cyclesUsedThisSession, lastCycleMs)
+
+    // --- The trigger ------------------------------------------------------------------------
+
+    @Test
+    fun `a repaired picture never escalates`() {
+        // The clock is only set while something is broken; zero means there is nothing to repair,
+        // however long the session has been running or however many cycles are left.
+        assertEquals(Action.NUDGE, decide(nowMs = 1_000_000L, unrepairedSinceMs = 0L))
+    }
+
+    @Test
+    fun `the drop that starts the clock only gets the nudge`() {
+        assertEquals(Action.NUDGE, decide(nowMs = 12_345L, unrepairedSinceMs = 12_345L))
+    }
+
+    @Test
+    fun `the cycle is earned the moment the window elapses, not before`() {
+        val broken = 10_000L
+        assertEquals(
+            Action.NUDGE,
+            decide(nowMs = broken + ESCALATE_AFTER_UNREPAIRED_MS - 1, unrepairedSinceMs = broken)
+        )
+        assertEquals(
+            Action.CYCLE_FOCUS,
+            decide(nowMs = broken + ESCALATE_AFTER_UNREPAIRED_MS, unrepairedSinceMs = broken)
+        )
+    }
+
+    // --- The budget -------------------------------------------------------------------------
+
+    @Test
+    fun `a spent budget degrades to the nudge`() {
+        val broken = 10_000L
+        assertEquals(
+            Action.NUDGE,
+            decide(
+                nowMs = broken + ESCALATE_AFTER_UNREPAIRED_MS,
+                unrepairedSinceMs = broken,
+                cyclesUsedThisSession = MAX_CYCLES_PER_SESSION,
+            )
+        )
+    }
+
+    @Test
+    fun `every cycle up to the cap is available`() {
+        val broken = 1_000_000L
+        for (spent in 0 until MAX_CYCLES_PER_SESSION) {
+            assertEquals(
+                "cycle ${spent + 1} of $MAX_CYCLES_PER_SESSION should still be available",
+                Action.CYCLE_FOCUS,
+                decide(
+                    nowMs = broken + ESCALATE_AFTER_UNREPAIRED_MS,
+                    unrepairedSinceMs = broken,
+                    cyclesUsedThisSession = spent,
+                    // Far enough back that the cooldown is not what is being tested here.
+                    lastCycleMs = broken - CYCLE_COOLDOWN_MS,
+                )
+            )
+        }
+    }
+
+    // --- The decay --------------------------------------------------------------------------
+
+    @Test
+    fun `a second cycle waits out the cooldown even with budget left`() {
+        val firstCycle = 100_000L
+        val broken = firstCycle + 5_000L
+        assertEquals(
+            Action.NUDGE,
+            decide(
+                nowMs = firstCycle + CYCLE_COOLDOWN_MS - 1,
+                unrepairedSinceMs = broken,
+                cyclesUsedThisSession = 1,
+                lastCycleMs = firstCycle,
+            )
+        )
+        assertEquals(
+            Action.CYCLE_FOCUS,
+            decide(
+                nowMs = firstCycle + CYCLE_COOLDOWN_MS,
+                unrepairedSinceMs = broken,
+                cyclesUsedThisSession = 1,
+                lastCycleMs = firstCycle,
+            )
+        )
+    }
+
+    @Test
+    fun `the first cycle of a session is not held back by an unset cooldown stamp`() {
+        // lastCycleMs is 0 before anything has fired, and must not read as "a cycle at time zero" -
+        // that would suppress the first escalation of every session for the first minute of uptime.
+        val broken = 10_000L
+        assertEquals(
+            Action.CYCLE_FOCUS,
+            decide(
+                nowMs = broken + ESCALATE_AFTER_UNREPAIRED_MS,
+                unrepairedSinceMs = broken,
+                cyclesUsedThisSession = 0,
+                lastCycleMs = 0L,
+            )
+        )
+    }
+
+    // --- Constants held against what was measured -------------------------------------------
+
+    @Test
+    fun `the escalation window clears two throttle windows`() {
+        // Escalating before a nudge has demonstrably gone unanswered would spend a focus release on
+        // a request the phone had not had a chance to answer yet.
+        assertTrue(
+            "escalation window ${ESCALATE_AFTER_UNREPAIRED_MS}ms does not clear two " +
+                "${VideoRecoveryPolicy.KEYFRAME_REQUEST_THROTTLE_MS}ms throttle windows",
+            ESCALATE_AFTER_UNREPAIRED_MS >= VideoRecoveryPolicy.KEYFRAME_REQUEST_THROTTLE_MS * 2
+        )
+    }
+
+    @Test
+    fun `the escalation window stays well under the fastest unaided repair ever measured`() {
+        // Past a third of the fastest natural keyframe gap on record, the phone's own cadence would
+        // often beat the escalation and the disturbance buys nothing.
+        assertTrue(
+            "escalation window ${ESCALATE_AFTER_UNREPAIRED_MS}ms is not clearly under a third of the " +
+                "${NATURAL_CADENCE_MIN_OBSERVED_MS}ms fastest natural keyframe gap",
+            ESCALATE_AFTER_UNREPAIRED_MS <= NATURAL_CADENCE_MIN_OBSERVED_MS / 3
+        )
+    }
+
+    @Test
+    fun `the cooldown keeps two focus cycles from ever being in flight together`() {
+        // AapTransport carries one shared regain runnable and replaces it rather than tracking one
+        // per cycle. That is only sound while a second release cannot land inside the first's regain
+        // gap. Shortening the cooldown towards the gap needs that bookkeeping first.
+        assertTrue(
+            "cooldown ${CYCLE_COOLDOWN_MS}ms is not comfortably clear of the ${FOCUS_CYCLE_GAP_MS}ms regain gap",
+            CYCLE_COOLDOWN_MS >= FOCUS_CYCLE_GAP_MS * 10
+        )
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/ProjectionWatchdogPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/ProjectionWatchdogPolicyTest.kt
@@ -1,0 +1,46 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.connection.CommManager
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The full state table is spelled out because the watchdog's original inline check accepted only
+ * HandshakeComplete — a state the session passes through once, briefly — and returned without
+ * re-posting, so it died on the first tick of every session. TransportStarted being live is the
+ * regression this table pins.
+ */
+class ProjectionWatchdogPolicyTest {
+
+    @Test
+    fun `the session is live through the handshake window and the whole projection`() {
+        assertTrue(ProjectionWatchdogPolicy.isSessionLive(CommManager.ConnectionState.HandshakeComplete))
+        assertTrue(ProjectionWatchdogPolicy.isSessionLive(CommManager.ConnectionState.TransportStarted))
+    }
+
+    @Test
+    fun `every state outside a live session stops the watchdog`() {
+        assertFalse(ProjectionWatchdogPolicy.isSessionLive(CommManager.ConnectionState.Disconnected()))
+        assertFalse(ProjectionWatchdogPolicy.isSessionLive(CommManager.ConnectionState.Connecting))
+        assertFalse(ProjectionWatchdogPolicy.isSessionLive(CommManager.ConnectionState.Connected))
+        assertFalse(ProjectionWatchdogPolicy.isSessionLive(CommManager.ConnectionState.StartingTransport))
+        assertFalse(ProjectionWatchdogPolicy.isSessionLive(CommManager.ConnectionState.Error("boom")))
+    }
+
+    @Test
+    fun `no request without the reconnecting overlay`() {
+        // The overlay is the watchdog's own 10s-frame-gap signal; without it the picture is fine
+        // and a focus request would only disturb a healthy stream.
+        assertFalse(ProjectionWatchdogPolicy.shouldRequestVideoFocus(false, nowMs = 100_000, lastRequestMs = 0))
+    }
+
+    @Test
+    fun `requests are paced by the keyframe throttle`() {
+        val throttle = VideoRecoveryPolicy.KEYFRAME_REQUEST_THROTTLE_MS
+        // Inside the throttle window: suppressed, boundary included (canRequestKeyframe is strict).
+        assertFalse(ProjectionWatchdogPolicy.shouldRequestVideoFocus(true, nowMs = throttle, lastRequestMs = 0))
+        // Past it: allowed.
+        assertTrue(ProjectionWatchdogPolicy.shouldRequestVideoFocus(true, nowMs = throttle + 1, lastRequestMs = 0))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/VideoKeyframeScannerTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/VideoKeyframeScannerTest.kt
@@ -1,0 +1,115 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VideoKeyframeScannerTest {
+
+    /** Builds an access unit from (nalHeaderByte, payloadBytes) pairs, 4-byte start codes. */
+    private fun accessUnit(vararg nals: Int): ByteArray {
+        val out = ArrayList<Byte>()
+        for (header in nals) {
+            out.add(0); out.add(0); out.add(0); out.add(1)
+            out.add(header.toByte())
+            repeat(3) { out.add(0x42) }
+        }
+        return out.toByteArray()
+    }
+
+    private fun scan(data: ByteArray, isHevc: Boolean) =
+        VideoKeyframeScanner.containsKeyframe(data, 0, data.size, isHevc)
+
+    // --- H.264 -----------------------------------------------------------------------------
+
+    @Test
+    fun `an h264 idr slice is a keyframe`() {
+        assertTrue(scan(accessUnit(0x65), isHevc = false)) // nal_ref_idc=3, type 5
+    }
+
+    @Test
+    fun `an h264 idr behind its parameter sets is still found`() {
+        // What the phone actually sends: SPS (7), PPS (8), then the IDR slice.
+        assertTrue(scan(accessUnit(0x67, 0x68, 0x65), isHevc = false))
+    }
+
+    @Test
+    fun `an h264 non-idr slice is not a keyframe`() {
+        assertFalse(scan(accessUnit(0x41), isHevc = false)) // type 1
+    }
+
+    @Test
+    fun `parameter sets alone are not a keyframe`() {
+        // A config-only message carries no picture, so it repairs nothing on its own.
+        assertFalse(scan(accessUnit(0x67, 0x68), isHevc = false))
+    }
+
+    // --- H.265 -----------------------------------------------------------------------------
+
+    @Test
+    fun `hevc irap types are keyframes across the whole range`() {
+        for (type in 16..21) {
+            assertTrue("HEVC NAL type $type", scan(accessUnit(type shl 1), isHevc = true))
+        }
+    }
+
+    @Test
+    fun `an hevc trailing picture is not a keyframe`() {
+        assertFalse(scan(accessUnit(0x02), isHevc = true)) // TRAIL_R, type 1
+    }
+
+    @Test
+    fun `an hevc idr behind vps sps pps is still found`() {
+        assertTrue(scan(accessUnit(32 shl 1, 33 shl 1, 34 shl 1, 19 shl 1), isHevc = true))
+    }
+
+    // --- The mismatch that froze a session once --------------------------------------------
+
+    @Test
+    fun `reading an h264 idr as hevc can go either way, which is why the pinned type is passed`() {
+        // The header byte carries nal_ref_idc as well as the type, and the two codecs read different
+        // bits of it. 0x65 (the IDR the phone actually sends, nal_ref_idc=3) reads as HEVC type 50
+        // and is correctly rejected - but 0x25, the same IDR at nal_ref_idc=1, reads as HEVC type 18
+        // and would be accepted. So a wrong codec type gives a wrong answer in both directions.
+        // That is the failure 66e59b2c hit by reading headers against the user's preference; the
+        // caller passes the decoder's pinned type instead. Pinned here so the reason stays visible.
+        assertTrue(scan(accessUnit(0x65), isHevc = false))
+        assertFalse(scan(accessUnit(0x65), isHevc = true))
+
+        assertTrue(scan(accessUnit(0x25), isHevc = false))
+        assertTrue(scan(accessUnit(0x25), isHevc = true))
+    }
+
+    // --- Framing -----------------------------------------------------------------------------
+
+    @Test
+    fun `three byte start codes are recognised`() {
+        val data = byteArrayOf(0, 0, 1, 0x65, 0x42, 0x42)
+        assertTrue(VideoKeyframeScanner.containsKeyframe(data, 0, data.size, isHevc = false))
+    }
+
+    @Test
+    fun `an offset into a larger buffer is honoured`() {
+        val prefix = byteArrayOf(0x11, 0x22)
+        val data = prefix + accessUnit(0x65)
+        assertTrue(
+            VideoKeyframeScanner.containsKeyframe(data, prefix.size, data.size - prefix.size, isHevc = false)
+        )
+        // The same bytes below the offset must not be reachable.
+        assertFalse(VideoKeyframeScanner.containsKeyframe(data, 0, prefix.size, isHevc = false))
+    }
+
+    @Test
+    fun `a truncated or empty access unit is not a keyframe`() {
+        assertFalse(VideoKeyframeScanner.containsKeyframe(ByteArray(0), 0, 0, isHevc = false))
+        assertFalse(VideoKeyframeScanner.containsKeyframe(byteArrayOf(0, 0, 1), 0, 3, isHevc = false))
+    }
+
+    @Test
+    fun `a keyframe buried past the header cap is not scanned for`() {
+        // Bounding the walk is deliberate - a keyframe access unit leads with its parameter sets, so
+        // anything this deep is not one. Pinned here so the bound cannot be widened silently.
+        val nals = IntArray(9) { if (it == 8) 0x65 else 0x41 }
+        assertFalse(scan(accessUnit(*nals), isHevc = false))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/VideoRecoveryPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/VideoRecoveryPolicyTest.kt
@@ -33,4 +33,41 @@ class VideoRecoveryPolicyTest {
             assertFalse(VideoRecoveryPolicy.canRequestKeyframe(last + offset, last))
         }
     }
+
+    @Test
+    fun `a drop before the first rendered frame never asks`() {
+        // A warming codec sheds frames while healthy, and the nudge does nothing before the
+        // phone has started its sink - that window belongs to WarmRelaunchKeyframePolicy.
+        assertFalse(
+            VideoRecoveryPolicy.shouldRequestOnDroppedFrame(
+                hasRendered = false, nowMs = 12_345L, lastRequestMs = 0L
+            )
+        )
+    }
+
+    @Test
+    fun `the first drop after a rendered frame asks immediately`() {
+        assertTrue(
+            VideoRecoveryPolicy.shouldRequestOnDroppedFrame(
+                hasRendered = true, nowMs = 12_345L, lastRequestMs = 0L
+            )
+        )
+    }
+
+    @Test
+    fun `drops share the corrupt-frame throttle window`() {
+        // A sustained backlog drops a frame per arrival; that must cost one request per window,
+        // not one per frame.
+        val last = 10_000L
+        assertFalse(
+            VideoRecoveryPolicy.shouldRequestOnDroppedFrame(
+                hasRendered = true, nowMs = last + KEYFRAME_REQUEST_THROTTLE_MS, lastRequestMs = last
+            )
+        )
+        assertTrue(
+            VideoRecoveryPolicy.shouldRequestOnDroppedFrame(
+                hasRendered = true, nowMs = last + KEYFRAME_REQUEST_THROTTLE_MS + 1, lastRequestMs = last
+            )
+        )
+    }
 }

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/WarmRelaunchKeyframePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/WarmRelaunchKeyframePolicyTest.kt
@@ -1,0 +1,134 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.WarmRelaunchKeyframePolicy.Action
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The gates are spelled out one at a time because each of them is what keeps a video-focus release
+ * away from a stream that is working. A release across a healthy stream is a known way to drop one
+ * to a few fps permanently, so the escalation is only ever correct in the one situation these
+ * arguments describe together: a decoder rebuilt under a surface that has never shown a frame, on a
+ * session that already proved itself, with the phone still sending.
+ */
+class WarmRelaunchKeyframePolicyTest {
+
+    /** A relaunch that has gone 2s without a picture while the phone streams: the whole point. */
+    private fun warmRelaunch(
+        sessionHasRendered: Boolean = true,
+        renderedSinceSurfaceSet: Boolean = false,
+        transportStarted: Boolean = true,
+        msSinceSurfaceSet: Long = 5_000,
+        msSincePhoneBytes: Long = 100,
+        phoneAliveThresholdMs: Long = 1_500,
+        cycleAlreadySpent: Boolean = false,
+        msSinceLastRequest: Long = 60_000
+    ) = WarmRelaunchKeyframePolicy.decide(
+        sessionHasRendered = sessionHasRendered,
+        renderedSinceSurfaceSet = renderedSinceSurfaceSet,
+        transportStarted = transportStarted,
+        msSinceSurfaceSet = msSinceSurfaceSet,
+        msSincePhoneBytes = msSincePhoneBytes,
+        phoneAliveThresholdMs = phoneAliveThresholdMs,
+        cycleAlreadySpent = cycleAlreadySpent,
+        msSinceLastRequest = msSinceLastRequest
+    )
+
+    @Test
+    fun `a warm relaunch with no picture gets the focus cycle`() {
+        assertEquals(Action.CYCLE_FOCUS, warmRelaunch())
+    }
+
+    @Test
+    fun `the cycle is spent once per surface and degrades to the nudge`() {
+        assertEquals(Action.NUDGE, warmRelaunch(cycleAlreadySpent = true))
+    }
+
+    @Test
+    fun `the nudge respects the shared keyframe throttle`() {
+        assertEquals(
+            Action.NONE,
+            warmRelaunch(
+                cycleAlreadySpent = true,
+                msSinceLastRequest = WarmRelaunchKeyframePolicy.NUDGE_THROTTLE_MS - 1
+            )
+        )
+        assertEquals(
+            Action.NUDGE,
+            warmRelaunch(
+                cycleAlreadySpent = true,
+                msSinceLastRequest = WarmRelaunchKeyframePolicy.NUDGE_THROTTLE_MS
+            )
+        )
+    }
+
+    @Test
+    fun `a picture on screen is never disturbed`() {
+        // The regression this exists to avoid: asking again is what costs a working stream.
+        assertEquals(Action.NONE, warmRelaunch(renderedSinceSurfaceSet = true))
+        assertEquals(
+            Action.NONE,
+            warmRelaunch(renderedSinceSurfaceSet = true, cycleAlreadySpent = true)
+        )
+    }
+
+    @Test
+    fun `a cold start is left to the phone's own sink setup`() {
+        // Nothing has ever rendered, so there is no proven stream to bring back and the phone is
+        // already running setup of its own accord.
+        assertEquals(Action.NONE, warmRelaunch(sessionHasRendered = false))
+    }
+
+    @Test
+    fun `nothing is sent unless the transport is in its steady state`() {
+        assertEquals(Action.NONE, warmRelaunch(transportStarted = false))
+    }
+
+    @Test
+    fun `a phone that stopped sending is a pause, not a stall`() {
+        assertEquals(
+            Action.NONE,
+            warmRelaunch(msSincePhoneBytes = 1_501, phoneAliveThresholdMs = 1_500)
+        )
+        assertEquals(
+            Action.CYCLE_FOCUS,
+            warmRelaunch(msSincePhoneBytes = 1_500, phoneAliveThresholdMs = 1_500)
+        )
+    }
+
+    @Test
+    fun `a fresh surface is given the healthy path's own worst case first`() {
+        // A surface younger than the escalation window may simply be about to render.
+        assertEquals(
+            Action.NONE,
+            warmRelaunch(msSinceSurfaceSet = WarmRelaunchKeyframePolicy.ESCALATE_AFTER_SURFACE_MS - 1)
+        )
+        assertEquals(
+            Action.CYCLE_FOCUS,
+            warmRelaunch(msSinceSurfaceSet = WarmRelaunchKeyframePolicy.ESCALATE_AFTER_SURFACE_MS)
+        )
+    }
+
+    @Test
+    fun `the escalation window stays clear of the slowest unaided first frame`() {
+        // The test above is relative to the constant, so it stays green whatever the constant
+        // becomes. This one pins the constant itself.
+        //
+        // Firing early is not a harmless false positive: it releases video focus across a stream
+        // that was about to render, which is the one thing this policy is built not to do. The
+        // window therefore has to sit clear of the slowest a surface has ever been measured taking
+        // to render on its own - 404ms, a SurfaceView return whose codec creation took 308ms and
+        // whose first frame followed 96ms later. Twice that is the rule the window is set by, and
+        // it is the reason the constant is 850 rather than a rounder 800, which would sit under it.
+        // If a future measurement raises the ceiling, raise the window with it rather than relaxing
+        // this assertion.
+        assertTrue(
+            "escalation window ${WarmRelaunchKeyframePolicy.ESCALATE_AFTER_SURFACE_MS}ms leaves too " +
+                "little margin over the ${WarmRelaunchKeyframePolicy.HEALTHY_FIRST_FRAME_CEILING_MS}ms " +
+                "slowest unaided first frame",
+            WarmRelaunchKeyframePolicy.ESCALATE_AFTER_SURFACE_MS >=
+                WarmRelaunchKeyframePolicy.HEALTHY_FIRST_FRAME_CEILING_MS * 2
+        )
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/DecoderRestartPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/DecoderRestartPolicyTest.kt
@@ -1,0 +1,48 @@
+package com.andrerinas.openheadunit.decoder
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DecoderRestartPolicyTest {
+
+    @Test
+    fun `a session that never rendered counts restarts against the pin`() {
+        // The one case the ladder exists for: a component that cannot decode this type at all.
+        assertTrue(
+            DecoderRestartPolicy.countsTowardFailure(
+                codecTypePinned = true, renderedSinceLastStart = false, renderedThisSession = false
+            )
+        )
+    }
+
+    @Test
+    fun `a stream that has already rendered is proven and never escalates`() {
+        // The relaunch case: the surface swap zeroed the per-start timestamp, but the session
+        // has decoded this stream - warm-up churn is not evidence the codec is broken.
+        assertFalse(
+            DecoderRestartPolicy.countsTowardFailure(
+                codecTypePinned = true, renderedSinceLastStart = false, renderedThisSession = true
+            )
+        )
+    }
+
+    @Test
+    fun `a restart after a frame from the current start never counts`() {
+        assertFalse(
+            DecoderRestartPolicy.countsTowardFailure(
+                codecTypePinned = true, renderedSinceLastStart = true, renderedThisSession = true
+            )
+        )
+    }
+
+    @Test
+    fun `an unpinned session never counts restarts`() {
+        // Before the first successful start there is no codec type to hold anything against.
+        assertFalse(
+            DecoderRestartPolicy.countsTowardFailure(
+                codecTypePinned = false, renderedSinceLastStart = false, renderedThisSession = false
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/VideoFeedQueuePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/VideoFeedQueuePolicyTest.kt
@@ -1,0 +1,88 @@
+package com.andrerinas.openheadunit.decoder
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The queue between the transport and the codec has to hold more video than the feed thread in front
+ * of it is willing to wait. Issue #830 is what happens when it does not: the queue sheds reference
+ * frames the feed thread has not given up on, and the picture drifts until the phone's next keyframe
+ * some ~69s later.
+ */
+class VideoFeedQueuePolicyTest {
+
+    /** The rates Android Auto actually negotiates, and the highest of them. */
+    private val realWorldRates = listOf(30, 60)
+    private val highestNegotiatedRate = 60
+
+    @Test
+    fun `the queue always holds more video than the feed thread waits for`() {
+        // The invariant the whole class exists for. Checked across every rate the setting can
+        // plausibly carry, not just the two below - a cap the user drags to an odd value must not
+        // quietly reopen #830.
+        for (fps in 15..120) {
+            assertTrue(
+                "at ${fps}fps the queue holds ${VideoFeedQueuePolicy.heldMsAt(fps)}ms, which does not " +
+                    "cover the ${VideoFeedQueuePolicy.INPUT_DEQUEUE_PATIENCE_MS}ms the feed thread waits",
+                VideoFeedQueuePolicy.heldMsAt(fps) >= VideoFeedQueuePolicy.INPUT_DEQUEUE_PATIENCE_MS
+            )
+        }
+    }
+
+    @Test
+    fun `the queue depth is the configured window at the rates Android Auto negotiates`() {
+        for (fps in realWorldRates) {
+            assertEquals(
+                "unexpected depth at ${fps}fps",
+                (fps * VideoFeedQueuePolicy.FRAME_QUEUE_MS / 1000),
+                VideoFeedQueuePolicy.capacityFor(fps)
+            )
+        }
+        // Spelled out, so a change to FRAME_QUEUE_MS shows up as a number a reader recognises.
+        assertEquals(15, VideoFeedQueuePolicy.capacityFor(30))
+        assertEquals(30, VideoFeedQueuePolicy.capacityFor(60))
+    }
+
+    @Test
+    fun `a low frame rate cap cannot produce a queue below the floor`() {
+        // fpsLimit is the user's cap, not the rate the phone negotiated, so it can understate what
+        // is really arriving. The floor is what keeps that from shrinking the queue under the
+        // patience it has to cover.
+        assertEquals(VideoFeedQueuePolicy.MIN_CAPACITY, VideoFeedQueuePolicy.capacityFor(1))
+        assertEquals(VideoFeedQueuePolicy.MIN_CAPACITY, VideoFeedQueuePolicy.capacityFor(20))
+    }
+
+    @Test
+    fun `a high frame rate cap cannot grow the queue past the memory ceiling`() {
+        // Every slot holds a pooled buffer that grows to the largest frame it has carried, so the
+        // ceiling is a memory bound, not a latency one.
+        assertEquals(VideoFeedQueuePolicy.MAX_CAPACITY, VideoFeedQueuePolicy.capacityFor(120))
+        assertEquals(VideoFeedQueuePolicy.MAX_CAPACITY, VideoFeedQueuePolicy.capacityFor(240))
+    }
+
+    @Test
+    fun `a nonsense frame rate degrades instead of dividing by zero`() {
+        // This is read on the feed thread's start path, where an arithmetic exception takes the
+        // decoder down rather than degrading it, and fpsLimit comes from stored settings.
+        for (fps in listOf(0, -1, Int.MIN_VALUE)) {
+            assertEquals(VideoFeedQueuePolicy.MIN_CAPACITY, VideoFeedQueuePolicy.capacityFor(fps))
+            assertTrue(VideoFeedQueuePolicy.heldMsAt(fps) > 0)
+        }
+    }
+
+    @Test
+    fun `the memory ceiling is where the patience guarantee runs out`() {
+        // Documented rather than asserted away: past this rate MAX_CAPACITY decides the depth and
+        // the queue no longer covers the patience. It sits far above anything Android Auto asks
+        // for, and this test is here so that stops being true loudly rather than silently.
+        val lastSafeRate = (VideoFeedQueuePolicy.MAX_CAPACITY * 1000L /
+            VideoFeedQueuePolicy.INPUT_DEQUEUE_PATIENCE_MS).toInt()
+        assertTrue(
+            "the patience guarantee now runs out at ${lastSafeRate}fps, at or below a rate Android " +
+                "Auto negotiates (${highestNegotiatedRate}fps)",
+            lastSafeRate > highestNegotiatedRate
+        )
+        assertEquals(133, lastSafeRate)
+    }
+}


### PR DESCRIPTION
Fixes #822 black screen

## Why

Bringing the main screen forward (the launcher icon, any deep link) destroys a live projection by `singleTask` semantics alone, and `MainActivity` immediately relaunches it. Two separate faults live on that path.

**1. The screen stayed black forever.** The relaunch itself works. What killed it was the *old* instance's teardown landing 250-650 ms later and acting on the shared session as if it still owned it: releasing video focus, stopping the singleton decoder its replacement had already claimed, nulling the new instance's listeners. Nothing re-requested video afterwards, because both watchdogs were dead in steady state. Only killing the app recovered it.

**2. Fixing that exposed a slow, erratic return.** 97-99% of it was spent waiting for the phone to send a decodable picture, not rendering. SurfaceView is fast by accident: its surface *is* destroyed by the cover, so its teardown releases video focus, and the return's gain makes the phone re-run video sink setup, which begins with a keyframe. `Media Start Request VIDEO` followed 4 of 4 SurfaceView returns and 0 of 10 TextureView/GLES ones. The other two never destroy their surface, so the phone is never told, and repeating the unsolicited gain does nothing: dozens go out per slow return, not one is followed by a picture.

| Behaviour | Before | After |
|---|---|---|
| Return to projection after backgrounding | Black indefinitely, audio still playing; only a force-stop recovered | Picture returns on every cycle, all three backends |
| Time to picture, GLES / TextureView | 30.8 s, 74.8 s, one cycle that never rendered, 49.3 s / 5.4-52.5 s | 2.00-2.08 s / 1.87-1.99 s |

SurfaceView, the control, is unchanged at 0.62-0.76 s and never triggers the new path.

## What changed

| Layer | Change |
|---|---|
| `aap/AapProjectionActivity`, `view/ProjectionView`, `main/MainActivity` | Surface-ownership gate on every teardown-side decoder stop, so a discarded instance's late callback cannot stop a decoder its replacement already claimed. |
| `aap/ProjectionWatchdogPolicy` (new) | The reconnecting watchdog gated on `HandshakeComplete`, a state the session passes through once, and returned without re-posting, so it died on its first tick. Steady state is `TransportStarted`. |
| `aap/WarmRelaunchKeyframePolicy` (new), `connection/CommManager` | A relaunched surface still black after 850 ms, on a session that has already rendered, with the phone still sending, releases video focus and takes it back 400 ms later. Once per surface. |
| `decoder/DecoderRestartPolicy` (new), `decoder/VideoDecoder` | Warm-up restarts on an already-decoding stream no longer feed the codec-flip/latch ladder; parameter sets survive a surface swap; `stop()` can no longer release a codec the feed thread is inside; a surface that dies mid-`configure` stops scheduling restarts that can only fail the same way. |

The three new decision points are pure objects with their transition tables pinned by tests, following the existing `WifiModePolicy` convention.

## Where to focus review

- **`WarmRelaunchKeyframePolicy.decide()`** is the one place that can release video focus. Releasing it across a *rendering* stream is the #755 regression, which is why `AapTransport`'s own recovery sends a gain only. Every gate here requires the opposite situation, a decoder rebuilt under a surface that has never shown a frame, so there is no picture to lose. Worth checking that reasoning rather than the arithmetic.
- **The 850 ms window** is twice the slowest a surface has been measured rendering unaided (404 ms), with a test pinning that relationship so it cannot drift under the healthy path.
- **`settleFocusCycle()`**: the release and the gain are one operation split across a delay, so anything that would cancel the pending half sends it instead. Focus left released is a permanent black screen.

## Verification

- **Unit tests**: 261 pass, including the three new policy tables. Run on the hardware rig; counts come from the JUnit XML reports.
- **On-device**: eight rounds on a UNISOC MT50 (Android 14), wireless mode 3, driving the real user route (cover the projection, hold 5/45/180/5 s, return via the launcher) across all three backends, with audio on and off. Every figure above is from device-log timestamps, and the last two rounds were same-day A/Bs against this branch's own parent build.
- No build-config, NDK or dependency changes, so CI's `:app:assembleGithubDebug` should be unaffected.

## Risks

- **The focus cycle is a behaviour change visible to the phone.** Gated to a black relaunched surface on a proven session, capped at once per surface, and it fired zero times on SurfaceView across two full rounds. Where the #755 sensitivity exists, the worst case is a picture that is currently absent arriving degraded rather than not at all.
- **`Media Sink Stop Request: VIDEO` after a return now has two meanings.** When it is ours it is immediately followed by `Video Sink Stopped -> Ignored (Forced Keyframe Request)`; triage should check for that pairing.
- Timings are from one SoC. The mechanism is protocol-level, but the constants were tuned against this unit.

## Out of scope

`AapProjectionActivity` keeps its `singleTask` teardown. Giving it its own `taskAffinity` would stop a launcher tap destroying a live projection at all, the largest remaining win and the largest blast radius (recents, back stack, every auto-start path). It belongs in its own change.

Detected on issue #822 


## #830 — washed-out picture after a dropped frame

3.2.4's stall catch-up put a bounded queue between the transport and the codec, and a queue that can overflow sheds reference frames silently. Everything after a shed frame predicts from it, so the picture drifts washed-out and blocky until the phone's next keyframe — and the phone runs a fixed ~69s GOP, so one lost frame costs ~35s of corruption on average. That is the reporter's "fixes itself after a minute", derived before their log arrived.

Two commits, one for each half.

**Not shedding the frame.** `feedInputBuffer` waited 300ms for the codec while the queue behind it held 12 frames — "around 200ms" by its own comment — so any stall between those figures shed frames the feed thread had not given up on. Both numbers now live in `VideoFeedQueuePolicy` with a test asserting the queue always holds more video than the thread in front of it waits for. Also stops splitting an oversized frame across input buffers, which corrupted the picture as surely as dropping it since every buffer on this API range is parsed as a complete access unit.

**Repairing it when one still gets through.** A shed frame starts a clock; `VideoKeyframeScanner` stops it when a keyframe actually reaches the codec. If the picture is still unrepaired after 2s, the transport spends a video-focus release/regain cycle, budgeted to 3 per session and 60s apart. AAP has no keyframe-request message — verified against the protobuf definitions extracted from Google's own Android Auto binary and against the Head Unit Integration Guide — so the focus cycle is the only lever that exists.

Measured on hardware over six rounds on a UNISOC MT50 / Android 14 unit: repair time 2.67s against the ~35s median the same drop cost before, and under an identical transient-stall lever the deeper queue shed 0 reference frames against the old queue's 4. No sign of #755 — `Codec initialized:` stayed at zero across every focus cycle.