### PR TITLE
Fix/773 headunit server socket leak

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -812,6 +812,14 @@ class AapService : Service(), UsbReceiver.Listener {
                         })
                     }
                     is CommManager.ConnectionState.Error -> {
+                        // Nothing may be counted here, and nothing new may be hung off this branch.
+                        // connectionState is a MutableStateFlow, so collection is conflated, and
+                        // startHandshake() calls disconnect() with no suspension point after
+                        // emitting Error — the value is already Disconnected by the time any
+                        // collector resumes, so this branch does not run while the Disconnected one
+                        // below runs normally. Anything that has to count failures counts them
+                        // where they happen; the silent-peer streak lives in CommManager for that
+                        // reason.
                         if (state.message.contains("Handshake failed")) {
                             onHandshakeFailed()
                         }
@@ -2413,7 +2421,9 @@ class AapService : Service(), UsbReceiver.Listener {
                     AppLog.i("One-shot scan finished.")
                     return
                 }
-                // Reschedule the next scan to avoid hammering the network.
+                // Reschedule the next scan to avoid hammering the network — and slow right down
+                // when the peer we keep reaching accepts the connection and never answers, which
+                // no amount of retrying fixes and which costs it a stranded socket each time.
                 //
                 // Unless the network changed while this sweep was running. Joining the phone's
                 // network has to start a scan promptly — waiting out the loop is most of a
@@ -2426,7 +2436,7 @@ class AapService : Service(), UsbReceiver.Listener {
                     AppLog.i("AapService: network changed during the last scan; rescanning immediately")
                     0L
                 } else {
-                    10000L
+                    UnresponsivePeerPolicy.rescanDelayMs(commManager.silentPeerFailures)
                 }
                 serviceScope.launch {
                     delay(delayMs)

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -548,6 +548,16 @@ class AapService : Service(), UsbReceiver.Listener {
                 }
                 Intent.ACTION_SHUTDOWN -> {
                     AppLog.i("WakeDetect: SHUTDOWN (system shutting down, not hibernating)")
+                    maybeTearDownBeforeLinkGoes(LinkLossTrigger.DEVICE_SHUTDOWN) { goAsync() }
+                }
+                android.net.wifi.WifiManager.WIFI_STATE_CHANGED_ACTION -> {
+                    val state = intent.getIntExtra(
+                        android.net.wifi.WifiManager.EXTRA_WIFI_STATE,
+                        android.net.wifi.WifiManager.WIFI_STATE_UNKNOWN
+                    )
+                    if (state == android.net.wifi.WifiManager.WIFI_STATE_DISABLING) {
+                        maybeTearDownBeforeLinkGoes(LinkLossTrigger.WIFI_STATION_DISABLING) { goAsync() }
+                    }
                 }
                 else -> {
                     // OEM boot/ACC/wake intents — log with extras for diagnostics
@@ -1381,6 +1391,10 @@ class AapService : Service(), UsbReceiver.Listener {
             addAction(Intent.ACTION_POWER_CONNECTED)
             addAction(Intent.ACTION_POWER_DISCONNECTED)
             addAction(Intent.ACTION_SHUTDOWN)
+            // Not a wake event: the warning that WiFi station mode is going away, which is the
+            // only chance to close a session riding it before the interface does. See
+            // LinkLossTeardownPolicy.
+            addAction(android.net.wifi.WifiManager.WIFI_STATE_CHANGED_ACTION)
             // Standard boot (dynamic duplicate — BootCompleteReceiver handles manifest side)
             addAction(Intent.ACTION_BOOT_COMPLETED)
             addAction(Intent.ACTION_LOCKED_BOOT_COMPLETED)
@@ -2344,6 +2358,61 @@ class AapService : Service(), UsbReceiver.Listener {
     private fun nativeTransport(): NativeTransport =
         NativeTransport.fromSetting(App.provide(this).settings.nativeApTransport)
 
+    /**
+     * Closes an active session while the link it rides still works.
+     *
+     * Android Auto's head unit server is wedged permanently by a peer that vanishes without
+     * closing, and only a restart on the phone clears it. A session that closes properly does not
+     * do that. The system warns us before some link losses and not others; this takes the ones it
+     * does warn about.
+     *
+     * [pendingResult] keeps the broadcast alive while the teardown runs, because it does socket
+     * work and the caller is a receiver on the main thread. It is always finished.
+     */
+    private fun maybeTearDownBeforeLinkGoes(
+        trigger: LinkLossTrigger,
+        pendingResult: () -> BroadcastReceiver.PendingResult
+    ) {
+        if (!commManager.isConnected) return
+        val settings = App.provide(this).settings
+        if (!LinkLossTeardownPolicy.shouldTearDown(
+                trigger,
+                settings.wifiConnectionMode,
+                settings.helperConnectionStrategy,
+                nativeTransport(),
+                // [BUG_FIX] Ask the session, not the settings. wifiConnectionMode is stored and
+                // says nothing about what is running: a USB drive with a WiFi mode selected was
+                // being disconnected by the user switching WiFi off, which the session never
+                // rode in the first place.
+                sessionIsWireless = commManager.isWirelessSession
+            )
+        ) {
+            AppLog.i("AapService: $trigger, but this session does not ride that link; leaving it alone")
+            return
+        }
+
+        val pending = pendingResult()
+        val startedAt = SystemClock.elapsedRealtime()
+        AppLog.i(
+            "AapService: $trigger with a live session — closing it now, while the link still " +
+                "works. A session that just vanishes leaves the phone's head unit server holding a " +
+                "peer that never came back, and only restarting it by hand clears that."
+        )
+        Thread {
+            try {
+                commManager.disconnectForLinkLoss(LINK_LOSS_TEARDOWN_BUDGET_MS)
+                AppLog.i(
+                    "AapService: link-loss teardown finished in " +
+                        "${SystemClock.elapsedRealtime() - startedAt}ms"
+                )
+            } catch (e: Exception) {
+                AppLog.e("AapService: link-loss teardown failed", e)
+            } finally {
+                try { pending.finish() } catch (e: Exception) {}
+            }
+        }.apply { name = "AapService-LinkLossTeardown"; start() }
+    }
+
     fun triggerWifiDirectRefresh() {
         val mode = App.provide(this).settings.wifiConnectionMode
         if (mode != 3) return
@@ -3113,6 +3182,14 @@ class AapService : Service(), UsbReceiver.Listener {
          * single join can produce several. One discovery kick per join is what is wanted.
          */
         private const val NETWORK_AVAILABLE_DEBOUNCE_MS = 1000L
+
+        /**
+         * How long a link-loss teardown may take. The interface is already on its way down and the
+         * broadcast is holding the system up, so this is a budget rather than a target: the
+         * ByeBye and the socket close together take well under 200 ms when the link still works,
+         * and when it does not there is nothing to wait for.
+         */
+        private const val LINK_LOSS_TEARDOWN_BUDGET_MS = 1500L
 
         /** Cooldown period after user-initiated exit. During this window, the WirelessServer
          *  rejects incoming connections to prevent the phone from instantly reconnecting. */

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -128,6 +128,21 @@ class AapService : Service(), UsbReceiver.Listener {
     @Volatile
     private var rescanWithoutWaiting: Boolean = false
 
+    /**
+     * Set when a link-loss teardown closed the session because station WiFi was going away.
+     *
+     * The ordinary answer to a disconnect is to restart the discovery loop two seconds later, and
+     * that is wrong here: the network it would scan is the one on its way down. What it finds is
+     * whatever interface enumerates first — a modem bridge, typically — and it sweeps that subnet
+     * every ten seconds until WiFi returns, which costs nothing but reads in a captured log
+     * exactly like discovery probing the wrong network for real.
+     *
+     * Cleared when a network comes back, which is also what revives the loop: `onAvailable` calls
+     * `startScan()` on the instance that is still there.
+     */
+    @Volatile
+    private var discoveryDormantAfterWifiLoss: Boolean = false
+
     private inline fun <T> safeMediaSessionCall(crossinline block: (MediaSessionCompat) -> T): T? {
         if (isDestroying) return null
         val session = mediaSession ?: return null
@@ -1294,6 +1309,11 @@ class AapService : Service(), UsbReceiver.Listener {
                         if (wifiManager.isWifiEnabled) {
                             wifiDirectManager?.makeVisible()
                         }
+                    } else if (discoveryDormantAfterWifiLoss) {
+                        AppLog.i(
+                            "AapService: link-loss teardown — leaving discovery down until a " +
+                                "network comes back, rather than scanning the one that went away."
+                        )
                     } else {
                         startDiscovery()
                     }
@@ -1435,6 +1455,12 @@ class AapService : Service(), UsbReceiver.Listener {
                 // wants: a scan is running, so the network is already being looked at.
                 // onAvailable also fires repeatedly (per network, and again on re-validation),
                 // hence the debounce.
+                // Whatever else this network is, it ends the wait a WiFi teardown started. The
+                // startScan() below is what actually revives the loop.
+                if (discoveryDormantAfterWifiLoss) {
+                    discoveryDormantAfterWifiLoss = false
+                    AppLog.i("NetworkMonitor: network is back after a link-loss teardown; discovery resumes")
+                }
                 val now = SystemClock.elapsedRealtime()
                 if (now - lastNetworkAvailableKickMs < NETWORK_AVAILABLE_DEBOUNCE_MS) {
                     AppLog.d("NetworkMonitor: Ignoring repeat onAvailable within debounce window")
@@ -2391,6 +2417,10 @@ class AapService : Service(), UsbReceiver.Listener {
             return
         }
 
+        // Only the WiFi trigger: a shutdown takes the whole device with it, so what the discovery
+        // loop does in the two seconds it has left does not matter.
+        if (trigger == LinkLossTrigger.WIFI_STATION_DISABLING) discoveryDormantAfterWifiLoss = true
+
         val pending = pendingResult()
         val startedAt = SystemClock.elapsedRealtime()
         AppLog.i(
@@ -2441,7 +2471,15 @@ class AapService : Service(), UsbReceiver.Listener {
         // inside the connect-and-handshake window -- up to twelve seconds -- opened a second socket
         // to the head unit server, which connect() then refused at its own Connecting guard and
         // closed. That wedges the server just as thoroughly as leaking it would.
-        if (commManager.isBusy || (wirelessServer == null && !oneShot)) return
+        //
+        // Logged rather than returned silently: this gate and the re-arm below are the only two
+        // ways the discovery loop can end without saying so, and a loop that stops for no visible
+        // reason is the one thing a submitted log cannot be read for.
+        if (commManager.isBusy) {
+            AppLog.i("AapService: Discovery not started — a connection is live or being set up")
+            return
+        }
+        if (wirelessServer == null && !oneShot) return
 
         scanningState.value = true
 
@@ -2509,7 +2547,13 @@ class AapService : Service(), UsbReceiver.Listener {
                 }
                 serviceScope.launch {
                     delay(delayMs)
-                    if (wirelessServer != null && !commManager.isBusy) startDiscovery()
+                    if (wirelessServer == null) {
+                        AppLog.i("AapService: Discovery loop ends — the wireless server is gone")
+                    } else if (commManager.isBusy) {
+                        AppLog.i("AapService: Discovery loop ends — a connection is live or being set up")
+                    } else {
+                        startDiscovery()
+                    }
                 }
             }
         })
@@ -2525,6 +2569,7 @@ class AapService : Service(), UsbReceiver.Listener {
         // Belongs to the discovery loop that is going away; a fresh one starts scanning at once
         // anyway and would only spend it on a sweep that needed no hurrying.
         rescanWithoutWaiting = false
+        discoveryDormantAfterWifiLoss = false
         wirelessServer?.stopServer()
         wirelessServer = null
         scanningState.value = false

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -117,6 +117,17 @@ class AapService : Service(), UsbReceiver.Listener {
     private var networkDiscovery: NetworkDiscovery? = null
     private var mediaSession: MediaSessionCompat? = null
 
+    /** Last `NetworkCallback.onAvailable` we acted on, for the debounce in [registerNetworkMonitor]. */
+    private var lastNetworkAvailableKickMs: Long = 0L
+
+    /**
+     * Set when a network-available kick found a sweep already in flight and was folded into it.
+     * The sweep it joined was started for the *previous* network, so the one after it should not
+     * wait out the ordinary re-arm. Consumed once, in the discovery listener's `onScanFinished`.
+     */
+    @Volatile
+    private var rescanWithoutWaiting: Boolean = false
+
     private inline fun <T> safeMediaSessionCall(crossinline block: (MediaSessionCompat) -> T): T? {
         if (isDestroying) return null
         val session = mediaSession ?: return null
@@ -1394,13 +1405,29 @@ class AapService : Service(), UsbReceiver.Listener {
             override fun onAvailable(network: Network) {
                 AppLog.i("NetworkMonitor: Network available: $network")
 
-                // force start scan, now that we are connected
+                // [BUG_FIX] force start scan, now that we are connected — but do not stop the
+                // scan already running to do it. stop() is cooperative, so the pair started a
+                // second sweep beside the first, and two sweeps probing the head unit server's
+                // port at once is how it ends up bound to a connection nobody owns.
+                // startScan() is a no-op while a healthy scan is in flight, which is what this
+                // wants: a scan is running, so the network is already being looked at.
+                // onAvailable also fires repeatedly (per network, and again on re-validation),
+                // hence the debounce.
+                val now = SystemClock.elapsedRealtime()
+                if (now - lastNetworkAvailableKickMs < NETWORK_AVAILABLE_DEBOUNCE_MS) {
+                    AppLog.d("NetworkMonitor: Ignoring repeat onAvailable within debounce window")
+                    return
+                }
+                lastNetworkAvailableKickMs = now
                 serviceScope.launch {
                     delay(500)
-                    val discovery = networkDiscovery
-                    if (discovery != null) {
-                        discovery.stop()
-                        discovery.startScan()
+                    val discovery = networkDiscovery ?: return@launch
+                    if (!discovery.startScan()) {
+                        // Folded into a sweep that was already running — which was started for the
+                        // network we have just left. Do not cancel it; just do not make the next
+                        // one wait ten seconds either.
+                        rescanWithoutWaiting = true
+                        AppLog.i("NetworkMonitor: a scan was already in flight; the next one will not wait")
                     }
                 }
             }
@@ -1539,8 +1566,9 @@ class AapService : Service(), UsbReceiver.Listener {
 
         AppLog.i("AapService: Initializing WiFi Mode: $mode (Strategy: $strategy)")
 
+        // stopWirelessServer() already stops the scan and nulls the field; the networkDiscovery
+        // .stop() that used to sit here could never see anything to stop.
         stopWirelessServer()
-        networkDiscovery?.stop()
         nearbyManager?.stop()
         nativeAaHandshakeManager?.stop()
         softApCredentialsProvider?.stop()
@@ -2331,18 +2359,28 @@ class AapService : Service(), UsbReceiver.Listener {
         val mode = settings.wifiConnectionMode
         val strategy = settings.helperConnectionStrategy
 
-        if (mode == 3) return
-        // Allow discovery for Strategy 0 (NSD), 3 (Phone Hotspot) and 4 (Headunit Hotspot)
-        if (mode == 2 && strategy != 0 && strategy != 3 && strategy != 4) return
-        if (commManager.isConnected || (wirelessServer == null && !oneShot)) return
+        if (!DiscoveryModePolicy.usesNetworkDiscovery(mode, strategy)) return
+        // [BUG_FIX] isBusy, not isConnected. isConnected excludes Connecting, so a rescan landing
+        // inside the connect-and-handshake window -- up to twelve seconds -- opened a second socket
+        // to the head unit server, which connect() then refused at its own Connecting guard and
+        // closed. That wedges the server just as thoroughly as leaking it would.
+        if (commManager.isBusy || (wirelessServer == null && !oneShot)) return
 
-        networkDiscovery?.stop()
         scanningState.value = true
 
-        networkDiscovery = NetworkDiscovery(this, object : NetworkDiscovery.Listener {
+        // [BUG_FIX] Reused rather than rebuilt. This used to stop the old instance and replace it,
+        // which defeated NetworkDiscovery's own guard: the replacement's scanJob is null, so it saw
+        // no scan to wait for and probed the head unit server while the discarded instance still
+        // had a probe in flight. Both reach port 5277, one of them is thrown away, and the server
+        // binds to the connection nobody follows through -- deaf until the user restarts it by
+        // hand. Keeping the instance lets startScan() serialise, which is what it was written for.
+        // A real mode change still gets a fresh instance: stopWirelessServer() nulls this.
+        val discovery = networkDiscovery ?: NetworkDiscovery(this, object : NetworkDiscovery.Listener {
             override fun onServiceFound(ip: String, port: Int, socket: java.net.Socket?) {
-                if (commManager.isConnected) {
-                    // Already connected by the time this callback fired; discard the socket
+                if (commManager.isBusy) {
+                    // Connected, or connecting, by the time this callback fired; discard the
+                    // socket. isBusy rather than isConnected because handing it to connect()
+                    // during a connect in flight only gets it closed one frame later.
                     try { socket?.close() } catch (e: Exception) {}
                     return
                 }
@@ -2366,20 +2404,38 @@ class AapService : Service(), UsbReceiver.Listener {
                 }
             }
 
-            override fun onScanFinished() {
+            // The flag comes from the scan that finished, not from the call that built this
+            // listener: the instance outlives any single request now, so capturing it here would
+            // pin every later scan to the first caller's choice.
+            override fun onScanFinished(wasOneShot: Boolean) {
                 scanningState.value = false
-                if (oneShot) {
+                if (wasOneShot) {
                     AppLog.i("One-shot scan finished.")
                     return
                 }
-                // Reschedule the next scan after 10 s to avoid hammering the network
+                // Reschedule the next scan to avoid hammering the network.
+                //
+                // Unless the network changed while this sweep was running. Joining the phone's
+                // network has to start a scan promptly — waiting out the loop is most of a
+                // minute at the moment the user is starting a drive — and this is how that is
+                // done safely. The kick must never cancel a live probe to get there: two sweeps
+                // probing the head unit server at once is what wedges it, so the kick only makes
+                // the *next* sweep immediate, on the network that has actually arrived.
+                val delayMs = if (rescanWithoutWaiting) {
+                    rescanWithoutWaiting = false
+                    AppLog.i("AapService: network changed during the last scan; rescanning immediately")
+                    0L
+                } else {
+                    10000L
+                }
                 serviceScope.launch {
-                    delay(10000)
-                    if (wirelessServer != null && !commManager.isConnected) startDiscovery()
+                    delay(delayMs)
+                    if (wirelessServer != null && !commManager.isBusy) startDiscovery()
                 }
             }
         })
-        networkDiscovery?.startScan()
+        networkDiscovery = discovery
+        discovery.startScan(oneShot)
     }
 
     private fun stopWirelessServer() {
@@ -2387,6 +2443,9 @@ class AapService : Service(), UsbReceiver.Listener {
         activeHelperStrategy = -1
         networkDiscovery?.stop()
         networkDiscovery = null
+        // Belongs to the discovery loop that is going away; a fresh one starts scanning at once
+        // anyway and would only spend it on a sweep that needed no hurrying.
+        rescanWithoutWaiting = false
         wirelessServer?.stopServer()
         wirelessServer = null
         scanningState.value = false
@@ -3038,6 +3097,12 @@ class AapService : Service(), UsbReceiver.Listener {
 
         /** Delay before retrying USB connection after an unexpected disconnect. */
         private const val USB_RECONNECT_DELAY_MS = 3000L
+
+        /**
+         * `NetworkCallback.onAvailable` fires per network and again on re-validation, so a
+         * single join can produce several. One discovery kick per join is what is wanted.
+         */
+        private const val NETWORK_AVAILABLE_DEBOUNCE_MS = 1000L
 
         /** Cooldown period after user-initiated exit. During this window, the WirelessServer
          *  rejects incoming connections to prevent the phone from instantly reconnecting. */

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
@@ -183,6 +183,11 @@ class AapTransport(
 
         val size = connection?.sendBlocking(ba.data, ba.limit, 250) ?: -1
 
+        // Silent until it matters. A failed write here is how "the ByeBye went out" and "the link
+        // was already gone" tell themselves apart, which is the whole question for a teardown
+        // racing an interface going down.
+        if (size < 0) AppLog.w("AapTransport: send failed (ret=$size); the link is already gone")
+
         if (AppLog.LOG_VERBOSE) {
             AppLog.v("Sent size: %d", size)
             // AapDump.logvHex("US", 0, ba.data, ba.limit) // AapDump might be removed or changed

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
@@ -87,6 +87,24 @@ class AapTransport(
     val isWireless: Boolean
         get() = connection is com.andrerinas.openheadunit.connection.SocketAccessoryConnection
     var ignoreNextStopRequest: Boolean = false
+    /** Why the last [startHandshake] failed, for callers that report it. */
+    enum class HandshakeFailure {
+        NONE,
+
+        /**
+         * The version exchange timed out on every attempt without the peer sending a single
+         * byte, and without any transport error of our own. The link is fine and the peer is
+         * simply not answering — on the WiFi head unit server path that means it is bound to
+         * an earlier connection and will stay that way until it is restarted.
+         */
+        PEER_SILENT,
+
+        OTHER
+    }
+
+    @Volatile var lastHandshakeFailure: HandshakeFailure = HandshakeFailure.NONE
+        private set
+
     /** Set by [AapControl] when VIDEO_FOCUS_NATIVE triggers a stop (user tapped Exit). */
     @Volatile var wasUserExit: Boolean = false
     @Volatile var onQuit: ((Boolean) -> Unit)? = null
@@ -274,6 +292,7 @@ class AapTransport(
     }
 
     private fun handshake(connection: AccessoryConnection): Boolean {
+        lastHandshakeFailure = HandshakeFailure.OTHER
         try {
             val isUsb = connection !is SocketAccessoryConnection && !connection.isSingleMessage
             // Increased delay for AA 16.4+ stability on USB - skip for Sockets
@@ -302,6 +321,10 @@ class AapTransport(
             var ret = -1
             var attempt = 0
             var received = false
+            // Separates "the peer is not answering" from "our own link broke". Only the first
+            // is worth reporting upwards: it is the one the user can do something about.
+            var peerSentBytes = false
+            var transportError = false
             // Outer deadline prevents the loop from running for minutes on an unresponsive device.
             // Each send+recv pair uses 2 s per operation; 3 attempts × 4 s ≈ 12 s worst-case,
             // capped here at HANDSHAKE_TIMEOUT_MS so a stuck device fails fast.
@@ -316,6 +339,7 @@ class AapTransport(
                 AppLog.d("Handshake: Version request sent. ret: $ret. attempt: $attempt. TS: ${SystemClock.elapsedRealtime()}")
                 if (ret < 0) {
                     AppLog.w("Handshake: Version request send failed (ret=$ret), attempt $attempt")
+                    transportError = true
                     SystemClock.sleep(200)
                     continue
                 }
@@ -332,6 +356,8 @@ class AapTransport(
                     val remaining = (recvDeadline - SystemClock.elapsedRealtime())
                         .toInt().coerceAtLeast(100)
                     ret = connection.recvBlocking(buffer, buffer.size, remaining, false)
+                    if (ret < 0) transportError = true   // EOF or IOException, not a timeout
+                    if (ret > 0) peerSentBytes = true
                     if (ret <= 0) break  // timeout or error — fall through to outer retry
                     if (ret >= 6
                         && buffer[0] == 0.toByte()
@@ -355,6 +381,16 @@ class AapTransport(
 
             if (!received) {
                 AppLog.e("Handshake: Version request/response failed after $attempt attempt(s). last ret: $ret")
+                if (!peerSentBytes && !transportError) {
+                    lastHandshakeFailure = HandshakeFailure.PEER_SILENT
+                    AppLog.e(
+                        "Handshake: the peer accepted the connection and then sent nothing at all. " +
+                            "Our link is fine — every read timed out rather than failing. On the WiFi " +
+                            "head unit server path this means Android Auto's server on the phone is " +
+                            "still bound to an earlier connection; it does not recover on its own and " +
+                            "has to be stopped and started again in Android Auto's developer settings."
+                    )
+                }
                 return false
             }
             AppLog.i("Handshake: Version response recv ret: %d", ret)
@@ -381,6 +417,7 @@ class AapTransport(
             AppLog.i("Handshake: Status OK sent: %d", ret)
             AppLog.d("Handshake: Handshake successful. TS: ${SystemClock.elapsedRealtime()}")
 
+            lastHandshakeFailure = HandshakeFailure.NONE
             return true
         } catch (e: Exception) {
             AppLog.e("Handshake failed with exception", e)

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/DiscoveryModePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/DiscoveryModePolicy.kt
@@ -1,0 +1,29 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Which wireless configurations reach [com.andrerinas.openheadunit.connection.NetworkDiscovery],
+ * and therefore probe Android Auto's head unit server on port 5277.
+ *
+ * Worth naming rather than leaving inline, because the answer surprises people: "Headunit Server"
+ * (mode 1) and "Wireless Helper / Phone Hotspot (Host)" (mode 2, strategy 3) look like unrelated
+ * features in the settings screen and are the same code path underneath. A defect found on one is
+ * a defect on the other, which is how one bug report has read like two.
+ *
+ * @see com.andrerinas.openheadunit.utils.Settings.wifiConnectionMode
+ * @see com.andrerinas.openheadunit.utils.Settings.helperConnectionStrategy
+ */
+object DiscoveryModePolicy {
+
+    /**
+     * @param mode 0 = Manual, 1 = Auto (Headunit Server), 2 = Helper, 3 = Native AA.
+     * @param strategy only meaningful when [mode] is 2: 0 = Common WiFi (NSD), 1 = WiFi Direct,
+     *   2 = Google Nearby, 3 = Phone Hotspot (Host), 4 = Headunit Hotspot (Passive).
+     */
+    fun usesNetworkDiscovery(mode: Int, strategy: Int): Boolean = when (mode) {
+        // Native AA runs its own handshake and never scans for a server.
+        3 -> false
+        // WiFi Direct and Nearby bring the phone to us; the others need us to go and find it.
+        2 -> strategy == 0 || strategy == 3 || strategy == 4
+        else -> true
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/LinkLossTeardownPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/LinkLossTeardownPolicy.kt
@@ -1,0 +1,58 @@
+package com.andrerinas.openheadunit.aap
+
+/** A warning that the link carrying an active session is about to go away. */
+enum class LinkLossTrigger {
+    /** The device is shutting down or rebooting. Everything is about to go away. */
+    DEVICE_SHUTDOWN,
+
+    /** WiFi station mode is being switched off. Only sessions riding it are affected. */
+    WIFI_STATION_DISABLING
+}
+
+/**
+ * Whether to close the current session *now*, while the link still works, rather than let it die
+ * with the interface.
+ *
+ * Android Auto's head unit server is wedged permanently by a peer that vanishes without closing: it
+ * goes on accepting connections and answering none of them, and only a restart on the phone brings
+ * it back. A session that closes properly does not do that — which is the difference between a
+ * drive that ends with the app disconnecting and one that ends with the power being cut.
+ *
+ * We cannot help the cases that arrive without warning (driving out of range, the access point
+ * restarting, a power cut with no orderly shutdown). We can help the ones the system tells us about
+ * first, and this decides which of those apply to the session actually running.
+ */
+object LinkLossTeardownPolicy {
+
+    /**
+     * @param mode [com.andrerinas.openheadunit.utils.Settings.wifiConnectionMode]
+     * @param strategy [com.andrerinas.openheadunit.utils.Settings.helperConnectionStrategy]
+     * @param transport applies to [mode] 3 only
+     * @param sessionIsWireless whether the session actually running rides a socket. The wireless
+     *   mode is a stored setting and says nothing about it: a USB session can be live while
+     *   [mode] names a WiFi route, and switching WiFi off must not end it.
+     */
+    fun shouldTearDown(
+        trigger: LinkLossTrigger,
+        mode: Int,
+        strategy: Int,
+        transport: NativeTransport = NativeTransport.WIFI_DIRECT,
+        sessionIsWireless: Boolean = true
+    ): Boolean = when (trigger) {
+        // The whole device is going, so every route's link is going with it — USB included.
+        LinkLossTrigger.DEVICE_SHUTDOWN -> true
+
+        // Only routes that ride WiFi station mode. A P2P group and a soft AP are separate
+        // interfaces, and on several chipsets they outlive the station toggle entirely — tearing
+        // a healthy Native AA session down here would cost a 45-90s reconnect to prevent nothing.
+        // A USB session rides none of it and must be left alone whatever the settings say.
+        LinkLossTrigger.WIFI_STATION_DISABLING ->
+            sessionIsWireless &&
+                !WifiModePolicy.usesWifiDirect(mode, strategy, transport) &&
+                !ridesOwnAccessPoint(mode, strategy, transport)
+    }
+
+    /** The two routes where the phone sits on an access point this device is hosting. */
+    private fun ridesOwnAccessPoint(mode: Int, strategy: Int, transport: NativeTransport): Boolean =
+        (mode == 3 && transport == NativeTransport.HOTSPOT) || (mode == 2 && strategy == 4)
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/UnresponsivePeerPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/UnresponsivePeerPolicy.kt
@@ -1,0 +1,55 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * How hard to keep retrying a peer that accepts the TCP connection and then says nothing.
+ *
+ * Android Auto's built-in head unit server (the "Start head unit server" developer option,
+ * port 5277) binds itself to one connection and does not rebind for the life of its process.
+ * Once something has claimed it — a connection we opened and abandoned, or a previous session
+ * that died without a clean close — every later connection is accepted, never served and never
+ * closed. It does not time out of that state: closing the offending connection does not recover
+ * it, and neither does waiting. Only restarting the server on the phone does.
+ *
+ * So retrying at the normal cadence cannot succeed, and it is not free: each attempt strands
+ * another socket on the phone, which never reaps them either.
+ *
+ * Back off instead, and say once what is actually wrong. Backing off rather than stopping
+ * matters — the user can fix this from the phone at any moment, and an app that has given up
+ * for good would not notice.
+ */
+object UnresponsivePeerPolicy {
+
+    /** Consecutive silent failures against one endpoint before the retry cadence drops. */
+    const val SILENT_FAILURES_BEFORE_BACKOFF = 3
+
+    /** The ordinary re-scan delay, unchanged from before this policy existed. */
+    const val NORMAL_RESCAN_MS = 10_000L
+
+    /** Slow enough to stop manufacturing stranded sockets, fast enough to notice a fix. */
+    const val BACKOFF_RESCAN_MS = 60_000L
+
+    /**
+     * Delay before the next discovery sweep, given how many times in a row the same endpoint
+     * has accepted a connection and then not answered.
+     */
+    fun rescanDelayMs(consecutiveSilentFailures: Int): Long =
+        if (consecutiveSilentFailures >= SILENT_FAILURES_BEFORE_BACKOFF) BACKOFF_RESCAN_MS
+        else NORMAL_RESCAN_MS
+
+    /**
+     * True exactly once per episode, at the point the backoff engages, so the explanation goes
+     * into the log once rather than on every cycle.
+     */
+    fun shouldExplain(consecutiveSilentFailures: Int): Boolean =
+        consecutiveSilentFailures == SILENT_FAILURES_BEFORE_BACKOFF
+
+    /**
+     * The new streak length after a silent failure. A different endpoint is a different
+     * server and starts its own count; the same one continues.
+     */
+    fun countAfterSilentFailure(
+        previousCount: Int,
+        previousEndpoint: String?,
+        endpoint: String?
+    ): Int = if (previousEndpoint != null && previousEndpoint == endpoint) previousCount + 1 else 1
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
@@ -8,6 +8,7 @@ import com.andrerinas.openheadunit.aap.AapTransport
 import com.andrerinas.openheadunit.aap.KeyDebouncePolicy
 import com.andrerinas.openheadunit.aap.MediaKeyRoutingPolicy
 import com.andrerinas.openheadunit.aap.PlaybackFocusPolicy
+import com.andrerinas.openheadunit.aap.UnresponsivePeerPolicy
 import com.andrerinas.openheadunit.aap.VideoStarvationPolicy
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.BluetoothHelper
@@ -136,6 +137,31 @@ class CommManager(
 
     /** @Volatile: written on IO thread, read on Main and IO threads. */
     @Volatile private var _transport: AapTransport? = null
+
+    /**
+     * `ip:port` of the most recent connection attempt, or `null` when it was not a socket
+     * (USB). Lets a caller attribute a handshake failure to the peer it happened with, which
+     * matters for the one failure that is a property of that peer rather than of the link —
+     * see [ERROR_HANDSHAKE_PEER_SILENT].
+     */
+    @Volatile var lastAttemptedEndpoint: String? = null
+        private set
+
+    /**
+     * Consecutive handshakes against one endpoint where the peer accepted the connection and then
+     * sent nothing at all. Read by the discovery rescheduler to back off — see
+     * [com.andrerinas.openheadunit.aap.UnresponsivePeerPolicy].
+     *
+     * Counted here rather than from a [ConnectionState.Error] collector because that state is not
+     * observable: [connectionState] is a `MutableStateFlow`, so collection is conflated, and
+     * [startHandshake] calls [disconnect] with no suspension point after emitting the error — the
+     * value has already moved on to `Disconnected` before any collector resumes.
+     */
+    @Volatile var silentPeerFailures: Int = 0
+        private set
+
+    /** The endpoint [silentPeerFailures] is counting; a different one starts its own streak. */
+    @Volatile private var silentPeerEndpoint: String? = null
     var onUpdateUiConfigReplyReceived: (() -> Unit)? = null
     @Volatile private var _connection: AccessoryConnection? = null
 
@@ -206,6 +232,8 @@ class CommManager(
             return@withContext
 
 
+        lastAttemptedEndpoint = null
+
         val usbManager = context.getSystemService(Context.USB_SERVICE) as UsbManager
         if (!usbManager.hasPermission(device)) {
             _connectionState.emit(ConnectionState.Error("USB permission not granted for device"))
@@ -264,6 +292,8 @@ class CommManager(
             return@withContext
         }
 
+        lastAttemptedEndpoint = socket.inetAddress?.hostAddress?.let { "$it:${socket.port}" }
+
         _disconnectJob?.join()
 
         try {
@@ -295,6 +325,8 @@ class CommManager(
         // Another caller already started the connection — do nothing.
         if (_connectionState.value is ConnectionState.Connecting)
             return@withContext
+
+        lastAttemptedEndpoint = "$ip:$port"
 
         _disconnectJob?.join()
 
@@ -366,22 +398,65 @@ class CommManager(
                     _transport!!.onAudioFocusStateChanged = { isPlaying -> onAudioFocusStateChanged?.invoke(isPlaying) }
                     _transport!!.onUpdateUiConfigReplyReceived = { onUpdateUiConfigReplyReceived?.invoke() }
                 }
-                if (_transport?.startHandshake(_connection!!) == true) {
+                // Held locally because startHandshake() quits the transport on failure, and
+                // quitting nulls _transport before it returns — the failure reason would be
+                // unreachable by the time we came to report it.
+                val transport = _transport
+                if (transport?.startHandshake(_connection!!) == true) {
                     // A session that got this far had a working link to carry video on. See
                     // VideoStarvationPolicy for what it means when one ends without carrying any.
                     sessionReachedHandshake = true
                     videoDecoder.framesRenderedThisSession = 0L
+                    silentPeerFailures = 0
                     _connectionState.emit(ConnectionState.HandshakeComplete)
                 } else {
-                    _connectionState.emit(ConnectionState.Error("Handshake failed"))
+                    val silent = transport?.lastHandshakeFailure == AapTransport.HandshakeFailure.PEER_SILENT
+                    noteHandshakeOutcome(silent)
+                    _connectionState.emit(
+                        ConnectionState.Error(if (silent) ERROR_HANDSHAKE_PEER_SILENT else "Handshake failed")
+                    )
                     disconnect()
                 }
             } else {
                 _connectionState.emit(ConnectionState.Error("Starting handshake without connection"))
             }
         } catch (e: Exception) {
+            // An exception is never the silent-peer case; clear the streak rather than leaving it
+            // to age into a backoff that no longer describes what is happening.
+            noteHandshakeOutcome(silent = false)
             _connectionState.emit(ConnectionState.Error("Handshake failed: ${e.message}"))
             disconnect()
+        }
+    }
+
+    /**
+     * Updates [silentPeerFailures] after a failed handshake, and explains the situation once when
+     * the streak reaches the point where the retry cadence drops.
+     */
+    private fun noteHandshakeOutcome(silent: Boolean) {
+        if (!silent) {
+            // Any other failure means this is not the deaf-peer case, so the streak — and the
+            // backoff resting on it — starts over.
+            silentPeerFailures = 0
+            return
+        }
+        val endpoint = lastAttemptedEndpoint
+        silentPeerFailures =
+            UnresponsivePeerPolicy.countAfterSilentFailure(silentPeerFailures, silentPeerEndpoint, endpoint)
+        silentPeerEndpoint = endpoint
+        // Only Android Auto's head unit server — the peer on 5277, so the discovery path and Self
+        // Mode — has something the user can restart. The phone dialling our own server on 5288 and
+        // the Nearby helper can both reach this branch, and sending their users into Android Auto's
+        // developer settings after a switch they never turned on would be worse than saying nothing.
+        if (UnresponsivePeerPolicy.shouldExplain(silentPeerFailures) && endpoint?.endsWith(":5277") == true) {
+            AppLog.e(
+                "CommManager: $endpoint has accepted $silentPeerFailures connections in a row " +
+                    "without answering any of them. Slowing discovery to one attempt every " +
+                    "${UnresponsivePeerPolicy.BACKOFF_RESCAN_MS / 1000}s. Android Auto's head unit " +
+                    "server does not recover on its own once this happens — stop and start it again " +
+                    "on the phone, in Android Auto's developer settings, and this will reconnect by " +
+                    "itself."
+            )
         }
     }
 
@@ -796,5 +871,16 @@ class CommManager(
     fun destroy() {
         doDisconnect()
         _scope.cancel()
+    }
+
+    companion object {
+        /**
+         * [ConnectionState.Error] message for the one handshake failure that says something
+         * specific about the *peer* rather than about us: the TCP connection was accepted, the
+         * version request went out, and not one byte ever came back.
+         *
+         * Still contains "Handshake failed" so the generic handling keeps working.
+         */
+        const val ERROR_HANDSHAKE_PEER_SILENT = "Handshake failed: the peer never responded"
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
@@ -170,6 +170,19 @@ class CommManager(
         }
 
     /**
+     * `true` while a connection exists **or** one is being set up.
+     *
+     * [isConnected] deliberately excludes [ConnectionState.Connecting], which is right for the
+     * questions it was written for. It is wrong for discovery: a scan started during that window
+     * finds the head unit server, hands the socket over, and [connect] refuses it at its own
+     * `Connecting` guard and closes it — and that server is wedged by any connection it accepts
+     * and nobody follows through. Closing afterwards does not undo it; the damage is done at
+     * `accept()`. Ask this before opening a probe, not [isConnected].
+     */
+    val isBusy: Boolean
+        get() = isConnected || connectionState.value is ConnectionState.Connecting
+
+    /**
      * Returns `true` if the current USB connection is to [device].
      * Used by AapService to decide whether a USB detach event should trigger a disconnect.
      */
@@ -234,9 +247,22 @@ class CommManager(
      */
     suspend fun connect(socket: Socket) = withContext(Dispatchers.IO) {
         // Another caller already started the connection — do nothing.
-        if (_connectionState.value is ConnectionState.Connecting)
+        if (_connectionState.value is ConnectionState.Connecting) {
+            // [BUG_FIX] But close what we are refusing. A socket handed to connect() has no
+            // other owner: NetworkDiscovery gives ownership up at this call, and WirelessServer's
+            // accept loop closes the sockets it refuses itself, so returning without closing
+            // leaves the peer holding a session nobody will ever read from. This guard is the
+            // only one of the three that did not, and it is the reachable one — isConnected
+            // deliberately excludes Connecting, and WirelessServer checks it from a detached
+            // coroutine, so two connections arriving together both get past it.
+            //
+            // The cost is worst on the head unit server path, where the server binds to one
+            // connection for the life of its process and an abandoned one leaves it deaf until
+            // the user restarts it by hand.
+            AppLog.i("CommManager: Connect already in progress; closing the handed-over socket")
+            try { socket.close() } catch (e: Exception) {}
             return@withContext
-
+        }
 
         _disconnectJob?.join()
 

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
@@ -209,6 +209,16 @@ class CommManager(
         get() = isConnected || connectionState.value is ConnectionState.Connecting
 
     /**
+     * `true` when the running session rides a socket rather than USB.
+     *
+     * The stored wireless mode says nothing about this — a USB session can be live while
+     * `wifiConnectionMode` names a WiFi route — so anything reacting to the WiFi radio going away
+     * has to ask the session, not the settings.
+     */
+    val isWirelessSession: Boolean
+        get() = _connection is SocketAccessoryConnection
+
+    /**
      * Returns `true` if the current USB connection is to [device].
      * Used by AapService to decide whether a USB detach event should trigger a disconnect.
      */
@@ -868,6 +878,31 @@ class CommManager(
      * Call this when the owning component (e.g. the foreground service) is destroyed.
      * After [destroy], the CommManager instance must not be used again.
      */
+    /**
+     * Closes the session because the link carrying it is about to go away, and blocks until the
+     * socket is actually closed or [timeoutMs] elapses. Never call from the main thread.
+     *
+     * Deliberately not [disconnect]. That one means "the user pressed Exit": it marks a user exit,
+     * which suppresses the reconnect, and it honours `killOnDisconnect`, which would finish the
+     * activities and stop the service. Neither is right for a WiFi toggle the user expects to come
+     * back from.
+     *
+     * Blocking is the whole point. [disconnect] only schedules the teardown, which is fine when
+     * something will still be running afterwards to notice; it is not fine when the interface is
+     * on its way down and what matters is that the close goes out before it.
+     */
+    fun disconnectForLinkLoss(timeoutMs: Long) {
+        if (_connectionState.value is ConnectionState.Disconnected) return
+
+        HeadUnitScreenConfig.unlockResolution()
+        // Not clean and not a user exit: an unexpected end the app should try to recover from,
+        // which is what the existing reconnect paths already key on.
+        _connectionState.value = ConnectionState.Disconnected(isClean = false, isUserExit = false)
+        val job = _scope.launch { doDisconnect(sendByeBye = true) }
+        _disconnectJob = job
+        runBlocking { withTimeoutOrNull(timeoutMs) { job.join() } }
+    }
+
     fun destroy() {
         doDisconnect()
         _scope.cancel()

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NetworkDiscovery.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NetworkDiscovery.kt
@@ -4,15 +4,19 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.os.Build
 import com.andrerinas.openheadunit.utils.AppLog
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.coroutineContext
 import java.net.Inet4Address
 import java.net.InetAddress
 import java.net.InetSocketAddress
@@ -22,21 +26,128 @@ import java.util.Collections
 
 class NetworkDiscovery(private val context: Context, private val listener: Listener) {
 
-    interface Listener {
-        fun onServiceFound(ip: String, port: Int, socket: Socket? = null)
-        fun onScanFinished()
+    companion object {
+        /**
+         * The most recently started scan, whichever instance owns it. Probing port 5277 is not an
+         * instance-local activity: the server on the other end is a process-wide singleton, so two
+         * instances probing at once break it exactly as two scans in one instance would.
+         *
+         * Guarded by [PROBE_LOCK] rather than by the instance, because the whole point is that the
+         * two racing callers are usually *different* instances, and a per-instance lock would let
+         * them straight past each other.
+         */
+        private var inFlightScan: Job? = null
+
+        /** Held across the read-modify-write of [inFlightScan]. Never held while blocking. */
+        private val PROBE_LOCK = Any()
     }
 
+    interface Listener {
+        fun onServiceFound(ip: String, port: Int, socket: Socket? = null)
+        /**
+         * [oneShot] is the disposition of the scan that just finished, not of the last request.
+         * A one-shot request made while a continuous scan was already running is ignored, so the
+         * running scan has to report its own kind or it would silently lose its re-arm.
+         */
+        fun onScanFinished(oneShot: Boolean)
+    }
+
+    /**
+     * One scan, with the disposition that belongs to it. Kept together rather than in an instance
+     * field so a scan can never report the *next* scan's kind: a cancelled scan is replaced while
+     * it is still unwinding, and a continuous sweep that reported itself as one-shot would decline
+     * to re-arm and end discovery for good.
+     */
+    private class Generation(initialOneShot: Boolean) {
+        /** Written by a promotion on another thread, read by this scan's own `finally`. */
+        @Volatile
+        var oneShot: Boolean = initialOneShot
+    }
+
+    /** @Volatile: written under [PROBE_LOCK], read by [stop] and by the promotion check. */
+    @Volatile
     private var scanJob: Job? = null
+
+    @Volatile
+    private var currentGeneration: Generation? = null
+
     private val reportedIps = Collections.synchronizedSet(mutableSetOf<String>())
 
-    fun startScan() {
-        if (scanJob?.isActive == true) return
+    /**
+     * [oneShot] belongs to the scan being started, not to the instance, because callers that want
+     * a single sweep and callers that want the 10 s re-arm now share one instance.
+     *
+     * @return `true` if a scan was started, `false` if one was already in flight and this request
+     *   was folded into it. A caller that kicked the scan because the *network changed* wants to
+     *   know the difference — see `AapService`'s network monitor.
+     */
+    fun startScan(oneShot: Boolean = false): Boolean {
+        var started = false
+        synchronized(PROBE_LOCK) {
+            val previous = scanJob
+            // A healthy scan is already running: leave it alone. Callers that want a fresh
+            // sweep call stop() first, and a cancelled job falls through to the join below.
+            if (previous != null && previous.isActive && !previous.isCancelled) {
+                // Continuous wins. Tying a one-shot scan to a caller that wanted the re-arm would
+                // otherwise end discovery altogether: the running scan would finish, decline to
+                // reschedule, and the request that asked for more was already dropped here.
+                val running = currentGeneration
+                if (!oneShot && running != null && running.oneShot) {
+                    AppLog.i("NetworkDiscovery: in-flight scan promoted to continuous")
+                    running.oneShot = false
+                }
+                return false
+            }
 
-        reportedIps.clear()
-        AppLog.i("NetworkDiscovery: Starting scan...")
+            // [BUG_FIX] The per-instance guard above is not enough on its own. AapService used to
+            // answer a scan request by throwing this object away and building a new one, whose
+            // scanJob is null -- so the guard saw nothing to wait for and the new instance probed
+            // port 5277 while the discarded one still had a probe in flight. One button press did
+            // exactly that, twice, four milliseconds apart. The resource being protected is the
+            // phone's head unit server, which is process-wide: it binds one connection and never
+            // rebinds, so a connection nobody follows through leaves it deaf until the user
+            // restarts it by hand. Serialise on that resource rather than on whoever happens to
+            // own the instance.
+            //
+            // [BUG_FIX] The test is "not finished", not "still active". Every cross-instance case
+            // arises *because* the previous instance was stopped -- AapService cancels its scan and
+            // nulls the field together -- and a cancelled job is in Cancelling, where isActive is
+            // already false while its probes are still unwinding. Asking for isActive here skipped
+            // the one state this guard exists to catch, so it never engaged on the path it was
+            // written for.
+            val priorProbe = inFlightScan?.takeIf { it !== previous && !it.isCompleted }
 
-        scanJob = CoroutineScope(Dispatchers.IO).launch {
+            AppLog.i("NetworkDiscovery: Starting scan...")
+            if (priorProbe != null) {
+                AppLog.i("NetworkDiscovery: waiting for an in-flight probe before scanning")
+            }
+
+            val generation = Generation(oneShot)
+            val job = newScanJob(previous, priorProbe, generation)
+            currentGeneration = generation
+            scanJob = job
+            inFlightScan = job
+            // Do not hold on to a finished scan for the life of the process; the next instance
+            // only ever needs the one that might still be probing.
+            job.invokeOnCompletion {
+                synchronized(PROBE_LOCK) { if (inFlightScan === job) inFlightScan = null }
+            }
+            started = true
+        }
+        return started
+    }
+
+    private fun newScanJob(previous: Job?, priorProbe: Job?, generation: Generation): Job =
+        CoroutineScope(Dispatchers.IO).launch {
+            // Cancellation is cooperative, so a stopped scan still has probes in flight and
+            // still holds a connected socket it has not handed over yet. Two scans probing
+            // port 5277 at once is how the head unit server ends up bound to a connection
+            // nobody owns. Wait for the old one to unwind before opening any of our own.
+            previous?.join()
+            priorProbe?.join()
+            // Cleared here rather than at the call, so the set belongs to this generation and
+            // the outgoing scan keeps its own dedupe while it winds down.
+            reportedIps.clear()
             try {
                 // 1. Quick Scan: Check likely Gateways first
                 AppLog.i("NetworkDiscovery: Step 1 - Quick Gateway Scan")
@@ -52,11 +163,12 @@ class NetworkDiscovery(private val context: Context, private val listener: Liste
                 scanSubnet()
             } finally {
                 withContext(Dispatchers.Main) {
-                    listener.onScanFinished()
+                    // Read now rather than captured at the top: a continuous request that arrived
+                    // while this scan was running promotes it, and it has to hear about that.
+                    listener.onScanFinished(generation.oneShot)
                 }
             }
         }
-    }
 
     private suspend fun scanGateways(): Boolean {
         var foundAny = false
@@ -91,17 +203,22 @@ class NetworkDiscovery(private val context: Context, private val listener: Liste
                     }
                 }
             }
+        } catch (e: CancellationException) {
+            // Not an error, and swallowing it hid the socket leak below: the scan reported
+            // "Gateway scan error" and carried on into the subnet sweep as if nothing had
+            // happened, while the probe socket it had already opened was left connected.
+            throw e
         } catch (e: Exception) {
             AppLog.e("NetworkDiscovery: Gateway scan error", e)
         }
         return foundAny
     }
 
-    private suspend fun scanSubnet() {
+    private suspend fun scanSubnet(): Unit = coroutineScope {
         val subnet = getSubnet()
         if (subnet == null) {
             AppLog.e("NetworkDiscovery: Could not determine subnet for deep scan")
-            return
+            return@coroutineScope
         }
 
         val myIp = getLocalIpAddress()
@@ -114,7 +231,10 @@ class NetworkDiscovery(private val context: Context, private val listener: Liste
             val ip = "$subnet.$i"
             if (ip == myIp) continue // Skip self
 
-            tasks.add(CoroutineScope(Dispatchers.IO).async {
+            // Children of the scan job, not of a detached scope: stop() has to be able to
+            // reach these. Detached, they outlived the scan that started them and kept
+            // probing a subnet the device had already left.
+            tasks.add(async(Dispatchers.IO) {
                 checkAndReport(ip)
             })
         }
@@ -144,6 +264,13 @@ class NetworkDiscovery(private val context: Context, private val listener: Liste
     private suspend fun checkAndReport(ip: String): Boolean {
         if (reportedIps.contains(ip)) return true
 
+        // [BUG_FIX] Check before connecting, not only after. Socket.connect() is not interruptible,
+        // so a probe that starts after stop() runs to completion, reaches the peer and is then
+        // thrown away -- and the head unit server is wedged by any connection it accepts and nobody
+        // follows through, whether or not we close it afterwards. Cancellation means stop working,
+        // and connecting is work.
+        coroutineContext.ensureActive()
+
         // Check Port 5289 (Wifi Launcher) - prioritizing this
         val launcherSocket = checkPort(ip, 5289, timeout = 300)
         if (launcherSocket != null) {
@@ -154,23 +281,53 @@ class NetworkDiscovery(private val context: Context, private val listener: Liste
             val holdMs = 500L
             AppLog.i("NetworkDiscovery: Found Wifi Launcher on $ip:5289, holding probe ${holdMs}ms to wake the helper")
             reportedIps.add(ip)
-            try { delay(holdMs) } catch (e: Exception) {}
-            withContext(Dispatchers.Main) {
-                try { launcherSocket.close() } catch (e: Exception) {}
-                AppLog.i("NetworkDiscovery: Wifi Launcher probe released; awaiting inbound helper connection on 5288")
-                listener.onServiceFound(ip, 5289)
+            var released = false
+            try {
+                try { delay(holdMs) } catch (e: Exception) {}
+                withContext(Dispatchers.Main) {
+                    try { launcherSocket.close() } catch (e: Exception) {}
+                    released = true
+                    AppLog.i("NetworkDiscovery: Wifi Launcher probe released; awaiting inbound helper connection on 5288")
+                    listener.onServiceFound(ip, 5289)
+                }
+            } finally {
+                // The hold is deliberate (it is what wakes the helper), so this socket is open
+                // for 500 ms by design. A cancellation anywhere in that window used to leak it.
+                if (!released) try { launcherSocket.close() } catch (e: Exception) {}
             }
             return true
         }
+
+        // Check Port 5277 (Standard Headunit). Re-checked because the 5289 probe above can have
+        // spent 300 ms, or 500 ms more holding a launcher socket open, since the last check.
+        coroutineContext.ensureActive()
 
         // Check Port 5277 (Standard Headunit)
         val serverSocket = checkPort(ip, 5277, timeout = 300)
         if (serverSocket != null) {
             AppLog.i("NetworkDiscovery: Found Headunit Server on $ip:5277")
             reportedIps.add(ip)
-            withContext(Dispatchers.Main) {
-                // DO NOT CLOSE serverSocket! Pass it to the listener.
-                listener.onServiceFound(ip, 5277, serverSocket)
+            var handedOver = false
+            try {
+                withContext(Dispatchers.Main) {
+                    // Ownership passes to the listener, which is why this is not closed here.
+                    listener.onServiceFound(ip, 5277, serverSocket)
+                    handedOver = true
+                }
+            } finally {
+                // [BUG_FIX] This socket is not a probe: it is already connected to Android Auto's
+                // head unit server, and that server binds itself to one connection and never
+                // rebinds for the life of its process. One it accepts that nobody follows through
+                // leaves it deaf to every later attempt until the user restarts it by hand, and
+                // closing the connection afterwards does not undo it. Cancelling the scan threw
+                // out of withContext above before the listener ran, which left exactly that
+                // behind.
+                // A cancelled scan closes the socket rather than delivering it: cancellation
+                // means stop working, and connecting is work.
+                if (!handedOver) {
+                    AppLog.w("NetworkDiscovery: Handover of $ip:5277 aborted; closing the probe socket")
+                    try { serverSocket.close() } catch (e: Exception) {}
+                }
             }
             return true
         }
@@ -179,11 +336,14 @@ class NetworkDiscovery(private val context: Context, private val listener: Liste
     }
 
     private fun checkPort(ip: String, port: Int, timeout: Int = 500): Socket? {
+        val socket = Socket()
         return try {
-            val socket = Socket()
             socket.connect(InetSocketAddress(ip, port), timeout)
             socket
         } catch (e: Exception) {
+            // A failed connect can still leave a half-open socket behind; close it rather than
+            // waiting for the finalizer, which on the subnet sweep means 254 of them.
+            try { socket.close() } catch (e2: Exception) {}
             // Surface a failed Wifi Launcher probe so logs can tell "helper not listening"
             // apart from "the scan never ran".
             if (port == 5289) AppLog.d("NetworkDiscovery: $ip:5289 probe failed (${e.javaClass.simpleName}); Wifi Launcher not listening")
@@ -240,10 +400,17 @@ class NetworkDiscovery(private val context: Context, private val listener: Liste
     }
 
     fun stop() {
-        if (scanJob == null || scanJob?.isActive == false) return
-        scanJob?.cancel()
-        scanJob = null
-        AppLog.i("NetworkDiscovery: Scan interrupted")
+        // Under the same lock as startScan(): cancel() is non-blocking, so holding it costs
+        // nothing and keeps the read of scanJob from racing the write that replaces it.
+        synchronized(PROBE_LOCK) {
+            val job = scanJob ?: return
+            if (!job.isActive) return
+            job.cancel()
+            // [BUG_FIX] Deliberately not nulled. Nulling it made the guard in startScan() blind to
+            // a scan that was still unwinding, so a stop()/startScan() pair ran two sweeps side by
+            // side; startScan() now joins this job instead of racing it.
+            AppLog.i("NetworkDiscovery: Scan interrupted")
+        }
     }
 
     private fun isEmulator(): Boolean {

--- a/app/src/main/java/com/andrerinas/openheadunit/main/NetworkListFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/NetworkListFragment.kt
@@ -122,7 +122,7 @@ class NetworkListFragment : Fragment(), NetworkDiscovery.Listener {
     
     private fun startScan() {
         showScanDialog()
-        networkDiscovery.startScan()
+        networkDiscovery.startScan(oneShot = true)
     }
 
     private fun showScanDialog() {
@@ -190,7 +190,9 @@ class NetworkListFragment : Fragment(), NetworkDiscovery.Listener {
         }
     }
 
-    override fun onScanFinished() {
+    // This scan is always one-shot, so the flag says nothing this fragment does not already know:
+    // the dialog closing is the end of it, and nothing re-arms.
+    override fun onScanFinished(oneShot: Boolean) {
         activity?.runOnUiThread {
             if (scanDialog?.isShowing == true) {
                 scanDialog?.dismiss()

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/DiscoveryModePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/DiscoveryModePolicyTest.kt
@@ -1,0 +1,56 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DiscoveryModePolicyTest {
+
+    @Test
+    fun `native AA never scans, whatever strategy happens to be stored`() {
+        // helperConnectionStrategy keeps whatever mode 2 last left there, so mode 3 has to be
+        // decided on the mode alone.
+        for (strategy in 0..4) {
+            assertFalse(DiscoveryModePolicy.usesNetworkDiscovery(3, strategy))
+        }
+    }
+
+    @Test
+    fun `headunit server scans in both its sub-modes, whatever strategy is stored`() {
+        for (strategy in 0..4) {
+            assertTrue(DiscoveryModePolicy.usesNetworkDiscovery(0, strategy))
+            assertTrue(DiscoveryModePolicy.usesNetworkDiscovery(1, strategy))
+        }
+    }
+
+    @Test
+    fun `helper mode scans only where we go looking for the phone`() {
+        assertTrue(DiscoveryModePolicy.usesNetworkDiscovery(2, 0))  // Common WiFi (NSD)
+        assertFalse(DiscoveryModePolicy.usesNetworkDiscovery(2, 1)) // WiFi Direct
+        assertFalse(DiscoveryModePolicy.usesNetworkDiscovery(2, 2)) // Google Nearby
+        assertTrue(DiscoveryModePolicy.usesNetworkDiscovery(2, 3))  // Phone Hotspot (Host)
+        assertTrue(DiscoveryModePolicy.usesNetworkDiscovery(2, 4))  // Headunit Hotspot (Passive)
+    }
+
+    @Test
+    fun `the headunit server mode and the phone hotspot strategy are the same path`() {
+        // The point of the object. These two look unrelated in the settings screen, so a defect in
+        // the 5277 probe reads as two separate bug reports unless this is written down.
+        assertTrue(DiscoveryModePolicy.usesNetworkDiscovery(1, 2))
+        assertTrue(DiscoveryModePolicy.usesNetworkDiscovery(2, 3))
+    }
+
+    @Test
+    fun `the routes that bring the phone to us are exactly the ones that skip discovery`() {
+        // WiFi Direct and Nearby are the two helper strategies with an inbound connection, and
+        // they are the two that must not scan. Stated as a complement so adding a strategy without
+        // deciding which side it falls on fails here.
+        for (strategy in 0..4) {
+            val inbound = strategy == 1 || strategy == 2
+            assertTrue(
+                "strategy $strategy",
+                DiscoveryModePolicy.usesNetworkDiscovery(2, strategy) != inbound
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/LinkLossTeardownPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/LinkLossTeardownPolicyTest.kt
@@ -1,0 +1,108 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LinkLossTeardownPolicyTest {
+
+    @Test
+    fun `a device shutdown takes every route down, so every route closes first`() {
+        for (mode in 1..3) {
+            for (strategy in 0..4) {
+                for (transport in NativeTransport.entries) {
+                    assertTrue(
+                        "mode=$mode strategy=$strategy transport=$transport",
+                        LinkLossTeardownPolicy.shouldTearDown(
+                            LinkLossTrigger.DEVICE_SHUTDOWN, mode, strategy, transport
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `station wifi going down closes the routes that ride it`() {
+        // Mode 1 (NSD) and mode 2 strategies 0 and 3 all reach the phone over station WiFi.
+        assertTrue(LinkLossTeardownPolicy.shouldTearDown(LinkLossTrigger.WIFI_STATION_DISABLING, 1, 0))
+        assertTrue(LinkLossTeardownPolicy.shouldTearDown(LinkLossTrigger.WIFI_STATION_DISABLING, 2, 0))
+        assertTrue(LinkLossTeardownPolicy.shouldTearDown(LinkLossTrigger.WIFI_STATION_DISABLING, 2, 3))
+    }
+
+    @Test
+    fun `station wifi going down leaves a wifi direct session alone`() {
+        // A P2P group is a separate interface and survives the station toggle on several chipsets.
+        // Tearing this down would cost a 45-90s reconnect to prevent nothing.
+        assertFalse(
+            LinkLossTeardownPolicy.shouldTearDown(
+                LinkLossTrigger.WIFI_STATION_DISABLING, 3, 0, NativeTransport.WIFI_DIRECT
+            )
+        )
+        assertFalse(LinkLossTeardownPolicy.shouldTearDown(LinkLossTrigger.WIFI_STATION_DISABLING, 2, 1))
+    }
+
+    @Test
+    fun `station wifi going down leaves a session on our own access point alone`() {
+        assertFalse(
+            LinkLossTeardownPolicy.shouldTearDown(
+                LinkLossTrigger.WIFI_STATION_DISABLING, 3, 0, NativeTransport.HOTSPOT
+            )
+        )
+        // Mode 2 strategy 4 is the head unit hotspot: same reasoning, different route.
+        assertFalse(LinkLossTeardownPolicy.shouldTearDown(LinkLossTrigger.WIFI_STATION_DISABLING, 2, 4))
+    }
+
+    @Test
+    fun `a usb session is left alone by a wifi toggle, whatever wireless mode is stored`() {
+        // The wireless mode is a setting, not a description of the session. A USB drive with mode 1
+        // stored would otherwise be ended by the user switching WiFi off.
+        for (mode in 1..3) {
+            for (strategy in 0..4) {
+                assertFalse(
+                    "mode=$mode strategy=$strategy",
+                    LinkLossTeardownPolicy.shouldTearDown(
+                        LinkLossTrigger.WIFI_STATION_DISABLING, mode, strategy,
+                        sessionIsWireless = false
+                    )
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a device shutdown still closes a usb session`() {
+        // Nothing survives the shutdown, and the phone's head unit server is wedged just as hard by
+        // a USB session that vanishes as by a wireless one.
+        assertTrue(
+            LinkLossTeardownPolicy.shouldTearDown(
+                LinkLossTrigger.DEVICE_SHUTDOWN, 1, 0, sessionIsWireless = false
+            )
+        )
+    }
+
+    @Test
+    fun `the wifi answer is the exact complement of the two routes that own their own network`() {
+        // Guards the pairing with WifiModePolicy: a combination must not be claimed by both, and
+        // a station-WiFi combination must not be missed by both. Stated for a wireless session,
+        // which is the only kind the complement is about.
+        for (mode in 1..3) {
+            for (strategy in 0..4) {
+                for (transport in NativeTransport.entries) {
+                    val tearsDown = LinkLossTeardownPolicy.shouldTearDown(
+                        LinkLossTrigger.WIFI_STATION_DISABLING, mode, strategy, transport,
+                        sessionIsWireless = true
+                    )
+                    val ownsItsNetwork =
+                        WifiModePolicy.usesWifiDirect(mode, strategy, transport) ||
+                            (mode == 3 && transport == NativeTransport.HOTSPOT) ||
+                            (mode == 2 && strategy == 4)
+                    assertTrue(
+                        "mode=$mode strategy=$strategy transport=$transport",
+                        tearsDown != ownsItsNetwork
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/UnresponsivePeerPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/UnresponsivePeerPolicyTest.kt
@@ -1,0 +1,86 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UnresponsivePeerPolicyTest {
+
+    private val phone = "192.168.41.113:5277"
+    private val otherPhone = "192.168.41.200:5277"
+
+    @Test
+    fun `the ordinary cadence is unchanged below the threshold`() {
+        for (failures in 0 until UnresponsivePeerPolicy.SILENT_FAILURES_BEFORE_BACKOFF) {
+            assertEquals(
+                UnresponsivePeerPolicy.NORMAL_RESCAN_MS,
+                UnresponsivePeerPolicy.rescanDelayMs(failures)
+            )
+        }
+    }
+
+    @Test
+    fun `the cadence drops at the threshold and stays down`() {
+        assertEquals(
+            UnresponsivePeerPolicy.BACKOFF_RESCAN_MS,
+            UnresponsivePeerPolicy.rescanDelayMs(UnresponsivePeerPolicy.SILENT_FAILURES_BEFORE_BACKOFF)
+        )
+        assertEquals(UnresponsivePeerPolicy.BACKOFF_RESCAN_MS, UnresponsivePeerPolicy.rescanDelayMs(34))
+    }
+
+    @Test
+    fun `backing off never becomes giving up`() {
+        // The user fixes this on the phone, at a moment we cannot predict. An app that stopped
+        // retrying for good would never notice, so every delay has to stay finite.
+        assertTrue(UnresponsivePeerPolicy.rescanDelayMs(Int.MAX_VALUE) < Long.MAX_VALUE)
+        assertTrue(UnresponsivePeerPolicy.rescanDelayMs(Int.MAX_VALUE) > 0)
+    }
+
+    @Test
+    fun `the explanation goes out once, at the point the backoff engages`() {
+        assertFalse(UnresponsivePeerPolicy.shouldExplain(0))
+        assertFalse(
+            UnresponsivePeerPolicy.shouldExplain(UnresponsivePeerPolicy.SILENT_FAILURES_BEFORE_BACKOFF - 1)
+        )
+        assertTrue(
+            UnresponsivePeerPolicy.shouldExplain(UnresponsivePeerPolicy.SILENT_FAILURES_BEFORE_BACKOFF)
+        )
+        // Not on every cycle afterwards: 34 consecutive failures is a measured run, and 34
+        // copies of the same paragraph would bury the log the user attaches to a report.
+        assertFalse(
+            UnresponsivePeerPolicy.shouldExplain(UnresponsivePeerPolicy.SILENT_FAILURES_BEFORE_BACKOFF + 1)
+        )
+        assertFalse(UnresponsivePeerPolicy.shouldExplain(34))
+    }
+
+    @Test
+    fun `a streak against one endpoint accumulates`() {
+        var count = 0
+        var endpoint: String? = null
+        repeat(3) {
+            count = UnresponsivePeerPolicy.countAfterSilentFailure(count, endpoint, phone)
+            endpoint = phone
+        }
+        assertEquals(3, count)
+    }
+
+    @Test
+    fun `a different endpoint is a different server and starts its own count`() {
+        assertEquals(1, UnresponsivePeerPolicy.countAfterSilentFailure(9, phone, otherPhone))
+    }
+
+    @Test
+    fun `the first failure counts as one even with nothing recorded before it`() {
+        assertEquals(1, UnresponsivePeerPolicy.countAfterSilentFailure(0, null, phone))
+    }
+
+    @Test
+    fun `an unknown endpoint does not inherit a previous streak`() {
+        // CommManager.lastAttemptedEndpoint is null on the USB path. Treating null as "the
+        // same endpoint" would let a silent USB dongle push the WiFi discovery loop into
+        // backoff, which has nothing to do with it.
+        assertEquals(1, UnresponsivePeerPolicy.countAfterSilentFailure(2, phone, null))
+        assertEquals(1, UnresponsivePeerPolicy.countAfterSilentFailure(2, null, null))
+    }
+}


### PR DESCRIPTION
Fixes #773.

Android Auto's "Start head unit server" developer option binds to one connection for the life of its process and never rebinds. Once it accepts a connection that nobody follows through, it stays deaf to every later attempt, only recoverable by toggling the option on the phone, which is exactly what the reporter had to do before every drive.

## What was leaking the connection

Four separate paths in the discovery/connection code opened a socket to the phone's server and walked away from it instead of following through: a race between onAvailable's stop/restart and a plain rescan, startDiscovery() replacing its NetworkDiscovery instance mid-scan and losing track of an in-flight probe, a cancelled scan that could still leave a connected socket behind, and CommManager.connect() silently dropping a socket handed to it during an in-flight connect instead of closing it. The reporter's log showed 13 "Found Headunit Server" hits against 10 actual connects, three sockets opened and abandoned. Discovery now reuses one instance, serializes scans, and closes any socket it isn't going to use.

## Backing off once the server is already wedged

If the phone's server is already wedged from a prior session, no amount of retrying fixes it from our side. AapTransport now distinguishes that case (every read times out, the peer sent nothing, none of our sends failed) as PEER_SILENT. UnresponsivePeerPolicy slows the rescan and tells the user once that the fix is on the phone, in Android Auto's developer settings, gated to only the head unit server endpoint so it doesn't fire for unrelated connection types.

## Closing sessions before the link actually disappears

A peer that vanishes without closing wedges the server the same way an abandoned probe does. The app now sends the ByeBye and closes the session when the system warns us first, on ACTION_SHUTDOWN and WIFI_STATE_DISABLING, rather than leaving the connection to rot. LinkLossTeardownPolicy decides which sessions a WiFi-station loss actually applies to, since a P2P group or soft AP outlives that toggle on several chipsets and shouldn't be torn down for it.

## Also included

Discovery restarts triggered by link loss no longer sweep whatever subnet happens to enumerate first while WiFi is on its way down, and the two silent early-return paths in the discovery loop now log why they stopped, so a submitted log shows what happened instead of nothing.
