### PR TITLE
Car GPS: deliver the head unit's fix when the phone asks, and keep it flowing

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/AapBroadcastReceiver.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/AapBroadcastReceiver.kt
@@ -46,7 +46,13 @@ class AapBroadcastReceiver : BroadcastReceiver() {
             }
 
             if (location.latitude != 0.0 && location.longitude != 0.0) {
-                component.settings.lastKnownLocation = location
+                // Only on change: a parked head unit delivers the same coordinates every few
+                // seconds, and each write rewrites the whole preferences file. Same position in,
+                // nothing to store.
+                val stored = component.settings.lastKnownLocation
+                if (stored.latitude != location.latitude || stored.longitude != location.longitude) {
+                    component.settings.lastKnownLocation = location
+                }
             }
         } else if (intent.action == MediaKeyIntent.action) {
             val event: KeyEvent? = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapControl.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapControl.kt
@@ -6,6 +6,7 @@ import android.media.AudioManager
 import com.andrerinas.openheadunit.aap.protocol.AudioConfigs
 import com.andrerinas.openheadunit.aap.protocol.Channel
 import com.andrerinas.openheadunit.aap.protocol.messages.DrivingStatusEvent
+import com.andrerinas.openheadunit.aap.protocol.messages.LocationUpdateEvent
 import com.andrerinas.openheadunit.aap.protocol.messages.ServiceDiscoveryResponse
 import com.andrerinas.openheadunit.aap.protocol.messages.VideoFocusEvent
 import com.andrerinas.openheadunit.aap.protocol.proto.Common
@@ -15,6 +16,7 @@ import com.andrerinas.openheadunit.aap.protocol.proto.Media
 import com.andrerinas.openheadunit.aap.protocol.proto.Sensors
 import com.andrerinas.openheadunit.decoder.MicRecorder
 import com.andrerinas.openheadunit.decoder.VideoDecoder
+import com.andrerinas.openheadunit.location.LocationHolder
 import com.andrerinas.openheadunit.utils.AppLog
 import com.andrerinas.openheadunit.utils.Settings
 
@@ -188,7 +190,10 @@ internal class AapControlTouch(private val aapTransport: AapTransport): AapContr
 
 }
 
-internal class AapControlSensor(private val aapTransport: AapTransport, private val context: Context): AapControl {
+internal class AapControlSensor(
+        private val aapTransport: AapTransport,
+        private val context: Context,
+        private val settings: Settings): AapControl {
 
     override fun execute(message: AapMessage): Int {
         when (message.type) {
@@ -217,6 +222,23 @@ internal class AapControlSensor(private val aapTransport: AapTransport, private 
             val intent = Intent(AapService.ACTION_REQUEST_NIGHT_MODE_UPDATE)
             intent.setPackage(context.packageName)
             context.sendBroadcast(intent)
+        }
+
+        if (request.type == Sensors.SensorType.LOCATION && settings.useGpsForNavigation) {
+            // The phone only accepts LOCATION events once this request has been answered, which
+            // can land well after TransportStarted (CommManager's own post-handshake flush can
+            // race this and lose). This is the actual earliest point sending can succeed.
+            //
+            // currentGpsFix, not currentLocation: only this head unit's own GPS may be sent as the
+            // car's position. A unit with no antenna attached passes every gate here and never
+            // locks, and the broader accessor would hand it a network fix to send instead.
+            val fix = LocationHolder.currentGpsFix(context)
+            if (fix != null) {
+                val sentOnWire = aapTransport.send(LocationUpdateEvent(fix))
+                AppLog.i("LOCATION sensor requested. Sending current fix immediately. sentOnWire=$sentOnWire")
+            } else {
+                AppLog.i("LOCATION sensor requested. No recent GPS fix to prime with.")
+            }
         }
         return 0
     }
@@ -404,7 +426,7 @@ internal class AapControlGateway(
             AapControlService(aapTransport, aapAudio, settings, context),
             AapControlMedia(aapTransport, micRecorder, aapAudio),
             AapControlTouch(aapTransport),
-            AapControlSensor(aapTransport, context))
+            AapControlSensor(aapTransport, context, settings))
 
     override fun execute(message: AapMessage): Int {
         if (message.type == 7) {

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
@@ -77,6 +77,8 @@ class AapTransport(
     private val micRecorder: MicRecorder = MicRecorder(settings.micSampleRate, context)
     private val sessionIds = SparseIntArray(4)
     private val startedSensors = HashSet<Int>(4)
+    private val droppedSensorEvents = HashMap<Int, Int>(4)
+    private var lastSensorDropLogMs = 0L
     private val keyCodes = mutableMapOf<Int, Int>()
     private val modeManager: UiModeManager =
         context.getSystemService(UI_MODE_SERVICE) as UiModeManager
@@ -151,6 +153,9 @@ class AapTransport(
         }
     }
 
+    // Synchronized against noteDroppedSensorEvent, whose log line iterates startedSensors from the
+    // main thread while this adds from the poll thread.
+    @Synchronized
     internal fun startSensor(type: Int) {
         startedSensors.add(type)
     }
@@ -415,17 +420,31 @@ class AapTransport(
     }
 
     fun send(sensor: SensorEvent): Boolean {
-        return if (isAlive && startedSensors.contains(sensor.sensorType)) {
+        if (isAlive && startedSensors.contains(sensor.sensorType)) {
             send(sensor as AapMessage)
-            true
-        } else {
-            if (!isAlive) {
-                //AppLog.w("AapTransport not alive, ignoring sensor event for sensor ${sensor.sensorType}")
-            } else {
-                //AppLog.e("Sensor " + sensor.sensorType + " is not started yet")
-            }
-            false
+            return true
         }
+        noteDroppedSensorEvent(sensor.sensorType)
+        return false
+    }
+
+    /**
+     * A dropped sensor event is worth knowing about once, not once per event. LOCATION resends on
+     * a timer for the whole session, so logging every drop would bury everything else in a log a
+     * reporter attaches to an issue. Report the first drop of a type straight away, then a running
+     * count at most every [SENSOR_DROP_LOG_INTERVAL_MS] for as long as it keeps happening.
+     */
+    @Synchronized
+    private fun noteDroppedSensorEvent(sensorType: Int) {
+        val previous = droppedSensorEvents[sensorType] ?: 0
+        droppedSensorEvents[sensorType] = previous + 1
+
+        val now = SystemClock.elapsedRealtime()
+        if (previous > 0 && now - lastSensorDropLogMs < SENSOR_DROP_LOG_INTERVAL_MS) {
+            return
+        }
+        lastSensorDropLogMs = now
+        AppLog.i("AapTransport: dropping sensor events, isAlive=$isAlive startedSensors=$startedSensors droppedByType=$droppedSensorEvents")
     }
 
     fun send(message: AapMessage) {
@@ -472,5 +491,6 @@ class AapTransport(
         // Maximum wall-clock time allowed for the version-exchange phase of the AAP handshake.
         // Prevents the retry loop from blocking for minutes on an unresponsive USB device.
         private const val HANDSHAKE_TIMEOUT_MS = 10_000L
+        private const val SENSOR_DROP_LOG_INTERVAL_MS = 30_000L
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/LocationUpdateEvent.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/LocationUpdateEvent.kt
@@ -8,6 +8,9 @@ class LocationUpdateEvent(location: Location)
     : SensorEvent(Sensors.SensorType.LOCATION_VALUE, makeProto(location)) {
 
     companion object {
+        /** Stand-in for a fix that reports no accuracy: 100 m, in the field's millimetres. */
+        private const val UNKNOWN_ACCURACY_MM = 100_000
+
         private fun makeProto(location: Location): Message {
             return Sensors.SensorBatch.newBuilder().also { batch ->
                 batch.addLocationData(
@@ -24,8 +27,15 @@ class LocationUpdateEvent(location: Location)
                         if (location.hasSpeed()) {
                             speed = (location.speed * 1E3).toInt()
                         }
-                        if (location.hasAccuracy()) {
-                            accuracy = (location.accuracy * 1E3).toInt()
+                        // accuracy is a proto2 `required` field, so leaving it unset throws
+                        // UninitializedMessageException out of build() - and on the control
+                        // channel that surfaces as a HandleException, which kills the session.
+                        // A fix without a reported accuracy is rare but does happen, so declare
+                        // it coarse rather than fail to build at all.
+                        accuracy = if (location.hasAccuracy()) {
+                            (location.accuracy * 1E3).toInt()
+                        } else {
+                            UNKNOWN_ACCURACY_MM
                         }
                     }
                 )

--- a/app/src/main/java/com/andrerinas/openheadunit/location/GpsLocation.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/location/GpsLocation.kt
@@ -7,13 +7,67 @@ import android.location.Location
 import android.location.LocationListener
 import android.location.LocationManager
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
 import androidx.core.content.PermissionChecker
+import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.contract.LocationUpdateIntent
 import com.andrerinas.openheadunit.utils.AppLog
 
 class GpsLocation constructor(private val context: Context): LocationListener {
     private val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+    private val settings by lazy { App.provide(context).settings }
     private var requested: Boolean = false
+    private val handler = Handler(Looper.getMainLooper())
+
+    // Only ever set from onLocationChanged, so a resend can never mislabel a network/passive
+    // fallback fix as this head unit's real GPS.
+    private var lastGpsFix: Location? = null
+
+    // Taken from the monotonic clock rather than Location.time, because a resend deliberately
+    // bumps that field and would otherwise keep declaring itself fresh.
+    private var lastGpsFixAtMs: Long = 0L
+
+    // When the subscription was made, so the first fix can be reported with how long it took.
+    private var subscribedAtMs: Long = 0L
+
+    private var staleFixReported = false
+
+    // Android Auto is reported to prefer the car's GPS but fall back to the phone's own once the
+    // car's signal looks interrupted, so a head unit that stops emitting looks like a head unit
+    // with no GPS. The subscription below asks for fixes on time alone, which keeps a parked unit
+    // emitting, but not every chip obliges - resend the last real fix on a timer as a backstop, the
+    // way a real GPS chip keeps outputting NMEA sentences whether or not the car moves.
+    //
+    // A resend only ever stands in for a beat the chip actually missed: while real fixes arrive on
+    // schedule it does nothing, so it duplicates nothing. And it stops once the last real fix is
+    // older than RESEND_MAX_AGE_MS - without that bound a GPS that genuinely dies mid-drive
+    // (tunnel, garage, antenna knocked loose) would be indistinguishable from a parked car forever,
+    // and Android Auto would stay pinned to the last position instead of falling back to the
+    // phone. A wrong position while moving is worse than the stall this resend exists to prevent.
+    private val periodicResend = object : Runnable {
+        override fun run() {
+            val fix = lastGpsFix
+            if (fix != null && settings.useGpsForNavigation) {
+                val ageMs = SystemClock.elapsedRealtime() - lastGpsFixAtMs
+                if (ageMs > RESEND_MAX_AGE_MS) {
+                    if (!staleFixReported) {
+                        staleFixReported = true
+                        AppLog.i("GpsLocation: no GPS fix for ${ageMs / 1000}s, stopping resend so the phone can fall back to its own location")
+                    }
+                } else if (ageMs >= RESEND_INTERVAL_MS) {
+                    val refreshed = Location(fix).apply {
+                        time = System.currentTimeMillis()
+                        elapsedRealtimeNanos = SystemClock.elapsedRealtimeNanos()
+                    }
+                    context.sendBroadcast(LocationUpdateIntent(refreshed).setPackage(context.packageName))
+                }
+                // ageMs < RESEND_INTERVAL_MS: a real fix just went out; nothing to stand in for.
+            }
+            handler.postDelayed(this, RESEND_INTERVAL_MS)
+        }
+    }
 
     @SuppressLint("MissingPermission")
     fun start() {
@@ -21,16 +75,56 @@ class GpsLocation constructor(private val context: Context): LocationListener {
             return
         }
         AppLog.i("Request location updates")
-        if (PermissionChecker.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PermissionChecker.PERMISSION_GRANTED
-                && locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
-            locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, 400, 5.0f, this)
+        val hasPermission = PermissionChecker.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PermissionChecker.PERMISSION_GRANTED
+        val providerEnabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)
+        if (hasPermission && providerEnabled) {
+            // No minDistance: Android ANDs the time and distance gates, so any non-zero distance
+            // stops a stationary head unit after its very first fix. Asking on time alone is what
+            // a real head unit does, and it costs nothing extra - the chip is already running.
+            //
+            // 1Hz is the automotive GPS norm and what Android Auto's navigation is tuned for.
+            // The old 5m gate delivered a fix every ~0.4-0.6s at driving speed, so this is fewer
+            // updates while moving, not more; the parked case goes from one fix ever to a steady
+            // stream, and the fan-out cost of that is paid at the sinks, not by starving nav.
+            locationManager.requestLocationUpdates(
+                LocationManager.GPS_PROVIDER, UPDATE_INTERVAL_MS, 0f, this
+            )
             val location = locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER)
             AppLog.i("Last known location:  ${location?.toString() ?: "Unknown"}")
             requested = true
+            subscribedAtMs = SystemClock.elapsedRealtime()
+            handler.postDelayed(periodicResend, RESEND_INTERVAL_MS)
+        } else {
+            AppLog.i("GpsLocation: not requesting updates, ACCESS_FINE_LOCATION granted=$hasPermission GPS_PROVIDER enabled=$providerEnabled")
         }
     }
 
     override fun onLocationChanged(location: Location) {
+        // A callback dispatched before removeUpdates() took effect must not repopulate state a
+        // stop() just cleared - the next start() would inherit a fix from the previous session.
+        if (!requested) {
+            return
+        }
+        // Once per subscription, and carrying no position: without it a head unit whose antenna is
+        // not connected is indistinguishable from a working one in a log. It passes every gate in
+        // start() - the provider exists and is enabled - and then simply never locks, so the only
+        // other evidence is the absence of lines that were never going to appear. How long the
+        // lock took separates a healthy chip from one that is barely hearing the satellites.
+        // lastGpsFix is the flag: it is null exactly between start() and the first fix.
+        if (lastGpsFix == null) {
+            AppLog.i("GpsLocation: first fix after ${(SystemClock.elapsedRealtime() - subscribedAtMs) / 1000}s")
+        }
+        // Cadence only, never a position: this is what lets a parked verbose log show whether the
+        // chip honours a time-only subscription (and so whether the resend backstop is needed).
+        if (AppLog.LOG_VERBOSE) {
+            AppLog.v("GpsLocation: fix received")
+        }
+        lastGpsFix = location
+        lastGpsFixAtMs = SystemClock.elapsedRealtime()
+        // Reset here rather than in the resend's fresh branch: on a healthy chip that branch never
+        // runs, and the flag left latched would silence the stale line for every outage after the
+        // first one in a session.
+        staleFixReported = false
         LocationHolder.update(location)
         context.sendBroadcast(LocationUpdateIntent(location).setPackage(context.packageName))
     }
@@ -50,6 +144,21 @@ class GpsLocation constructor(private val context: Context): LocationListener {
     fun stop() {
         AppLog.i("Remove location updates")
         requested = false
+        // Every field start() depends on goes back to its initial value, so a re-armed instance
+        // cannot resend a fix acquired during the previous connection.
+        lastGpsFix = null
+        lastGpsFixAtMs = 0L
+        subscribedAtMs = 0L
+        staleFixReported = false
         locationManager.removeUpdates(this)
+        handler.removeCallbacks(periodicResend)
+    }
+
+    private companion object {
+        const val UPDATE_INTERVAL_MS = 1000L
+        const val RESEND_INTERVAL_MS = 3000L
+
+        /** How stale the last real fix may be before a resend stops standing in for it. */
+        const val RESEND_MAX_AGE_MS = 60_000L
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/location/LocationHolder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/location/LocationHolder.kt
@@ -53,6 +53,24 @@ object LocationHolder {
     }
 
     /**
+     * The freshest fix from this head unit's own GPS chip, within [maxAgeMs] - the only kind of
+     * fix that may be forwarded to the phone as the car's LOCATION sensor. A network- or
+     * passive-derived position must never travel under that label: on a unit whose GPS never
+     * locks it is often derived from the very hotspot or P2P group we created. Returns null when
+     * the GPS has produced nothing recent, which is the correct answer - the phone then keeps
+     * using its own location.
+     */
+    fun currentGpsFix(context: Context, maxAgeMs: Long = MAX_AGE_MS): Location? {
+        val newest = listOfNotNull(
+            lastFix?.takeIf { it.provider == LocationManager.GPS_PROVIDER },
+            bestEffortFix(context, listOf(LocationManager.GPS_PROVIDER))
+        ).maxByOrNull { it.time } ?: return null
+        // <= rather than in 0..: system clocks on these units routinely lag GPS time, which makes
+        // a live fix look future-dated. A negative age means clock skew, not staleness.
+        return newest.takeIf { System.currentTimeMillis() - newest.time <= maxAgeMs }
+    }
+
+    /**
      * The best available fix for geofence containment tests, IGNORING age. A parked
      * head unit may not get a fresh fix for a long time, but its last known position
      * is still exactly where it is, so for "am I inside this area?" the newest known
@@ -70,8 +88,17 @@ object LocationHolder {
      * by the automation gate before any connection exists. Returns null if no
      * permission / provider / cached fix is available.
      */
+    fun bestEffortDeviceFix(context: Context): Location? = bestEffortFix(
+        context,
+        listOf(
+            LocationManager.GPS_PROVIDER,
+            LocationManager.NETWORK_PROVIDER,
+            LocationManager.PASSIVE_PROVIDER
+        )
+    )
+
     @SuppressLint("MissingPermission")
-    fun bestEffortDeviceFix(context: Context): Location? {
+    private fun bestEffortFix(context: Context, providers: List<String>): Location? {
         if (PermissionChecker.checkSelfPermission(
                 context, Manifest.permission.ACCESS_FINE_LOCATION
             ) != PermissionChecker.PERMISSION_GRANTED
@@ -80,11 +107,6 @@ object LocationHolder {
         }
         return try {
             val lm = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
-            val providers = listOf(
-                LocationManager.GPS_PROVIDER,
-                LocationManager.NETWORK_PROVIDER,
-                LocationManager.PASSIVE_PROVIDER
-            )
             providers.mapNotNull { p ->
                 try { lm.getLastKnownLocation(p) } catch (e: Exception) { null }
             }.maxByOrNull { it.time }


### PR DESCRIPTION
## Why

Addresses the native GPS half of #832. With "Gps for navigation" on, the head unit's own GPS never reached the phone in practice, so Android Auto fell back to the phone's location. Two independent bugs caused it:

1. The first fix was sent before the phone had started the LOCATION sensor, so the transport silently dropped it, and there is no queue behind that gate.
2. The location subscription asked for updates every 400 ms AND 5 m. Android applies both filters, so a stationary head unit received exactly one fix, ever. To Android Auto that is indistinguishable from a car GPS that died, which is its documented cue to fall back to the phone. Also could explain #726 

## What changed

- `AapControl`: when the phone's SENSOR_STARTREQUEST for LOCATION arrives, the freshest head unit GPS fix is sent immediately, mirroring the existing NIGHT pattern. This is the earliest moment a send can pass the started-sensor gate. Both outcomes are logged.
- `LocationHolder`: new `currentGpsFix` accessor, restricted to the GPS provider. A unit whose GPS never locks (no antenna) must send nothing rather than a network fix derived from the very hotspot or P2P group the app created. Its staleness check tolerates GPS-vs-system clock skew, common on these units.
- `GpsLocation`: subscribes on time alone at 1 Hz (the automotive norm; the old 5 m gate delivered faster than that while driving anyway). A 3 s resend backstop covers chips that only emit on movement; it fires only for a missed beat, is skipped when the toggle is off, and gives up after 60 s without a real fix so a GPS that dies mid-drive lets Android Auto fall back instead of pinning a stale position. Diagnostics carry no coordinates.
- `LocationUpdateEvent`: `accuracy` is a proto2 required field but was set conditionally; an accuracy-less fix threw out of build() and killed the session. Now always set.
- `AapTransport`: dropped sensor events are reported (first drop per type, then a rate-limited count) instead of silently discarded.
- `AapBroadcastReceiver`: the stored last-known-location write is skipped when coordinates are unchanged, so a parked unit no longer rewrites the prefs file every few seconds.

## Verification

Verified on hardware (UNISOC MT50, Android 14, Native AA wireless), single round, full logs kept:

- Unit tests and `assembleGithubDebug` green.
- Priming: `sentOnWire=true` on the first try after the phone's LOCATION request.
- Cadence: 1 Hz subscription honoured for every fix the OS delivered; 303 consecutive fixes over one stationary session with zero LOCATION drops after the channel opened.
- Resend cutoff: measured at 60 s and 62 s across four starvation windows, one log line each, re-arming correctly on the next real fix.
- Toggle off: LOCATION is not advertised, the phone never requests it, nothing is sent.
- Permission or provider refusals produce one explicit log line naming which gate failed.

One honest limitation, measured in the same round: this guarantees the car's position is delivered continuously, not that Android Auto prefers it. A mock location app on the phone can still win, because Maps on the phone also reads the phone's own provider directly. That is Google's fusion logic, outside any head unit's control.

## Where to focus review

- The priming block in `AapControlSensor.sensorStartRequest` (send point and its gate on the setting).
- The resend bounds in `GpsLocation.periodicResend` (missed-beat gate, 60 s cutoff, toggle skip).
- `LocationHolder.currentGpsFix` sourcing (GPS provider only, on purpose).
