### PR TITLE
Fix/video and wireless stack

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/AppComponent.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/AppComponent.kt
@@ -6,6 +6,7 @@ import android.net.wifi.WifiManager
 import com.andrerinas.openheadunit.connection.CommManager
 import com.andrerinas.openheadunit.connection.carkey.CarKeysManager
 import com.andrerinas.openheadunit.decoder.AudioDecoder
+import com.andrerinas.openheadunit.decoder.DeviceMemoryProfile
 import com.andrerinas.openheadunit.decoder.VideoDecoder
 import com.andrerinas.openheadunit.utils.SUExecutor
 import com.andrerinas.openheadunit.utils.Settings
@@ -13,7 +14,7 @@ import com.andrerinas.openheadunit.utils.Settings
 class AppComponent(private val app: App) {
 
     val settings = Settings(app)
-    val videoDecoder = VideoDecoder(settings)
+    val videoDecoder = VideoDecoder(settings, DeviceMemoryProfile.readWithOverride(app, settings.debugForceMemoryProfile))
     val audioDecoder = AudioDecoder()
 
     val notificationManager: NotificationManager

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapMessageHandlerType.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapMessageHandlerType.kt
@@ -24,6 +24,11 @@ internal class AapMessageHandlerType(
     @Throws(AapMessageHandler.HandleException::class)
     override fun handle(message: AapMessage) {
 
+        // Every decrypted inbound message passes through here, on every channel, which makes this
+        // the one place that can say the link is alive rather than just that the picture is moving.
+        // See AapTransport.lastMessageReceivedMs for why that distinction matters.
+        transport.noteMessageReceived()
+
         val msgType = message.type
         val flags = message.flags
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapMessageIncoming.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapMessageIncoming.kt
@@ -40,8 +40,11 @@ internal class AapMessageIncoming(header: EncryptedHeader, ba: ByteArrayWithLimi
 
             val ba = ssl.decrypt(offset, header.enc_len, buf) ?: return null
 
-            if (ba.data.size < 2) {
-                AppLog.e("Decrypted payload too short: " + ba.data.size)
+            // The payload length is ba.limit, not ba.data.size: the SSL layer hands back one reused
+            // buffer whose length is the session ceiling, so data.size is always large enough and
+            // this guard would never fire. Two bytes are needed for the message type read below.
+            if (ba.limit < 2) {
+                AppLog.e("Decrypted payload too short: " + ba.limit)
                 return null
             }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
@@ -216,10 +216,16 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
                 commManager.send(VideoFocusEvent(gain = true, unsolicited = true))
             }
             WarmRelaunchKeyframePolicy.Action.CYCLE_FOCUS -> {
+                // The transport's own escalation spends the same lever. If it holds it, no release
+                // went out for this policy to complete, so nothing here may be marked as spent -
+                // and the keyframe that cycle brings is the one this was asking for anyway.
+                if (!commManager.releaseVideoFocusForKeyframe()) {
+                    AppLog.w("AapProjectionActivity: relaunched surface has no picture, but a focus cycle is already in flight - waiting for it")
+                    return
+                }
                 warmRelaunchCycleSpent = true
                 lastVideoFocusRequestMs = now
                 AppLog.w("AapProjectionActivity: relaunched surface has no picture after ${now - lastSurfaceSetMs}ms - cycling video focus")
-                commManager.releaseVideoFocusForKeyframe()
                 focusCycleGainPending = true
                 watchdogHandler.removeCallbacks(focusCycleGainRunnable)
                 watchdogHandler.postDelayed(
@@ -250,7 +256,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
     private val focusCycleGainRunnable = Runnable {
         focusCycleGainPending = false
         AppLog.w("AapProjectionActivity: retaking video focus to complete the keyframe cycle")
-        commManager.send(VideoFocusEvent(gain = true, unsolicited = true))
+        commManager.retakeVideoFocusForKeyframe()
     }
 
     /**

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
@@ -119,24 +119,42 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
     private var isKeyEventReceiverRegistered = false
     private var isSettingsReceiverRegistered = false
 
+    /**
+     * Asks for video while the surface the decoder holds has never shown a picture.
+     *
+     * Deliberately **not** gated on the loading overlay any more. It was, and that let a cosmetic
+     * decision end recovery: `onCreate` hides the overlay when the previous instance had rendered,
+     * and this runnable does not re-post when it declines, so one relaunch in two lost the loop on
+     * its first tick and sat black with nothing asking. See
+     * [ProjectionWatchdogPolicy.shouldNudgeForFirstFrame].
+     *
+     * It still hides the overlay when it finds a picture, because that is a fact about the picture
+     * rather than a condition on running.
+     */
     private val videoWatchdogRunnable = object : Runnable {
         override fun run() {
-            val loadingOverlay = findViewById<View>(R.id.loading_overlay)
-            if (loadingOverlay?.visibility == View.VISIBLE && commManager.isConnected) {
-                // If the decoder already rendered something, hide the overlay immediately
-                if (videoDecoder.lastFrameRenderedMs > 0) {
+            val rendered = videoDecoder.lastFrameRenderedMs > 0
+            if (rendered) {
+                val loadingOverlay = findViewById<View>(R.id.loading_overlay)
+                if (loadingOverlay?.visibility == View.VISIBLE) {
                     AppLog.i("Watchdog: Decoder is already rendering frames. Hiding overlay.")
                     hideLoadingOverlay(loadingOverlay)
-                    return
                 }
-
-                AppLog.w("Watchdog: No video received yet. Requesting Keyframe (Unsolicited Focus)...")
-                // Shares one throttle clock with the reconnecting watchdog's mid-session
-                // re-request, so the two never double-fire across the overlay transition.
-                lastVideoFocusRequestMs = SystemClock.elapsedRealtime()
-                commManager.send(VideoFocusEvent(gain = true, unsolicited = true))
-                watchdogHandler.postDelayed(this, 1500)
             }
+            if (!ProjectionWatchdogPolicy.shouldNudgeForFirstFrame(
+                    sessionLive = ProjectionWatchdogPolicy.isSessionLive(commManager.connectionState.value),
+                    surfaceSet = isSurfaceSet,
+                    renderedSinceSurfaceSet = rendered,
+                    warmRelaunchCycleSpent = warmRelaunchCycleSpent,
+                )
+            ) return
+
+            AppLog.w("Watchdog: No video received yet. Requesting Keyframe (Unsolicited Focus)...")
+            // Shares one throttle clock with the reconnecting watchdog's mid-session
+            // re-request, so the two never double-fire across the overlay transition.
+            lastVideoFocusRequestMs = SystemClock.elapsedRealtime()
+            commManager.send(VideoFocusEvent(gain = true, unsolicited = true))
+            watchdogHandler.postDelayed(this, 1500)
         }
     }
     private val reconnectingWatchdog = object : Runnable {
@@ -162,20 +180,38 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
                 return
             }
             val gap = SystemClock.elapsedRealtime() - lastFrame
-            if (overlayState == OverlayState.HIDDEN && gap > 10000) {
+            val linkQuiet = linkQuietMs()
+            val pictureStopped = gap > ProjectionWatchdogPolicy.FRAME_GAP_MS
+            if (overlayState == OverlayState.HIDDEN &&
+                ProjectionWatchdogPolicy.shouldShowReconnecting(gap, linkQuiet)
+            ) {
+                AppLog.w(
+                    "AapProjectionActivity: picture idle for ${gap}ms and the link has been silent " +
+                        "for ${describeQuiet(linkQuiet)} - treating this as a lost connection"
+                )
                 showReconnectingOverlay()
             } else if (overlayState == OverlayState.RECONNECTING && gap < 2000) {
                 hideReconnectingOverlay()
             } else {
+                if (!pictureStopped) {
+                    lastIdleReportMs = 0L
+                } else if (overlayState == OverlayState.HIDDEN) {
+                    reportIdlePicture(gap, linkQuiet)
+                }
                 // Decoder producing but display possibly frozen (issue #650).
                 maybeRecoverFromDisplayStall()
             }
-            maybeRequestVideoFocus()
+            maybeRequestVideoFocus(pictureStopped)
             watchdogHandler.postDelayed(this, 2000)
         }
     }
 
     private var lastVideoFocusRequestMs = 0L
+
+    // Throttle for the idle-picture line. Cleared the moment frames resume, so each idle stretch
+    // reports immediately instead of inheriting the previous one's window.
+    private var lastIdleReportMs = 0L
+    private val idleReportCooldownMs = 10000L
 
     // Age and escalation state of the surface the decoder currently renders to. Reset together in
     // onSurfaceChanged, so each relaunch gets exactly one focus cycle.
@@ -203,8 +239,11 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
             renderedSinceSurfaceSet = videoDecoder.lastFrameRenderedMs != 0L,
             transportStarted = commManager.connectionState.value is CommManager.ConnectionState.TransportStarted,
             msSinceSurfaceSet = now - lastSurfaceSetMs,
-            msSincePhoneBytes = now - videoDecoder.lastInputBytesReceivedMs,
-            phoneAliveThresholdMs = phoneAliveThresholdMs,
+            // The link, not the video channel. An idle Android Auto screen sends no video for
+            // minutes at a time and still answers on the link, and reading video bytes here shut
+            // this escalation for the whole of exactly the case it is needed in.
+            msSinceLinkActivity = linkQuietMs(),
+            linkQuietThresholdMs = ProjectionWatchdogPolicy.LINK_QUIET_MS,
             cycleAlreadySpent = warmRelaunchCycleSpent,
             msSinceLastRequest = now - lastVideoFocusRequestMs
         )
@@ -274,16 +313,62 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
     }
 
     /**
-     * Mid-session recovery: the connection is proven live (the state check above) but no frame
-     * has arrived for long enough that the reconnecting overlay is up, so ask the phone for
-     * video again. Without this, the one unsolicited focus gain sent when a surface appears was
-     * the only request in the whole session - if the stream stopped after that, nothing ever
-     * asked for it back and the screen stayed black until the app was killed.
+     * How long ago the phone last sent anything at all, on any AAP channel.
+     *
+     * [Long.MAX_VALUE] when it has not sent anything yet this session. That case has to be spelled
+     * out rather than left to arithmetic: `lastAapMessageMs` is 0 until the first message arrives,
+     * and `now - 0` is a very large number that reads as a *silent* link - so the obvious
+     * subtraction would report a session that has merely not started as one that has died.
      */
-    private fun maybeRequestVideoFocus() {
+    private fun linkQuietMs(): Long {
+        val last = commManager.lastAapMessageMs
+        if (last == 0L) return Long.MAX_VALUE
+        return SystemClock.elapsedRealtime() - last
+    }
+
+    /** Renders [linkQuietMs] for a log line, so "not yet" never prints as 9223372036854775807ms. */
+    private fun describeQuiet(quietMs: Long): String =
+        if (quietMs == Long.MAX_VALUE) "the whole session" else "${quietMs}ms"
+
+    /**
+     * Records that the picture stopped without the link doing so - the case that used to be shown
+     * to the user as a lost connection.
+     *
+     * Android Auto sends no video at all while nothing on screen animates, so this is the normal
+     * state of a paused full-screen music player, and the overlay it produced was the whole of
+     * issue #852. The line stays because [ProjectionWatchdogPolicy.LINK_QUIET_MS] is a judgement
+     * and not yet a measurement: every one of these carries the phone's real idle cadence, so two
+     * reporter logs are enough to replace the guess with a number.
+     *
+     * Rate-limited to one per idle stretch rather than one per 2s tick.
+     */
+    private fun reportIdlePicture(gapMs: Long, quietMs: Long) {
+        val now = SystemClock.elapsedRealtime()
+        if (lastIdleReportMs != 0L && now - lastIdleReportMs < idleReportCooldownMs) return
+        lastIdleReportMs = now
+        AppLog.w(
+            "AapProjectionActivity: picture idle for ${gapMs}ms but the link spoke " +
+                "${describeQuiet(quietMs)} ago - Android Auto has stopped sending, not disconnected"
+        )
+    }
+
+    /**
+     * Mid-session recovery: the connection is proven live (the state check above) but no frame has
+     * arrived for [ProjectionWatchdogPolicy.FRAME_GAP_MS], so ask the phone for video again.
+     * Without this, the one unsolicited focus gain sent when a surface appears was the only request
+     * in the whole session - if the stream stopped after that, nothing ever asked for it back and
+     * the screen stayed black until the app was killed.
+     *
+     * Gated on [pictureStopped] and deliberately **not** on the reconnecting overlay, which is what
+     * it used to read. The overlay now also requires the link to have gone quiet (issue #852), and
+     * an idle-looking stream is exactly the shape a genuinely stalled one has - so tying recovery
+     * to the overlay would leave the stalled case with nothing asking for video back, which is the
+     * failure this watchdog was revived to fix.
+     */
+    private fun maybeRequestVideoFocus(pictureStopped: Boolean) {
         val now = SystemClock.elapsedRealtime()
         if (!ProjectionWatchdogPolicy.shouldRequestVideoFocus(
-                overlayState == OverlayState.RECONNECTING, now, lastVideoFocusRequestMs
+                pictureStopped, now, lastVideoFocusRequestMs
             )
         ) return
         lastVideoFocusRequestMs = now
@@ -405,6 +490,10 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
     //     the GL consumer does not fully stop but drops to 2-5fps with single frames taking ~2s, so
     //     a plain "no frame for N seconds" check misses it (issue #650).
     private val displayFreezeThresholdMs = 5000L
+    // "The phone is still streaming video" - for [maybeRecoverFromDisplayStall] only, where that is
+    // the right question: that path is about the display consumer freezing while video flows. The
+    // warm-relaunch escalation used to share it and asks about the link instead, because there a
+    // stream with no video is the normal idle screen rather than evidence of anything.
     private val phoneAliveThresholdMs = 1500L
     private val displayStallRecoveryCooldownMs = 10000L
     private val displayStallRecoveryResetMs = 60000L
@@ -497,7 +586,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
             com.andrerinas.openheadunit.utils.ToastUtils.showToast(this, R.string.renderer_fallback_surface, duration = android.widget.Toast.LENGTH_LONG, force = true)
             // SurfaceView can't be observed for stalls (issue #767); if it too shows black, offer the
             // manual escape so the user isn't stranded on the terminal fallback.
-            showRendererConfirmBanner()
+            showRendererConfirmBanner("the SurfaceView fallback is also showing black")
         } else {
             AppLog.w("Display stall ($reason). Rebuilding projection view (attempt $displayStallRecoveries). See issue #650.")
         }
@@ -518,14 +607,31 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         val now = SystemClock.elapsedRealtime()
         if (now - input > rendererConfirmPhoneAliveMs) return
         if (projectionStartMs == 0L || now - projectionStartMs < rendererConfirmNoFrameMs) return
-        showRendererConfirmBanner()
+        showRendererConfirmBanner("the phone is streaming and nothing has drawn")
     }
 
-    /** A dismissible bottom bar: "Do you see the screen?" with Yes / Switch renderer. */
-    private fun showRendererConfirmBanner() {
+    /**
+     * A dismissible bottom bar: "Do you see the screen?" with Yes / Switch renderer.
+     *
+     * @param reason which of the four situations armed it, for the log. They are four different
+     *   things - a terminal fallback that is also black, a phone streaming into a blank screen, a
+     *   renderer just switched, and the setup wizard asking for confirmation - and they used to
+     *   produce one indistinguishable line. A round saw the banner with `pendingRendererConfirm`
+     *   persisted false and had to reason out which path had armed it.
+     */
+    private fun showRendererConfirmBanner(reason: String) {
         runOnUiThread {
             if (rendererBanner != null || rendererConfirmResolved) return@runOnUiThread
             val container = findViewById<FrameLayout>(R.id.container) ?: return@runOnUiThread
+            // Said out loud because until now nothing was. A session sitting behind this banner
+            // logs exactly like a connected one showing a static screen, and a hardware round lost
+            // a whole capture to the difference - only a screenshot told the two apart.
+            AppLog.w(
+                "AapProjectionActivity: the renderer confirmation banner is up (%s) - projection " +
+                    "is waiting on the user to answer it, and the screen will not change until " +
+                    "they do.",
+                reason
+            )
             fun dp(v: Int) = (v * resources.displayMetrics.density).toInt()
             val bar = LinearLayout(this).apply {
                 orientation = LinearLayout.HORIZONTAL
@@ -598,7 +704,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         // which nothing can detect automatically).
         dismissRendererConfirmBanner()
         recreateProjectionView()
-        showRendererConfirmBanner()
+        showRendererConfirmBanner("the renderer was just switched and may still be blank")
     }
 
     private val nightModeReceiver = object : BroadcastReceiver() {
@@ -800,7 +906,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
                 // The wizard changed the renderer: the picture is up, so ask the user to confirm it
                 // (issue #767). If they don't, the auto-offer above still catches a broken renderer.
                 if (settings.pendingRendererConfirm && !rendererConfirmResolved) {
-                    showRendererConfirmBanner()
+                    showRendererConfirmBanner("the setup wizard changed the renderer")
                 }
 
                 // Show one-time gesture hint

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapRead.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapRead.kt
@@ -13,10 +13,61 @@ import com.andrerinas.openheadunit.utils.Settings
 internal interface AapRead {
     fun read(): Int
 
+    /**
+     * @param onVideoRunHoled called when a video fragment run turns out to be short of the bytes it
+     *   declared. A callback rather than an [AapVideo] reference: the reader owes the video path one
+     *   fact and nothing else, and the two are wired together in [Factory] the way every other
+     *   cross-manager coupling in this app is.
+     * @param faultInjector reader-stage fault injection, or null. Distinct from the injector
+     *   [AapVideo] holds because the two act at different points in the receive path - see
+     *   [VideoFaultInjector.Stage]. Only one of the two is ever non-null in a session.
+     */
     abstract class Base internal constructor(
             private val connection: AccessoryConnection?,
             internal val ssl: AapSsl,
-            internal val handler: AapMessageHandler) : AapRead {
+            internal val handler: AapMessageHandler,
+            private val onVideoRunHoled: () -> Unit = {},
+            internal val faultInjector: VideoFaultInjector? = null) : AapRead {
+
+        /** Every line [faultInjector] prints. Shared wording with [AapVideo]'s - see the class. */
+        internal val faultReporter = VideoFaultReporter("AapRead")
+
+        init {
+            faultInjector?.let { faultReporter.announce(it) }
+        }
+
+        /**
+         * Whether this message should be treated as one that never arrived.
+         *
+         * Called by both readers once the whole body is in hand and **before** [auditFragment], which
+         * is the entire point: a fragment dropped here is short in the audit's own accounting, and an
+         * assembler-stage drop can never reproduce that because the audit has already counted it.
+         *
+         * ### The caller must still decrypt the message it drops
+         *
+         * An earlier version of this said the drop was safe because only bytes already consumed from
+         * the connection are discarded, so the stream stays framed. The framing part is true and was
+         * measured - a hardware round killed four sessions this way and produced **zero** of the
+         * framing-desync lines. It is also not sufficient, because the byte stream is not the only
+         * ordered state in the receive path.
+         *
+         * [AapSslContext.decrypt] calls `SSLEngine.unwrap`, whose TLS record sequence advances per
+         * record, and the phone's sending side advances its own for every record it encrypts whether
+         * or not we choose to look at it. A record we never unwrap leaves this engine permanently one
+         * behind, every later unwrap fails authentication, and the session dies within seconds:
+         * measured at 3.9s from handshake to `Connection closed (EOF)` on the first injected fault,
+         * with a storm of `Decrypted payload too short: 0` in between.
+         *
+         * So both readers resolve this into a local, skip only [auditFragment] and the handler, and
+         * decrypt unconditionally. Do not turn either back into an early return.
+         */
+        protected fun shouldDropForFaultInjection(channel: Int, flags: Int, encLen: Int): Boolean {
+            val injector = faultInjector ?: return false
+            if (channel != Channel.ID_VID) return false
+            val effect = injector.effectFor(flags)
+            faultReporter.onMessage(injector, effect, flags, encLen)
+            return effect == VideoFaultInjector.Effect.DROP
+        }
 
         private val fragmentAudit = FragmentedMessageAudit()
 
@@ -67,6 +118,14 @@ internal interface AapRead {
                 }
             }
             val result = fragmentAudit.onMessage(channel, flags, encLen, declaredTotal) ?: return
+
+            // Before the report budget, deliberately. That budget decides how often this finding is
+            // *printed*; a suppressed line must not also suppress the repair. The ask has its own
+            // throttle in VideoRecoveryPolicy, which every keyframe request in the app is held to.
+            if (AuditRecoveryPolicy.shouldRequestKeyframe(result.outcome, result.channel)) {
+                onVideoRunHoled()
+            }
+
             val channelName = Channel.name(channel)
             if (result.outcome == FragmentedMessageAudit.Outcome.FIRST_OBSERVATION) {
                 AppLog.i("AapRead: fragment accounting established for %s: %s", channelName, result)
@@ -119,10 +178,20 @@ internal interface AapRead {
             // in AapReadMultipleMessages. Do NOT key this off isSingleMessage - that flag only
             // controls the Nearby-specific handshake settle-delay/drain skip in
             // AapTransport.handshake() and is unrelated to read framing.
+            // Only ever non-null for a Stage.READER mode; Stage.ASSEMBLER modes stay with AapVideo,
+            // and VideoFaultInjector.isActiveAt is what keeps the two from both claiming one mode.
+            val readerFaults = VideoFaultInjector(
+                settings.debugVideoFaultInjection,
+                settings.debugVideoFaultRate,
+                settings.debugVideoFaultBudget
+            ).takeIf { it.isActiveAt(VideoFaultInjector.Stage.READER) }
+
+            val onVideoRunHoled = { aapVideo.onFragmentRunHoled() }
+
             return if (connection is SocketAccessoryConnection)
-                AapReadSingleMessage(connection, transport.ssl, handler)
+                AapReadSingleMessage(connection, transport.ssl, handler, onVideoRunHoled, readerFaults)
             else
-                AapReadMultipleMessages(connection, transport.ssl, handler)
+                AapReadMultipleMessages(connection, transport.ssl, handler, onVideoRunHoled, readerFaults)
         }
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapRead.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapRead.kt
@@ -1,10 +1,12 @@
 package com.andrerinas.openheadunit.aap
 
 import android.content.Context
+import android.os.SystemClock
 import com.andrerinas.openheadunit.connection.AccessoryConnection
 import com.andrerinas.openheadunit.connection.SocketAccessoryConnection
 import com.andrerinas.openheadunit.decoder.MicRecorder
 import com.andrerinas.openheadunit.utils.AppLog
+import com.andrerinas.openheadunit.aap.protocol.Channel
 import com.andrerinas.openheadunit.aap.protocol.proto.MediaPlayback
 import com.andrerinas.openheadunit.utils.Settings
 
@@ -16,6 +18,26 @@ internal interface AapRead {
             internal val ssl: AapSsl,
             internal val handler: AapMessageHandler) : AapRead {
 
+        private val fragmentAudit = FragmentedMessageAudit()
+
+        /**
+         * Per-outcome print budget: how many have been printed, when the last one was, and how many
+         * went unprinted since. See [AuditReportPolicy] for why this refills instead of running out.
+         */
+        private val auditReports = IntArray(FragmentedMessageAudit.Outcome.entries.size)
+        private val auditLastReportMs = LongArray(FragmentedMessageAudit.Outcome.entries.size)
+        private val auditSuppressed = IntArray(FragmentedMessageAudit.Outcome.entries.size)
+
+        /**
+         * Largest single message body seen, reported each time it crosses a power of two.
+         *
+         * `msgBuffer` is a flat 4MB in both readers, which on a 1GB unit is a fifth of the whole Java
+         * heap standing reserved for a message size nobody has measured. Shrinking it on a guess would
+         * turn a large frame into "Invalid message size ... Skipping", so measure it first: at most a
+         * dozen lines ever, and they say exactly how small it could safely be.
+         */
+        private var maxEncLenSeen = 0
+
         override fun read(): Int {
             if (connection == null) {
                 AppLog.e("No connection.")
@@ -23,6 +45,45 @@ internal interface AapRead {
             }
 
             return doRead(connection)
+        }
+
+        /**
+         * Cross-checks a fragment run against the total size its first fragment declared.
+         *
+         * Both readers already read that 4-byte total and discarded it, which left the one corruption
+         * mode nothing downstream can see: a missing *middle* fragment leaves the run looking intact
+         * to the reassembler, so the frame is assembled with a hole and decoded as though it were
+         * whole. See [FragmentedMessageAudit] for why the check learns the convention rather than
+         * assuming one.
+         *
+         * [declaredTotal] is only meaningful on a first fragment and is ignored otherwise.
+         */
+        protected fun auditFragment(channel: Int, flags: Int, encLen: Int, declaredTotal: Int) {
+            if (encLen > maxEncLenSeen) {
+                val crossedBoundary = Integer.highestOneBit(encLen) > Integer.highestOneBit(maxEncLenSeen)
+                maxEncLenSeen = encLen
+                if (crossedBoundary) {
+                    AppLog.i("AapRead: largest message body so far: %d bytes (on %s)", encLen, Channel.name(channel))
+                }
+            }
+            val result = fragmentAudit.onMessage(channel, flags, encLen, declaredTotal) ?: return
+            val channelName = Channel.name(channel)
+            if (result.outcome == FragmentedMessageAudit.Outcome.FIRST_OBSERVATION) {
+                AppLog.i("AapRead: fragment accounting established for %s: %s", channelName, result)
+                return
+            }
+            val index = result.outcome.ordinal
+            val now = SystemClock.elapsedRealtime()
+            if (!AuditReportPolicy.shouldReport(auditReports[index], auditLastReportMs[index], now)) {
+                auditSuppressed[index]++
+                return
+            }
+            val suppressed = auditSuppressed[index]
+            auditSuppressed[index] = 0
+            auditReports[index]++
+            auditLastReportMs[index] = now
+            val suffix = if (suppressed > 0) " (and $suppressed more since the last report)" else ""
+            AppLog.w("AapRead: %s on %s - %s%s", result.outcome, channelName, result, suffix)
         }
 
         protected abstract fun doRead(connection: AccessoryConnection): Int

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapReadMultipleMessages.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapReadMultipleMessages.kt
@@ -10,8 +10,10 @@ import java.nio.ByteBuffer
 internal class AapReadMultipleMessages(
         connection: AccessoryConnection,
         ssl: AapSsl,
-        handler: AapMessageHandler)
-    : AapRead.Base(connection, ssl, handler) {
+        handler: AapMessageHandler,
+        onVideoRunHoled: () -> Unit = {},
+        faultInjector: VideoFaultInjector? = null)
+    : AapRead.Base(connection, ssl, handler, onVideoRunHoled, faultInjector) {
 
     // Increase buffers to 4MB to handle large 1080p/4K/HEVC I-frames
     private val fifo = ByteBuffer.allocate(4 * 1024 * 1024) 
@@ -88,14 +90,25 @@ internal class AapReadMultipleMessages(
 
             fifo.get(msgBuffer, 0, recvHeader.enc_len)
 
+            // Reader-stage fault injection - see the same branch in AapReadSingleMessage, and
+            // shouldDropForFaultInjection for why the decrypt below is not skipped with it.
+            val injectedDrop =
+                shouldDropForFaultInjection(recvHeader.chan, recvHeader.flags, recvHeader.enc_len)
+
             // The whole body arrived, so this fragment can be counted against the run's declared
-            // total. Done before decryption because the total is a framing quantity.
-            auditFragment(recvHeader.chan, recvHeader.flags, recvHeader.enc_len, declaredTotal)
+            // total. Done before decryption because the total is a framing quantity - and skipped
+            // for an injected drop, which is what leaves the run short of what it declared.
+            if (!injectedDrop) {
+                auditFragment(recvHeader.chan, recvHeader.flags, recvHeader.enc_len, declaredTotal)
+            }
 
             try {
+                // Unconditional, including for a message about to be dropped: the SSL engine's
+                // record sequence advances per record and a record we never unwrap desynchronises
+                // the session for good.
                 val msg = AapMessageIncoming.decrypt(recvHeader, 0, msgBuffer, ssl)
 
-                if (msg != null) {
+                if (msg != null && !injectedDrop) {
                     handler.handle(msg)
                 }
             } catch (e: Exception) {

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapReadMultipleMessages.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapReadMultipleMessages.kt
@@ -64,12 +64,15 @@ internal class AapReadMultipleMessages(
             fifo.get(recvHeader.buf, 0, recvHeader.buf.size)
             recvHeader.decode()
 
+            // Only a first fragment carries the total size, and only then is this meaningful.
+            var declaredTotal = 0
             if (recvHeader.flags == 0x09) {
                 if (fifo.remaining() < 4) {
                     fifo.reset()
                     break
                 }
                 fifo.get(skipBuffer, 0, 4)
+                declaredTotal = Utils.bytesToInt(skipBuffer, 0, false)
             }
 
             if (recvHeader.enc_len > msgBuffer.size || recvHeader.enc_len < 0) {
@@ -84,6 +87,10 @@ internal class AapReadMultipleMessages(
             }
 
             fifo.get(msgBuffer, 0, recvHeader.enc_len)
+
+            // The whole body arrived, so this fragment can be counted against the run's declared
+            // total. Done before decryption because the total is a framing quantity.
+            auditFragment(recvHeader.chan, recvHeader.flags, recvHeader.enc_len, declaredTotal)
 
             try {
                 val msg = AapMessageIncoming.decrypt(recvHeader, 0, msgBuffer, ssl)

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapReadRecoveryPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapReadRecoveryPolicy.kt
@@ -1,0 +1,102 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Decides, for each way a read can come up short, whether the byte stream can still be framed.
+ *
+ * AAP over a socket is a continuous byte stream with no resynchronisation mechanism: a message is
+ * found only by having read exactly the bytes of every message before it. So the question after a
+ * failed read is not "was this message important" but "do we still know where the next one starts".
+ *
+ * Every one of these sites used to answer "carry on" ([Outcome.CONTINUE]) - which reads as the
+ * conservative choice and is the opposite. Measured on a reporter's capture: a body read that timed
+ * out at 12:12:42 was followed within four seconds by 69 `WRONG FLAG` lines with channel numbers
+ * like -120 and flags like 0xffffffc7, and 63 `SSL Decrypt failed / Unable to parse TLS packet
+ * header`, until the socket finally closed. Nothing after that point was ever going to decode. A
+ * reconnect costs seconds; carrying on costs the session.
+ *
+ * The sibling reader already knows this. `AapReadMultipleMessages` keeps its unread bytes in a FIFO
+ * and rewinds with `mark()`/`reset()` rather than skipping, and says why in a comment: *"Do NOT
+ * clear the FIFO because USB/TCP is reliable and no bytes were lost. Discarding FIFO would
+ * desynchronize the stream."* The socket reader had no equivalent, and the socket path is the one
+ * every wireless user is on.
+ *
+ * ### Why a short read means an *unknown* number of bytes were consumed
+ *
+ * `SocketAccessoryConnection.recvBlocking` calls `DataInputStream.readFully` and returns `0` from
+ * its `SocketTimeoutException` catch. `readFully` loops internally until the buffer is full, so a
+ * timeout partway through an 8 KB body has already taken an unknown number of bytes off the socket.
+ * The `0` is the catch block's value, not a count. That is why [afterBodyRead] cannot subtract and
+ * resume: there is no number to subtract.
+ */
+object AapReadRecoveryPolicy {
+
+    /** What the reader should do next. */
+    enum class Outcome {
+        /** Alignment is intact and nothing was consumed that we cannot account for. Keep reading. */
+        CONTINUE,
+
+        /** The peer closed the stream. Ordinary end of session. */
+        DISCONNECT_EOF,
+
+        /**
+         * Nothing arrived within the read timeout. Alignment is intact - no bytes were taken - but
+         * on a socket a gap this long means the link is gone, and waiting longer only delays the
+         * reconnect.
+         */
+        DISCONNECT_IDLE,
+
+        /**
+         * Bytes were consumed and we cannot say how many, so the next header cannot be located.
+         * Only a fresh connection recovers from this.
+         */
+        DISCONNECT_DESYNC,
+    }
+
+    /** Return value of a read that hit end of stream. */
+    const val END_OF_STREAM = -1
+
+    /** Return value of a read that timed out having taken nothing. */
+    const val NOTHING_READ = 0
+
+    /**
+     * The fixed-size message header.
+     *
+     * [isSocketTransport] separates the two transports' idle rules rather than their alignment
+     * rules: USB tolerates a quiet bus and keeps polling, a socket does not.
+     */
+    fun afterHeaderRead(bytesRead: Int, expected: Int, isSocketTransport: Boolean): Outcome = when {
+        bytesRead == expected -> Outcome.CONTINUE
+        bytesRead == END_OF_STREAM -> Outcome.DISCONNECT_EOF
+        bytesRead == NOTHING_READ -> if (isSocketTransport) Outcome.DISCONNECT_IDLE else Outcome.CONTINUE
+        else -> Outcome.DISCONNECT_DESYNC
+    }
+
+    /**
+     * The 4-byte total that accompanies a first fragment.
+     *
+     * Short here is as bad as short anywhere else even though the field is tiny: the header before
+     * it is already gone, so continuing would read the body as though it were the next header.
+     */
+    fun afterFragmentTotalRead(bytesRead: Int, expected: Int): Outcome = when {
+        bytesRead == expected -> Outcome.CONTINUE
+        bytesRead == END_OF_STREAM -> Outcome.DISCONNECT_EOF
+        else -> Outcome.DISCONNECT_DESYNC
+    }
+
+    /**
+     * The length the header declared, before any of the body has been read.
+     *
+     * A length outside the buffer is nearly always a symptom of a desync that already happened -
+     * garbage bytes read as a header - rather than a real message we cannot hold. Either way the
+     * body cannot be consumed, so the alignment is lost from here on and skipping compounds it.
+     */
+    fun afterDeclaredLength(declaredLength: Int, bufferCapacity: Int): Outcome =
+        if (declaredLength in 0..bufferCapacity) Outcome.CONTINUE else Outcome.DISCONNECT_DESYNC
+
+    /** The message body. See the class KDoc for why a short read here is unrecoverable. */
+    fun afterBodyRead(bytesRead: Int, expected: Int): Outcome = when {
+        bytesRead == expected -> Outcome.CONTINUE
+        bytesRead == END_OF_STREAM -> Outcome.DISCONNECT_EOF
+        else -> Outcome.DISCONNECT_DESYNC
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapReadSingleMessage.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapReadSingleMessage.kt
@@ -3,8 +3,13 @@ package com.andrerinas.openheadunit.aap
 import com.andrerinas.openheadunit.connection.AccessoryConnection
 import com.andrerinas.openheadunit.utils.AppLog
 
-internal class AapReadSingleMessage(connection: AccessoryConnection, ssl: AapSsl, handler: AapMessageHandler)
-    : AapRead.Base(connection, ssl, handler) {
+internal class AapReadSingleMessage(
+        connection: AccessoryConnection,
+        ssl: AapSsl,
+        handler: AapMessageHandler,
+        onVideoRunHoled: () -> Unit = {},
+        faultInjector: VideoFaultInjector? = null)
+    : AapRead.Base(connection, ssl, handler, onVideoRunHoled, faultInjector) {
 
     private val recvHeader = AapMessageIncoming.EncryptedHeader()
     // Increase to 4MB to handle large 1080p/4K/HEVC I-frames
@@ -19,20 +24,27 @@ internal class AapReadSingleMessage(connection: AccessoryConnection, ssl: AapSsl
             // TCP keepAlive will detect a truly dead connection.
             val isSocket = connection is com.andrerinas.openheadunit.connection.SocketAccessoryConnection
             val timeout = if (isSocket) 15000 else 0
-            val headerSize = connection.recvBlocking(recvHeader.buf, recvHeader.buf.size, timeout, true) 
-            if (headerSize != AapMessageIncoming.EncryptedHeader.SIZE) {
-                if (headerSize == -1) {
+            val headerSize = connection.recvBlocking(recvHeader.buf, recvHeader.buf.size, timeout, true)
+            when (AapReadRecoveryPolicy.afterHeaderRead(headerSize, AapMessageIncoming.EncryptedHeader.SIZE, isSocket)) {
+                AapReadRecoveryPolicy.Outcome.CONTINUE -> {
+                    // Either the whole header arrived, or nothing did on a transport that tolerates
+                    // a quiet bus. Only the second needs to go round again without one.
+                    if (headerSize != AapMessageIncoming.EncryptedHeader.SIZE) return 0
+                }
+                AapReadRecoveryPolicy.Outcome.DISCONNECT_EOF -> {
                     AppLog.i("AapRead: Connection closed (EOF). Disconnecting.")
                     return -1
-                } else if (headerSize == 0) {
-                    if (isSocket) {
-                        AppLog.w("AapRead: WiFi read timeout (15s) - connection lost.")
-                        return -1
-                    }
-                    return 0
-                } else {
-                    AppLog.e("AapRead: Partial header read. Expected ${AapMessageIncoming.EncryptedHeader.SIZE}, got $headerSize. Skipping.")
-                    return 0
+                }
+                AapReadRecoveryPolicy.Outcome.DISCONNECT_IDLE -> {
+                    AppLog.w("AapRead: WiFi read timeout (${timeout}ms) - connection lost.")
+                    return -1
+                }
+                AapReadRecoveryPolicy.Outcome.DISCONNECT_DESYNC -> {
+                    AppLog.e(
+                        "AapRead: partial header, $headerSize of ${AapMessageIncoming.EncryptedHeader.SIZE} bytes. " +
+                            "The rest of it is still on the socket and cannot be located again - disconnecting to resync."
+                    )
+                    return -1
                 }
             }
 
@@ -50,35 +62,70 @@ internal class AapReadSingleMessage(connection: AccessoryConnection, ssl: AapSsl
             if (recvHeader.flags == 0x09) {
                 // Once header arrived, data should be flowing — 10s timeout is valid here
                 val readSize = connection.recvBlocking(fragmentSizeBuffer, 4, 10000, true)
-                if(readSize != 4) {
-                    AppLog.e("AapRead: Failed to read fragment total size. Skipping.")
-                    return 0
+                when (AapReadRecoveryPolicy.afterFragmentTotalRead(readSize, 4)) {
+                    AapReadRecoveryPolicy.Outcome.CONTINUE -> Unit
+                    AapReadRecoveryPolicy.Outcome.DISCONNECT_EOF -> {
+                        AppLog.i("AapRead: Connection closed reading the fragment total.")
+                        return -1
+                    }
+                    else -> {
+                        AppLog.e(
+                            "AapRead: fragment total read returned $readSize of 4 - this message's header is " +
+                                "already consumed, so the body would be read as the next header. Disconnecting to resync."
+                        )
+                        return -1
+                    }
                 }
                 declaredTotal = Utils.bytesToInt(fragmentSizeBuffer, 0, false)
             }
 
             // Step 2: Read the encrypted message body
             // Header arrived so body should follow quickly — 10s timeout
-            if (recvHeader.enc_len > msgBuffer.size || recvHeader.enc_len < 0) {
-                AppLog.e("AapRead: Invalid message size (${recvHeader.enc_len} bytes). Skipping.")
-                return 0
+            if (AapReadRecoveryPolicy.afterDeclaredLength(recvHeader.enc_len, msgBuffer.size) !=
+                AapReadRecoveryPolicy.Outcome.CONTINUE
+            ) {
+                // Nearly always a header read out of garbage rather than a message too big to hold.
+                // Either way the body cannot be consumed, so skipping would compound the loss.
+                AppLog.e(
+                    "AapRead: declared message size ${recvHeader.enc_len} is outside the ${msgBuffer.size}-byte " +
+                        "buffer - the stream is no longer framed. Disconnecting to resync."
+                )
+                return -1
             }
-            
+
             val msgSize = connection.recvBlocking(msgBuffer, recvHeader.enc_len, 10000, true)
-            if (msgSize != recvHeader.enc_len) {
-                if (msgSize == -1) {
+            when (AapReadRecoveryPolicy.afterBodyRead(msgSize, recvHeader.enc_len)) {
+                AapReadRecoveryPolicy.Outcome.CONTINUE -> Unit
+                AapReadRecoveryPolicy.Outcome.DISCONNECT_EOF -> {
                     AppLog.i("AapRead: Connection closed during body read.")
                     return -1
                 }
-                AppLog.e("AapRead: Failed to read full message body. Expected ${recvHeader.enc_len}, got $msgSize. Skipping.")
-                return 0
+                else -> {
+                    // "got 0" is the timeout catch's return value, not a count: recvBlocking uses
+                    // readFully, which loops, so an unknown number of these bytes are already gone.
+                    AppLog.e(
+                        "AapRead: body read returned $msgSize of ${recvHeader.enc_len} expected - an unknown " +
+                            "number of bytes were consumed, so the stream can no longer be framed. Disconnecting to resync."
+                    )
+                    return -1
+                }
             }
 
-            // The whole body arrived, so this fragment can be counted against the run's declared
-            // total. Done before decryption because the total is a framing quantity.
-            auditFragment(recvHeader.chan, recvHeader.flags, recvHeader.enc_len, declaredTotal)
+            // Reader-stage fault injection, resolved before the audit and acted on after the
+            // decrypt. Both halves of that are load-bearing - see shouldDropForFaultInjection.
+            val injectedDrop =
+                shouldDropForFaultInjection(recvHeader.chan, recvHeader.flags, recvHeader.enc_len)
 
-            // Step 3: Decrypt the message
+            // The whole body arrived, so this fragment can be counted against the run's declared
+            // total. Done before decryption because the total is a framing quantity - and skipped
+            // for an injected drop, which is what leaves the run short of what it declared.
+            if (!injectedDrop) {
+                auditFragment(recvHeader.chan, recvHeader.flags, recvHeader.enc_len, declaredTotal)
+            }
+
+            // Step 3: Decrypt the message. Unconditionally, including a message about to be dropped:
+            // the SSL engine's record sequence advances per record and the phone's does too, so a
+            // record we never unwrap desynchronises the session for good.
             val msg = AapMessageIncoming.decrypt(recvHeader, 0, msgBuffer, ssl)
 
             if (msg == null) {
@@ -90,10 +137,19 @@ internal class AapReadSingleMessage(connection: AccessoryConnection, ssl: AapSsl
                 return 0
             }
 
+            // Now the message can be thrown away: the SSL engine has seen it, the audit has not,
+            // and nothing downstream ever will - which is a fragment that failed to arrive, as far
+            // as everything past this point can tell.
+            if (injectedDrop) return 0
+
             // Step 4: Handle the decrypted message
             handler.handle(msg)
             return 0
         } catch (e: Exception) {
+            // Stays at 0 on purpose, unlike the read sites above. recvBlocking catches its own
+            // IOException and SocketTimeoutException, so anything reaching here was thrown after the
+            // body had been read in full - decode, decrypt or a handler - and the stream is still
+            // framed. Carrying on costs one message; the read failures above cost the session.
             AppLog.e("AapRead: Error in read loop (ignored): ${e.message}")
             return 0
         }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapReadSingleMessage.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapReadSingleMessage.kt
@@ -45,6 +45,8 @@ internal class AapReadSingleMessage(connection: AccessoryConnection, ssl: AapSsl
                 return -2
             }
 
+            // Only a first fragment carries the total size, and only then is this meaningful.
+            var declaredTotal = 0
             if (recvHeader.flags == 0x09) {
                 // Once header arrived, data should be flowing — 10s timeout is valid here
                 val readSize = connection.recvBlocking(fragmentSizeBuffer, 4, 10000, true)
@@ -52,6 +54,7 @@ internal class AapReadSingleMessage(connection: AccessoryConnection, ssl: AapSsl
                     AppLog.e("AapRead: Failed to read fragment total size. Skipping.")
                     return 0
                 }
+                declaredTotal = Utils.bytesToInt(fragmentSizeBuffer, 0, false)
             }
 
             // Step 2: Read the encrypted message body
@@ -70,6 +73,10 @@ internal class AapReadSingleMessage(connection: AccessoryConnection, ssl: AapSsl
                 AppLog.e("AapRead: Failed to read full message body. Expected ${recvHeader.enc_len}, got $msgSize. Skipping.")
                 return 0
             }
+
+            // The whole body arrived, so this fragment can be counted against the run's declared
+            // total. Done before decryption because the total is a framing quantity.
+            auditFragment(recvHeader.chan, recvHeader.flags, recvHeader.enc_len, declaredTotal)
 
             // Step 3: Decrypt the message
             val msg = AapMessageIncoming.decrypt(recvHeader, 0, msgBuffer, ssl)

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -113,7 +113,14 @@ class AapService : Service(), UsbReceiver.Listener {
     private var nativeAaHandshakeManager: NativeAaHandshakeManager? = null
     private var nearbyManager: NearbyManager? = null
     private var wifiAutoStartReceiver: WifiAutoStartReceiver? = null
-    private var wirelessServer: WirelessServer? = null
+    // @Volatile: the handshake can now ask for a repair from Dispatchers.IO, so this is no
+    // longer read only from Main.
+    @Volatile private var wirelessServer: WirelessServer? = null
+    // Rebuild bookkeeping for WirelessServerRestartPolicy. The handshake asks about every 4s while a
+    // phone keeps arriving, so without a bound a port that cannot bind becomes a rebuild loop.
+    private var lastWirelessRebuildAtMs = 0L
+    private var wirelessRebuildsInWindow = 0
+    private var wirelessRebuildWindowStartedAtMs = 0L
     private var networkDiscovery: NetworkDiscovery? = null
     private var mediaSession: MediaSessionCompat? = null
 
@@ -2337,7 +2344,50 @@ class AapService : Service(), UsbReceiver.Listener {
      * No-op if the server is already running.
      */
     private fun startWirelessServer() {
-        if (wirelessServer != null) return
+        val existing = wirelessServer
+        val action = WirelessServerRestartPolicy.decide(
+            assigned = existing != null,
+            alive = existing?.isAlive == true,
+            listening = existing?.isListening == true,
+            nowMs = android.os.SystemClock.elapsedRealtime(),
+            sessionBusy = commManager.isConnected,
+            lastRebuildAtMs = lastWirelessRebuildAtMs,
+            rebuildsInWindow = wirelessRebuildsInWindow,
+            windowStartedAtMs = wirelessRebuildWindowStartedAtMs,
+        )
+        val why = WirelessServerRestartPolicy.describe(action, existing != null, existing?.isListening == true)
+        when (action) {
+            WirelessServerRestartPolicy.Action.NO_OP,
+            WirelessServerRestartPolicy.Action.AWAIT -> {
+                AppLog.d("AapService: Wireless server not started - $why.")
+                return
+            }
+            WirelessServerRestartPolicy.Action.BACKOFF -> {
+                // INFO, not DEBUG. This is the state a stuck unit sits in, and the reporter logs
+                // that would have identified it are captured at INFO.
+                AppLog.i("AapService: Wireless server on 5288 is not accepting connections - $why.")
+                return
+            }
+            WirelessServerRestartPolicy.Action.REBUILD -> {
+                val now = android.os.SystemClock.elapsedRealtime()
+                wirelessRebuildsInWindow = WirelessServerRestartPolicy.nextRebuildCount(
+                    now, wirelessRebuildWindowStartedAtMs, wirelessRebuildsInWindow
+                )
+                wirelessRebuildWindowStartedAtMs =
+                    WirelessServerRestartPolicy.nextWindowStart(now, wirelessRebuildWindowStartedAtMs)
+                lastWirelessRebuildAtMs = now
+                AppLog.w("AapService: Rebuilding the wireless server on 5288 - $why (attempt $wirelessRebuildsInWindow).")
+                // Only this object, never stopWirelessServer(): that also clears activeWifiMode and
+                // activeHelperStrategy, and the mode has not changed - we are repairing inside it.
+                try { existing?.stopServer() } catch (e: Exception) {
+                    AppLog.d("AapService: Error stopping the previous wireless server: ${e.message}")
+                }
+                wirelessServer = null
+            }
+            WirelessServerRestartPolicy.Action.START -> {
+                AppLog.d("AapService: Starting the wireless server on 5288 - $why.")
+            }
+        }
         val settings = App.provide(this).settings
         val mode = settings.wifiConnectionMode
         val strategy = settings.helperConnectionStrategy
@@ -2388,6 +2438,40 @@ class AapService : Service(), UsbReceiver.Listener {
      * only then talk to the phone.
      */
     fun isWirelessServerListening(): Boolean = wirelessServer?.isListening == true
+
+    /**
+     * Tries to get the AAP port bound, and reports whether it is.
+     *
+     * Called by the Bluetooth handshake when it finds the port unbound with credentials already in
+     * hand. Until this existed the handshake could only give up, so a server that died once stayed
+     * dead for the life of the mode: the phone was woken, told to join a network, and left dialling
+     * a port nothing was listening on, every few seconds, indefinitely.
+     *
+     * The start is marshalled onto Main because every other caller of [startWirelessServer] runs
+     * there. Without that, this one arrives from `Dispatchers.IO` and can pass the "nothing is
+     * assigned" check at the same moment [initWifiMode] does, and both bind. `SO_REUSEADDR` does not
+     * help there - it covers a port in TIME_WAIT, not one with a live listener on it - so the loser
+     * throws and spends its retry budget losing to its own sibling.
+     *
+     * @param reason what asked, for the log.
+     * @param timeoutMs how long to wait for the bind after asking.
+     */
+    suspend fun ensureWirelessServerListening(reason: String, timeoutMs: Long): Boolean {
+        if (isWirelessServerListening()) return true
+        AppLog.i("AapService: $reason found port 5288 unbound. Trying to start the wireless server.")
+        withContext(Dispatchers.Main.immediate) { startWirelessServer() }
+
+        val deadline = android.os.SystemClock.elapsedRealtime() + timeoutMs
+        while (android.os.SystemClock.elapsedRealtime() < deadline) {
+            if (isWirelessServerListening()) {
+                AppLog.i("AapService: port 5288 is bound now.")
+                return true
+            }
+            delay(250)
+        }
+        AppLog.w("AapService: port 5288 is still not bound ${timeoutMs}ms after trying to start it.")
+        return false
+    }
 
     /** The transport mode 3 is configured to use. Read fresh: the user can change it in settings. */
     private fun nativeTransport(): NativeTransport =
@@ -3080,6 +3164,15 @@ class AapService : Service(), UsbReceiver.Listener {
         @Volatile var isListening = false
             private set
 
+        /**
+         * Whether the coroutine that owns the bind is still running.
+         *
+         * [isListening] alone cannot separate "binding, give it a moment" from "died and will never
+         * bind"; both are false. Replacing a server on the strength of that would tear down one that
+         * was about to succeed, and the replacement would then race it for the same port.
+         */
+        val isAlive: Boolean get() = job?.isActive == true
+
         fun start(registerNsd: Boolean = true) {
             nsdManager = getSystemService(Context.NSD_SERVICE) as? NsdManager
             if (nsdManager == null) {
@@ -3087,6 +3180,12 @@ class AapService : Service(), UsbReceiver.Listener {
             } else if (registerNsd) {
                 registerNsd()
             }
+
+            // Outside the coroutine on purpose. Everything below runs on a scope that can already
+            // be cancelled, in which case the block never executes and prints nothing at all; this
+            // line is what tells a reader the difference between "never asked" and "asked, and the
+            // answer never came". Two complete reporter captures could not be told apart without it.
+            AppLog.i("WirelessServer: binding port 5288...")
 
             job = serviceScope.launch(Dispatchers.IO) {
                 try {
@@ -3097,11 +3196,34 @@ class AapService : Service(), UsbReceiver.Listener {
                     // ends, so a re-init within that window threw BindException, isListening stayed
                     // false, and the next handshake woke the phone over Bluetooth and handed it
                     // nothing (NativeAaHandshakeManager aborts with "nothing is listening on 5288").
-                    serverSocket = ServerSocket().apply {
-                        reuseAddress = true
-                        bind(java.net.InetSocketAddress(5288))
+                    var bound: ServerSocket? = null
+                    var attempt = 0
+                    while (isActive && bound == null) {
+                        attempt++
+                        try {
+                            bound = ServerSocket().apply {
+                                reuseAddress = true
+                                bind(java.net.InetSocketAddress(5288))
+                            }
+                        } catch (e: Exception) {
+                            // The last attempt rethrows, so a permanent failure still reaches the
+                            // catch below and is reported as an error rather than disappearing.
+                            if (attempt >= BIND_ATTEMPTS) throw e
+                            AppLog.w("WirelessServer: port 5288 did not bind on attempt $attempt of $BIND_ATTEMPTS (${e.javaClass.simpleName}: ${e.message}). Retrying in ${BIND_RETRY_DELAY_MS}ms.")
+                            delay(BIND_RETRY_DELAY_MS)
+                        }
                     }
+                    if (bound == null) {
+                        AppLog.i("WirelessServer: stopped before port 5288 could be bound.")
+                        return@launch
+                    }
+                    serverSocket = bound
                     isListening = true
+                    // A bind that worked ends the rebuild budget: the next failure, whenever it
+                    // comes, is a fresh one and gets its own attempts.
+                    lastWirelessRebuildAtMs = 0L
+                    wirelessRebuildsInWindow = 0
+                    wirelessRebuildWindowStartedAtMs = 0L
                     AppLog.i("Wireless Server listening on port 5288")
                     logLocalNetworkInterfaces()
 
@@ -3129,7 +3251,10 @@ class AapService : Service(), UsbReceiver.Listener {
                         }
                     }
                 } catch (e: Exception) {
+                    // The cancelled branch used to be silent, which made a server that was torn
+                    // down indistinguishable from one that was never started.
                     if (isActive) AppLog.e("Wireless server error", e)
+                    else AppLog.i("WirelessServer: port 5288 released (${e.javaClass.simpleName}).")
                 } finally {
                     isListening = false
                     unregisterNsd()
@@ -3190,6 +3315,12 @@ class AapService : Service(), UsbReceiver.Listener {
     // -------------------------------------------------------------------------
 
     companion object {
+        /** Bind attempts before the wireless server gives up and reports the port unusable. */
+        private const val BIND_ATTEMPTS = 3
+
+        /** Gap between them. A port released by a peer that just left frees within this. */
+        private const val BIND_RETRY_DELAY_MS = 700L
+
         /**
          * If set to `true`, the service will call [System.exit] at the very end of [onDestroy].
          * This is used by `killOnDisconnect` to ensure all cleanup (like Car Mode) completes

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapService.kt
@@ -1934,6 +1934,15 @@ class AapService : Service(), UsbReceiver.Listener {
                     if (activeWifiMode != 3 || settings.wifiConnectionMode != 3) {
                         AppLog.i("AapService: Initializing Native AA mode before poke...")
                         initWifiMode(force = true)
+                    } else if (nativeAaHandshakeManager?.isActive() != true) {
+                        // A completed handoff closes the AA listeners while leaving the manager
+                        // running, and start() returns immediately on isRunning - so calling it here
+                        // reopened nothing. The poke then woke the phone, the phone opened RFCOMM,
+                        // and nothing was listening: the button appeared to do nothing however many
+                        // times it was pressed. A full re-init is what reopens them, which is what
+                        // the Bluetooth auto-start path below already does for the same reason.
+                        AppLog.i("AapService: Native AA listeners are closed — re-arming before the poke.")
+                        initWifiMode(force = true)
                     } else {
                         AppLog.d("AapService: Already in Native AA mode, skipping re-init.")
                         // Just ensure servers are running if they were stopped for some reason
@@ -3081,7 +3090,17 @@ class AapService : Service(), UsbReceiver.Listener {
 
             job = serviceScope.launch(Dispatchers.IO) {
                 try {
-                    serverSocket = ServerSocket(5288).apply { reuseAddress = true }
+                    // Unbound first, then the option, then bind. ServerSocket(int) binds inside the
+                    // constructor, so setting reuseAddress after it is a no-op on a socket that is
+                    // already bound - which is the whole failure this line was written to prevent.
+                    // The previous peer's connection sits in TIME_WAIT for minutes after a session
+                    // ends, so a re-init within that window threw BindException, isListening stayed
+                    // false, and the next handshake woke the phone over Bluetooth and handed it
+                    // nothing (NativeAaHandshakeManager aborts with "nothing is listening on 5288").
+                    serverSocket = ServerSocket().apply {
+                        reuseAddress = true
+                        bind(java.net.InetSocketAddress(5288))
+                    }
                     isListening = true
                     AppLog.i("Wireless Server listening on port 5288")
                     logLocalNetworkInterfaces()

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapSslContext.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapSslContext.kt
@@ -145,6 +145,10 @@ class AapSslContext(keyManager: SingleKeyKeyManager): AapSsl {
 
                 txBuffer = ByteBuffer.allocateDirect(netBufferMax)
                 rxBuffer = ByteBuffer.allocateDirect(Messages.DEF_BUFFER_LENGTH.coerceAtLeast(appBufferMax + 50))
+                // One plaintext buffer for the whole session, sized to what rxBuffer can hold, which
+                // is the ceiling on what a single unwrap can produce. See decrypt() for why it is
+                // reused rather than allocated per message.
+                plaintextBuffer = ByteArray(rxBuffer.capacity())
             }
         }
         sslEngine.beginHandshake()
@@ -207,6 +211,33 @@ class AapSslContext(keyManager: SingleKeyKeyManager): AapSsl {
         return receivedHandshakeData.size
     }
 
+    /**
+     * Plaintext of the message currently being handled, reused across messages.
+     *
+     * This used to be `ByteArray(result.bytesProduced())` per call, and the call is per AAP *message*
+     * - so per video *fragment*, not per frame. At 50fps with two or three fragments a frame that is
+     * 150-250 short-lived arrays a second, each tens of kilobytes, which is large enough to land in
+     * the large-object space. It is the churn behind #839's collector running every five to ten
+     * seconds, freeing 84-208 large objects a cycle and once pausing for 1.4 seconds on a unit whose
+     * decoder was keeping up the whole time.
+     *
+     * Reusing it is only safe because every consumer of the returned array finishes with it before
+     * the next message is decrypted: the poll thread reads, decrypts, dispatches and returns, all
+     * synchronously, and the three paths that could have outlived that all copy first - the video
+     * feed queue arraycopies into a pooled frame, the audio path arraycopies into its own pooled
+     * chunk, and protobuf parsing copies. Every consumer also bounds its reads by the message's
+     * `size` field rather than by `data.size`, which is what makes a buffer larger than the payload
+     * safe; that was checked call site by call site, and the one place that did not - the short-payload
+     * guard in AapMessageIncoming - is fixed alongside this.
+     *
+     * If anything is ever added that hands `AapMessage.data` to another thread without copying, this
+     * is the field that makes it a corruption bug rather than a slow one.
+     */
+    private lateinit var plaintextBuffer: ByteArray
+
+    /** Reused wrapper, so the per-message allocation is zero rather than one small object. */
+    private val plaintextHolder = ByteArrayWithLimit(ByteArray(0), 0)
+
     override fun decrypt(start: Int, length: Int, buffer: ByteArray): ByteArrayWithLimit? {
         // The status line is built under the lock but emitted outside it. encrypt() takes this same
         // monitor, so logging in here put the whole logging pipeline — formatting, the caller-name
@@ -214,7 +245,7 @@ class AapSslContext(keyManager: SingleKeyKeyManager): AapSsl {
         // decrypted packet, which at verbose is several times per video frame.
         var statusLine: String? = null
         val decrypted = synchronized(this) {
-            if (!::sslEngine.isInitialized || !::rxBuffer.isInitialized) {
+            if (!::sslEngine.isInitialized || !::rxBuffer.isInitialized || !::plaintextBuffer.isInitialized) {
                 AppLog.w("SSL Decrypt: Not initialized yet")
                 return null
             }
@@ -228,10 +259,19 @@ class AapSslContext(keyManager: SingleKeyKeyManager): AapSsl {
                     statusLine = "SSL Decrypt Status: ${result.status}, Produced: ${result.bytesProduced()}, Consumed: ${result.bytesConsumed()}"
                 }
 
-                val resultBuffer = ByteArray(result.bytesProduced())
+                val produced = result.bytesProduced()
+                if (produced > plaintextBuffer.size) {
+                    // Cannot happen: rxBuffer is what unwrap writes into and plaintextBuffer is its
+                    // capacity. Checked anyway, because silently truncating a message here would look
+                    // exactly like stream corruption further down.
+                    AppLog.e("SSL Decrypt: produced $produced bytes, larger than the ${plaintextBuffer.size}-byte plaintext buffer")
+                    plaintextBuffer = ByteArray(produced)
+                }
                 rxBuffer.flip()
-                rxBuffer.get(resultBuffer)
-                ByteArrayWithLimit(resultBuffer, resultBuffer.size)
+                rxBuffer.get(plaintextBuffer, 0, produced)
+                plaintextHolder.data = plaintextBuffer
+                plaintextHolder.limit = produced
+                plaintextHolder
             } catch (e: Exception) {
                 // Check for Magic Garbage disconnect signal from Wireless Helper
                 if (length >= 16) {

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
@@ -156,10 +156,32 @@ class AapTransport(
     private var focusCyclesUsedThisSession = 0
     private var lastFocusCycleMs = 0L
 
+    /** The one claim on the release/regain cycle, shared with the projection activity's escalation. */
+    private val focusCycleLever = FocusCycleLever()
+
+    /** Takes the lever for one cycle. False when the other escalation already holds it. */
+    internal fun beginFocusCycle(): Boolean = focusCycleLever.tryClaim()
+
+    /**
+     * Sends the first half of a keyframe cycle.
+     *
+     * Both escalations go through here, so the release and the [ignoreNextStopRequest] that marks
+     * its answering sink stop as expected are written once rather than in two places that have to
+     * stay in step.
+     */
+    internal fun sendKeyframeCycleRelease() {
+        ignoreNextStopRequest = true
+        send(VideoFocusEvent(gain = false, unsolicited = false))
+    }
+
+    /** Hands the lever back. Idempotent - see [FocusCycleLever.release]. */
+    internal fun endFocusCycle() = focusCycleLever.release()
+
     /** Second half of an escalated focus cycle - see [WarmRelaunchKeyframePolicy.FOCUS_CYCLE_GAP_MS]. */
     private val focusCycleGainRunnable = Runnable {
         AppLog.w("AapTransport: retaking video focus to complete the keyframe cycle")
         send(VideoFocusEvent(gain = true, unsolicited = true))
+        endFocusCycle()
     }
 
     /**
@@ -180,11 +202,16 @@ class AapTransport(
      * release can, and has only ever been tested against one phone. It stays the first response.
      *
      * @param escalatable whether this caller's stream is live enough to earn a focus release if the
-     *   nudge goes unanswered. Only the dropped-frame path passes true: it is already gated on the
-     *   decoder having rendered, so the picture provably exists. A decoder error fires while the
-     *   codec is being rebuilt, which is [WarmRelaunchKeyframePolicy]'s window, and pointing a second
-     *   decider at the same lever there is how two escalations end up racing. Frame corruption on a
-     *   live stream would qualify on merit, but [AapVideo] has no rendered-frame signal to gate on.
+     *   nudge goes unanswered. True for the dropped-frame path, which is gated on the decoder having
+     *   rendered, and for both decoder paths - a rebuilt or keyframe-starved codec is the case where
+     *   the picture is most certainly gone and least able to come back on its own. That last pair
+     *   used to pass false, on the grounds that a rebuild belongs to [WarmRelaunchKeyframePolicy]'s
+     *   window and two deciders must not reach for the same lever. The lever now has one owner
+     *   ([com.andrerinas.openheadunit.connection.CommManager.releaseVideoFocusForKeyframe]), so the
+     *   overlap is refused rather than argued about, and the ordering still favours the surface path:
+     *   it escalates at 850ms against this one's 2000ms.
+     *   [AapVideo]'s corruption path stays false only because it has no rendered-frame signal to
+     *   gate on.
      */
     @Synchronized
     private fun triggerFocusCycleRecovery(escalatable: Boolean) {
@@ -223,19 +250,39 @@ class AapTransport(
             )
 
             KeyframeCycleEscalationPolicy.Action.CYCLE_FOCUS -> {
+                // Resolved before the claim, not after: a release whose regain can never be posted
+                // is the one outcome worse than not cycling at all, and it would strand the lever.
+                val handler = sendHandler ?: return
+                if (!beginFocusCycle()) {
+                    // The other escalation holds the lever. Its release will bring the keyframe this
+                    // one wanted, so leave the clock running and let that keyframe clear it; spending
+                    // the budget on a cycle we are not going to send would lose it for nothing.
+                    AppLog.w("AapTransport: picture unrepaired for ${now - since}ms - a focus cycle is already in flight, waiting for it")
+                    // Look again once that cycle has had its regain and the keyframe it brings has
+                    // had time to land. Returning without re-arming would leave unrepairedSinceMs set
+                    // with nothing pending to clear it but the phone's own keyframe a GOP away, and
+                    // triggerFocusCycleRecovery() returns early on that latch - so every later drop
+                    // would be ignored too. If the other cycle worked, the keyframe has already
+                    // zeroed the clock and this check returns at its first line.
+                    handler.removeCallbacks(unrepairedCheckRunnable)
+                    handler.postDelayed(
+                        unrepairedCheckRunnable,
+                        KeyframeCycleEscalationPolicy.ESCALATE_AFTER_UNREPAIRED_MS
+                    )
+                    return
+                }
                 focusCyclesUsedThisSession++
                 lastFocusCycleMs = now
                 AppLog.w(
                     "AapTransport: picture unrepaired for ${now - since}ms - cycling video focus " +
                         "($focusCyclesUsedThisSession/${KeyframeCycleEscalationPolicy.MAX_CYCLES_PER_SESSION})"
                 )
-                ignoreNextStopRequest = true
-                send(VideoFocusEvent(gain = false, unsolicited = false))
+                sendKeyframeCycleRelease()
                 // One shared regain runnable, replaced rather than tracked per cycle. Sound because
                 // CYCLE_COOLDOWN_MS keeps two cycles sixty seconds apart against a 400ms regain gap,
                 // so two can never be in flight together - see that constant before shortening it.
-                sendHandler?.removeCallbacks(focusCycleGainRunnable)
-                sendHandler?.postDelayed(focusCycleGainRunnable, WarmRelaunchKeyframePolicy.FOCUS_CYCLE_GAP_MS)
+                handler.removeCallbacks(focusCycleGainRunnable)
+                handler.postDelayed(focusCycleGainRunnable, WarmRelaunchKeyframePolicy.FOCUS_CYCLE_GAP_MS)
             }
         }
 
@@ -265,21 +312,6 @@ class AapTransport(
         sendHandler?.removeCallbacks(unrepairedCheckRunnable)
     }
 
-    /**
-     * Drops the escalation clock without treating the picture as repaired.
-     *
-     * Called when the decoder is being rebuilt. Whatever was corrupt belongs to a codec that no
-     * longer exists, and the window that follows is [WarmRelaunchKeyframePolicy]'s - if the clock
-     * were left running it could spend a cycle in the middle of that policy's own escalation, which
-     * is two deciders reaching for the same lever. The next shed frame after the new codec renders
-     * starts a fresh clock.
-     */
-    @Synchronized
-    private fun abandonUnrepairedClock() {
-        unrepairedSinceMs = 0L
-        sendHandler?.removeCallbacks(unrepairedCheckRunnable)
-    }
-
     init {
         micRecorder.listener = this
         aapAudio = AapAudio(audioDecoder, audioManager, settings, context)
@@ -287,9 +319,18 @@ class AapTransport(
             triggerFocusCycleRecovery(escalatable = false)
         }
 
-        videoDecoder.onDecoderError = {
-            abandonUnrepairedClock()
-            triggerFocusCycleRecovery(escalatable = false)
+        // A rebuilt codec resumes on a P-frame and can render nothing until an IDR arrives, which
+        // the phone sends on its own ~69s cadence and which nothing in AAP can request. So this is
+        // the moment the picture is most certainly broken, and it used to be the moment the only
+        // lever that can repair it was switched off: the old wiring abandoned the escalation clock
+        // and armed nothing, so a decoder restarting every ten seconds could never reach a cycle.
+        videoDecoder.onDecoderError = { _ ->
+            triggerFocusCycleRecovery(escalatable = true)
+        }
+
+        // Same ask, from a decoder that is deliberately *not* rebuilding while it waits.
+        videoDecoder.onKeyframeStarved = {
+            triggerFocusCycleRecovery(escalatable = true)
         }
 
         videoDecoder.onFrameDropped = {
@@ -357,7 +398,12 @@ class AapTransport(
         aapAudio.releaseAllFocus()
         aapVideo.release()
 
+        // Never let a half-finished cycle outlive the transport that owed the regain: the claim is
+        // session state, and a stuck one would refuse every cycle of the next session.
+        endFocusCycle()
+
         videoDecoder.onDecoderError = null
+        videoDecoder.onKeyframeStarved = null
         videoDecoder.onFrameDropped = null
         videoDecoder.onKeyframeObserved = null
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
@@ -149,12 +149,62 @@ class AapTransport(
     val isAlive: Boolean
         get() = pollThread?.isAlive ?: false
 
+    /**
+     * When the phone last said anything at all, on any channel. Zero until it has.
+     *
+     * The picture stopping and the link dying look identical if the only thing being measured is
+     * frames: Android Auto sends no video while nothing on screen animates, so a paused full-screen
+     * music player is indistinguishable from a dead socket to anything watching the decoder. This is
+     * the signal that separates them - control, sensor, media-playback and audio traffic all keep
+     * flowing while the picture is legitimately still.
+     *
+     * Written from the poll thread, read from the main thread by the projection watchdog.
+     */
+    @Volatile
+    var lastMessageReceivedMs: Long = 0L
+        private set
+
+    /**
+     * How long the link goes silent, and how often. Fed from the same funnel as
+     * [lastMessageReceivedMs], because "the phone said something" is exactly the event it measures.
+     */
+    private val linkGapMonitor = LinkGapMonitor()
+
+    /** Called for every decrypted inbound message, from [AapMessageHandlerType.handle]. */
+    internal fun noteMessageReceived() {
+        val now = SystemClock.elapsedRealtime()
+        lastMessageReceivedMs = now
+        linkGapMonitor.onMessage(now)?.let { AppLog.i("AapTransport: %s", it) }
+    }
+
     // Escalation state for KeyframeCycleEscalationPolicy - see triggerFocusCycleRecovery().
     // unrepairedSinceMs is when the picture was last known good: set by a shed reference frame,
     // cleared when a keyframe reaches the codec. Zero means nothing is broken.
     private var unrepairedSinceMs = 0L
     private var focusCyclesUsedThisSession = 0
     private var lastFocusCycleMs = 0L
+
+    /**
+     * When an access unit last arrived broken on the wire, as opposed to when the decoder last had
+     * no picture. Zero until the first one. Session state like the two fields above, and reset the
+     * same way they are - by the transport being torn down and rebuilt.
+     */
+    private var lastWireCorruptionMs = 0L
+
+    /**
+     * Print budget for the held-cycle line, in the shape [AuditReportPolicy] already governs.
+     *
+     * A hold is re-checked every [KeyframeCycleEscalationPolicy.ESCALATE_AFTER_UNREPAIRED_MS], which
+     * has to stay short so a reserved cycle lands promptly once the wire settles. The last cycle of
+     * a session holds without a ceiling, so that check can repeat for minutes - a hundred identical
+     * lines across the injection run that motivated the reserve. Reset when the unrepaired clock
+     * arms, not when a cycle fires: one broken stretch is one story, and it can hold, cycle and hold
+     * again inside itself. What the reset guarantees is that the *first* line of every new stretch
+     * prints, which is the one a rig round reads.
+     */
+    private var quietHoldReports = 0
+    private var quietHoldLastLogMs = 0L
+    private var quietHoldSuppressed = 0
 
     /** The one claim on the release/regain cycle, shared with the projection activity's escalation. */
     private val focusCycleLever = FocusCycleLever()
@@ -218,12 +268,20 @@ class AapTransport(
         AppLog.w("AapTransport: Requesting recovery keyframe (unsolicited focus gain).")
         send(VideoFocusEvent(gain = true, unsolicited = true))
 
+        // Stamped before the returns below, and deliberately on the path that returns early: a
+        // stream that is still losing frames is exactly the case where the clock is already running,
+        // and that is the case the stamp exists to let the escalation see.
+        if (!escalatable) lastWireCorruptionMs = SystemClock.elapsedRealtime()
+
         if (!escalatable || unrepairedSinceMs != 0L) return
         // Stamped only once the check is actually armed. Setting it without a handler to run the
         // check on would latch the clock with nothing able to clear it but a keyframe, and every
         // later drop would return early on it - the stuck-latch failure this design exists to avoid.
         val handler = sendHandler ?: return
         unrepairedSinceMs = SystemClock.elapsedRealtime()
+        quietHoldReports = 0
+        quietHoldLastLogMs = 0L
+        quietHoldSuppressed = 0
         handler.removeCallbacks(unrepairedCheckRunnable)
         handler.postDelayed(
             unrepairedCheckRunnable,
@@ -233,7 +291,9 @@ class AapTransport(
 
     /**
      * The picture has been broken for [KeyframeCycleEscalationPolicy.ESCALATE_AFTER_UNREPAIRED_MS]
-     * and no keyframe has arrived to repair it. Spend a cycle if the budget allows.
+     * and no keyframe has arrived to repair it. Spend a cycle if the budget allows and the wire has
+     * settled - a cycle spent while frames are still arriving broken buys a keyframe that arrives
+     * broken too, and stamps the cooldown that then holds off the one that would have worked.
      */
     @Synchronized
     private fun escalateIfStillUnrepaired() {
@@ -243,11 +303,32 @@ class AapTransport(
         val now = SystemClock.elapsedRealtime()
         val spent = "$focusCyclesUsedThisSession/${KeyframeCycleEscalationPolicy.MAX_CYCLES_PER_SESSION}"
 
-        when (KeyframeCycleEscalationPolicy.decide(now, since, focusCyclesUsedThisSession, lastFocusCycleMs)) {
+        val action = KeyframeCycleEscalationPolicy.decide(
+            now, since, focusCyclesUsedThisSession, lastFocusCycleMs, lastWireCorruptionMs
+        )
+        when (action) {
             KeyframeCycleEscalationPolicy.Action.NUDGE -> AppLog.w(
                 "AapTransport: picture unrepaired for ${now - since}ms, no cycle available now " +
                     "($spent spent) - waiting for the phone's own keyframe"
             )
+
+            KeyframeCycleEscalationPolicy.Action.WAIT_FOR_QUIET -> {
+                if (AuditReportPolicy.shouldReport(quietHoldReports, quietHoldLastLogMs, now)) {
+                    val suppressed = quietHoldSuppressed
+                    quietHoldSuppressed = 0
+                    quietHoldReports++
+                    quietHoldLastLogMs = now
+                    val suffix =
+                        if (suppressed > 0) " (and $suppressed more checks since the last report)" else ""
+                    AppLog.w(
+                        "AapTransport: picture unrepaired for ${now - since}ms but the stream is " +
+                            "still losing frames (last ${now - lastWireCorruptionMs}ms ago) - " +
+                            "holding the cycle until it settles ($spent spent)$suffix"
+                    )
+                } else {
+                    quietHoldSuppressed++
+                }
+            }
 
             KeyframeCycleEscalationPolicy.Action.CYCLE_FOCUS -> {
                 // Resolved before the claim, not after: a release whose regain can never be posted
@@ -292,16 +373,28 @@ class AapTransport(
         // already running deliberately does not re-arm anything. Once the budget is gone nothing is
         // re-armed and the line above has said so.
         if (focusCyclesUsedThisSession < KeyframeCycleEscalationPolicy.MAX_CYCLES_PER_SESSION) {
+            // A refused cycle and a held one clear on different clocks. The budget and the cooldown
+            // are minute-scale, but a wire that has gone quiet does so in a couple of seconds, and
+            // looking again in sixty would hand back everything holding the cycle was meant to save.
+            val retryIn = if (action == KeyframeCycleEscalationPolicy.Action.WAIT_FOR_QUIET) {
+                KeyframeCycleEscalationPolicy.ESCALATE_AFTER_UNREPAIRED_MS
+            } else {
+                KeyframeCycleEscalationPolicy.CYCLE_COOLDOWN_MS
+            }
             sendHandler?.removeCallbacks(unrepairedCheckRunnable)
-            sendHandler?.postDelayed(unrepairedCheckRunnable, KeyframeCycleEscalationPolicy.CYCLE_COOLDOWN_MS)
+            sendHandler?.postDelayed(unrepairedCheckRunnable, retryIn)
         }
     }
 
     /**
-     * A keyframe reached the codec, so whatever was broken is repaired. Stops the clock and disarms
-     * the escalation.
+     * A keyframe produced a picture, so whatever was broken is repaired. Stops the clock and
+     * disarms the escalation.
      *
-     * Runs on the decoder's feed thread. Everything it touches is this object's own state and it
+     * The signal is the decoder's output, not its input: an access unit that lost a fragment in the
+     * middle still scans as a keyframe and is fed like one, and cancelling the escalation on that
+     * left a sustained-loss stream with nothing able to ask for a keyframe it could actually decode.
+     *
+     * Runs on the decoder's output thread. Everything it touches is this object's own state and it
      * never waits on the decoder, which is what keeps it clear of [VideoDecoder.stop] - that holds
      * the decoder's monitor while joining the very thread this runs on.
      */
@@ -434,6 +527,10 @@ class AapTransport(
         AppLog.i("Start Aap transport handshake for $connection")
         this.connection = connection
         wasUserExit = false
+        // This object outlives a session and is re-armed for the next one, so a stamp left by the
+        // previous phone would read as a live link for the first seconds of this one.
+        lastMessageReceivedMs = 0L
+        linkGapMonitor.reset()
 
         sendThread = HandlerThread("AapTransport:Handler::Send", Process.THREAD_PRIORITY_AUDIO)
         sendThread!!.start()

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapVideo.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapVideo.kt
@@ -14,6 +14,9 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
 
         /** Ceiling for [ensureCapacity]. ~8MB, which covers H.265 at 4K. */
         private const val MAX_BUFFER_BYTES = Messages.DEF_BUFFER_LENGTH * 64
+
+        /** Spacing of the anomaly summary, matched to the decoder's throughput line so they interleave. */
+        private const val ANOMALY_REPORT_INTERVAL_MS = 5000L
     }
 
     /**
@@ -29,54 +32,142 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
      */
     private var messageBuffer = ByteBuffer.allocate(INITIAL_BUFFER_BYTES)
     private var legacyAssembledBuffer: ByteArray? = null
-    private var isFrameCorrupt = false
     private var lastKeyframeRequestMs = 0L
-    private var isAssemblingFrame = false
+    private var lastAnomalyReportMs = 0L
 
     /**
-     * Marks the frame being assembled unusable and asks the phone for a fresh keyframe.
-     *
-     * Corruption is scoped to the current frame only: flags 8 and 10 skip the rest of it, and the
-     * next flag 9 or 11 clears the mark. There is deliberately no lockout that holds every
-     * subsequent P-frame back until a keyframe is positively identified - one existed, and because
-     * nothing could reliably tell a keyframe from a P-frame for every codec the app negotiates, it
-     * could latch for the rest of the session and freeze the picture with the connection still
-     * healthy. Dropping one frame and letting the stream heal on the phone's next keyframe is both
-     * cheaper and unable to get stuck.
+     * Stamped at construction, which is session start, so the first summary is one interval into the
+     * run rather than on the first frame - the constructor has already said the injector is on.
      */
-    private fun markCorruptAndRequestRecovery() {
-        isFrameCorrupt = true
+    private var lastInjectorSummaryMs = android.os.SystemClock.elapsedRealtime()
+
+    /** Ordering rules for the fragment run. Pure and unit-tested; see [VideoFragmentAssembler]. */
+    private val assembler = VideoFragmentAssembler()
+
+    /**
+     * Null unless the user has deliberately turned fault injection on, so the healthy path costs one
+     * null check. See [VideoFaultInjector] for why this exists at all.
+     */
+    private val faultInjector: VideoFaultInjector? =
+        VideoFaultInjector(settings.debugVideoFaultInjection, settings.debugVideoFaultRate)
+            .takeIf { it.isActive }
+            ?.also {
+                AppLog.w(
+                    "AapVideo: FAULT INJECTION IS ON - mode=%s, one in %d. The video stream is being " +
+                        "corrupted on purpose; this log does not show a real fault.",
+                    settings.debugVideoFaultInjection, it.rate
+                )
+            }
+
+    /**
+     * Says periodically what the injector has had to work with, so a run that injects nothing says so
+     * rather than looking like a run where the setting never took. See [VideoFaultInjector.describe].
+     */
+    private fun reportInjectorProgress(injector: VideoFaultInjector) {
+        val now = android.os.SystemClock.elapsedRealtime()
+        if (now - lastInjectorSummaryMs < VideoFaultInjector.SUMMARY_INTERVAL_MS) return
+        lastInjectorSummaryMs = now
+        AppLog.w("AapVideo: fault injection - %s", injector.describe())
+    }
+
+    /**
+     * Asks the phone for a fresh keyframe because a frame was lost or arrived unusable.
+     *
+     * Every anomaly [VideoFragmentAssembler] reports means some later frame will predict from a
+     * reference we never decoded, so the picture drifts - washed out and blocky, "melting" - until
+     * a keyframe lands. On an idle stream the phone's own cadence is a fixed ~69s GOP, so waiting
+     * for it costs about half a minute of broken picture; asking brings that down to seconds.
+     *
+     * Throttled by [VideoRecoveryPolicy] because the ask is not free: [AapTransport] implements it
+     * as an unsolicited focus nudge, escalating to a real focus cycle only under much stricter
+     * gates, and the phone rebuilds the stream in response.
+     */
+    private fun requestKeyframe(reason: String) {
         val now = android.os.SystemClock.elapsedRealtime()
         if (VideoRecoveryPolicy.canRequestKeyframe(now, lastKeyframeRequestMs)) {
             lastKeyframeRequestMs = now
-            AppLog.w("AapVideo: Frame corrupted, requesting keyframe to recover stream")
+            AppLog.w("AapVideo: %s, requesting keyframe to recover stream", reason)
             onFrameCorrupted()
         }
     }
 
-    private fun checkFragmentState(message: AapMessage) {
-        when (val flags = message.flags.toInt()) {
-            11, 9 -> {
-                // 11 (Single) and 9 (First) should always start a clean slate.
-                if (isAssemblingFrame) {
-                    AppLog.w("AapVideo: Previous frame was truncated! Resetting assembly state.")
-                }
-                isAssemblingFrame = (flags == 9) // Only 9 means we are assembling
+    /**
+     * Logs, counts and reacts to one broken-stream event.
+     *
+     * The counters live on the assembler and are summarised periodically by [reportAnomalies]; the
+     * per-event line is what tells a reporter's log *when* it happened relative to what they saw.
+     */
+    private fun handleAnomaly(anomaly: VideoFragmentAssembler.Anomaly, message: AapMessage) {
+        when (anomaly) {
+            VideoFragmentAssembler.Anomaly.TRUNCATED_PREVIOUS -> {
+                // The previous frame never got its flag 10 and was dropped unassembled. Nothing bad
+                // reached the codec, but a reference frame is missing all the same, which is why
+                // this asks for a keyframe rather than only logging as it used to.
+                AppLog.w("AapVideo: Previous frame was truncated! Resetting assembly state.")
+                messageBuffer.clear()
+                requestKeyframe("frame truncated")
             }
-            8, 10 -> {
-                // 8 (Middle) and 10 (Last) MUST belong to an active assembly.
-                if (!isAssemblingFrame) {
-                    AppLog.e("AapVideo: Orphaned fragment (Flag $flags) detected! Frame data lost.")
-                    markCorruptAndRequestRecovery()
-                    messageBuffer.clear()
-                    // The mark makes the flag 8/10 arms below skip this fragment. It is cleared
-                    // again by the next flag 9 or 11, so the stream resumes on the frame after.
-                }
-                if (flags == 10) {
-                    isAssemblingFrame = false // Assembly finished
-                }
+            VideoFragmentAssembler.Anomaly.ORPHANED_FRAGMENT -> {
+                AppLog.e("AapVideo: Orphaned fragment (Flag ${message.flags.toInt()}) detected! Frame data lost.")
+                messageBuffer.clear()
+                requestKeyframe("orphaned fragment")
+            }
+            VideoFragmentAssembler.Anomaly.HEADLESS_FIRST_FRAGMENT -> {
+                AppLog.w(
+                    "AapVideo: First fragment has no start code at offset 10 or 2 (len=%d, first bytes %s). " +
+                        "Discarding the frame instead of assembling it headless.",
+                    message.size, firstBytesOf(message)
+                )
+                messageBuffer.clear()
+                requestKeyframe("first fragment has no start code")
+            }
+            VideoFragmentAssembler.Anomaly.OVERFLOW -> {
+                // Message logged at the overflow site, which knows which flag and how far in.
+                messageBuffer.clear()
+                requestKeyframe("frame exceeded the reassembly buffer")
             }
         }
+    }
+
+    /**
+     * A periodic count of everything the stream got wrong, emitted only when something did.
+     *
+     * A line that appears only when the reassembler is unhappy is worth more in a bug report than a
+     * field that reads zero on every healthy line, so this is its own summary rather than extra
+     * columns on the decoder's throughput line.
+     */
+    private fun reportAnomalies() {
+        if (!assembler.hasAnomalies()) return
+        val now = android.os.SystemClock.elapsedRealtime()
+        if (lastAnomalyReportMs == 0L) {
+            // Arm the window on the first event rather than reporting a zero-length one. A single
+            // isolated anomaly is already covered by its own line above; the summary exists to show
+            // a rate.
+            lastAnomalyReportMs = now
+            return
+        }
+        val elapsed = now - lastAnomalyReportMs
+        if (elapsed < ANOMALY_REPORT_INTERVAL_MS) return
+        lastAnomalyReportMs = now
+        AppLog.w(
+            "AapVideo: reassembly anomalies over %dms: truncated=%d, orphan=%d, headless=%d, overflow=%d",
+            elapsed,
+            assembler.countOf(VideoFragmentAssembler.Anomaly.TRUNCATED_PREVIOUS),
+            assembler.countOf(VideoFragmentAssembler.Anomaly.ORPHANED_FRAGMENT),
+            assembler.countOf(VideoFragmentAssembler.Anomaly.HEADLESS_FIRST_FRAGMENT),
+            assembler.countOf(VideoFragmentAssembler.Anomaly.OVERFLOW)
+        )
+        assembler.resetCounts()
+    }
+
+    private fun firstBytesOf(message: AapMessage): String {
+        val end = minOf(message.size, 8)
+        val sb = StringBuilder(end * 3)
+        for (i in 0 until end) {
+            if (i > 0) sb.append(' ')
+            sb.append(String.format("%02x", message.data[i]))
+        }
+        return sb.toString()
     }
 
     /**
@@ -99,88 +190,110 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
         return true
     }
 
-    private fun findStartCode(buf: ByteArray, offset: Int): Int {
-        if (offset + 3 > buf.size) return -1
+    /**
+     * Length of the Annex B start code at [offset], or -1 if there is none.
+     *
+     * Bounded by [len] - the message's payload length - and not by `buf.size`. The two are only
+     * equal because the SSL layer currently hands out an exactly-sized array per message; reading
+     * to the end of the array would become a stale-data read the moment that buffer is pooled, and
+     * a start code found in the previous message's leftovers would send a garbage frame to the
+     * codec.
+     */
+    private fun findStartCode(buf: ByteArray, offset: Int, len: Int): Int {
+        if (offset + 3 > len) return -1
         if (buf[offset].toInt() == 0 && buf[offset + 1].toInt() == 0) {
             if (buf[offset + 2].toInt() == 1) return 3 // 3-byte start code
-            if (offset + 4 <= buf.size && buf[offset + 2].toInt() == 0 && buf[offset + 3].toInt() == 1) return 4 // 4-byte start code
+            if (offset + 4 <= len && buf[offset + 2].toInt() == 0 && buf[offset + 3].toInt() == 1) return 4 // 4-byte start code
         }
         return -1
     }
 
-    fun process(message: AapMessage): Boolean {
-        // Fix smearing happening after some while
-        checkFragmentState(message)
+    /** Whether a frame starts at [offset], i.e. there is a start code there with payload behind it. */
+    private fun payloadStartsAt(buf: ByteArray, offset: Int, len: Int): Boolean {
+        val startCodeLen = findStartCode(buf, offset, len)
+        return startCodeLen > 0 && len > offset + startCodeLen
+    }
 
-        val flags = message.flags.toInt()
+    fun process(message: AapMessage): Boolean {
         val buf = message.data
         val len = message.size
+        val flags = message.flags.toInt()
 
-        when (flags) {
-            11 -> {
-                // Single fragment frame - corruption only affects this frame
-                isFrameCorrupt = false
+        val injector = faultInjector
+        val fault = injector?.effectFor(flags) ?: VideoFaultInjector.Effect.NONE
+        if (injector != null) {
+            if (fault != VideoFaultInjector.Effect.NONE) {
+                AppLog.w(
+                    "AapVideo: FAULT INJECTED (#%d of %d candidates): %s on flag %d, len=%d",
+                    injector.injectedCount, injector.matchingCount, fault, flags, len
+                )
+            }
+            reportInjectorProgress(injector)
+            // A dropped message must not reach the assembler at all - that is the point. Reported as
+            // consumed, because from the protocol's side it did arrive.
+            if (fault == VideoFaultInjector.Effect.DROP) return true
+        }
+        val hideStartCode = fault == VideoFaultInjector.Effect.HIDE_START_CODE
+
+        val decision = assembler.onMessage(
+            flags = flags,
+            payloadStartsAt10 = !hideStartCode &&
+                payloadStartsAt(buf, VideoFragmentAssembler.OFFSET_TIMESTAMP_INDICATION, len),
+            payloadStartsAt2 = !hideStartCode &&
+                payloadStartsAt(buf, VideoFragmentAssembler.OFFSET_MEDIA_INDICATION, len)
+        )
+
+        decision.anomaly?.let { handleAnomaly(it, message) }
+        reportAnomalies()
+
+        return when (val action = decision.action) {
+            is VideoFragmentAssembler.Action.DecodeWhole -> {
                 messageBuffer.clear()
-
-                // Timestamp Indication (Offset 10)
-                val sc10 = findStartCode(buf, 10)
-                if (len > 10 + sc10 && sc10 > 0) {
-                    videoDecoder.decode(buf, 10, len - 10, settings.forceSoftwareDecoding, settings.videoCodec)
-                    return true
-                }
-
-                // Media Indication or Config (Offset 2)
-                val sc2 = findStartCode(buf, 2)
-                if (len > 2 + sc2 && sc2 > 0) {
-                    videoDecoder.decode(buf, 2, len - 2, settings.forceSoftwareDecoding, settings.videoCodec)
-                    return true
-                }
-                AppLog.w("AapVideo: Dropped Flag 11 packet. len=$len")
+                videoDecoder.decode(buf, action.payloadOffset, len - action.payloadOffset, settings.forceSoftwareDecoding, settings.videoCodec)
+                true
             }
-            9 -> {
-                // First fragment - reset corruption state for the new frame
-                isFrameCorrupt = false
+
+            is VideoFragmentAssembler.Action.BeginAssembly -> {
                 messageBuffer.clear()
-
-                // Timestamp Indication (Offset 10)
-                val sc10 = findStartCode(buf, 10)
-                if (len > 10 + sc10 && sc10 > 0) {
-                    messageBuffer.put(message.data, 10, message.size - 10)
-                    return true
-                }
-                // Media Indication (Offset 2)
-                val sc2 = findStartCode(buf, 2)
-                if (len > 2 + sc2 && sc2 > 0) {
-                    messageBuffer.put(message.data, 2, message.size - 2)
-                    return true
-                }
-            }
-            8 -> {
-                if (isFrameCorrupt) return true // Skip fragments of an already corrupt frame
-
-                // Middle fragment - append to buffer with overflow detection
-                if (ensureCapacity(message.size)) {
-                    messageBuffer.put(message.data, 0, message.size)
+                val bytes = len - action.payloadOffset
+                if (ensureCapacity(bytes)) {
+                    messageBuffer.put(buf, action.payloadOffset, bytes)
                 } else {
-                    AppLog.e("AapVideo: Fragment overflow (Flag 8)! Size ${message.size} on top of ${messageBuffer.position()} exceeds the ${MAX_BUFFER_BYTES / 1024}KB cap. Invalidating frame.")
-                    markCorruptAndRequestRecovery()
-                    messageBuffer.clear()
+                    // A first fragment on its own larger than the ceiling. Used to throw a
+                    // BufferOverflowException that the read loop swallowed, taking the rest of the
+                    // frame's fragments with it and explaining nothing.
+                    AppLog.e(
+                        "AapVideo: First fragment overflow (Flag 9)! Size $bytes exceeds the " +
+                            "${MAX_BUFFER_BYTES / 1024}KB cap. Invalidating frame."
+                    )
+                    handleAnomaly(assembler.onOverflow(), message)
                 }
-                return true
+                true
             }
-            10 -> {
-                if (isFrameCorrupt) return true // Skip fragments of an already corrupt frame
 
-                // Last fragment - append, assemble, and decode
-                if (ensureCapacity(message.size)) {
-                    messageBuffer.put(message.data, 0, message.size)
+            VideoFragmentAssembler.Action.Append -> {
+                if (ensureCapacity(len)) {
+                    messageBuffer.put(buf, 0, len)
                 } else {
-                    AppLog.e("AapVideo: Final fragment overflow (Flag 10)! Frame exceeds the ${MAX_BUFFER_BYTES / 1024}KB cap. Invalidating frame.")
-                    markCorruptAndRequestRecovery()
-                    messageBuffer.clear()
+                    AppLog.e(
+                        "AapVideo: Fragment overflow (Flag 8)! Size $len on top of ${messageBuffer.position()} " +
+                            "exceeds the ${MAX_BUFFER_BYTES / 1024}KB cap. Invalidating frame."
+                    )
+                    handleAnomaly(assembler.onOverflow(), message)
+                }
+                true
+            }
+
+            VideoFragmentAssembler.Action.AppendAndDecode -> {
+                if (!ensureCapacity(len)) {
+                    AppLog.e(
+                        "AapVideo: Final fragment overflow (Flag 10)! Frame exceeds the " +
+                            "${MAX_BUFFER_BYTES / 1024}KB cap. Invalidating frame."
+                    )
+                    handleAnomaly(assembler.onOverflow(), message)
                     return true
                 }
-
+                messageBuffer.put(buf, 0, len)
                 messageBuffer.flip()
                 val assembledSize = messageBuffer.limit()
 
@@ -195,14 +308,27 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
                 }
 
                 messageBuffer.clear()
-                return true
+                true
+            }
+
+            is VideoFragmentAssembler.Action.Discard -> {
+                if (flags == VideoFragmentAssembler.FLAG_SINGLE) {
+                    // A complete frame we cannot find the start of. Deliberately not an anomaly:
+                    // the small ones seen in the wild (len=4, len=6 at session start) are control
+                    // traffic on the video channel, not lost picture, and asking for a keyframe for
+                    // each would fire during setup for no reason.
+                    AppLog.w("AapVideo: Dropped Flag 11 packet. len=$len")
+                }
+                action.consumed
             }
         }
-
-        return false
     }
 
     fun release() {
-        // Kept for AapTransport lifecycle compatibility. Decoding is synchronous here.
+        // Decoding is synchronous here, so there is nothing to drain - but the fragment run has to
+        // be closed, or a session that ends mid-frame leaves the next one's first fragments looking
+        // like a truncation.
+        assembler.reset()
+        lastAnomalyReportMs = 0L
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapVideo.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapVideo.kt
@@ -35,40 +35,26 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
     private var lastKeyframeRequestMs = 0L
     private var lastAnomalyReportMs = 0L
 
-    /**
-     * Stamped at construction, which is session start, so the first summary is one interval into the
-     * run rather than on the first frame - the constructor has already said the injector is on.
-     */
-    private var lastInjectorSummaryMs = android.os.SystemClock.elapsedRealtime()
-
     /** Ordering rules for the fragment run. Pure and unit-tested; see [VideoFragmentAssembler]. */
     private val assembler = VideoFragmentAssembler()
+
+    /** Every line the injector prints. Declared first: [faultInjector]'s initializer announces on it. */
+    private val reporter = VideoFaultReporter("AapVideo")
 
     /**
      * Null unless the user has deliberately turned fault injection on, so the healthy path costs one
      * null check. See [VideoFaultInjector] for why this exists at all.
      */
     private val faultInjector: VideoFaultInjector? =
-        VideoFaultInjector(settings.debugVideoFaultInjection, settings.debugVideoFaultRate)
-            .takeIf { it.isActive }
-            ?.also {
-                AppLog.w(
-                    "AapVideo: FAULT INJECTION IS ON - mode=%s, one in %d. The video stream is being " +
-                        "corrupted on purpose; this log does not show a real fault.",
-                    settings.debugVideoFaultInjection, it.rate
-                )
-            }
-
-    /**
-     * Says periodically what the injector has had to work with, so a run that injects nothing says so
-     * rather than looking like a run where the setting never took. See [VideoFaultInjector.describe].
-     */
-    private fun reportInjectorProgress(injector: VideoFaultInjector) {
-        val now = android.os.SystemClock.elapsedRealtime()
-        if (now - lastInjectorSummaryMs < VideoFaultInjector.SUMMARY_INTERVAL_MS) return
-        lastInjectorSummaryMs = now
-        AppLog.w("AapVideo: fault injection - %s", injector.describe())
-    }
+        VideoFaultInjector(
+            settings.debugVideoFaultInjection,
+            settings.debugVideoFaultRate,
+            settings.debugVideoFaultBudget
+        )
+            // Stage-scoped, so a reader-stage mode is applied once in the reader and not a second
+            // time here. See VideoFaultInjector.isActiveAt.
+            .takeIf { it.isActiveAt(VideoFaultInjector.Stage.ASSEMBLER) }
+            ?.also { reporter.announce(it) }
 
     /**
      * Asks the phone for a fresh keyframe because a frame was lost or arrived unusable.
@@ -82,6 +68,20 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
      * as an unsolicited focus nudge, escalating to a real focus cycle only under much stricter
      * gates, and the phone rebuilds the stream in response.
      */
+    /**
+     * The reader's framing audit found a run short of the bytes its first fragment declared.
+     *
+     * This is the one corruption mode nothing downstream of the reader can see. A middle fragment
+     * that never arrives leaves [VideoFragmentAssembler] looking at a first, some middles and a last
+     * in order, so the frame is assembled with a hole and decoded as though it were whole - no
+     * anomaly, no ask, and a picture that drifts until the phone's own keyframe cadence comes round.
+     * [FragmentedMessageAudit] is the only thing that notices, and until now all it did was log.
+     *
+     * Runs on the poll thread, which is the thread [process] and every other keyframe request
+     * already run on, so it shares their throttle and their ordering without any locking of its own.
+     */
+    fun onFragmentRunHoled() = requestKeyframe("fragment run lost bytes")
+
     private fun requestKeyframe(reason: String) {
         val now = android.os.SystemClock.elapsedRealtime()
         if (VideoRecoveryPolicy.canRequestKeyframe(now, lastKeyframeRequestMs)) {
@@ -222,13 +222,7 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
         val injector = faultInjector
         val fault = injector?.effectFor(flags) ?: VideoFaultInjector.Effect.NONE
         if (injector != null) {
-            if (fault != VideoFaultInjector.Effect.NONE) {
-                AppLog.w(
-                    "AapVideo: FAULT INJECTED (#%d of %d candidates): %s on flag %d, len=%d",
-                    injector.injectedCount, injector.matchingCount, fault, flags, len
-                )
-            }
-            reportInjectorProgress(injector)
+            reporter.onMessage(injector, fault, flags, len)
             // A dropped message must not reach the assembler at all - that is the point. Reported as
             // consumed, because from the protocol's side it did arrive.
             if (fault == VideoFaultInjector.Effect.DROP) return true

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AuditRecoveryPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AuditRecoveryPolicy.kt
@@ -1,0 +1,49 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.protocol.Channel
+
+/**
+ * Which [FragmentedMessageAudit] findings are worth a keyframe request rather than only a log line.
+ *
+ * The audit was written as an instrument and wired like one: it computes its outcome, `AapRead`
+ * prints it, and nothing else happens. That left the app able to *see* the one corruption mode
+ * nothing else can see, and unable to *do* anything about it. A hardware round measured the cost -
+ * 37 and 59 injected middle-fragment faults, zero keyframe requests, zero escalation activity, and a
+ * recovery time indistinguishable from the round before the recovery work landed.
+ *
+ * ### Why only DELTA_CHANGED
+ *
+ * A run whose fragment count cannot explain its own byte delta is missing a fragment, and a *middle*
+ * fragment going missing is invisible everywhere else: [VideoFragmentAssembler] still sees a first,
+ * some middles and a last in order, so it assembles the frame and hands the decoder a hole. This is
+ * the only outcome with no second reporter.
+ *
+ * The other three are deliberately excluded:
+ *
+ * - [FragmentedMessageAudit.Outcome.TRUNCATED_RUN] and
+ *   [FragmentedMessageAudit.Outcome.ORPHANED_FRAGMENT] are already seen downstream as
+ *   [VideoFragmentAssembler.Anomaly.TRUNCATED_PREVIOUS] and
+ *   [VideoFragmentAssembler.Anomaly.ORPHANED_FRAGMENT], which already ask. Asking here too would
+ *   double-ask for one fault - and, since the ask is also what stamps the corruption clock
+ *   [KeyframeCycleEscalationPolicy] reads, would make one lost fragment look like a wire that is
+ *   still breaking.
+ * - [FragmentedMessageAudit.Outcome.FIRST_OBSERVATION] is the baseline the channel's convention is
+ *   learned from. It is not a fault and fires once per channel per session.
+ *
+ * ### Why only video
+ *
+ * The audit runs per channel, and a holed run on `MUSIC_PLAYBACK` is real but a video keyframe
+ * cannot repair it. There is no equivalent ask for audio in the protocol.
+ *
+ * Pure: no clock, no logging. Throttling the ask stays with [VideoRecoveryPolicy], which every other
+ * keyframe request in the app is already held to.
+ */
+object AuditRecoveryPolicy {
+
+    /**
+     * @param outcome what [FragmentedMessageAudit.onMessage] returned.
+     * @param channel the AAP channel the run was on.
+     */
+    fun shouldRequestKeyframe(outcome: FragmentedMessageAudit.Outcome, channel: Int): Boolean =
+        outcome == FragmentedMessageAudit.Outcome.DELTA_CHANGED && channel == Channel.ID_VID
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AuditReportPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AuditReportPolicy.kt
@@ -1,7 +1,11 @@
 package com.andrerinas.openheadunit.aap
 
 /**
- * How often one [FragmentedMessageAudit] outcome may be printed.
+ * How often one repeating diagnostic line may be printed.
+ *
+ * Written for a [FragmentedMessageAudit] outcome, which is the case the rest of this describes, and
+ * since reused for [AapTransport]'s held-cycle line - a check that repeats every two seconds and can
+ * hold for minutes. Callers keep their own counters, so two of them never share a budget.
  *
  * The first version of this was a hard cap: ten lines per outcome per session, then silence. It was
  * meant to stop a broken link filling the log with one line per frame, and on a healthy link it

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AuditReportPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AuditReportPolicy.kt
@@ -1,0 +1,43 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * How often one [FragmentedMessageAudit] outcome may be printed.
+ *
+ * The first version of this was a hard cap: ten lines per outcome per session, then silence. It was
+ * meant to stop a broken link filling the log with one line per frame, and on a healthy link it
+ * would never have been reached. Hardware reached it in **200 milliseconds** - a
+ * scaling bug in the audit produced ten false `DELTA_CHANGED` lines at connect - and the check was
+ * then dead for the remaining five minutes, including both windows in which a reporter's artifact
+ * was visible on screen. The audit read clean because it had been switched off, and that absence was
+ * very nearly written up as evidence.
+ *
+ * A cap that can be exhausted is a cap that will be exhausted by whichever bug is noisiest, and the
+ * quiet fault it was hiding is always the one worth having. So the budget refills: the first
+ * [BURST_REPORTS] print in full, and after that one line per [SUMMARY_INTERVAL_MS] carries however
+ * many were suppressed since. The log stays bounded at roughly one line a minute per outcome, and
+ * something that starts going wrong in minute nine still says so.
+ *
+ * Pure, so the interaction that failed in the field is testable without a device or a clock: the
+ * caller passes the time in.
+ */
+object AuditReportPolicy {
+
+    /** Reports printed in full before the periodic summary takes over. */
+    const val BURST_REPORTS = 10
+
+    /** Smallest gap between reports once the burst is spent. */
+    const val SUMMARY_INTERVAL_MS = 60_000L
+
+    /**
+     * Whether this occurrence should be printed.
+     *
+     * [reportsSoFar] counts what has already been printed for this outcome, [lastReportMs] is when
+     * the most recent one was, and [nowMs] is a monotonic clock reading - `SystemClock.elapsedRealtime`
+     * at the call site. Anything not printed is expected to be counted by the caller and named in
+     * the next line that is.
+     */
+    fun shouldReport(reportsSoFar: Int, lastReportMs: Long, nowMs: Long): Boolean {
+        if (reportsSoFar < BURST_REPORTS) return true
+        return nowMs - lastReportMs >= SUMMARY_INTERVAL_MS
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/ByteArrayWithLimit.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/ByteArrayWithLimit.kt
@@ -1,3 +1,10 @@
 package com.andrerinas.openheadunit.aap
 
-class ByteArrayWithLimit(val data: ByteArray, var limit: Int)
+/**
+ * A byte array plus how much of it is meaningful.
+ *
+ * [data] is mutable so the SSL layer can hand out one reused buffer per session instead of one
+ * allocation per message - see `AapSslContext.plaintextBuffer`. **Read [limit], never `data.size`:**
+ * the array is at least as long as the payload and usually longer.
+ */
+class ByteArrayWithLimit(var data: ByteArray, var limit: Int)

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/CodecConfigScanner.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/CodecConfigScanner.kt
@@ -1,0 +1,151 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Answers what an access unit is made of, so `BUFFER_FLAG_CODEC_CONFIG` can be set on the ones that
+ * are only configuration and never on the ones that also carry a picture.
+ *
+ * `BUFFER_FLAG_CODEC_CONFIG` tells MediaCodec the buffer is codec-specific data and nothing else, so
+ * a component is entitled to consume it and produce no output. Setting it on an access unit that also
+ * contains a coded slice therefore risks the slice being discarded - and if that slice is the IDR, the
+ * picture never repairs.
+ *
+ * The check this replaces read only the **first** NAL of the access unit and answered for the whole
+ * thing. Two ways for that to be wrong, in opposite directions:
+ *
+ * - A unit led by an access-unit delimiter or an SEI was reported as carrying no parameter sets even
+ *   when SPS and PPS followed, so decoders that require the flag - Moonlight's errata names TI OMAP4
+ *   as crashing on the IDR without it - never got it.
+ * - A unit led by SPS and continuing into PPS and an IDR slice was reported as configuration, so on
+ *   the three chipset families that flag every config packet (Rockchip, Allwinner, Telechips) the
+ *   whole keyframe was handed over marked as configuration.
+ *
+ * Reading every NAL header in the unit, bounded, answers both.
+ */
+object CodecConfigScanner {
+
+    /** What an access unit contains, as far as the config flag is concerned. */
+    enum class Content {
+        /** Parameter sets and nothing that decodes to a picture. Safe to flag as codec config. */
+        PARAMETER_SETS_ONLY,
+
+        /**
+         * Parameter sets *and* a coded picture, which is how a keyframe usually arrives.
+         *
+         * Must not be flagged as codec config. Decoders read in-band parameter sets from an ordinary
+         * buffer perfectly well; what they cannot do is give back a picture from a buffer they were
+         * told contains no picture.
+         */
+        PARAMETER_SETS_WITH_PICTURE,
+
+        /** An ordinary frame. */
+        NO_PARAMETER_SETS,
+    }
+
+    /** H.264 parameter-set NAL types: SPS, PPS, and the two SPS extensions. */
+    private val AVC_PARAMETER_SETS = intArrayOf(7, 8, 13, 15)
+
+    /** H.264 VCL NAL types - anything that codes picture data. */
+    private val AVC_PICTURE_RANGE = 1..5
+
+    /** H.265 parameter-set NAL types: VPS, SPS, PPS. */
+    private val HEVC_PARAMETER_SETS = intArrayOf(32, 33, 34)
+
+    /** H.265 VCL NAL types. Everything from 32 up is non-VCL. */
+    private val HEVC_PICTURE_RANGE = 0..31
+
+    /**
+     * How many NAL headers to look at before giving up.
+     *
+     * A parameter-set unit is a handful of small NALs; a keyframe leads with them and then has its
+     * slices, so everything this needs to see is at the front.
+     */
+    const val MAX_NAL_HEADERS_SCANNED = 16
+
+    /**
+     * How far into the unit to look before giving up.
+     *
+     * This runs on the feed thread once per frame, so an unbounded walk is 60 scans a second over
+     * frames that reach hundreds of kilobytes - and a P-frame contains no start code after its first,
+     * so an unbounded walk really does read all of it. Everything that decides the answer is in the
+     * leading run of delimiters, SEIs, parameter sets and the first slice header, which a few hundred
+     * bytes covers with room to spare.
+     *
+     * Bounding it is only safe because hitting the bound is treated as *not knowing*, and not knowing
+     * resolves to [Content.PARAMETER_SETS_WITH_PICTURE] - the answer that withholds the flag. A
+     * config-only unit is fifty-odd bytes and finishes long before the bound, so it is never the one
+     * that gets cut off.
+     */
+    const val MAX_BYTES_SCANNED = 512
+
+    /**
+     * Classifies the access unit in [data] between [offset] and [offset] + [size].
+     *
+     * @param isHevc the codec the decoder has **pinned** for this session, never a user preference -
+     *   the NAL type encoding differs between the two and reading one as the other is how a previous
+     *   keyframe latch froze sessions.
+     */
+    fun classify(data: ByteArray, offset: Int, size: Int, isHevc: Boolean): Content {
+        if (size < 5) return Content.NO_PARAMETER_SETS
+        val end = (offset + size).coerceAtMost(data.size)
+        val scanEnd = minOf(end, offset + MAX_BYTES_SCANNED)
+        val parameterSets = if (isHevc) HEVC_PARAMETER_SETS else AVC_PARAMETER_SETS
+        val pictureRange = if (isHevc) HEVC_PICTURE_RANGE else AVC_PICTURE_RANGE
+
+        var i = offset
+        var headersSeen = 0
+        var sawParameterSet = false
+        var sawPicture = false
+        // True when the walk stopped at a bound rather than at the end of the unit, i.e. there may be
+        // more in the unit than we looked at.
+        var incomplete = false
+
+        while (i + 3 < scanEnd) {
+            if (headersSeen >= MAX_NAL_HEADERS_SCANNED) {
+                incomplete = true
+                break
+            }
+            val headerPos = startCodeHeaderPos(data, i, end)
+            if (headerPos < 0) {
+                i++
+                continue
+            }
+            headersSeen++
+            val b = data[headerPos].toInt()
+            val nalType = if (isHevc) (b and 0x7E) shr 1 else b and 0x1F
+
+            if (parameterSets.contains(nalType)) sawParameterSet = true
+            if (nalType in pictureRange) sawPicture = true
+
+            // Both answers are settled; the rest of the unit cannot change them.
+            if (sawParameterSet && sawPicture) return Content.PARAMETER_SETS_WITH_PICTURE
+
+            i = headerPos + 1
+        }
+        if (scanEnd < end) incomplete = true
+
+        return when {
+            // Not knowing resolves to the answer that withholds the flag, never to the one that
+            // risks a picture being consumed as configuration.
+            sawParameterSet && incomplete -> Content.PARAMETER_SETS_WITH_PICTURE
+            sawParameterSet -> Content.PARAMETER_SETS_ONLY
+            else -> Content.NO_PARAMETER_SETS
+        }
+    }
+
+    /**
+     * Position of the NAL header byte if a 3- or 4-byte start code begins at [i], else -1.
+     *
+     * Same walk as [VideoKeyframeScanner]'s, deliberately duplicated rather than shared: the two
+     * answer different questions and the temptation to fuse them into one pass over the frame is how
+     * a change for one silently alters the other.
+     */
+    private fun startCodeHeaderPos(data: ByteArray, i: Int, end: Int): Int {
+        if (data[i].toInt() != 0 || data[i + 1].toInt() != 0) return -1
+        val headerPos = when {
+            data[i + 2].toInt() == 1 -> i + 3
+            data[i + 2].toInt() == 0 && i + 3 < end && data[i + 3].toInt() == 1 -> i + 4
+            else -> return -1
+        }
+        return if (headerPos < end) headerPos else -1
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/FocusCycleLever.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/FocusCycleLever.kt
@@ -1,0 +1,48 @@
+package com.andrerinas.openheadunit.aap
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Exclusive claim on the video-focus release/regain cycle.
+ *
+ * The cycle is the only thing in AAP that makes the phone produce a keyframe on demand, and it is
+ * one operation split across a 400 ms gap: a release, then a regain. Two escalations spend it -
+ * [KeyframeCycleEscalationPolicy], for a picture left corrupt by a shed frame, and
+ * [WarmRelaunchKeyframePolicy], for a surface that has never shown one - each with its own budget
+ * and its own handler.
+ *
+ * Their class comments assert the two can never overlap, and until now nothing enforced it. That was
+ * tolerable while a decoder rebuild switched the first policy's clock off; it stopped being
+ * tolerable the moment a rebuilt decoder started arming it instead, because a rebuild storm is
+ * exactly when both policies see a surface with no picture at the same time.
+ *
+ * The cost of getting it wrong is not a wasted message. A second release issued between the first
+ * cycle's two halves is answered with a second sink stop, and the single shared regain runnable that
+ * each side keeps - replaced rather than tracked per cycle - can then complete only one of them. The
+ * phone is left with its video sink down and nothing asking for it back: a permanent black screen
+ * with audio still playing.
+ *
+ * So: whoever claims it owns it until it hands it back. A refused claim is not a failure - the cycle
+ * already in flight brings the same keyframe both callers wanted - so the refused caller waits rather
+ * than spending its own budget on a release it never sent.
+ */
+class FocusCycleLever {
+
+    private val held = AtomicBoolean(false)
+
+    /** Takes the lever for one cycle. False when somebody else already holds it. */
+    fun tryClaim(): Boolean = held.compareAndSet(false, true)
+
+    /**
+     * Hands it back.
+     *
+     * Idempotent on purpose: a cycle can be completed early by a settle path as well as by its own
+     * delayed regain, and both must be safe to call.
+     */
+    fun release() {
+        held.set(false)
+    }
+
+    /** Whether a cycle is between its two halves. */
+    val isHeld: Boolean get() = held.get()
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/FragmentedMessageAudit.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/FragmentedMessageAudit.kt
@@ -1,0 +1,258 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Checks a run of message fragments against the total size the first one declared.
+ *
+ * Every fragmented AAP message begins with a first fragment carrying a 4-byte total size, which both
+ * readers have always read and thrown away - one into a field called `fragmentSizeBuffer`, the other
+ * into one called `skipBuffer`. That number is the only cross-check the protocol offers, and without
+ * it one corruption mode is completely invisible: a *middle* fragment that never arrives leaves the
+ * run looking intact to [VideoFragmentAssembler] - a first, some middles, a last, in order - so the
+ * frame is assembled with a hole in it and handed to the decoder as though it were whole. There is
+ * no log, no keyframe request, and nothing to see afterwards except a smeared picture.
+ *
+ * What the declared total is counted in is not documented anywhere we can check, and it need not be:
+ * this class learns the convention from the stream.
+ *
+ * ### The convention is per fragment, not per run
+ *
+ * The difference between the declared total and the sum of the fragment lengths scales with the
+ * number of fragments, because each fragment carries its own framing and encryption overhead in the
+ * `encLen` this class is given. Hardware measured it at a flat **29 bytes per fragment**:
+ *
+ * ```
+ * fragments=2 -> delta=-58    fragments=5 -> delta=-145
+ * fragments=3 -> delta=-87    fragments=7 -> delta=-203
+ * fragments=4 -> delta=-116   fragments=8 -> delta=-232
+ * ```
+ *
+ * — exact in all 20+ observations of a hardware round, across two codecs, two sessions and two
+ * channels (VIDEO and MUSIC_PLAYBACK carried the same 29). An earlier version of this class learned
+ * the *whole-run* difference instead and compared every later run against it, so every message whose
+ * fragment count differed from the establishing message's tripped the warning: 10 false
+ * `DELTA_CHANGED` lines in the first 200ms of every session on that rig, which then exhausted the
+ * report budget and left the check silent for the rest of it. The one instrument that can see a
+ * missing middle fragment was therefore muted during exactly the windows an artifact was visible.
+ *
+ * So the expectation is scaled to each run's own fragment count. The comparison is done by
+ * cross-multiplication rather than division, so it stays exact whatever the convention turns out to
+ * be - including one that does not divide evenly, which the measured 29 does but a future stream
+ * might not.
+ *
+ * A missing fragment moves the difference by that fragment's own length, which no amount of scaling
+ * explains away, and that is the deviation worth a line in a log.
+ *
+ * Per-channel, because video, audio and control messages interleave on one connection and a run on
+ * one channel says nothing about a run on another.
+ *
+ * Pure: no clock, no logging, no allocation on the healthy path. How often a report may be *printed*
+ * is [AuditReportPolicy]'s decision, not this class's.
+ */
+class FragmentedMessageAudit(channelCount: Int = DEFAULT_CHANNEL_COUNT) {
+
+    /** Why a run is worth reporting. Runs that match the established convention are not reported. */
+    enum class Outcome {
+        /** The first complete run on this channel. Its difference becomes the expected one. */
+        FIRST_OBSERVATION,
+
+        /** A complete run whose difference is not the one this channel had settled on. */
+        DELTA_CHANGED,
+
+        /** A middle or last fragment arrived with no run open. */
+        ORPHANED_FRAGMENT,
+
+        /** A new message started while a run was still open, so the previous one lost its tail. */
+        TRUNCATED_RUN,
+    }
+
+    /**
+     * A run worth reporting.
+     *
+     * [delta] is `declaredTotal - observedTotal`. [expectedDelta] is what a run of *this* fragment
+     * count should have shown, scaled from the establishing run, or null if the channel has not
+     * settled yet or there is nothing to expect. [perFragmentDelta] is the learned constant behind
+     * that expectation, present only when the establishing run divided evenly - it is the number a
+     * human can sanity-check at a glance, and the reason it may be absent is that nothing here
+     * requires the convention to divide.
+     */
+    data class Result(
+        val channel: Int,
+        val outcome: Outcome,
+        val declaredTotal: Int,
+        val observedTotal: Int,
+        val fragments: Int,
+        val delta: Int,
+        val expectedDelta: Int?,
+        val perFragmentDelta: Int?,
+    ) {
+        override fun toString(): String = buildString {
+            append("channel=$channel ")
+            append("fragments=$fragments ")
+            append("declaredTotal=$declaredTotal observed=$observedTotal delta=$delta")
+            expectedDelta?.let { append(" expectedDelta=$it") }
+            perFragmentDelta?.let { append(" perFragment=$it") }
+        }
+    }
+
+    private val open = BooleanArray(channelCount)
+    private val declared = IntArray(channelCount)
+    private val observed = IntArray(channelCount)
+    private val fragments = IntArray(channelCount)
+
+    /**
+     * The establishing run's difference and fragment count, per channel.
+     *
+     * Kept as the pair rather than as a ratio so the comparison can cross-multiply and stay exact.
+     * A completed fragmented run always has at least two fragments, so a zero here means "this
+     * channel has not settled yet" and cannot collide with a real observation.
+     */
+    private val establishedDelta = IntArray(channelCount)
+    private val establishedFragments = IntArray(channelCount)
+
+    /**
+     * Applies one message.
+     *
+     * [flags] is the raw header flags byte: bit 0 marks a first fragment, bit 1 a last one, so an
+     * unfragmented message has both and a middle fragment has neither. [encLen] is the message's own
+     * encrypted body length, and [declaredTotal] is the 4-byte total that accompanies a first
+     * fragment - ignored for every other kind.
+     *
+     * Returns null when there is nothing to report, which is the overwhelming majority of calls.
+     */
+    fun onMessage(channel: Int, flags: Int, encLen: Int, declaredTotal: Int): Result? {
+        if (channel < 0 || channel >= open.size) return null
+
+        val isFirst = flags and FLAG_BIT_FIRST != 0
+        val isLast = flags and FLAG_BIT_LAST != 0
+
+        if (isFirst) {
+            val truncated = if (open[channel]) {
+                val seen = fragments[channel]
+                Result(
+                    channel = channel,
+                    outcome = Outcome.TRUNCATED_RUN,
+                    declaredTotal = declared[channel],
+                    observedTotal = observed[channel],
+                    fragments = seen,
+                    delta = declared[channel] - observed[channel],
+                    expectedDelta = expectedFor(channel, seen),
+                    perFragmentDelta = perFragmentFor(channel),
+                )
+            } else {
+                null
+            }
+
+            if (isLast) {
+                // Unfragmented: nothing to audit, and no run to leave open.
+                open[channel] = false
+            } else {
+                open[channel] = true
+                declared[channel] = declaredTotal
+                observed[channel] = encLen
+                fragments[channel] = 1
+            }
+            return truncated
+        }
+
+        if (!open[channel]) {
+            return Result(
+                channel = channel,
+                outcome = Outcome.ORPHANED_FRAGMENT,
+                declaredTotal = 0,
+                observedTotal = encLen,
+                fragments = 0,
+                delta = 0,
+                // Nothing arrived that a convention could have predicted, so quoting one here would
+                // only invite a comparison that means nothing.
+                expectedDelta = null,
+                perFragmentDelta = null,
+            )
+        }
+
+        observed[channel] += encLen
+        fragments[channel]++
+
+        if (!isLast) return null
+
+        open[channel] = false
+        val runFragments = fragments[channel]
+        val delta = declared[channel] - observed[channel]
+
+        if (establishedFragments[channel] == 0) {
+            establishedDelta[channel] = delta
+            establishedFragments[channel] = runFragments
+            return Result(
+                channel = channel,
+                outcome = Outcome.FIRST_OBSERVATION,
+                declaredTotal = declared[channel],
+                observedTotal = observed[channel],
+                fragments = runFragments,
+                delta = delta,
+                expectedDelta = null,
+                perFragmentDelta = perFragmentFor(channel),
+            )
+        }
+
+        // Exact: delta/runFragments == establishedDelta/establishedFragments, without dividing.
+        // Long because a corrupt declaredTotal can be arbitrarily large and the product must not wrap.
+        if (delta.toLong() * establishedFragments[channel] ==
+            establishedDelta[channel].toLong() * runFragments
+        ) {
+            return null
+        }
+
+        return Result(
+            channel = channel,
+            outcome = Outcome.DELTA_CHANGED,
+            declaredTotal = declared[channel],
+            observedTotal = observed[channel],
+            fragments = runFragments,
+            delta = delta,
+            expectedDelta = expectedFor(channel, runFragments),
+            perFragmentDelta = perFragmentFor(channel),
+        )
+    }
+
+    /**
+     * What a run of [runFragments] fragments should have shown on this channel, or null if the
+     * channel has not settled.
+     *
+     * Truncating division, and for display only - every decision is made by the exact
+     * cross-multiplication above.
+     */
+    private fun expectedFor(channel: Int, runFragments: Int): Int? {
+        val establishedCount = establishedFragments[channel]
+        if (establishedCount == 0) return null
+        return (establishedDelta[channel].toLong() * runFragments / establishedCount).toInt()
+    }
+
+    /** The learned per-fragment constant, or null when the establishing run did not divide evenly. */
+    private fun perFragmentFor(channel: Int): Int? {
+        val establishedCount = establishedFragments[channel]
+        if (establishedCount == 0) return null
+        val total = establishedDelta[channel]
+        if (total % establishedCount != 0) return null
+        return total / establishedCount
+    }
+
+    /** Forgets every channel's run and learned convention. For a new session. */
+    fun reset() {
+        open.fill(false)
+        declared.fill(0)
+        observed.fill(0)
+        fragments.fill(0)
+        establishedDelta.fill(0)
+        establishedFragments.fill(0)
+    }
+
+    companion object {
+        /** Channel ids run 0..13 (see `protocol/Channel`); a little headroom costs nothing. */
+        const val DEFAULT_CHANNEL_COUNT = 16
+
+        /** Header flags bit marking the first fragment of a message. */
+        const val FLAG_BIT_FIRST = 0x01
+
+        /** Header flags bit marking the last fragment of a message. */
+        const val FLAG_BIT_LAST = 0x02
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicy.kt
@@ -43,6 +43,36 @@ package com.andrerinas.openheadunit.aap
  * component never re-initialised - but that is one rig and one phone. Hence a budget rather than a
  * free hand: [MAX_CYCLES_PER_SESSION] in total, no two closer together than [CYCLE_COOLDOWN_MS].
  *
+ * ### Why a cycle is held while the stream is still breaking
+ *
+ * The cycle repairs the picture by making the phone rebuild the stream, which it does by sending a
+ * fresh keyframe. That keyframe travels the same wire the picture was lost on, so spending a cycle
+ * while frames are still arriving broken buys a keyframe that arrives broken too - and stamps
+ * [CYCLE_COOLDOWN_MS], putting the next cycle a minute away.
+ *
+ * Measured. A round that stopped its injected corruption at a known instant spent cycle 1 eight
+ * seconds *before* that instant, on a wire that was still losing frames; the picture then stayed
+ * dead for the full cooldown, and cycle 2 - the first one fired on a clean wire - repaired it in
+ * 0.96s. Sixty-three of those sixty-four seconds were the first cycle being thrown away. Two cycles
+ * were still unspent throughout.
+ *
+ * So the wire's own quiet is a precondition, bounded by [DEFER_FOR_QUIET_LIMIT_MS] so a stream that
+ * never fully settles can still reach the lever.
+ *
+ * ### Why the last cycle is kept back
+ *
+ * The round after that one measured the same waste at a longer timescale, and found the gate could
+ * not see it. Its corruption arrived every ~12s against a 2s quiet window checked 2s after each
+ * arming, so the hold fired once in six checks; all three cycles went inside the first three and a
+ * half minutes, and the loss ran for another **207 seconds** after the last of them. The picture
+ * came back 44.5s after the wire went quiet, by way of three of the decoder's own `sync_stall`
+ * restarts - with nothing left to spend on the one moment a cycle was certain to work.
+ *
+ * [CORRUPTION_QUIET_MS] is now sized against that spacing, and the last cycle of a session is held
+ * for real quiet with no ceiling. That is the asymmetry worth carrying: cycles 1 and 2 are worth
+ * spending speculatively on a wire that may never settle, because more remain; the last one is
+ * worth only what it buys at the moment the loss stops, which is a keyframe 0.5-1.6s later.
+ *
  * ### Who arms the clock
  *
  * A shed reference frame is no longer the only caller. A decoder that has just been rebuilt, and one
@@ -118,12 +148,60 @@ object KeyframeCycleEscalationPolicy {
      */
     const val MAX_CYCLES_PER_SESSION = 3
 
+    /**
+     * How long the wire has to have been free of corrupt access units before a cycle is spent.
+     *
+     * Sized against how far apart faults actually land, which is the thing it has to outlast. The
+     * first version was twice [VideoRecoveryPolicy.KEYFRAME_REQUEST_THROTTLE_MS] - reasoning about
+     * the throttle rather than about the stream - and that made the whole gate unreachable. A
+     * hardware round injected one fault every ~12s and asked this question 2s after each arming, so
+     * only corruption landing inside that same 2s window could ever defer anything: **one hold in
+     * six checks**, all three cycles spent 207 seconds before the loss stopped, and the picture
+     * recovered by the decoder's own restart ladder 44.5s later rather than by the lever this
+     * policy exists to schedule.
+     *
+     * Fifteen seconds covers that measured spacing (30 faults across ~450s). It is longer than
+     * [ESCALATE_AFTER_UNREPAIRED_MS], which is why the isolated dropped frame needs its own guard -
+     * see `corruptionSinceArm` in [decide] - and shorter than [DEFER_FOR_QUIET_LIMIT_MS], so the
+     * ceiling still bites on every cycle that has one. A test pins both relations.
+     */
+    const val CORRUPTION_QUIET_MS = 15_000L
+
+    /**
+     * Ceiling on that deferral. Past this the cycle is spent even on a wire that is still noisy.
+     *
+     * A stream losing frames lightly but continuously may still be repairable by a keyframe, and
+     * waiting for a quiet it never reaches would put the only lever that exists out of reach.
+     *
+     * A full [CYCLE_COOLDOWN_MS], because that is what a wasted cycle costs. Spending one on a wire
+     * that is still breaking buys a keyframe that arrives broken and blocks the next cycle for a
+     * minute, so a ceiling shorter than the cooldown can lose more time than the wait it cut short -
+     * which is the fault this whole gate exists to stop. At sixty seconds, holding on is only
+     * abandoned once it has already cost as much as the worst case it is avoiding. A test pins the
+     * relation.
+     *
+     * It also sits just inside the phone's own ~69s keyframe cadence, so a picture this policy has
+     * given up deferring is one the stream was about to repair unaided anyway.
+     *
+     * **The last cycle of a session is exempt** - see [decide]. This ceiling exists so a wire that
+     * never settles can still reach the lever, and with cycles left in the budget that trade is
+     * worth making. With one left it is not: the whole value of the last cycle is being there for
+     * the moment the loss stops.
+     */
+    const val DEFER_FOR_QUIET_LIMIT_MS = CYCLE_COOLDOWN_MS
+
     enum class Action {
         /** Send the unsolicited focus gain, the existing behaviour. */
         NUDGE,
 
         /** Release video focus and take it back, so the phone rebuilds the stream. */
         CYCLE_FOCUS,
+
+        /**
+         * The picture is broken, the budget has something in it, and the wire is still losing
+         * frames. Hold the cycle and look again shortly - see [CORRUPTION_QUIET_MS].
+         */
+        WAIT_FOR_QUIET,
     }
 
     /**
@@ -131,17 +209,42 @@ object KeyframeCycleEscalationPolicy {
      *   since. Zero means nothing is broken, and nothing is escalated.
      * @param cyclesUsedThisSession how many [Action.CYCLE_FOCUS] escalations this session has spent.
      * @param lastCycleMs when the last one fired, or zero if none has.
+     * @param lastWireCorruptionMs when an access unit last arrived broken *on the wire*, or zero if
+     *   none has this session. Not when the decoder last had no picture: that is the consequence,
+     *   and it outlives the fault by however long the repair takes.
      */
     fun decide(
         nowMs: Long,
         unrepairedSinceMs: Long,
         cyclesUsedThisSession: Int,
         lastCycleMs: Long,
+        lastWireCorruptionMs: Long,
     ): Action {
         if (unrepairedSinceMs == 0L) return Action.NUDGE
         if (nowMs - unrepairedSinceMs < ESCALATE_AFTER_UNREPAIRED_MS) return Action.NUDGE
         if (cyclesUsedThisSession >= MAX_CYCLES_PER_SESSION) return Action.NUDGE
         if (lastCycleMs != 0L && nowMs - lastCycleMs < CYCLE_COOLDOWN_MS) return Action.NUDGE
+        // Last, so a spent budget and a running cooldown still answer with the plain nudge. Both are
+        // reasons to stop asking for a while, and both clear on a minute-scale clock the caller
+        // re-checks against; this one clears in seconds and gets a correspondingly shorter re-check.
+        val wireQuiet = lastWireCorruptionMs == 0L ||
+            nowMs - lastWireCorruptionMs >= CORRUPTION_QUIET_MS
+        if (!wireQuiet) {
+            // The last cycle is the one that has to still be there when the loss stops, so it waits
+            // for real quiet with no ceiling. A session whose wire never settles ends with it
+            // unspent, which costs nothing: that session was not repairable by a keyframe anyway.
+            if (cyclesUsedThisSession == MAX_CYCLES_PER_SESSION - 1) return Action.WAIT_FOR_QUIET
+            // An isolated dropped frame stamps the corruption at the instant the clock arms, so
+            // without this it would be deferred by a whole quiet window - taxing the common case to
+            // pay for the sustained-loss one. Which of the two stamps lands first is not fixed:
+            // AapVideo reports the corrupt access unit, the decoder sheds the reference frame, and
+            // the order depends on the decoder. Hence a tolerance rather than a strict comparison.
+            val corruptionSinceArm =
+                lastWireCorruptionMs - unrepairedSinceMs >= ESCALATE_AFTER_UNREPAIRED_MS
+            if (corruptionSinceArm && nowMs - unrepairedSinceMs < DEFER_FOR_QUIET_LIMIT_MS) {
+                return Action.WAIT_FOR_QUIET
+            }
+        }
         return Action.CYCLE_FOCUS
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicy.kt
@@ -43,6 +43,17 @@ package com.andrerinas.openheadunit.aap
  * component never re-initialised - but that is one rig and one phone. Hence a budget rather than a
  * free hand: [MAX_CYCLES_PER_SESSION] in total, no two closer together than [CYCLE_COOLDOWN_MS].
  *
+ * ### Who arms the clock
+ *
+ * A shed reference frame is no longer the only caller. A decoder that has just been rebuilt, and one
+ * that is waiting for a keyframe rather than rebuilding, both arm it too - those are the cases where
+ * the picture is most certainly gone and least able to return on its own, since a rebuilt codec
+ * resumes on a P-frame and the next scheduled keyframe is up to a GOP away. They used to do the
+ * opposite: a rebuild *cancelled* the clock and armed nothing, so a decoder restarting every ten
+ * seconds could never reach an escalation, which is how one corrupt access unit turned into a
+ * permanent black screen. The [WarmRelaunchKeyframePolicy] overlap that motivated the old wiring is
+ * handled by [FocusCycleLever] rather than by declining to ask.
+ *
  * Deliberately blind to everything except its own timeline and the keyframe signal. An earlier
  * attempt (commit 66e59b2c) latched on a `waitingForKeyframe` flag that gated the *feed*, and could
  * stick for a whole session with no timeout. Nothing here can stick: the clock clears on a keyframe,

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/LinkGapMonitor.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/LinkGapMonitor.kt
@@ -1,0 +1,182 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * How long the inbound AAP link goes completely silent, and how often.
+ *
+ * Two reporters on Android 8.1 head units describe the same thing in the same words - the music
+ * cuts in and out - and on both the fault is neither the audio path nor the decoder. The whole
+ * link stops, on every channel at once, on a fixed cadence, and then resumes. One capture measured
+ * 1.59 s of silence every 11.57 s; another, on different hardware, 5-6 s every 10-11 s with the
+ * picture and the sound dying together.
+ *
+ * Neither was readable from what the app prints. The only instrument that could see it was an
+ * offline script over `RECV:` lines, which exist solely at VERBOSE - so recognising the first case
+ * took a 151,366-line export, and the second could not be diagnosed at all, because the reporter
+ * had been asked for INFO. A fault this distinctive should not need a special capture to notice.
+ *
+ * So the same measurement runs in the app, at INFO, reporting the fields the script reports so a
+ * log line and a rig run can be compared directly.
+ *
+ * **Diagnostic only - nothing reads the report.** The [GAP_THRESHOLD_MS] below rests on one
+ * observed phone behaviour rather than on anything in the protocol, which is reason enough not to
+ * hang recovery off it. The line says what was measured and leaves the conclusion to the reader.
+ *
+ * Pure and clock-free: the caller passes the time in, so both measured waveforms are replayable in
+ * a unit test.
+ */
+class LinkGapMonitor {
+
+    /**
+     * Silence longer than this counts as a gap.
+     *
+     * The phone sends a `CONTROL Ping Request` once a second for the life of the session, so a full
+     * second in which *no* channel says anything is already outside what a working link does. The
+     * value matches the offline script's default, which is what makes the two comparable.
+     */
+    private val gapThresholdMs = GAP_THRESHOLD_MS
+
+    /** How much link time one report covers. */
+    private val windowMs = WINDOW_MS
+
+    /**
+     * Whether any message has been seen since the last [reset]. A separate flag rather than a
+     * sentinel value of [lastMessageMs], because zero is a timestamp a monotonic clock can legally
+     * produce and overloading it makes the very first interval of a session unmeasurable.
+     */
+    private var started = false
+    private var lastMessageMs = 0L
+    private var windowStartMs = 0L
+    private var gapCount = 0
+    private var deadMs = 0L
+    private var longestMs = 0L
+
+    /**
+     * When each gap in this window began, for the start-to-start interval. Bounded because a link
+     * that is more gap than traffic would otherwise grow this without limit; the counters above stay
+     * exact regardless, and only the interval degrades.
+     */
+    private val gapStarts = ArrayList<Long>()
+
+    /**
+     * Feed one inbound message and get a report when a window closes with something to say.
+     *
+     * [nowMs] is a monotonic clock reading - `SystemClock.elapsedRealtime` at the call site.
+     *
+     * Returns `null` for every message that does not close a window, and for every window that had
+     * no gaps in it. A healthy session therefore prints nothing at all, which is the property that
+     * makes a line worth reading.
+     */
+    fun onMessage(nowMs: Long): Report? {
+        if (!started) {
+            // First message of the session. There is no interval before it to measure, and the
+            // window has to start somewhere.
+            started = true
+            lastMessageMs = nowMs
+            windowStartMs = nowMs
+            return null
+        }
+
+        val gapMs = nowMs - lastMessageMs
+        val gapStartMs = lastMessageMs
+        lastMessageMs = nowMs
+
+        if (gapMs > gapThresholdMs) {
+            gapCount++
+            deadMs += gapMs
+            if (gapMs > longestMs) longestMs = gapMs
+            if (gapStarts.size < MAX_TRACKED_STARTS) gapStarts.add(gapStartMs)
+        }
+
+        // The window can only close on a message, so a window that ends mid-outage runs long. The
+        // report carries the elapsed time rather than the nominal one, so the percentage stays true.
+        val elapsedMs = nowMs - windowStartMs
+        if (elapsedMs < windowMs) return null
+
+        val report = if (gapCount == 0) null else Report(
+            gaps = gapCount,
+            windowMs = elapsedMs,
+            deadMs = deadMs,
+            longestMs = longestMs,
+            medianPeriodMs = medianPeriodMs()
+        )
+
+        windowStartMs = nowMs
+        gapCount = 0
+        deadMs = 0L
+        longestMs = 0L
+        gapStarts.clear()
+        return report
+    }
+
+    /**
+     * Forget the previous session.
+     *
+     * The transport outlives a session and is re-armed for the next one, so a stamp left by the
+     * previous phone would otherwise be measured as this session's first gap.
+     */
+    fun reset() {
+        started = false
+        lastMessageMs = 0L
+        windowStartMs = 0L
+        gapCount = 0
+        deadMs = 0L
+        longestMs = 0L
+        gapStarts.clear()
+    }
+
+    /**
+     * Median start-to-start interval between consecutive gaps, or `null` with fewer than two.
+     *
+     * The interval is the field that separates a periodic fault from an unlucky patch of traffic:
+     * both measured waveforms hold theirs to within a second across an entire session, which is not
+     * something congestion does.
+     *
+     * It is the interval between *gaps*, not between cycles, and on a link whose outages arrive in
+     * pairs - one long, one short - it reports the spacing inside the pair rather than the cycle
+     * length. That is the honest answer to what was asked, but it is not the number a reader
+     * eyeballing the cycle would predict, so read it alongside the count.
+     */
+    private fun medianPeriodMs(): Long? {
+        if (gapStarts.size < 2) return null
+        val periods = LongArray(gapStarts.size - 1) { gapStarts[it + 1] - gapStarts[it] }
+        periods.sort()
+        val mid = periods.size / 2
+        return if (periods.size % 2 == 1) periods[mid] else (periods[mid - 1] + periods[mid]) / 2
+    }
+
+    /** One window's worth of silence, in the offline script's fields. */
+    data class Report(
+        val gaps: Int,
+        val windowMs: Long,
+        val deadMs: Long,
+        val longestMs: Long,
+        val medianPeriodMs: Long?
+    ) {
+        /** Dead time as a whole percentage of the window. */
+        val deadPercent: Int
+            get() = if (windowMs <= 0L) 0 else (deadMs * 100 / windowMs).toInt()
+
+        override fun toString(): String {
+            val period = medianPeriodMs?.let { ", period~${it}ms" } ?: ""
+            return "inbound link quiet $gaps time${if (gaps == 1) "" else "s"} in ${windowMs}ms: " +
+                "dead=${deadMs}ms ($deadPercent%), longest=${longestMs}ms$period"
+        }
+    }
+
+    companion object {
+        /** Silence longer than this is a gap. See [gapThresholdMs]. */
+        const val GAP_THRESHOLD_MS = 1_200L
+
+        /**
+         * How much link time one report covers.
+         *
+         * Long enough to hold about three cycles of either measured waveform, so a period can be
+         * read off a single line, and clear of the decoder's own five-second throughput cadence so
+         * the two do not interleave into noise.
+         */
+        const val WINDOW_MS = 30_000L
+
+        /** Cap on remembered gap starts. See [gapStarts]. */
+        const val MAX_TRACKED_STARTS = 256
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/NativeGroupBandPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/NativeGroupBandPolicy.kt
@@ -1,0 +1,61 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Which band the Native AA P2P group is requested on, and whether a group that came up on the other
+ * one should be torn down and remade.
+ *
+ * Native AA asks for 5 GHz because that is the band the reporters' working sessions run on, and a
+ * group that lands on 2.4 GHz anyway is recreated rather than used. That default is not in question
+ * here. What this exists for is the opposite case: two reporter threads describe a link that dies
+ * for seconds at a time on a fixed cadence, on 2.4 GHz head units, and nothing on the rig could ever
+ * be put on that band to look for it - `createQuietGroup` asks for 5 GHz and
+ * `onGroupInfoAvailable` undoes any group that does not come up there, so the rig had two
+ * independent reasons never to run the configuration the reports come from.
+ *
+ * The override is a debug lever, off by default, and it turns off *both* of those: asking for 2.4
+ * GHz while leaving the mismatch retry armed would tear the group down as soon as it succeeded.
+ * That coupling is the whole reason this is one object with a test rather than two booleans read in
+ * two places.
+ */
+object NativeGroupBandPolicy {
+
+    enum class Band {
+        GHZ_2_4,
+        GHZ_5,
+
+        /**
+         * No band was asked for - the standard `createGroup` fallback, where the platform picks.
+         * A group nobody chose a band for cannot be on the wrong one, so it is never remade.
+         */
+        UNSPECIFIED,
+    }
+
+    /** Below this, a P2P group is on 2.4 GHz. The 5 GHz band starts at 5170 MHz. */
+    private const val MAX_24GHZ_FREQUENCY_MHZ = 4000
+
+    fun bandFor(force24Ghz: Boolean): Band = if (force24Ghz) Band.GHZ_2_4 else Band.GHZ_5
+
+    /**
+     * True when the group that came up must be torn down and remade because it is not on the band
+     * that was asked for.
+     *
+     * Only ever true when 5 GHz was requested: a group we deliberately put on 2.4 GHz is on the band
+     * it was asked for, so there is nothing to correct, and retrying it would recreate the group
+     * every time it succeeded.
+     */
+    fun shouldRetryFor5Ghz(
+        requested: Band,
+        frequencyMhz: Int,
+        retriesSoFar: Int,
+        maxRetries: Int,
+    ): Boolean = requested == Band.GHZ_5 &&
+        frequencyMhz in 1..MAX_24GHZ_FREQUENCY_MHZ &&
+        retriesSoFar < maxRetries
+
+    /** The band label used in the log, so a capture says which band was asked for and which arrived. */
+    fun label(band: Band): String = when (band) {
+        Band.GHZ_2_4 -> "2.4GHz"
+        Band.GHZ_5 -> "5GHz"
+        Band.UNSPECIFIED -> "unspecified"
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/P2pChannelPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/P2pChannelPolicy.kt
@@ -25,8 +25,14 @@ object P2pChannelPolicy {
     /** Channel 13, the top of the regular 5 MHz spacing. */
     private const val CHANNEL_13_MHZ = 2472
 
-    /** Channel 14: Japan only, 802.11b only, and off the 5 MHz grid. */
-    private const val CHANNEL_14_MHZ = 2484
+    /**
+     * Channel 14: Japan only, 802.11b only, and off the 5 MHz grid.
+     *
+     * Public because [P2pOperatingChannelPolicy] converts the other way and needs the same exception.
+     * The two were written independently and only this one had it, so the number is shared rather
+     * than repeated.
+     */
+    const val CHANNEL_14_MHZ = 2484
 
     /** True for a 2.4 GHz frequency, by the span the band occupies rather than by exact channel. */
     fun is24GHz(frequencyMhz: Int): Boolean = frequencyMhz in CHANNEL_1_MHZ..CHANNEL_14_MHZ

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/P2pOperatingChannelPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/P2pOperatingChannelPolicy.kt
@@ -1,0 +1,99 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Which operating channel to ask the P2P stack for, on the devices that have no band API.
+ *
+ * [NativeGroupBandPolicy] asks for a *band*, and that request only exists from API 29
+ * (`WifiP2pConfig.Builder.setGroupOperatingBand`). Below it the app calls the no-argument
+ * `createGroup` and the driver picks unaided, which is what every pre-Android-10 head unit in the
+ * reports has been doing: `Standard createGroup SUCCESS!`, then `Freq: 0 MHz (unknown)`, with the
+ * band unrecorded on our side and unchosen on theirs.
+ *
+ * There is one lever left on those devices. `WifiP2pManager.setWifiP2pChannels(c, listen, operating,
+ * listener)` is hidden but present, and in AOSP 8.1's `SupplicantP2pIfaceHal` an operating channel is
+ * turned into `setDisallowedFrequencies` around the single frequency it names - channel 36 becomes
+ * 5180 MHz and everything either side of it is disallowed, so the group owner has nowhere else to go.
+ * Reflection reaches it because the non-SDK blocklist only starts at API 28, and this app already
+ * reflects into the same class for `setDeviceName`.
+ *
+ * Two constraints come from the platform and both are encoded here rather than left to the caller:
+ *
+ *  - The channel must be set **while no group exists**. `WifiP2pServiceImpl` handles `SET_CHANNEL`
+ *    only in its inactive state, so a request made after `createGroup` is dropped silently.
+ *  - The **listen** channel must be left alone. Discovery happens on the 2.4 GHz social channels
+ *    (1, 6, 11) whatever the group runs on, and restricting it would make the unit undiscoverable.
+ *    [LISTEN_CHANNEL_UNCHANGED] is the value that means "do not touch it".
+ *
+ * Channel 36 rather than any other: it is the bottom of UNII-1, it is not a DFS channel, and it is
+ * what the reference implementations use - `WirelessAndroidAutoDongle` brings its access point up on
+ * channel 36, and the AAWireless dongle's own filing lists 5180-5240 and 5745-5825 while avoiding the
+ * DFS range between them. [CHANNEL_UPPER] is offered for the same reason the filing lists two ranges:
+ * a unit whose regulatory domain refuses UNII-1 may still take UNII-3.
+ */
+object P2pOperatingChannelPolicy {
+
+    /** Ask for nothing and leave the platform's own choice alone. */
+    const val CHANNEL_UNRESTRICTED = 0
+
+    /** Pass this as the listen channel: discovery must stay where the phone looks for it. */
+    const val LISTEN_CHANNEL_UNCHANGED = 0
+
+    /** 5180 MHz, bottom of UNII-1. Not a DFS channel. */
+    const val CHANNEL_LOWER = 36
+
+    /** 5745 MHz, bottom of UNII-3, for a regulatory domain that refuses UNII-1. */
+    const val CHANNEL_UPPER = 149
+
+    /** The last 2.4 GHz channel, and the one the linear formula does not describe. */
+    const val CHANNEL_24_GHZ_TOP = 14
+
+    /** The band request exists from here up, so below it is where this policy applies. */
+    const val FIRST_API_WITH_BAND_REQUEST = 29
+
+    /**
+     * True when asking for an operating channel is the only way to influence the band.
+     *
+     * From API 29 the band request is a supported call with a supported fallback, and it is what
+     * [NativeGroupBandPolicy] already drives; reaching for a hidden method there would be trading a
+     * guarantee for a reflection.
+     */
+    fun appliesTo(sdkInt: Int): Boolean = sdkInt < FIRST_API_WITH_BAND_REQUEST
+
+    /**
+     * The operating channel to request, or [CHANNEL_UNRESTRICTED] to ask for nothing.
+     *
+     * @param sdkInt this device's API level.
+     * @param requestFiveGhz the user's opt-in. Off by default, because a unit whose P2P firmware
+     *   cannot host a 5 GHz group owner would be left with a frequency list it cannot satisfy, and
+     *   the failure would be a group that never forms rather than a group on the wrong band.
+     * @param useUpperBand ask for UNII-3 instead of UNII-1.
+     */
+    fun operatingChannel(sdkInt: Int, requestFiveGhz: Boolean, useUpperBand: Boolean = false): Int = when {
+        !appliesTo(sdkInt) -> CHANNEL_UNRESTRICTED
+        !requestFiveGhz -> CHANNEL_UNRESTRICTED
+        useUpperBand -> CHANNEL_UPPER
+        else -> CHANNEL_LOWER
+    }
+
+    /**
+     * The frequency a channel number names: 2.4 GHz channels count from 2407 MHz, 5 GHz channels from
+     * 5000 MHz, and channel 14 is the standard's own exception to both.
+     *
+     * Here so a test can assert what the app is actually asking the driver for, and so the log can
+     * name the frequency rather than a channel number the reader has to convert.
+     */
+    fun frequencyMhzFor(channel: Int): Int = when {
+        channel !in 1..165 -> 0
+        // Channel 14 sits 12 MHz above 13 rather than 5, so the arithmetic does not reach it and
+        // AOSP special-cases it in ScanResult.convertChannelToFrequencyMhzIfSupported for the same
+        // reason. It is Japan-only and 802.11b-only, so operatingChannel() will never return it -
+        // but a converter that quietly answers 2477 is worse than one that refuses. The constant is
+        // P2pChannelPolicy's because that object converts the other way and must agree with this one.
+        channel == CHANNEL_24_GHZ_TOP -> P2pChannelPolicy.CHANNEL_14_MHZ
+        channel <= CHANNEL_24_GHZ_TOP -> 2407 + channel * 5
+        else -> 5000 + channel * 5
+    }
+
+    /** A channel the platform will accept. Outside this it rejects the whole request. */
+    fun isRequestable(channel: Int): Boolean = channel == CHANNEL_UNRESTRICTED || channel in 1..165
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/ProjectionWatchdogPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/ProjectionWatchdogPolicy.kt
@@ -3,8 +3,11 @@ package com.andrerinas.openheadunit.aap
 import com.andrerinas.openheadunit.connection.CommManager
 
 /**
- * Decides when the projection activity's recovery watchdog keeps running and when a black
- * mid-session picture warrants asking the phone for video again.
+ * Decides when the projection activity's recovery watchdog keeps running, when a stopped picture is
+ * worth telling the user about, and when it is worth asking the phone for video again.
+ *
+ * The last two used to be one decision, and separating them is the point of this object: a picture
+ * that has stopped is always worth a recovery request and only sometimes worth an overlay.
  *
  * Extracted because the previous inline check cost the watchdog its life on the first tick of
  * every session: it accepted only [CommManager.ConnectionState.HandshakeComplete], but that state
@@ -25,15 +28,84 @@ object ProjectionWatchdogPolicy {
         state is CommManager.ConnectionState.HandshakeComplete ||
             state is CommManager.ConnectionState.TransportStarted
 
+    /** How long without a rendered frame before the picture stopping is worth reacting to. */
+    const val FRAME_GAP_MS = 10_000L
+
+    /**
+     * How long the whole AAP link must *also* have been silent before a stopped picture is called a
+     * lost connection.
+     *
+     * Android Auto's idle cadence has never been recorded - the phone's `PingRequest` is answered in
+     * `AapControl` without logging anything - so this number is a judgement rather than a
+     * measurement. It is a safe one because the gate is monotonic: if the real cadence is faster
+     * than this the false positive disappears, and if it is slower the behaviour is exactly what
+     * shipped before the gate existed. It can remove a false positive; it cannot add one. The
+     * watchdog logs both gaps so a reporter's next capture replaces the judgement with a number.
+     */
+    const val LINK_QUIET_MS = 10_000L
+
+    /**
+     * Whether a stopped picture should be shown to the user as a lost connection.
+     *
+     * The overlay says "Connection lost", so the connection is what has to be measured. Frames alone
+     * cannot carry that claim: Android Auto stops sending video whenever nothing on screen animates,
+     * which made a paused full-screen music player identical to a dead socket and covered the
+     * projection every 15-30s (issue #852). A real disconnect does not depend on this path at all -
+     * `AapProjectionActivity` shows the same overlay immediately from
+     * [CommManager.ConnectionState.Disconnected] - so what is left here is the narrow case of a
+     * socket that is still up while the phone has gone silent.
+     *
+     * [linkQuietMs] is how long ago the phone last sent anything on any channel; pass
+     * [Long.MAX_VALUE] when it has not sent anything yet, so a session that never started cannot
+     * read as one that stopped.
+     */
+    fun shouldShowReconnecting(frameGapMs: Long, linkQuietMs: Long): Boolean =
+        frameGapMs > FRAME_GAP_MS && linkQuietMs > LINK_QUIET_MS
+
     /**
      * Whether a black mid-session picture warrants asking the phone for video focus again.
-     * Gated on the reconnecting overlay being up, which the watchdog only shows after a 10s
-     * frame gap on a live connection, and paced by [VideoRecoveryPolicy] so a stuck session
-     * asks about once per throttle window rather than on every tick.
+     *
+     * Gated on the picture having stopped, **not** on the overlay being up. The two were the same
+     * condition until the overlay learned to check the link as well, and tying recovery to the
+     * overlay after that would have made an idle-looking stream unrecoverable - which is the exact
+     * failure the watchdog was revived to fix. Asking for video that had simply paused costs one
+     * throttled message and nothing else; not asking for video that really stopped costs the rest of
+     * the session. Paced by [VideoRecoveryPolicy] so a stuck session asks about once per throttle
+     * window rather than on every tick.
      */
     fun shouldRequestVideoFocus(
-        reconnectingOverlayShown: Boolean,
+        pictureStopped: Boolean,
         nowMs: Long,
         lastRequestMs: Long
-    ): Boolean = reconnectingOverlayShown && VideoRecoveryPolicy.canRequestKeyframe(nowMs, lastRequestMs)
+    ): Boolean = pictureStopped && VideoRecoveryPolicy.canRequestKeyframe(nowMs, lastRequestMs)
+
+    /**
+     * Whether the surface the decoder was just handed still has no picture, and is worth nudging for.
+     *
+     * The nudge loop this drives used to be gated on the loading overlay being visible, which made a
+     * cosmetic state decide whether recovery ran at all - and one relaunch in two hid that overlay
+     * before the loop's first tick, because the overlay decision reads a rendered-frame stamp that
+     * the surface handoff zeroes a moment later. The loop does not re-post when it declines, so a
+     * single silent tick ended it for that instance. Measured on a reporter's capture: four
+     * relaunches, alternating, two of them silent for 11.8s and 23s with a black screen and nothing
+     * asking for video.
+     *
+     * The same reasoning as [shouldRequestVideoFocus], which was moved off the overlay for the same
+     * reason. What decides recovery is the picture, not what is drawn over it.
+     *
+     * [warmRelaunchCycleSpent] is the bound. The overlay used to supply one incidentally, being up
+     * only before a session's first frame; without it this would nudge every window forever on a
+     * screen that simply has nothing to draw. Once the escalation has spent its cycle,
+     * [WarmRelaunchKeyframePolicy]'s own throttled nudge takes over and this steps back.
+     *
+     * @param sessionLive see [isSessionLive].
+     * @param surfaceSet whether the decoder has been handed a surface at all yet.
+     * @param renderedSinceSurfaceSet whether any frame has reached the screen on that surface.
+     */
+    fun shouldNudgeForFirstFrame(
+        sessionLive: Boolean,
+        surfaceSet: Boolean,
+        renderedSinceSurfaceSet: Boolean,
+        warmRelaunchCycleSpent: Boolean,
+    ): Boolean = sessionLive && surfaceSet && !renderedSinceSurfaceSet && !warmRelaunchCycleSpent
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/VideoFaultInjector.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/VideoFaultInjector.kt
@@ -20,31 +20,55 @@ package com.andrerinas.openheadunit.aap
  * Off unless explicitly enabled. When it is on, every injected fault is logged, so a log that has
  * been captured with this left on can never be mistaken for a log of a real fault.
  *
- * ### What it cannot reach
+ * ### Where a mode is injected decides what can see it
  *
- * This injector runs in [AapVideo.process], which is **downstream of [FragmentedMessageAudit]** -
- * that check runs in the readers, on the header, before decryption ([AapReadSingleMessage] and
- * [AapReadMultipleMessages] both call `auditFragment` there). Every message the injector pretends
- * never arrived has already been counted by the audit as arriving. So no mode here can produce a
- * framing-audit outcome, and an earlier version of this file said the opposite for all four of them.
- * Hardware measured it: **449 faults injected across the three drop modes, and not one
- * `AapRead:` line attributable to any of them.** (Audit lines did appear in those captures - the
- * connect-time `DELTA_CHANGED` burst that this commit's scaling fix removes - but they landed in the
- * opening seconds, before the injector had dropped anything.) Only [VideoFragmentAssembler]'s
- * counters - `headless=`, `orphan=`, `truncated=` - respond to this injector.
+ * [Stage.ASSEMBLER] modes run in [AapVideo.process], which is **downstream of
+ * [FragmentedMessageAudit]** - that check runs in the readers, on the header, before decryption
+ * ([AapReadSingleMessage] and [AapReadMultipleMessages] both call `auditFragment` there). Every
+ * message such a mode pretends never arrived has already been counted by the audit as arriving, so
+ * no assembler-stage mode can produce a framing-audit outcome. Hardware measured it: **449 faults
+ * injected across the three drop modes, and not one `AapRead:` line attributable to any of them.**
+ * Only [VideoFragmentAssembler]'s counters - `headless=`, `orphan=`, `truncated=` - respond to them.
+ *
+ * [Stage.READER] modes exist because that made one fault untestable. A middle fragment missing from a
+ * run is invisible to [VideoFragmentAssembler] by construction, so the audit is the only thing that
+ * can see it - and an assembler-stage drop cannot exercise the audit, because the audit has already
+ * counted the fragment. A reader-stage mode drops the message before `auditFragment` is called, so
+ * the run really is short of the bytes its first fragment declared. A hardware round measured the
+ * cost of not having one: 37 and 59 injected middle-fragment faults produced zero keyframe requests
+ * and zero escalation activity, because nothing downstream of the reader could tell anything was
+ * missing.
+ *
+ * What that reproduces is a fragment that **never reaches the reassembler**, not one lost in transit.
+ * Nothing can be silently lost in transit here: AAP runs TLS over TCP, and a record that goes missing
+ * takes the session with it rather than leaving a hole - which a round found out by writing this mode
+ * to skip the decrypt as well as the delivery. The distinction matters because the effect on
+ * everything downstream is identical, and the cause is not.
+ *
+ * A mode belongs to exactly one stage and [isActiveAt] is how each site asks. Neither call site
+ * re-derives the condition - two that did drifted apart once already, elsewhere in this package.
  */
-class VideoFaultInjector(private val mode: Mode, rate: Int) {
+class VideoFaultInjector(private val mode: Mode, rate: Int, budget: Int = UNLIMITED_BUDGET) {
+
+    /** Where in the receive path a mode is applied, which decides what can observe the fault. */
+    enum class Stage {
+        /** In [AapVideo.process], after the reader has framed and audited the message. */
+        ASSEMBLER,
+
+        /** In the reader, before `auditFragment` counts the fragment - a fragment that never was. */
+        READER,
+    }
 
     /** What the injector does to the stream. */
-    enum class Mode(val value: Int) {
+    enum class Mode(val value: Int, val stage: Stage) {
         /** Nothing. The only mode a user should ever be in. */
-        OFF(0),
+        OFF(0, Stage.ASSEMBLER),
 
         /**
          * Swallow first fragments. The 8s and 10 behind each one arrive with no run open, so expect
          * `orphan=` on the reassembly summary. Nothing from the framing audit - see the note above.
          */
-        DROP_FIRST_FRAGMENT(1),
+        DROP_FIRST_FRAGMENT(1, Stage.ASSEMBLER),
 
         /**
          * Swallow middle fragments.
@@ -53,21 +77,24 @@ class VideoFaultInjector(private val mode: Mode, rate: Int) {
          * some middles, a last, in order - so the frame is assembled with a hole in it and decoded
          * as though it were whole, and the reassembly summary stays at zero.
          *
-         * **Nothing reports it, by construction.** [FragmentedMessageAudit] is the check that could,
-         * but it sits upstream of this injector and has already counted the fragment this mode
-         * discards. That makes this mode a test of the *decoder's* tolerance of a holed access unit
-         * and nothing else - and hardware found it has none: at one fault in three the
+         * **Nothing reports it, and that is the point of keeping this mode.** [FragmentedMessageAudit]
+         * is the check that could, but it sits upstream of this stage and has already counted the
+         * fragment this mode discards. So this is a test of the *decoder's* tolerance of a holed
+         * access unit and nothing else - and hardware found it has none: at one fault in three the
          * decoder stopped emitting frames entirely, burned its four-restart budget in 33 seconds and
-         * never recovered. Reproducing the audit's own detection needs a fault injected in the
-         * reader, which this class deliberately is not.
+         * never recovered.
+         *
+         * Use [DROP_MIDDLE_FRAGMENT_IN_READER] to exercise the detection instead. The two are worth
+         * keeping apart: this one answers "what does the decoder do with a hole", that one answers
+         * "does anything notice the hole", and a round that confuses them measures neither.
          */
-        DROP_MIDDLE_FRAGMENT(2),
+        DROP_MIDDLE_FRAGMENT(2, Stage.ASSEMBLER),
 
         /**
          * Swallow last fragments. The run stays open until the next 9 or 11, so expect `truncated=`
          * on the reassembly summary. Nothing from the framing audit - see the note above.
          */
-        DROP_LAST_FRAGMENT(3),
+        DROP_LAST_FRAGMENT(3, Stage.ASSEMBLER),
 
         /**
          * Present a first fragment as having no start code at either offset, which is the exact
@@ -78,7 +105,26 @@ class VideoFaultInjector(private val mode: Mode, rate: Int) {
          * the run genuinely is complete, every byte having arrived, so this is the one mode where
          * that silence would be correct even if the injector could reach it.
          */
-        HIDE_START_CODE(4);
+        HIDE_START_CODE(4, Stage.ASSEMBLER),
+
+        /**
+         * Swallow middle fragments **in the reader**, before the framing audit counts them.
+         *
+         * The same loss as [DROP_MIDDLE_FRAGMENT] injected one step earlier, and the step is the
+         * whole difference: here the run really is short of the bytes its first fragment declared,
+         * so [FragmentedMessageAudit] sees a delta no fragment count explains and reports
+         * `DELTA_CHANGED`. That is the only signal in the app for a middle fragment missing from a
+         * run, and this is the only way to produce it on a healthy rig.
+         *
+         * Everything downstream sees exactly what a holed access unit looks like: the reassembler
+         * still finds a first, some middles and a last in order, and still hands the decoder a frame
+         * with a hole in it. So this mode exercises the detection *and* the damage together.
+         *
+         * The message is dropped after it has been decrypted, never before - see
+         * `AapRead.Base.shouldDropForFaultInjection` for the session this mode killed by getting
+         * that backwards.
+         */
+        DROP_MIDDLE_FRAGMENT_IN_READER(5, Stage.READER);
 
         companion object {
             fun fromInt(value: Int): Mode? = entries.firstOrNull { it.value == value }
@@ -100,11 +146,29 @@ class VideoFaultInjector(private val mode: Mode, rate: Int) {
     /** Faults are applied to one in this many matching messages. */
     val rate: Int = rate.coerceIn(MIN_RATE, MAX_RATE)
 
+    /**
+     * How many faults this injector will inject before it stops, or [UNLIMITED_BUDGET] for no limit.
+     *
+     * Continuous injection measures one thing: that a stream still being broken stays broken. It
+     * cannot measure the thing that matters more, which is whether the picture comes back once the
+     * loss stops - and every recovery lever in the app is bounded per session, so a run with no end
+     * to the faults spends them all and ends wedged whatever the code does. A budget puts both in
+     * one capture: the damage, then the repair, with the moment between them in the log.
+     */
+    val budget: Int = budget.coerceAtLeast(UNLIMITED_BUDGET)
+
     private var matching = 0L
     private var injected = 0L
 
     /** How many faults have been injected so far, for the log. */
     val injectedCount: Long get() = injected
+
+    /**
+     * Whether the budget is spent and the stream is being left alone from here.
+     *
+     * The caller says so once, and that line is what a recovery measurement is timed from.
+     */
+    val budgetSpent: Boolean get() = budget != UNLIMITED_BUDGET && injected >= budget
 
     /**
      * How many messages the current mode has targeted so far - the denominator [injectedCount] is a
@@ -123,11 +187,22 @@ class VideoFaultInjector(private val mode: Mode, rate: Int) {
      * screen. Without the candidate count that reads as "the setting did not take" rather than "the
      * stream did not fragment", and the only way to tell was to read this file.
      */
-    fun describe(): String =
-        "$mode 1-in-$rate, $matching candidates seen, $injected injected"
+    fun describe(): String {
+        val cap = if (budget == UNLIMITED_BUDGET) "no budget" else "budget $injected/$budget"
+        return "$mode 1-in-$rate, $matching candidates seen, $injected injected, $cap"
+    }
 
     /** Whether this injector will ever do anything. */
     val isActive: Boolean get() = mode != Mode.OFF
+
+    /**
+     * Whether this injector acts at [stage].
+     *
+     * Both injection sites ask this rather than comparing modes themselves, so a mode can never be
+     * applied twice - once in the reader and again in the assembler - or added to one site and
+     * forgotten at the other.
+     */
+    fun isActiveAt(stage: Stage): Boolean = isActive && mode.stage == stage
 
     /**
      * Decides what to do with a message carrying [flags].
@@ -139,7 +214,10 @@ class VideoFaultInjector(private val mode: Mode, rate: Int) {
     fun effectFor(flags: Int): Effect {
         val target = targetFlag(mode) ?: return Effect.NONE
         if (flags != target) return Effect.NONE
+        // Counted even once the budget is spent, so the summary keeps saying how much of the stream
+        // went by untouched - which is what the recovery half of a bounded run is measured against.
         matching++
+        if (budgetSpent) return Effect.NONE
         if (matching % rate != 0L) return Effect.NONE
         injected++
         return when (mode) {
@@ -152,6 +230,9 @@ class VideoFaultInjector(private val mode: Mode, rate: Int) {
     companion object {
         /** How often [describe] is worth repeating while a mode is active. */
         const val SUMMARY_INTERVAL_MS = 15_000L
+
+        /** No limit on how many faults are injected: the injector runs for the whole session. */
+        const val UNLIMITED_BUDGET = 0
 
         /** One in one would break every frame and never reach a picture at all. */
         const val MIN_RATE = 2
@@ -169,7 +250,8 @@ class VideoFaultInjector(private val mode: Mode, rate: Int) {
         fun targetFlag(mode: Mode): Int? = when (mode) {
             Mode.OFF -> null
             Mode.DROP_FIRST_FRAGMENT, Mode.HIDE_START_CODE -> VideoFragmentAssembler.FLAG_FIRST
-            Mode.DROP_MIDDLE_FRAGMENT -> VideoFragmentAssembler.FLAG_MIDDLE
+            Mode.DROP_MIDDLE_FRAGMENT,
+            Mode.DROP_MIDDLE_FRAGMENT_IN_READER -> VideoFragmentAssembler.FLAG_MIDDLE
             Mode.DROP_LAST_FRAGMENT -> VideoFragmentAssembler.FLAG_LAST
         }
     }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/VideoFaultInjector.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/VideoFaultInjector.kt
@@ -1,0 +1,176 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Deliberately breaks the video fragment stream, so the reassembler's failure paths can be exercised
+ * on a head unit that is working correctly.
+ *
+ * The artifact reports this exists for - a melting or smearing picture - come from units we do not
+ * have, and the conditions that cause it are properties of the link rather than of the app: a
+ * fragment that never arrives, or a first fragment whose payload does not start where the protocol
+ * says it should. A healthy rig produces none of them, which is why three rounds of hardware testing
+ * on the decoder measured `dropped=0` and never reproduced the bug at all.
+ *
+ * This turns that around. Injecting the exact loss pattern reproduces each failure mode on any unit,
+ * deterministically, so "the fix works" becomes something that can be measured rather than inferred
+ * from a reporter's next drive.
+ *
+ * Deterministic on purpose: every Nth matching message rather than a random draw, so two builds
+ * given the same stream see the same faults and an A/B comparison means something.
+ *
+ * Off unless explicitly enabled. When it is on, every injected fault is logged, so a log that has
+ * been captured with this left on can never be mistaken for a log of a real fault.
+ *
+ * ### What it cannot reach
+ *
+ * This injector runs in [AapVideo.process], which is **downstream of [FragmentedMessageAudit]** -
+ * that check runs in the readers, on the header, before decryption ([AapReadSingleMessage] and
+ * [AapReadMultipleMessages] both call `auditFragment` there). Every message the injector pretends
+ * never arrived has already been counted by the audit as arriving. So no mode here can produce a
+ * framing-audit outcome, and an earlier version of this file said the opposite for all four of them.
+ * Hardware measured it: **449 faults injected across the three drop modes, and not one
+ * `AapRead:` line attributable to any of them.** (Audit lines did appear in those captures - the
+ * connect-time `DELTA_CHANGED` burst that this commit's scaling fix removes - but they landed in the
+ * opening seconds, before the injector had dropped anything.) Only [VideoFragmentAssembler]'s
+ * counters - `headless=`, `orphan=`, `truncated=` - respond to this injector.
+ */
+class VideoFaultInjector(private val mode: Mode, rate: Int) {
+
+    /** What the injector does to the stream. */
+    enum class Mode(val value: Int) {
+        /** Nothing. The only mode a user should ever be in. */
+        OFF(0),
+
+        /**
+         * Swallow first fragments. The 8s and 10 behind each one arrive with no run open, so expect
+         * `orphan=` on the reassembly summary. Nothing from the framing audit - see the note above.
+         */
+        DROP_FIRST_FRAGMENT(1),
+
+        /**
+         * Swallow middle fragments.
+         *
+         * The interesting one: the run still looks intact to [VideoFragmentAssembler] - a first,
+         * some middles, a last, in order - so the frame is assembled with a hole in it and decoded
+         * as though it were whole, and the reassembly summary stays at zero.
+         *
+         * **Nothing reports it, by construction.** [FragmentedMessageAudit] is the check that could,
+         * but it sits upstream of this injector and has already counted the fragment this mode
+         * discards. That makes this mode a test of the *decoder's* tolerance of a holed access unit
+         * and nothing else - and hardware found it has none: at one fault in three the
+         * decoder stopped emitting frames entirely, burned its four-restart budget in 33 seconds and
+         * never recovered. Reproducing the audit's own detection needs a fault injected in the
+         * reader, which this class deliberately is not.
+         */
+        DROP_MIDDLE_FRAGMENT(2),
+
+        /**
+         * Swallow last fragments. The run stays open until the next 9 or 11, so expect `truncated=`
+         * on the reassembly summary. Nothing from the framing audit - see the note above.
+         */
+        DROP_LAST_FRAGMENT(3),
+
+        /**
+         * Present a first fragment as having no start code at either offset, which is the exact
+         * shape of the case that used to be assembled headless and silently. The bytes are not
+         * touched - only what the reassembler is told about them - because the buffer is shared.
+         *
+         * Expect `headless=` on the reassembly summary. Nothing from the framing audit - and here
+         * the run genuinely is complete, every byte having arrived, so this is the one mode where
+         * that silence would be correct even if the injector could reach it.
+         */
+        HIDE_START_CODE(4);
+
+        companion object {
+            fun fromInt(value: Int): Mode? = entries.firstOrNull { it.value == value }
+        }
+    }
+
+    /** What the caller should do with the message it just asked about. */
+    enum class Effect {
+        /** Handle it normally. */
+        NONE,
+
+        /** Behave as though it never arrived. */
+        DROP,
+
+        /** Handle it, but as a fragment whose payload starts at neither known offset. */
+        HIDE_START_CODE,
+    }
+
+    /** Faults are applied to one in this many matching messages. */
+    val rate: Int = rate.coerceIn(MIN_RATE, MAX_RATE)
+
+    private var matching = 0L
+    private var injected = 0L
+
+    /** How many faults have been injected so far, for the log. */
+    val injectedCount: Long get() = injected
+
+    /**
+     * How many messages the current mode has targeted so far - the denominator [injectedCount] is a
+     * share of, and the number that says whether a rate is doing anything.
+     */
+    val matchingCount: Long get() = matching
+
+    /**
+     * One line saying what the injector is set to and what it has actually managed to do.
+     *
+     * Worth printing periodically rather than only per fault, because the interesting failure is the
+     * one where nothing is injected: [rate] counts the messages carrying the flag this mode attacks,
+     * and how often a frame fragments at all is a property of what the phone happens to be
+     * projecting. A five-minute run at one in twenty produced zero faults on a rig where an earlier
+     * run at one in three produced ten in ninety seconds - same code, same setting, different
+     * screen. Without the candidate count that reads as "the setting did not take" rather than "the
+     * stream did not fragment", and the only way to tell was to read this file.
+     */
+    fun describe(): String =
+        "$mode 1-in-$rate, $matching candidates seen, $injected injected"
+
+    /** Whether this injector will ever do anything. */
+    val isActive: Boolean get() = mode != Mode.OFF
+
+    /**
+     * Decides what to do with a message carrying [flags].
+     *
+     * Counts only the messages the current mode targets, so the rate means "one in N of the flag we
+     * are attacking" rather than one in N of all video traffic - at three fragments per frame the
+     * two differ by a factor of three, and the brief has to be able to say how often a fault lands.
+     */
+    fun effectFor(flags: Int): Effect {
+        val target = targetFlag(mode) ?: return Effect.NONE
+        if (flags != target) return Effect.NONE
+        matching++
+        if (matching % rate != 0L) return Effect.NONE
+        injected++
+        return when (mode) {
+            Mode.HIDE_START_CODE -> Effect.HIDE_START_CODE
+            Mode.OFF -> Effect.NONE
+            else -> Effect.DROP
+        }
+    }
+
+    companion object {
+        /** How often [describe] is worth repeating while a mode is active. */
+        const val SUMMARY_INTERVAL_MS = 15_000L
+
+        /** One in one would break every frame and never reach a picture at all. */
+        const val MIN_RATE = 2
+
+        const val MAX_RATE = 100000
+
+        /**
+         * One in 300, which at the ~50 messages per second a healthy link carries is a fault every
+         * few seconds - often enough to measure in a five-minute run, rare enough that the picture
+         * in between is a fair sample of normal behaviour.
+         */
+        const val DEFAULT_RATE = 300
+
+        /** Which fragment flag a mode attacks, or null if it attacks nothing. */
+        fun targetFlag(mode: Mode): Int? = when (mode) {
+            Mode.OFF -> null
+            Mode.DROP_FIRST_FRAGMENT, Mode.HIDE_START_CODE -> VideoFragmentAssembler.FLAG_FIRST
+            Mode.DROP_MIDDLE_FRAGMENT -> VideoFragmentAssembler.FLAG_MIDDLE
+            Mode.DROP_LAST_FRAGMENT -> VideoFragmentAssembler.FLAG_LAST
+        }
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/VideoFaultReporter.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/VideoFaultReporter.kt
@@ -1,0 +1,92 @@
+package com.andrerinas.openheadunit.aap
+
+import android.os.SystemClock
+import com.andrerinas.openheadunit.utils.AppLog
+
+/**
+ * The log an active [VideoFaultInjector] owes its reader.
+ *
+ * Three lines, all of them load on a hardware round: the announcement that the stream is being
+ * broken on purpose, the per-fault line, and a periodic summary. A fourth, the budget-spent line,
+ * marks the moment the injector stops - which is where a recovery measurement is timed from.
+ *
+ * This exists as its own class because the injector is now applied at two stages
+ * ([VideoFaultInjector.Stage]) and both need identical lines. Two copies would be two chances for
+ * the wording to drift, and every brief and results document on this thread greps these strings:
+ * `FAULT INJECTED`, `fault injection - `, `fault injection budget spent after`. They are an
+ * interface, not prose, and changing one silently invalidates the rounds that quoted it.
+ *
+ * [prefix] names the site, so a capture says where a fault was injected as well as that it was.
+ */
+class VideoFaultReporter(private val prefix: String) {
+
+    /** Stamped at construction so the first summary is one interval in, not on the first message. */
+    private var lastSummaryMs = SystemClock.elapsedRealtime()
+
+    /** The budget-spent line is a moment, not a state, so it is said once. */
+    private var reportedBudgetSpent = false
+
+    /**
+     * Says the injector is on, at construction of the injector rather than on its first fault.
+     *
+     * A run that injects nothing is the interesting failure, and it has to be distinguishable from a
+     * run where the setting never took. This line is the half of that answer that does not depend on
+     * the stream fragmenting at all.
+     */
+    fun announce(injector: VideoFaultInjector) {
+        AppLog.w(
+            "$prefix: FAULT INJECTION IS ON - %s. The video stream is being corrupted on purpose; " +
+                "this log does not show a real fault.",
+            injector.describe()
+        )
+    }
+
+    /**
+     * Reports one injected fault, then the summary lines that give it context.
+     *
+     * Called for every message the injector was asked about, faulted or not, because the summary and
+     * the budget-spent line are about the stream going by rather than about any one message.
+     */
+    fun onMessage(injector: VideoFaultInjector, effect: VideoFaultInjector.Effect, flags: Int, len: Int) {
+        if (effect != VideoFaultInjector.Effect.NONE) {
+            AppLog.w(
+                "$prefix: FAULT INJECTED (#%d of %d candidates): %s on flag %d, len=%d",
+                injector.injectedCount, injector.matchingCount, effect, flags, len
+            )
+        }
+        reportBudgetSpentOnce(injector)
+        reportProgress(injector)
+    }
+
+    /**
+     * Marks the moment the injector stops breaking the stream.
+     *
+     * A bounded run is two measurements and this line is the boundary: everything before it is the
+     * damage, everything after it is how long the picture took to come back. It lands immediately
+     * after the last `FAULT INJECTED` line and exists to say that that one *was* the last - which a
+     * reader counting faults against a setting cannot otherwise know until the capture ends.
+     */
+    private fun reportBudgetSpentOnce(injector: VideoFaultInjector) {
+        if (reportedBudgetSpent || !injector.budgetSpent) return
+        reportedBudgetSpent = true
+        AppLog.w(
+            "$prefix: fault injection budget spent after %d faults - the stream is clean from here",
+            injector.injectedCount
+        )
+    }
+
+    /**
+     * Says periodically what the injector has had to work with, so a run that injects nothing says
+     * so rather than looking like a run where the setting never took.
+     *
+     * See [VideoFaultInjector.describe] for why the candidate count matters as much as the fault
+     * count: how often a frame fragments at all is a property of what the phone is projecting, and
+     * two rounds at the same rate have differed by a factor of forty-five because of it.
+     */
+    private fun reportProgress(injector: VideoFaultInjector) {
+        val now = SystemClock.elapsedRealtime()
+        if (now - lastSummaryMs < VideoFaultInjector.SUMMARY_INTERVAL_MS) return
+        lastSummaryMs = now
+        AppLog.w("$prefix: fault injection - %s", injector.describe())
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/VideoFragmentAssembler.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/VideoFragmentAssembler.kt
@@ -1,0 +1,211 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * The rules for turning a stream of AAP video messages back into whole access units.
+ *
+ * Video arrives either complete in one message (flags 11) or split across a run of them: 9 first,
+ * 8 in the middle, 10 last. Reassembly is only correct while that run is intact, and the stream
+ * gives us three ways for it not to be - a run that stops before its 10, a fragment that arrives
+ * with no run open, and a first fragment whose payload does not begin with a start code at either
+ * offset the protocol uses. All three end with the codec being handed something that is not a
+ * decodable access unit, which is what a smeared or melting picture is.
+ *
+ * This object holds the ordering rules and nothing else: no buffer, no logging, no clock. That is
+ * what makes it testable without a device, and the transition table in its test is the record of
+ * what each of the ten reachable (flag, state) pairs is supposed to do. The I/O - the reassembly
+ * buffer, the decoder call, the keyframe request and its throttle - stays in [AapVideo].
+ */
+class VideoFragmentAssembler {
+
+    /** What [AapVideo] should do with the message just handed to [onMessage]. */
+    sealed class Action {
+        /** Hand the message body to the decoder as-is, starting at [payloadOffset]. */
+        data class DecodeWhole(val payloadOffset: Int) : Action()
+
+        /** Start a fresh assembly with the message body from [payloadOffset] onward. */
+        data class BeginAssembly(val payloadOffset: Int) : Action()
+
+        /** Append the whole message body to the assembly in progress. */
+        object Append : Action()
+
+        /** Append the whole message body, then hand the assembled frame to the decoder. */
+        object AppendAndDecode : Action()
+
+        /**
+         * Throw this message away.
+         *
+         * [consumed] mirrors what `AapVideo.process` has always returned for the case, because the
+         * caller uses it to decide whether to send a media ack and whether to try the other channel
+         * handlers. Getting it wrong changes protocol behaviour, so it is carried explicitly rather
+         * than inferred.
+         */
+        data class Discard(val consumed: Boolean) : Action()
+    }
+
+    /**
+     * A way the stream broke. Every one of these means the picture is about to drift, so each is
+     * counted and each asks for a keyframe - subject to [VideoRecoveryPolicy]'s throttle, applied
+     * by the caller.
+     */
+    enum class Anomaly {
+        /** A 9 or 11 arrived while a run was still open: the previous frame lost its tail. */
+        TRUNCATED_PREVIOUS,
+
+        /** An 8 or 10 arrived with no run open: this frame lost its head. */
+        ORPHANED_FRAGMENT,
+
+        /**
+         * A first fragment whose payload begins with no start code at offset 10 or offset 2.
+         *
+         * This is the one that used to be silent. The run stayed open, so the 8s and 10 behind it
+         * were appended and assembled without it, and the codec was fed an access unit missing its
+         * own beginning - with nothing logged and no keyframe asked for. Closing the run here turns
+         * those followers into [ORPHANED_FRAGMENT]s, which are discarded instead.
+         */
+        HEADLESS_FIRST_FRAGMENT,
+
+        /** The frame grew past the reassembly buffer's ceiling. Reported by the caller. */
+        OVERFLOW,
+    }
+
+    /** [Action] plus the anomaly, if any, that the caller should count and log. */
+    data class Decision(val action: Action, val anomaly: Anomaly? = null)
+
+    /** Whether a run of fragments is open, i.e. a 9 has been seen and its 10 has not. */
+    var isAssembling: Boolean = false
+        private set
+
+    /**
+     * Whether the frame being assembled is already known to be unusable.
+     *
+     * Scoped to the current frame only, deliberately. There is no lockout that holds every
+     * subsequent P-frame back until a keyframe is positively identified - one existed, and because
+     * nothing could reliably tell a keyframe from a P-frame for every codec the app negotiates, it
+     * could latch for the rest of the session and freeze the picture with the connection still
+     * healthy.
+     */
+    var isFrameCorrupt: Boolean = false
+        private set
+
+    private val counts = IntArray(Anomaly.entries.size)
+
+    /**
+     * Applies one video message to the state machine.
+     *
+     * [payloadStartsAt10] and [payloadStartsAt2] are the two offsets the protocol puts a frame at -
+     * 10 for a timestamp indication, 2 for a media indication - and each is true only when a start
+     * code is present there *and* there is payload behind it. The caller resolves them because it
+     * owns the bytes; which one wins, and what happens when neither does, is decided here.
+     */
+    fun onMessage(flags: Int, payloadStartsAt10: Boolean, payloadStartsAt2: Boolean): Decision {
+        var anomaly: Anomaly? = null
+
+        when (flags) {
+            FLAG_SINGLE, FLAG_FIRST -> {
+                if (isAssembling) anomaly = Anomaly.TRUNCATED_PREVIOUS
+                isAssembling = false
+                isFrameCorrupt = false
+            }
+            FLAG_MIDDLE, FLAG_LAST -> {
+                if (!isAssembling) {
+                    anomaly = Anomaly.ORPHANED_FRAGMENT
+                    isFrameCorrupt = true
+                }
+                if (flags == FLAG_LAST) isAssembling = false
+            }
+            else -> return Decision(Action.Discard(consumed = false))
+        }
+
+        anomaly?.let { counts[it.ordinal]++ }
+
+        val payloadOffset = when {
+            payloadStartsAt10 -> OFFSET_TIMESTAMP_INDICATION
+            payloadStartsAt2 -> OFFSET_MEDIA_INDICATION
+            else -> null
+        }
+
+        return when (flags) {
+            FLAG_SINGLE -> {
+                if (payloadOffset != null) {
+                    Decision(Action.DecodeWhole(payloadOffset), anomaly)
+                } else {
+                    // A complete frame we cannot find the start of is simply dropped. Nothing was
+                    // assembled and nothing follows it, so the stream resumes on the next message.
+                    Decision(Action.Discard(consumed = false), anomaly)
+                }
+            }
+
+            FLAG_FIRST -> {
+                if (payloadOffset != null) {
+                    isAssembling = true
+                    Decision(Action.BeginAssembly(payloadOffset), anomaly)
+                } else {
+                    // Leave the run closed. See Anomaly.HEADLESS_FIRST_FRAGMENT.
+                    isFrameCorrupt = true
+                    counts[Anomaly.HEADLESS_FIRST_FRAGMENT.ordinal]++
+                    Decision(Action.Discard(consumed = false), Anomaly.HEADLESS_FIRST_FRAGMENT)
+                }
+            }
+
+            FLAG_MIDDLE -> {
+                if (isFrameCorrupt) Decision(Action.Discard(consumed = true), anomaly)
+                else Decision(Action.Append, anomaly)
+            }
+
+            // FLAG_LAST. Anything outside the four payload flags returned above, so the else is
+            // only reachable for 10 - it is an else rather than a branch to keep the when
+            // exhaustive as an expression.
+            else -> {
+                if (isFrameCorrupt) Decision(Action.Discard(consumed = true), anomaly)
+                else Decision(Action.AppendAndDecode, anomaly)
+            }
+        }
+    }
+
+    /**
+     * Records that the frame being assembled outgrew the reassembly buffer, and invalidates it.
+     *
+     * Separate from [onMessage] because it is only discovered once the caller tries to make room.
+     */
+    fun onOverflow(): Anomaly {
+        isFrameCorrupt = true
+        counts[Anomaly.OVERFLOW.ordinal]++
+        return Anomaly.OVERFLOW
+    }
+
+    /** How many times [anomaly] has been seen since the last [resetCounts]. */
+    fun countOf(anomaly: Anomaly): Int = counts[anomaly.ordinal]
+
+    /** Whether anything at all has been counted since the last [resetCounts]. */
+    fun hasAnomalies(): Boolean = counts.any { it != 0 }
+
+    /** Zeroes the counters, leaving the assembly state alone. For periodic reporting. */
+    fun resetCounts() = counts.fill(0)
+
+    /** Returns the machine to its start state. For a new session. */
+    fun reset() {
+        isAssembling = false
+        isFrameCorrupt = false
+        resetCounts()
+    }
+
+    companion object {
+        /** A whole frame in one message. */
+        const val FLAG_SINGLE = 11
+
+        /** The first fragment of a frame. */
+        const val FLAG_FIRST = 9
+
+        /** A fragment that is neither the first nor the last. */
+        const val FLAG_MIDDLE = 8
+
+        /** The last fragment of a frame. */
+        const val FLAG_LAST = 10
+
+        /** Payload offset for a timestamp indication: 2 bytes of message type, 8 of timestamp. */
+        const val OFFSET_TIMESTAMP_INDICATION = 10
+
+        /** Payload offset for a media indication or a config message: 2 bytes of message type. */
+        const val OFFSET_MEDIA_INDICATION = 2
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/WarmRelaunchKeyframePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/WarmRelaunchKeyframePolicy.kt
@@ -116,9 +116,9 @@ object WarmRelaunchKeyframePolicy {
      * @param transportStarted whether the AAP session is in its steady state. Nothing can be sent
      *   otherwise, and a handshake in progress will produce sink setup on its own.
      * @param msSinceSurfaceSet age of the current surface.
-     * @param msSincePhoneBytes age of the last video bytes from the phone. A phone that has stopped
-     *   sending has paused the stream deliberately; the reconnecting overlay owns that case.
-     * @param phoneAliveThresholdMs how recent [msSincePhoneBytes] must be to count as streaming.
+     * @param msSinceLinkActivity age of the last AAP message of any kind from the phone - the whole
+     *   link, not the video channel. See the gate below for why the distinction decides this policy.
+     * @param linkQuietThresholdMs how long that may be before the phone counts as gone.
      * @param cycleAlreadySpent whether this surface has already had its one focus cycle.
      * @param msSinceLastRequest age of the last keyframe request of any kind.
      */
@@ -127,8 +127,8 @@ object WarmRelaunchKeyframePolicy {
         renderedSinceSurfaceSet: Boolean,
         transportStarted: Boolean,
         msSinceSurfaceSet: Long,
-        msSincePhoneBytes: Long,
-        phoneAliveThresholdMs: Long,
+        msSinceLinkActivity: Long,
+        linkQuietThresholdMs: Long,
         cycleAlreadySpent: Boolean,
         msSinceLastRequest: Long
     ): Action {
@@ -137,8 +137,18 @@ object WarmRelaunchKeyframePolicy {
         if (renderedSinceSurfaceSet) return Action.NONE
         // A cold start has never rendered, so there is no "was working a moment ago" to restore.
         if (!sessionHasRendered) return Action.NONE
-        // The phone has stopped sending. A focus cycle cannot fix a stream that is paused upstream.
-        if (msSincePhoneBytes > phoneAliveThresholdMs) return Action.NONE
+        // The phone is gone. Nothing to ask, and the reconnecting overlay owns that case.
+        //
+        // This used to read the age of the last *video* bytes, against a 1.5s window, on the
+        // reasoning that a focus cycle cannot fix a stream paused upstream. Both halves were wrong.
+        // Android Auto sends no video at all while nothing on screen animates - the substance of the
+        // idle-screen work elsewhere in this package - so on a paused full-screen player the gate
+        // shuts within seconds and stays shut, taking the escalation with it. And a reporter's
+        // capture has the cycle repairing exactly that stream: paused upstream for minutes, keyframe
+        // 0.68s after the release, picture 0.70s.
+        //
+        // What the gate is for is a link that has gone away, and the app has that signal directly.
+        if (msSinceLinkActivity > linkQuietThresholdMs) return Action.NONE
         // Give the surface the healthy path's own worst case before escalating.
         if (msSinceSurfaceSet < ESCALATE_AFTER_SURFACE_MS) return Action.NONE
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/WirelessServerRestartPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/WirelessServerRestartPolicy.kt
@@ -1,0 +1,132 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * Whether the TCP server the phone is told to dial should be started, left alone, or rebuilt.
+ *
+ * The server is one object held in a field, and the bind happens asynchronously inside a coroutine
+ * it launches. That split is where the bug lives: a bind that throws, or an accept loop that exits,
+ * leaves the object assigned to the field with its listening flag false. The old guard was
+ * `if (wirelessServer != null) return`, which reads that as "already running" and returns. Nothing
+ * rebinds after that, and the only thing that clears the field is a full mode re-initialisation.
+ *
+ * What the user sees is the whole of the failure: the head unit hosts its network, wakes the phone
+ * over Bluetooth, hands out credentials, and the phone joins and finds nothing on the port. The
+ * handshake aborts, the phone is woken again seconds later, and it repeats until someone changes a
+ * setting.
+ *
+ * So "assigned" and "working" have to be separate questions, and the answer to a dead server has to
+ * be a rebuild. The rebuild then needs a bound, because the caller is a handshake that retries about
+ * every four seconds: without one, a port that cannot be bound at all turns into a rebuild loop that
+ * is worse than the stall it replaces.
+ */
+object WirelessServerRestartPolicy {
+
+    /**
+     * How long to wait before another rebuild after one has been attempted.
+     *
+     * Above the handshake's own retry cadence on purpose. A phone that keeps arriving must not be
+     * able to drive one rebuild per arrival; the point of a rebuild is to recover from a transient
+     * bind failure, and a transient failure clears on the first or second attempt.
+     */
+    const val REBUILD_COOLDOWN_MS = 10_000L
+
+    /** Rebuilds allowed in one window before the answer becomes "this is not going to work". */
+    const val MAX_REBUILDS_PER_WINDOW = 3
+
+    /** The window those rebuilds are counted in. Cleared whenever a bind succeeds. */
+    const val REBUILD_WINDOW_MS = 60_000L
+
+    enum class Action {
+        /** Already bound and accepting. Do nothing. */
+        NO_OP,
+
+        /** Nothing has been created yet. Create it. */
+        START,
+
+        /**
+         * An instance exists and its coroutine is still running, but the port is not bound yet.
+         *
+         * Distinct from [REBUILD] and the distinction is load-bearing: the bind is retried inside
+         * the coroutine, so an instance can legitimately be assigned and not listening for a second
+         * or two. Reading that as dead would tear down a server that was about to succeed, and the
+         * replacement would then race the original's socket for the same port.
+         */
+        AWAIT,
+
+        /** An instance exists, its coroutine has ended, and it never bound. Replace it. */
+        REBUILD,
+
+        /** A rebuild is due but too soon, or too many have been tried. Do nothing this time. */
+        BACKOFF,
+    }
+
+    /**
+     * @param assigned whether the server field currently holds an instance.
+     * @param alive whether that instance's coroutine is still running (`job?.isActive`). This is
+     *   what separates a bind in progress from one that died, which the listening flag alone
+     *   cannot do, and it is the reason the old guard could never self-heal.
+     * @param listening whether that instance reports its port bound.
+     * @param nowMs monotonic clock, `SystemClock.elapsedRealtime()` at the call site.
+     * @param sessionBusy whether a projection session is already up. A live session arrived over
+     *   this very socket, so replacing it can only do harm.
+     * @param lastRebuildAtMs when a rebuild was last attempted, or 0 if never.
+     * @param rebuildsInWindow how many rebuilds have been attempted since the window opened.
+     * @param windowStartedAtMs when the current window opened, or 0 if none is open.
+     */
+    fun decide(
+        assigned: Boolean,
+        alive: Boolean,
+        listening: Boolean,
+        nowMs: Long,
+        sessionBusy: Boolean = false,
+        lastRebuildAtMs: Long,
+        rebuildsInWindow: Int,
+        windowStartedAtMs: Long,
+    ): Action {
+        if (assigned && listening) return Action.NO_OP
+        if (!assigned) return Action.START
+        if (alive) return Action.AWAIT
+        if (sessionBusy) return Action.NO_OP
+
+        // Assigned, not listening, and its coroutine has ended: it is dead and nothing else will
+        // revive it. The cooldown is for the port that refuses to bind at all.
+        if (lastRebuildAtMs > 0L && nowMs - lastRebuildAtMs < REBUILD_COOLDOWN_MS) return Action.BACKOFF
+        if (windowIsOpen(nowMs, windowStartedAtMs) && rebuildsInWindow >= MAX_REBUILDS_PER_WINDOW) {
+            return Action.BACKOFF
+        }
+        return Action.REBUILD
+    }
+
+    /** True while [windowStartedAtMs] is recent enough for its rebuild count to still apply. */
+    fun windowIsOpen(nowMs: Long, windowStartedAtMs: Long): Boolean =
+        windowStartedAtMs > 0L && nowMs - windowStartedAtMs < REBUILD_WINDOW_MS
+
+    /**
+     * The rebuild count to carry forward after an attempt at [nowMs].
+     *
+     * A window that has aged out restarts at one rather than continuing to climb, so a unit that
+     * fails once an hour is never talked out of trying again.
+     */
+    fun nextRebuildCount(nowMs: Long, windowStartedAtMs: Long, rebuildsInWindow: Int): Int =
+        if (windowIsOpen(nowMs, windowStartedAtMs)) rebuildsInWindow + 1 else 1
+
+    /** The window start to carry forward after an attempt at [nowMs]. */
+    fun nextWindowStart(nowMs: Long, windowStartedAtMs: Long): Long =
+        if (windowIsOpen(nowMs, windowStartedAtMs)) windowStartedAtMs else nowMs
+
+    /**
+     * Why a decision came out the way it did, for the log.
+     *
+     * The reason is the point of this whole change. Before it, a server that was never started and
+     * one that was started and silently skipped produced identical logs, which is to say no log at
+     * all, and two complete reporter captures could not be told apart.
+     */
+    fun describe(action: Action, assigned: Boolean, listening: Boolean): String = when (action) {
+        Action.NO_OP -> if (listening) "already listening" else "a session is already running on it"
+        Action.START -> "no server yet"
+        Action.AWAIT -> "a server is starting and has not finished binding its port"
+        Action.REBUILD ->
+            if (assigned && !listening) "a server exists but its port is not bound" else "restarting"
+        Action.BACKOFF -> "the port would not bind on the last attempt, waiting before trying again"
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/ServiceDiscoveryResponse.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/ServiceDiscoveryResponse.kt
@@ -101,6 +101,7 @@ class ServiceDiscoveryResponse(private val context: Context)
                     mediaSinkServiceBuilder.availableWhileInCall = true
 
                     AppLog.i("[ServiceDiscovery] NegotiatedResolution is: ${HeadUnitScreenConfig.getNegotiatedWidth()}x${HeadUnitScreenConfig.getNegotiatedHeight()}")
+                    logNegotiatedCodecCapability(effectiveCodec, settings)
                     AppLog.i("[ServiceDiscovery] Margins are: ${phoneWidthMargin}x${phoneHeightMargin}")
 
                     mediaSinkServiceBuilder.addVideoConfigs(Control.Service.MediaSinkService.VideoConfiguration.newBuilder().apply {
@@ -255,6 +256,44 @@ class ServiceDiscoveryResponse(private val context: Context)
 
                 addAllServices(services)
             }.build()
+        }
+
+        /**
+         * Records whether a decoder on this device claims it can carry the profile we are about to
+         * ask the phone for.
+         *
+         * Nothing acts on the answer. It exists because this is the one place where the codec is
+         * decided - the 1440p rule above overrides the user's own choice - and until now nothing in
+         * the app asked a decoder anything before making it. A #219 reporter's Galaxy Tab S7 FE runs
+         * the resulting 2560x1440 HEVC on `c2.qti.hevc.decoder` and sheds frames in bursts, with the
+         * shedding confined to windows that also spent up to 2019ms of 5000 waiting for an input
+         * buffer. No log has ever said what that component claimed beforehand.
+         *
+         * A WARN here from a unit that reports artifacts is what would justify revisiting the rule.
+         */
+        private fun logNegotiatedCodecCapability(codec: Media.MediaCodecType, settings: com.andrerinas.openheadunit.utils.Settings) {
+            val mime = when (codec) {
+                Media.MediaCodecType.MEDIA_CODEC_VIDEO_H265 -> VideoDecoder.CodecType.H265.mimeType
+                Media.MediaCodecType.MEDIA_CODEC_VIDEO_H264_BP -> VideoDecoder.CodecType.H264.mimeType
+                else -> return
+            }
+            val width = HeadUnitScreenConfig.getNegotiatedWidth()
+            val height = HeadUnitScreenConfig.getNegotiatedHeight()
+            if (width <= 0 || height <= 0) return
+            val capability = com.andrerinas.openheadunit.decoder.DecoderCapabilityReport
+                .query(mime, width, height, settings.fpsLimit)
+            if (capability == null) {
+                AppLog.i("[ServiceDiscovery] No decoder capability available for $mime at ${width}x$height")
+                return
+            }
+            if (capability.adequate) {
+                AppLog.i("[ServiceDiscovery] Negotiating a profile this device claims to carry: $capability")
+            } else {
+                AppLog.w(
+                    "[ServiceDiscovery] Negotiating a profile no decoder here claims to carry: $capability. " +
+                        "Frames shed under load and the artifacts that follow are the expected consequence."
+                )
+            }
         }
 
         private fun makeSensorType(type: Sensors.SensorType): Control.Service.SensorSourceService.Sensor {

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
@@ -756,13 +756,33 @@ class CommManager(
      * rather than calling here, because it has to pair the release with a regain on the send handler.
      * Releasing focus across a stream that is rendering is a known way to lose one permanently, which
      * is why both sets of gates are as reluctant as they are.
+     *
+     * Both go through the transport's single claim on the lever, so a release can never be issued
+     * while another cycle is still waiting to send its regain. Returns false when the claim is
+     * refused - the caller must not then spend its own budget or schedule a regain, because no
+     * release went out for it to complete.
      */
-    fun releaseVideoFocusForKeyframe() {
-        if (_connectionState.value !is ConnectionState.TransportStarted) return
-        val transport = _transport ?: return
-        transport.ignoreNextStopRequest = true
+    fun releaseVideoFocusForKeyframe(): Boolean {
+        if (_connectionState.value !is ConnectionState.TransportStarted) return false
+        val transport = _transport ?: return false
+        if (!transport.beginFocusCycle()) {
+            AppLog.i("CommManager: a video-focus cycle is already in flight - not starting a second")
+            return false
+        }
         AppLog.i("CommManager: releasing video focus to force a keyframe")
-        transport.send(com.andrerinas.openheadunit.aap.protocol.messages.VideoFocusEvent(gain = false, unsolicited = false))
+        transport.sendKeyframeCycleRelease()
+        return true
+    }
+
+    /**
+     * Second half of a cycle started by [releaseVideoFocusForKeyframe], and the only correct way to
+     * end one: it sends the regain *and* hands the lever back, which a bare [send] would not.
+     */
+    fun retakeVideoFocusForKeyframe() {
+        _transport?.let {
+            it.send(com.andrerinas.openheadunit.aap.protocol.messages.VideoFocusEvent(gain = true, unsolicited = true))
+            it.endFocusCycle()
+        }
     }
 
     fun updateAudioGains() {

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/CommManager.kt
@@ -196,6 +196,15 @@ class CommManager(
         }
 
     /**
+     * When the phone last sent anything on any AAP channel, or `0` if it has not yet this session.
+     *
+     * Proof the link is alive, as distinct from proof the picture is moving. See
+     * [AapTransport.lastMessageReceivedMs].
+     */
+    val lastAapMessageMs: Long
+        get() = _transport?.lastMessageReceivedMs ?: 0L
+
+    /**
      * `true` while a connection exists **or** one is being set up.
      *
      * [isConnected] deliberately excludes [ConnectionState.Connecting], which is right for the

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -135,10 +135,29 @@ class NativeAaHandshakeManager(
     // again rather than hiding behind a line from minutes earlier.
     @Volatile private var handsFreeSkipLogged = false
 
-    private var currentSsid: String? = null
-    private var currentPsk: String? = null
-    private var currentIp: String? = null
-    private var currentBssid: String? = null
+    /**
+     * The credentials to hand the phone, as one value.
+     *
+     * Four separate fields were written by WifiDirectManager's delivery thread and read by the
+     * handshake coroutine with no synchronisation, which allowed two failures. A read could see the
+     * SSID and passphrase of one group beside the BSSID of another, and Gearhead joins with a
+     * WifiNetworkSpecifier matching SSID *and* BSSID under a full mask, so it rejects the pair with
+     * no clue as to why. And the null check and the `!!` that followed it were separate reads, so an
+     * invalidate landing between them threw a KotlinNullPointerException that surfaced as
+     * "Handshake error: null" and named nothing.
+     *
+     * One immutable snapshot behind one volatile reference: a reader gets all four fields from the
+     * same group or none of them, and reads them once.
+     */
+    private data class WifiCredentials(
+        val ssid: String,
+        val psk: String,
+        val ip: String,
+        val bssid: String,
+    )
+
+    @Volatile
+    private var credentials: WifiCredentials? = null
     private var pokeJob: Job? = null
     // Last (ssid, ip, bssid) triggerPoke() restarted for - dedupes redundant restarts when
     // WifiDirectManager redelivers the same credentials, which was starving the poke before it
@@ -203,19 +222,13 @@ class NativeAaHandshakeManager(
      */
     fun updateWifiCredentials(ssid: String, psk: String, ip: String, bssid: String) {
         AppLog.i("NativeAA: Credentials updated. SSID=$ssid, IP=$ip, BSSID=$bssid")
-        currentSsid = ssid
-        currentPsk = psk
-        currentIp = ip
-        currentBssid = bssid
+        credentials = WifiCredentials(ssid = ssid, psk = psk, ip = ip, bssid = bssid)
     }
 
     /** Clears cached credentials so an in-progress wait doesn't hand out stale ones for a group
      *  that's about to be torn down. */
     fun invalidateCredentials() {
-        currentSsid = null
-        currentPsk = null
-        currentIp = null
-        currentBssid = null
+        credentials = null
     }
 
     // isRunning alone isn't enough once closeAaListeners() can close the AA_UUID listener while
@@ -654,12 +667,15 @@ class NativeAaHandshakeManager(
         }
         val adapter = BluetoothHelper.getBluetoothAdapter(context) ?: return
 
-        val credentials = Triple(currentSsid ?: "", currentIp ?: "", currentBssid ?: "")
-        if (pokeJob?.isActive == true && credentials == lastPokeTriggerCredentials) {
+        // Named pokeKey, not credentials: the coroutine below tests the *property* for readiness, and
+        // a local called credentials would shadow it with a Triple that is never null.
+        val snapshot = credentials
+        val pokeKey = Triple(snapshot?.ssid ?: "", snapshot?.ip ?: "", snapshot?.bssid ?: "")
+        if (pokeJob?.isActive == true && pokeKey == lastPokeTriggerCredentials) {
             AppLog.d("NativeAA: triggerPoke() called again with unchanged credentials while a poke is already running - not restarting it.")
             return
         }
-        lastPokeTriggerCredentials = credentials
+        lastPokeTriggerCredentials = pokeKey
 
         pokeJob?.cancel()
         pokeJob = scope.launch(Dispatchers.IO + CoroutineName("NativeAa-Wakeup")) {
@@ -719,11 +735,11 @@ class NativeAaHandshakeManager(
 
                     // Pre-flight: Ensure WiFi credentials (SSID/IP) are ready before connecting RFCOMM to phone.
                     // If RFCOMM connects before WiFi credentials exist, the phone times out after 10s waiting for WifiStartRequest.
-                    if (currentSsid.isNullOrEmpty() || currentIp.isNullOrEmpty()) {
+                    if (credentials == null) {
                         AppLog.i("NativeAA: WiFi credentials not ready before poke. Requesting WiFi refresh...")
                         (context as? AapService)?.triggerWifiDirectRefresh()
                         var waitedMs = 0
-                        while ((currentSsid.isNullOrEmpty() || currentIp.isNullOrEmpty()) && waitedMs < 4000 && isRunning && isActive) {
+                        while (credentials == null && waitedMs < 4000 && isRunning && isActive) {
                             delay(200)
                             waitedMs += 200
                         }
@@ -783,15 +799,15 @@ class NativeAaHandshakeManager(
             pokeJob?.cancel()
             pokeJob = scope.launch(Dispatchers.IO + CoroutineName("NativeAa-ManualWakeup")) {
                 // Pre-flight: Ensure WiFi credentials (SSID/IP) are ready before connecting RFCOMM to phone.
-                if (currentSsid.isNullOrEmpty() || currentIp.isNullOrEmpty()) {
+                if (credentials == null) {
                     AppLog.i("NativeAA: WiFi credentials not ready before manual poke. Requesting WiFi refresh...")
                     (context as? AapService)?.triggerWifiDirectRefresh()
                     var waitedMs = 0
-                    while ((currentSsid.isNullOrEmpty() || currentIp.isNullOrEmpty()) && waitedMs < 4000 && isRunning && isActive) {
+                    while (credentials == null && waitedMs < 4000 && isRunning && isActive) {
                         delay(200)
                         waitedMs += 200
                     }
-                    AppLog.i("NativeAA: Pre-poke credential wait completed. SSID=$currentSsid, IP=$currentIp (waited ${waitedMs}ms)")
+                    AppLog.i("NativeAA: Pre-poke credential wait completed. SSID=${credentials?.ssid}, IP=${credentials?.ip} (waited ${waitedMs}ms)")
                 }
 
                 AppLog.i("NativeAA: Attempting manual poke to ${device.name}...")
@@ -1119,7 +1135,7 @@ class NativeAaHandshakeManager(
             // buys the whole bring-up window.
             feed(WppEvent.SocketReady)
 
-            AppLog.i("NativeAA: Phone connected. Current credentials state: SSID=${currentSsid ?: "<null>"}, IP=${currentIp ?: "<null>"}")
+            AppLog.i("NativeAA: Phone connected. Current credentials state: SSID=${credentials?.ssid ?: "<null>"}, IP=${credentials?.ip ?: "<null>"}")
             AppLog.i("NativeAA: Waiting for WiFi credentials to be ready (Max ${CREDENTIALS_WAIT_MS / 1000}s)...")
 
             // Wait for credentials (P2P group / hotspot bring-up can be slow), servicing the
@@ -1128,7 +1144,7 @@ class NativeAaHandshakeManager(
             val credentialsDeadline = SystemClock.elapsedRealtime() + CREDENTIALS_WAIT_MS
             var lastRefreshAt = SystemClock.elapsedRealtime()
             var lastProgressLogAt = SystemClock.elapsedRealtime()
-            while ((currentSsid == null || currentIp == null) && isRunning && isActive &&
+            while (credentials == null && isRunning && isActive &&
                 !session.isTerminal() && SystemClock.elapsedRealtime() < credentialsDeadline) {
                 val now = SystemClock.elapsedRealtime()
                 val waitedS = (CREDENTIALS_WAIT_MS - (credentialsDeadline - now)) / 1000
@@ -1138,22 +1154,25 @@ class NativeAaHandshakeManager(
                     context.triggerWifiDirectRefresh()
                 } else if (now - lastProgressLogAt >= 5_000) {
                     lastProgressLogAt = now
-                    AppLog.d("NativeAA: Still waiting... SSID=${currentSsid != null}, IP=${currentIp != null} (${waitedS}s)")
+                    AppLog.d("NativeAA: Still waiting... credentials=${credentials != null} (${waitedS}s)")
                 }
                 tick(500)
             }
 
-            if (currentSsid == null || currentIp == null) {
-                AppLog.e("NativeAA: Handshake failed - No WiFi credentials available after ${CREDENTIALS_WAIT_MS / 1000}s wait. Missing: ${if (currentSsid == null) "SSID " else ""}${if (currentIp == null) "IP" else ""}")
+            // Read once. The check and the use used to be separate reads of four separate fields,
+            // so an invalidate between them threw on the `!!` and reported "Handshake error: null".
+            val snapshot = credentials
+            if (snapshot == null) {
+                AppLog.e("NativeAA: Handshake failed - No WiFi credentials available after ${CREDENTIALS_WAIT_MS / 1000}s wait.")
                 abortedLocally = true
                 feed(WppEvent.CredentialsUnavailable)
                 return@withContext
             }
 
-            credIp = currentIp!!
-            credSsid = currentSsid!!
-            credPsk = currentPsk ?: ""
-            credBssid = (currentBssid ?: "").uppercase()
+            credIp = snapshot.ip
+            credSsid = snapshot.ssid
+            credPsk = snapshot.psk
+            credBssid = snapshot.bssid.uppercase()
 
             // [FIX] Ensure BSSID is uppercase and not zeroed if possible
             if (!NativeCredentialsPolicy.isUsableBssid(credBssid)) {
@@ -1386,10 +1405,7 @@ class NativeAaHandshakeManager(
         }
         aaServerSocket = null
         hfpServerSocket = null
-        currentSsid = null
-        currentIp = null
-        currentPsk = null
-        currentBssid = null
+        credentials = null
         pokeJob?.cancel()
         pokeJob = null
         lastPokeTriggerCredentials = null

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/NativeAaHandshakeManager.kt
@@ -53,6 +53,15 @@ class NativeAaHandshakeManager(
         /** How long to wait for the AAP TCP port to be bound before giving up on a handshake. */
         private const val PORT_WAIT_MS = 3_000L
 
+        /**
+         * How long to wait for the port after asking for the server to be (re)started.
+         *
+         * Deliberately short. [awaitWirelessServerListening] delays without pumping the session's
+         * inbound channel, so everything spent here is time the phone's keepalives go unserviced;
+         * the bind's own retry budget is under two seconds, so this only has to cover it.
+         */
+        private const val PORT_ENSURE_MS = 4_000L
+
         /** Which of [allServiceNames] are secondary Bluetooth radios, i.e. not [primaryServiceName]
          *  (dual-Bluetooth-radio head units). Pure and unit-testable: identity is by system
          *  service name, not MAC address, since BluetoothAdapter.getAddress() returns the fixed
@@ -1212,10 +1221,17 @@ class NativeAaHandshakeManager(
             // with it unbound means a genuine failure, not a race — but a session torn down and
             // rebuilt a moment ago can still be releasing it.
             if (!awaitWirelessServerListening(PORT_WAIT_MS)) {
-                AppLog.e("NativeAA: Handshake aborted — nothing is listening on port 5288 after ${PORT_WAIT_MS / 1000}s, so the phone would join the network and find no head unit. Restart the app if this persists.")
-                abortedLocally = true
-                feed(WppEvent.CredentialsUnavailable)
-                return@withContext
+                // Ask for a repair before giving up. A server that failed to bind once used to stay
+                // dead for the life of the mode, because the only thing that rebuilt it was a full
+                // mode re-initialisation - so this abort repeated every few seconds, forever, with
+                // the phone woken each time and told nothing.
+                if (!context.ensureWirelessServerListening("the Bluetooth handshake", PORT_ENSURE_MS)) {
+                    AppLog.e("NativeAA: Handshake aborted — nothing is listening on port 5288 after ${PORT_WAIT_MS / 1000}s, and starting it here did not work either, so the phone would join the network and find no head unit. Restart the app if this persists.")
+                    abortedLocally = true
+                    feed(WppEvent.CredentialsUnavailable)
+                    return@withContext
+                }
+                AppLog.i("NativeAA: port 5288 was not bound, and is now. Carrying on with the handshake.")
             }
 
             AppLog.i("NativeAA: Starting Handshake Exchange:")

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/WifiDirectManager.kt
@@ -869,7 +869,18 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             }
             manager?.discoverPeers(ch, object : WifiP2pManager.ActionListener {
                 override fun onSuccess() {
-                    AppLog.d("WifiDirectManager: Discovery active")
+                    // INFO, not DEBUG: discoverPeers() puts the P2P radio into find mode, sweeping
+                    // the social channels, and on a single-radio unit hosting a group that is
+                    // seconds of silence for everything already on it. Two reporters' captures show
+                    // exactly that shape on this loop's ten-second cadence, and neither could be
+                    // checked against it - the only line the loop left was at a level nobody is
+                    // ever asked to capture. A search running under a live session is the anomaly,
+                    // so say which case this is.
+                    val sessionLive = isNativeSessionConnected?.invoke() == true
+                    AppLog.i(
+                        "WifiDirectManager: Discovery active - peer search running%s",
+                        if (sessionLive) " while an Android Auto session is connected" else ""
+                    )
                     if (appSettings.wifiConnectionMode == 2 && appSettings.helperConnectionStrategy == 1) {
                         handler.postDelayed({
                             if (!isClientConnected) {

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/WifiDirectManager.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/WifiDirectManager.kt
@@ -19,7 +19,9 @@ import androidx.core.content.ContextCompat
 import com.andrerinas.openheadunit.App
 import com.andrerinas.openheadunit.R
 import com.andrerinas.openheadunit.aap.AapService
+import com.andrerinas.openheadunit.aap.NativeGroupBandPolicy
 import com.andrerinas.openheadunit.aap.NativeHandoffPolicy
+import com.andrerinas.openheadunit.aap.P2pOperatingChannelPolicy
 import com.andrerinas.openheadunit.aap.P2pChannelPolicy
 import com.andrerinas.openheadunit.utils.ToastUtils
 import com.andrerinas.openheadunit.utils.AppLog
@@ -37,6 +39,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         private const val MAX_NATIVE_STANDARD_CREATE_RETRIES = 3
         private const val NATIVE_GROUP_MODE_UNKNOWN = "unknown"
         private const val NATIVE_GROUP_MODE_5GHZ_REQUESTED = "5GHz requested"
+        private const val NATIVE_GROUP_MODE_24GHZ_FORCED = "2.4GHz forced (debug)"
         private const val NATIVE_GROUP_MODE_STANDARD_FALLBACK = "standard fallback"
         private const val NATIVE_GROUP_MODE_STANDARD_LEGACY = "standard (no 5GHz API)"
         // Native AA join recovery: if no phone joins the quiet-host group within this window,
@@ -87,6 +90,64 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
     private var discoveredInterface: String? = null
     private var nativeGroupCreationMode = NATIVE_GROUP_MODE_UNKNOWN
     private var native5GhzBandMismatchRetries = 0
+
+    /**
+     * The band the current Native AA group was asked for. Only 5 GHz can be mismatched: a group
+     * put on 2.4 GHz on purpose is on the band it was asked for, so it must not be remade.
+     */
+    private var nativeRequestedBand = NativeGroupBandPolicy.Band.UNSPECIFIED
+
+    /**
+     * True while a 5 GHz operating-channel restriction is in place on a pre-Q device. It lives in the
+     * supplicant rather than here, so it has to be cleared deliberately - see [WifiP2pChannelCompat].
+     */
+    @Volatile
+    private var legacyChannelRestrictionApplied = false
+
+    /** One clear-and-retry per bring-up, so a unit that cannot host 5 GHz still gets a group. */
+    private var legacyChannelFallbackUsed = false
+
+    /**
+     * Bumped by [stop]. Every P2P callback that continues into another framework call captures this
+     * first and gives up if it has moved, because [stop] can cancel posted runnables but nothing can
+     * cancel an `ActionListener` the framework is already holding - and those continuations create
+     * groups. Without the fence, a user exit that lands mid-recovery removes the group and then a
+     * continuation puts a new one up with no receiver, no watchdog and nobody expecting it, which is
+     * exactly what the exit was for.
+     */
+    @Volatile
+    private var generation = 0
+
+    /** One token per checkGroupAndCreate run, so a stale safety timer cannot clear a later run's guard. */
+    private var checkGroupAndCreateToken = 0
+
+    /**
+     * Bumped whenever the group these credentials describe stops being the current one.
+     *
+     * The delivery thread below waits up to 15s for an IP and then hands the SSID, passphrase and
+     * BSSID it captured at spawn to the handshake. Nothing cancels it, and its IP fallback means it
+     * always produces something - so a group torn down mid-wait still delivers, overwriting the live
+     * group's credentials with a dead group's. The phone then joins a network that no longer exists
+     * and sits on "Obtaining IP address" forever, having been told the truth about the wrong group.
+     */
+    @Volatile
+    private var credentialsEpoch = 0
+
+    /** The group the join watchdog is currently armed for, so repeat callbacks cannot push it out. */
+    private var nativeJoinWatchdogSsid: String? = null
+
+    /**
+     * True when [stop] has run since [gen] was captured, meaning this continuation belongs to a
+     * session that is over and must not create anything.
+     */
+    private fun supersededByStop(gen: Int, what: String): Boolean {
+        if (gen == generation) return false
+        AppLog.i("WifiDirectManager: $what abandoned - the manager was stopped while it was in flight.")
+        return true
+    }
+
+    /** Says the frequency is unreadable once per group, not once per group-info callback. */
+    private var lastFrequencyUnreadableSsid: String? = null
 
     /**
      * SSID of the last group reported as being on a channel most phones cannot join, so the several
@@ -505,26 +566,23 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 lastKnownBssid = bssid
             }
 
-            // Try to get frequency via reflection (hidden field in WifiP2pGroup)
+            // Below API 29 there is nothing to read. WifiP2pGroup gained getFrequency() in Q, and
+            // before that it carries no frequency at all - the supplicant callback is handed one and
+            // discards it, so there is no field for reflection to find and the old attempt to guess
+            // at "frequency"/"mFrequency" could only ever return 0. Reported once per group rather
+            // than left as a bare 0, because every band decision downstream reads as "unknown" here
+            // and a reader needs to know that is the platform's limit and not this unit's fault.
             var frequency = 0
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                // For Android 10 (API 29) and above, use the official public API via WifiDirectCompat
                 frequency = WifiDirectCompat.getGroupFrequency(group)
-            } else {
-                try {
-                    // Try several common field names used by different OEMs
-                    val fieldNames = arrayOf("frequency", "mFrequency")
-                    for (name in fieldNames) {
-                        try {
-                            val field = group.javaClass.getDeclaredField(name)
-                            field.isAccessible = true
-                            frequency = field.getInt(group)
-                            if (frequency > 0) break
-                        } catch (e: Exception) {
-                        }
-                    }
-                } catch (e: Exception) {
-                }
+            } else if (ssid != lastFrequencyUnreadableSsid) {
+                lastFrequencyUnreadableSsid = ssid
+                AppLog.i(
+                    "WifiDirectManager: this Android (API ${Build.VERSION.SDK_INT}) does not report a " +
+                        "P2P group's frequency - WifiP2pGroup only carries it from API 29 - so the band " +
+                        "below is unknown rather than missing. Read it from the phone's WiFi details, or " +
+                        "from wpa_supplicant's own \"P2P: Set GO freq\" line."
+                )
             }
 
             val band = if (frequency > 4000) "5GHz" else if (frequency > 0) "2.4GHz" else "unknown"
@@ -574,11 +632,12 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             if (isNativeAaMode() && isOwner) {
                 notifyNativeGroupStarted(ssid, frequency, band)
                 // The group is up. If no phone joins within the window, recover (recreate fresh).
-                armNativeJoinWatchdog()
+                armNativeJoinWatchdog(ssid)
             }
 
             if (ssid.isNotEmpty()) {
                 // Wait for the IP address to be assigned to the interface
+                val deliveryEpoch = credentialsEpoch
                 Thread {
                     try {
                         var ip = getWifiDirectIp(iface)
@@ -592,7 +651,13 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
 
                         // For Native AA, we almost always expect 192.168.49.1 if we are GO
                         val finalIp = ip ?: (if (isOwner) "192.168.49.1" else null)
-                        if (finalIp != null && bssid != null) {
+                        if (deliveryEpoch != credentialsEpoch) {
+                            AppLog.i(
+                                "WifiDirectManager: not delivering credentials for $ssid - that group was " +
+                                    "replaced while this was waiting for an IP, and the phone must not be " +
+                                    "sent a network that no longer exists."
+                            )
+                        } else if (finalIp != null && bssid != null) {
                             AppLog.i("WifiDirectManager: SUCCESS - Providing credentials to listener. SSID=$ssid, IP=$finalIp, BSSID=$bssid")
                             onCredentialsReady?.invoke(ssid, psk, finalIp, bssid)
                         } else {
@@ -785,7 +850,14 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             return
         }
         checkGroupAndCreateInFlight = true
-        handler.postDelayed({ checkGroupAndCreateInFlight = false }, 8000L)
+        // Keyed: an un-keyed timer from an earlier run fires 8s later and clears a guard this run
+        // is relying on, which lets two teardown/create pairs run at once - the very race the flag
+        // exists to prevent.
+        val guardToken = ++checkGroupAndCreateToken
+        val gen = generation
+        handler.postDelayed({
+            if (guardToken == checkGroupAndCreateToken) checkGroupAndCreateInFlight = false
+        }, 8000L)
 
         isGroupOwner = false
         isConnected = false
@@ -794,6 +866,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             if (group == null) {
                 AppLog.i("No existing P2P group, creating new one")
                 checkGroupAndCreateInFlight = false
+                if (supersededByStop(gen, "group creation")) return@requestGroupInfo
                 createNewGroup(0)
                 return@requestGroupInfo
             }
@@ -812,10 +885,15 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             // be delivered for the new one.
             lastKnownBssid = null
             manager?.removeGroup(channel, object : WifiP2pManager.ActionListener {
-                override fun onSuccess() { checkGroupAndCreateInFlight = false; createNewGroup(0) }
+                override fun onSuccess() {
+                    checkGroupAndCreateInFlight = false
+                    if (supersededByStop(gen, "group recreate")) return
+                    createNewGroup(0)
+                }
                 override fun onFailure(reason: Int) {
                     AppLog.w("WifiDirectManager: removeGroup before recreate failed: ${getP2pErrorString(reason)}")
                     checkGroupAndCreateInFlight = false
+                    if (supersededByStop(gen, "group recreate")) return
                     createNewGroup(0)
                 }
             })
@@ -985,8 +1063,12 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         nativeGroupCreationMode = NATIVE_GROUP_MODE_UNKNOWN
         lastNativeGroupStatusMessage = null
         native5GhzBandMismatchRetries = 0
+        nativeRequestedBand = NativeGroupBandPolicy.Band.UNSPECIFIED
+        legacyChannelFallbackUsed = false
         lastUnfriendlyChannelSsid = null
         lastCoexistenceSsid = null
+        lastFrequencyUnreadableSsid = null
+        nativeJoinWatchdogSsid = null
         nativeRecreateCount = 0
         cancelNativeJoinWatchdog()
         recreateNativeGroup(forceStandard = false)
@@ -1001,6 +1083,13 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         val mgr = manager ?: return
         val ch = channel ?: return
 
+        // Read once per attempt rather than held in a field: the setting is written between runs on
+        // a rig, and a group made after the write must be the one the write asked for.
+        val appSettings = App.provide(context).settings
+        val force24 = appSettings.debugForceP2pBand24
+        val band = NativeGroupBandPolicy.bandFor(force24)
+        val bandLabel = NativeGroupBandPolicy.label(band)
+
         AppLog.i("WifiDirectManager: Attempting createGroup for Native AA (Attempt $retryCount)...")
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -1009,16 +1098,24 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 // throws IllegalStateException — onGroupInfoAvailable() reads the real values
                 // back afterwards, same as the standard-fallback path.
                 val config = WifiP2pConfig.Builder()
-                    .setGroupOperatingBand(WifiP2pConfig.GROUP_OWNER_BAND_5GHZ)
+                    .setGroupOperatingBand(
+                        if (band == NativeGroupBandPolicy.Band.GHZ_2_4) WifiP2pConfig.GROUP_OWNER_BAND_2GHZ
+                        else WifiP2pConfig.GROUP_OWNER_BAND_5GHZ
+                    )
                     .setNetworkName(generateP2pNetworkName())
                     .setPassphrase(generateP2pPassphrase())
                     .build()
 
-                AppLog.i("WifiDirectManager: Requesting Native AA P2P group on 5GHz band.")
+                // Recorded here and not before the gate: this is the only branch that asks for a
+                // band, so it is the only one whose answer can be mismatched. Below Q the request
+                // does not exist and standardCreateGroup leaves the field UNSPECIFIED.
+                nativeRequestedBand = band
+                AppLog.i("WifiDirectManager: Requesting Native AA P2P group on $bandLabel band.${if (force24) " Forced by debug setting." else ""}")
                 mgr.createGroup(ch, config, object : WifiP2pManager.ActionListener {
                     override fun onSuccess() {
-                        AppLog.i("WifiDirectManager: 5GHz createGroup SUCCESS!")
-                        nativeGroupCreationMode = NATIVE_GROUP_MODE_5GHZ_REQUESTED
+                        AppLog.i("WifiDirectManager: $bandLabel createGroup SUCCESS!")
+                        nativeGroupCreationMode =
+                            if (force24) NATIVE_GROUP_MODE_24GHZ_FORCED else NATIVE_GROUP_MODE_5GHZ_REQUESTED
                         isGroupOwner = true
                         handler.postDelayed({
                             mgr.requestConnectionInfo(ch, this@WifiDirectManager)
@@ -1028,13 +1125,13 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                     override fun onFailure(reason: Int) {
                         val reasonStr = getP2pErrorString(reason)
                         if (retryCount < MAX_NATIVE_5GHZ_CREATE_RETRIES) {
-                            AppLog.w("WifiDirectManager: 5GHz createGroup failed ($reasonStr), removing group and retrying 5GHz in 2s (retry ${retryCount + 1}/$MAX_NATIVE_5GHZ_CREATE_RETRIES)...")
+                            AppLog.w("WifiDirectManager: $bandLabel createGroup failed ($reasonStr), removing group and retrying $bandLabel in 2s (retry ${retryCount + 1}/$MAX_NATIVE_5GHZ_CREATE_RETRIES)...")
                             mgr.removeGroup(ch, object : WifiP2pManager.ActionListener {
                                 override fun onSuccess() { handler.postDelayed({ createQuietGroup(retryCount + 1) }, 2000L) }
                                 override fun onFailure(r: Int) { handler.postDelayed({ createQuietGroup(retryCount + 1) }, 2000L) }
                             })
                         } else {
-                            AppLog.w("WifiDirectManager: 5GHz createGroup retries exhausted ($reasonStr). Falling back to standard createGroup.")
+                            AppLog.w("WifiDirectManager: $bandLabel createGroup retries exhausted ($reasonStr). Falling back to standard createGroup.")
                             standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_FALLBACK)
                         }
                     }
@@ -1042,7 +1139,7 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                 return
             } catch (t: Throwable) {
                 if (retryCount < MAX_NATIVE_5GHZ_CREATE_RETRIES) {
-                    AppLog.e("WifiDirectManager: 5GHz createGroup crashed before async result. Retrying 5GHz.", t)
+                    AppLog.e("WifiDirectManager: $bandLabel createGroup crashed before async result. Retrying $bandLabel.", t)
                     handler.postDelayed({ createQuietGroup(retryCount + 1) }, 2000L)
                     return
                 }
@@ -1052,8 +1149,38 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             }
         }
 
-        AppLog.i("WifiDirectManager: 5GHz P2P group request requires Android 10+. Using standard createGroup.")
-        standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_LEGACY)
+        // Below Q there is no band request, so the driver picks the channel unless it is given a
+        // frequency list. This has to happen before createGroup: the platform only accepts a channel
+        // change while no group exists, and drops it silently afterwards.
+        val operatingChannel = P2pOperatingChannelPolicy.operatingChannel(
+            sdkInt = Build.VERSION.SDK_INT,
+            requestFiveGhz = appSettings.p2pLegacyFiveGhz && !force24,
+            useUpperBand = appSettings.p2pLegacyFiveGhzUpperBand,
+        )
+        if (operatingChannel == P2pOperatingChannelPolicy.CHANNEL_UNRESTRICTED) {
+            AppLog.i("WifiDirectManager: 5GHz P2P group request requires Android 10+. Using standard createGroup.")
+            standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_LEGACY)
+            return
+        }
+
+        val frequency = P2pOperatingChannelPolicy.frequencyMhzFor(operatingChannel)
+        AppLog.i(
+            "WifiDirectManager: no band request below Android 10, so asking for operating channel " +
+                "$operatingChannel ($frequency MHz) instead. The group cannot be told which band to " +
+                "use here; this restricts which frequencies it may pick."
+        )
+        WifiP2pChannelCompat.setOperatingChannel(mgr, ch, operatingChannel) { applied, detail ->
+            legacyChannelRestrictionApplied = applied
+            if (applied) {
+                AppLog.i("WifiDirectManager: operating channel $operatingChannel ($frequency MHz) $detail.")
+            } else {
+                AppLog.w(
+                    "WifiDirectManager: this unit would not take an operating channel ($detail), so " +
+                        "the group's band stays the driver's choice, as it was before."
+                )
+            }
+            standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_LEGACY)
+        }
     }
 
     private fun generateP2pNetworkName(): String {
@@ -1085,7 +1212,14 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
             override fun onSuccess() {
                 AppLog.i("WifiDirectManager: Standard createGroup SUCCESS!")
                 nativeGroupCreationMode = groupMode
+                // The platform chose the band here, so there is no mismatch to correct.
+                nativeRequestedBand = NativeGroupBandPolicy.Band.UNSPECIFIED
                 isGroupOwner = true
+                // The restriction is a whitelist of one frequency and it applies to the whole P2P
+                // interface, not just to group creation - while it stands, the 2.4 GHz social
+                // channels are banned and discovery cannot run. The group keeps the channel it was
+                // formed on, so the restriction has done its work and must come off now.
+                releaseLegacyChannelRestriction(mgr, ch)
                 handler.postDelayed({
                     mgr.requestConnectionInfo(ch, this@WifiDirectManager)
                     mgr.requestGroupInfo(ch, this@WifiDirectManager)
@@ -1099,6 +1233,21 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
                         override fun onSuccess() { handler.postDelayed({ standardCreateGroup(mgr, ch, retryCount + 1, groupMode) }, 2000L) }
                         override fun onFailure(r: Int) { handler.postDelayed({ standardCreateGroup(mgr, ch, retryCount + 1, groupMode) }, 2000L) }
                     })
+                } else if (legacyChannelRestrictionApplied && !legacyChannelFallbackUsed) {
+                    // The restriction is a frequency list, so a unit whose P2P firmware cannot host a
+                    // group owner on that band has nowhere legal to put one and fails outright rather
+                    // than landing on 2.4 GHz. Give the list back and let it choose, once.
+                    legacyChannelFallbackUsed = true
+                    AppLog.w(
+                        "WifiDirectManager: no group formed while the 5 GHz operating channel was " +
+                            "requested ($reasonStr). Clearing the restriction and letting this unit " +
+                            "pick its own channel - it cannot host a group owner on that band."
+                    )
+                    WifiP2pChannelCompat.clearOperatingChannel(mgr, ch) { _, detail ->
+                        legacyChannelRestrictionApplied = false
+                        AppLog.i("WifiDirectManager: operating channel restriction cleared ($detail).")
+                        standardCreateGroup(mgr, ch, 0, groupMode)
+                    }
                 } else {
                     AppLog.e("WifiDirectManager: createQuietGroup failed completely! Reason: $reasonStr")
                     isGroupCreatingOrCreated = false
@@ -1107,15 +1256,39 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         })
     }
 
+    /**
+     * Gives the frequency list back once the group exists.
+     *
+     * Not tidiness: the restriction bans every frequency except the one it names, including the
+     * 2.4 GHz social channels discovery runs on, and it is state in the supplicant that outlives
+     * this app. A group that has already formed keeps its channel, so nothing is lost by clearing.
+     */
+    private fun releaseLegacyChannelRestriction(mgr: WifiP2pManager, ch: WifiP2pManager.Channel) {
+        if (!legacyChannelRestrictionApplied) return
+        legacyChannelRestrictionApplied = false
+        WifiP2pChannelCompat.clearOperatingChannel(mgr, ch) { applied, detail ->
+            if (applied) {
+                AppLog.i("WifiDirectManager: operating channel restriction released; discovery can use the social channels again.")
+            } else {
+                AppLog.w(
+                    "WifiDirectManager: could not release the operating channel restriction ($detail). " +
+                        "Peer discovery may stay crippled until WiFi is restarted."
+                )
+            }
+        }
+    }
+
     private fun isNativeAaMode(): Boolean {
         return com.andrerinas.openheadunit.App.provide(context).settings.wifiConnectionMode == 3
     }
 
-    private fun shouldRetryNativeGroupFor5Ghz(frequency: Int): Boolean {
-        return nativeGroupCreationMode == NATIVE_GROUP_MODE_5GHZ_REQUESTED &&
-            frequency in 1..4000 &&
-            native5GhzBandMismatchRetries < MAX_NATIVE_5GHZ_BAND_MISMATCH_RETRIES
-    }
+    private fun shouldRetryNativeGroupFor5Ghz(frequency: Int): Boolean =
+        NativeGroupBandPolicy.shouldRetryFor5Ghz(
+            requested = nativeRequestedBand,
+            frequencyMhz = frequency,
+            retriesSoFar = native5GhzBandMismatchRetries,
+            maxRetries = MAX_NATIVE_5GHZ_BAND_MISMATCH_RETRIES,
+        )
 
     @SuppressLint("MissingPermission")
     private fun removeGroupAndRetryNative5Ghz() {
@@ -1125,10 +1298,18 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         // MAC — a cached BSSID from the group we're tearing down is now stale and must never
         // be delivered for the new one.
         lastKnownBssid = null
+        // The group this replaces is gone; any credential delivery still waiting on it describes a
+        // network that will not exist by the time it lands.
+        credentialsEpoch++
+        val gen = generation
         mgr.removeGroup(ch, object : WifiP2pManager.ActionListener {
-            override fun onSuccess() { delayedCreateQuietGroup(0) }
+            override fun onSuccess() {
+                if (supersededByStop(gen, "5GHz band-mismatch retry")) return
+                delayedCreateQuietGroup(0)
+            }
             override fun onFailure(reason: Int) {
                 AppLog.w("WifiDirectManager: removeGroup before 5GHz band-mismatch retry failed: ${getP2pErrorString(reason)}")
+                if (supersededByStop(gen, "5GHz band-mismatch retry")) return
                 delayedCreateQuietGroup(0)
             }
         })
@@ -1147,9 +1328,15 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
         val ch = channel ?: return
         lastKnownBssid = null
         // Let an in-progress credential wait pick up the fresh group's creds, not stale ones.
+        credentialsEpoch++
         onNativeGroupInvalidated?.invoke()
+        val gen = generation
         val createFresh = {
-            if (forceStandard) standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_FALLBACK)
+            // The removeGroup below is the teardown a user exit relies on. If stop() ran while it was
+            // in flight, recreating here puts a group back up that nothing is managing and that the
+            // phone will keep trying to join - the opposite of what the exit asked for.
+            if (supersededByStop(gen, "Native AA group recreate")) Unit
+            else if (forceStandard) standardCreateGroup(mgr, ch, 0, NATIVE_GROUP_MODE_STANDARD_FALLBACK)
             else delayedCreateQuietGroup(0)
         }
         mgr.removeGroup(ch, object : WifiP2pManager.ActionListener {
@@ -1183,7 +1370,19 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
 
     /** (Re)arm the native join watchdog; no-op unless we are a native-mode group owner with no
      *  client yet. */
-    private fun armNativeJoinWatchdog() {
+    /**
+     * Arms the join watchdog, at most once per group.
+     *
+     * [groupSsid] identifies the group this is being armed for. `onGroupInfoAvailable` fires three or
+     * four times per group and once more for every CONNECTION_CHANGED, and re-arming pushed the
+     * deadline out by the full timeout each time - so a phone retrying its join at any cadence faster
+     * than the timeout starved the watchdog indefinitely and the bounded recovery it exists to run
+     * never ran. Pass null where the re-arm is a real state change (a client leaving, WiFi coming
+     * back), which resets the identity and lets the next group arm afresh.
+     */
+    private fun armNativeJoinWatchdog(groupSsid: String? = null) {
+        if (groupSsid != null && groupSsid == nativeJoinWatchdogSsid) return
+        nativeJoinWatchdogSsid = groupSsid
         handler.removeCallbacks(nativeJoinWatchdog)
         if (isNativeAaMode() && isGroupOwner && !isClientConnected && isNativeSessionConnected?.invoke() != true) {
             handler.postDelayed(nativeJoinWatchdog, NATIVE_JOIN_TIMEOUT_MS)
@@ -1302,17 +1501,33 @@ class WifiDirectManager(private val context: Context) : WifiP2pManager.Connectio
 
     fun stop() {
         AppLog.i("WifiDirectManager: Stopping and cleaning up...")
+        generation++
+        credentialsEpoch++
         isGroupCreatingOrCreated = false
         handler.removeCallbacksAndMessages(null)
+        // Both of these guard an operation that is finished the moment we stop, and both used to be
+        // cleared only by a posted runnable that the line above just cancelled - so a stop() landing
+        // inside either window latched it true for the life of the process. A flag set in only one
+        // direction is how a long-lived manager ends up unable to re-arm.
+        checkGroupAndCreateInFlight = false
         isClientConnected = false
         nativeGroupCreationMode = NATIVE_GROUP_MODE_UNKNOWN
         native5GhzBandMismatchRetries = 0
         lastUnfriendlyChannelSsid = null
         lastCoexistenceSsid = null
+        lastFrequencyUnreadableSsid = null
+        nativeJoinWatchdogSsid = null
         nativeRecreateCount = 0
         lastNativeGroupStatusMessage = null
+        legacyChannelFallbackUsed = false
+        manager?.let { mgr -> channel?.let { ch -> releaseLegacyChannelRestriction(mgr, ch) } }
         AapService.scanningState.value = false
         try { context.unregisterReceiver(receiver) } catch (e: Exception) {}
+        // Follows the receiver rather than outliving it: registerReceiverIfNeeded() is a no-op while
+        // this is true, so leaving it set means a restarted manager never hears CONNECTION_CHANGED
+        // again - no client-connected state, and a join watchdog that fires on a group the phone has
+        // successfully joined.
+        isReceiverRegistered = false
 
         if (isGroupOwner) {
             manager?.removeGroup(channel, object : WifiP2pManager.ActionListener {

--- a/app/src/main/java/com/andrerinas/openheadunit/connection/WifiP2pChannelCompat.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/connection/WifiP2pChannelCompat.kt
@@ -1,0 +1,98 @@
+package com.andrerinas.openheadunit.connection
+
+import android.net.wifi.p2p.WifiP2pManager
+import com.andrerinas.openheadunit.aap.P2pOperatingChannelPolicy
+import com.andrerinas.openheadunit.utils.AppLog
+
+/**
+ * Reaches `WifiP2pManager.setWifiP2pChannels`, which is hidden on every API level but is the only way
+ * a pre-Android-10 device can be told which frequency to host its group on.
+ *
+ * The same reflection shape as `setDeviceName` in [WifiDirectManager], for the same reason: the
+ * method is `@hide` rather than absent, and the non-SDK blocklist that would refuse it only starts at
+ * API 28, below which this is the only lever there is. See [P2pOperatingChannelPolicy] for what the
+ * platform does with the value and why the listen channel must be left alone.
+ *
+ * Every failure here is non-fatal by construction. A group on the platform's own choice of channel is
+ * the behaviour that shipped; a group that never forms because a reflection threw is not, so the
+ * caller is told and carries on either way.
+ */
+object WifiP2pChannelCompat {
+
+    private const val METHOD = "setWifiP2pChannels"
+
+    /**
+     * Requests [operatingChannel], leaving the listen channel untouched.
+     *
+     * @param onResult invoked exactly once, with the platform's own verdict where there is one and
+     *   with the reflection's where there is not. [onResult] is what continues group creation, so it
+     *   must run on every path - including the one where the method does not exist.
+     */
+    fun setOperatingChannel(
+        manager: WifiP2pManager,
+        channel: WifiP2pManager.Channel,
+        operatingChannel: Int,
+        onResult: (applied: Boolean, detail: String) -> Unit,
+    ) {
+        if (!P2pOperatingChannelPolicy.isRequestable(operatingChannel)) {
+            onResult(false, "channel $operatingChannel is outside what the platform accepts")
+            return
+        }
+        try {
+            val method = manager.javaClass.getMethod(
+                METHOD,
+                WifiP2pManager.Channel::class.java,
+                Int::class.javaPrimitiveType,
+                Int::class.javaPrimitiveType,
+                WifiP2pManager.ActionListener::class.java,
+            )
+            var answered = false
+            val listener = object : WifiP2pManager.ActionListener {
+                override fun onSuccess() {
+                    if (answered) return
+                    answered = true
+                    onResult(true, "accepted")
+                }
+
+                override fun onFailure(reason: Int) {
+                    if (answered) return
+                    answered = true
+                    onResult(false, "refused (reason=$reason)")
+                }
+            }
+            method.invoke(
+                manager,
+                channel,
+                P2pOperatingChannelPolicy.LISTEN_CHANNEL_UNCHANGED,
+                operatingChannel,
+                listener,
+            )
+        } catch (e: NoSuchMethodException) {
+            onResult(false, "this platform has no $METHOD")
+        } catch (e: Throwable) {
+            // A SecurityException belongs here too: the manager-level call asks only for
+            // CHANGE_WIFI_STATE, but the service side is free to want more, and a unit that says no
+            // should still get a group.
+            AppLog.d("WifiP2pChannelCompat: $METHOD threw: ${e.message}")
+            onResult(false, "${e.javaClass.simpleName}: ${e.message}")
+        }
+    }
+
+    /**
+     * Gives the frequency list back to the platform.
+     *
+     * The restriction outlives the group and the process that set it - it is state in the supplicant,
+     * not in this app - so leaving it in place would follow the user into whatever else the unit does
+     * with WiFi Direct. Called on teardown for that reason, not for tidiness.
+     */
+    fun clearOperatingChannel(
+        manager: WifiP2pManager,
+        channel: WifiP2pManager.Channel,
+        onResult: (applied: Boolean, detail: String) -> Unit = { _, _ -> },
+    ) = setOperatingChannel(
+        manager,
+        channel,
+        P2pOperatingChannelPolicy.CHANNEL_UNRESTRICTED,
+        onResult,
+    )
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/CodecInputSizePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/CodecInputSizePolicy.kt
@@ -1,0 +1,77 @@
+package com.andrerinas.openheadunit.decoder
+
+/**
+ * How large an input buffer to ask a video decoder for.
+ *
+ * `KEY_MAX_INPUT_SIZE` is not advice. A component sizes its whole input port from it, and on a
+ * 1 GB MediaTek head unit a 2 MB request for a 1280x720 H.265 stream was answered with
+ *
+ *     ACodec: Allocating 8 buffers of size 2097152 ... on input port
+ *
+ * which is 16 MB of graphics memory for video input alone, on a device whose entire Java heap was
+ * running at 12-20 MB. The decoder was keeping up the whole time; the size of the machinery was the
+ * problem, not its speed.
+ *
+ * The fixed tiers this replaces - 1 MB or 2 MB for H.264 by API level, 2 MB or 8 MB for H.265 by
+ * resolution - were chosen against real hardware defects and are kept, as *caps*. What changes is
+ * that the request is now derived from the picture, so a small stream asks for a small buffer.
+ * At 1280x720 the derived figure is about 675 KB rather than 2 MB.
+ *
+ * The derivation is ExoPlayer's, from `MediaCodecVideoRenderer.getCodecMaxInputSize`: round the
+ * picture up to whole macroblocks, take the 4:2:0 sample count, and divide by the minimum
+ * compression ratio a conformant H.264 or H.265 encoder can achieve. A frame larger than that would
+ * be essentially uncompressed. It is also strictly safe against the alternative Moonlight takes,
+ * which is not to set the key at all and let the component choose.
+ *
+ * A frame that does not fit is already handled: [VideoDecoder] re-reads the real capacity from the
+ * dequeued buffer - components allocate more or less than asked - and drops an oversized frame whole
+ * rather than truncating it, which asks the phone for a keyframe. So the failure mode of asking for
+ * too little is a logged, repaired frame, not a corrupt picture.
+ */
+object CodecInputSizePolicy {
+
+    /** Macroblocks are 16x16 in both codecs. */
+    private const val MACROBLOCK = 16
+
+    /**
+     * Bytes per pixel of a 4:2:0 frame, as a fraction: 3/2. Luma plus two half-resolution chroma
+     * planes.
+     */
+    private const val YUV420_NUMERATOR = 3
+    private const val YUV420_DENOMINATOR = 2
+
+    /**
+     * The lowest compression ratio a conformant H.264 or H.265 stream can have, per ExoPlayer's
+     * table. Dividing by it turns "the whole uncompressed frame" into "the largest legal coded
+     * frame".
+     */
+    private const val MIN_COMPRESSION_RATIO = 2
+
+    /**
+     * Floor on the request.
+     *
+     * Chosen so it binds only *below* 800x480, which is the smallest picture Android Auto negotiates
+     * - so it never decides the answer for a real session, and it still catches a mis-parsed or
+     * absurd dimension. Deliberately not larger: a floor set for comfort rather than for a reason
+     * would throw away most of the saving at exactly the resolutions the cheap units use.
+     */
+    const val MIN_INPUT_SIZE_BYTES = 256 * 1024
+
+    /**
+     * The buffer size to request for a [width] x [height] picture, never above [cap].
+     *
+     * [cap] carries the existing per-codec, per-device tier so this can only ever ask for less than
+     * before. A non-positive dimension means we do not know the picture yet, and the answer is then
+     * the cap unchanged - shrinking a buffer on a guess is how a working unit stops working.
+     */
+    fun maxInputSizeFor(width: Int, height: Int, cap: Int): Int {
+        if (width <= 0 || height <= 0) return cap
+        val macroblocks = ceilDivide(width, MACROBLOCK).toLong() * ceilDivide(height, MACROBLOCK).toLong()
+        val samples = macroblocks * MACROBLOCK * MACROBLOCK
+        val derived = samples * YUV420_NUMERATOR / (YUV420_DENOMINATOR.toLong() * MIN_COMPRESSION_RATIO)
+        val floored = maxOf(derived, MIN_INPUT_SIZE_BYTES.toLong())
+        return minOf(floored, cap.toLong()).toInt()
+    }
+
+    private fun ceilDivide(numerator: Int, denominator: Int): Int = (numerator + denominator - 1) / denominator
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/CodecTypeSelectionPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/CodecTypeSelectionPolicy.kt
@@ -1,0 +1,61 @@
+package com.andrerinas.openheadunit.decoder
+
+/**
+ * Decides which codec to build for the first packet of a session, given what the stream looks like
+ * and what the user asked for.
+ *
+ * The two inputs disagree more often than they look like they should, because the codec setting is
+ * a *preference* everywhere except here. `ServiceDiscoveryResponse`
+ * announces H.265 only when an HEVC decoder actually exists and quietly announces H.264 otherwise,
+ * so a unit with no HEVC support set to "H.265" is told H.264 by us, is sent H.264 by the phone -
+ * and used to build an HEVC decoder for it anyway, because the setting was treated as a command and
+ * the stream sniff was thrown away. That produces a codec that errors on every access unit, which is
+ * the `ERROR(0x80001005)` storm read off a reporter capture: 52 rebuilds in 275s on a stream the
+ * decoder could never have played.
+ *
+ * The phone can also simply send H.264 on a session where we asked for H.265, which is the same
+ * failure from the other direction and needs no misconfiguration at all.
+ *
+ * Why the setting cannot just be ignored in favour of the sniff: `VideoDecoder.detectCodecType` is
+ * asymmetric. It recognises HEVC parameter sets only when [VideoDecoder.isHevcSupported] is true, so
+ * on a unit without hardware HEVC it walks past the VPS/SPS/PPS of a real H.265 stream and can then
+ * read an HEVC IDR_N_LP header (NAL 20, byte 0x28) as an H.264 PPS, because `0x28 and 0x1F` is 8.
+ * On such a unit the sniff's "H.264" answer is not evidence, and the explicit setting is the only
+ * thing that knows the stream is H.265 - which is exactly the software-HEVC case.
+ *
+ * So the sniff is trusted when it is symmetric, the setting is trusted when it is not, and a unit
+ * that cannot decode HEVC by any route gets H.264 regardless of what its setting says, because that
+ * is what we told the phone to send.
+ */
+object CodecTypeSelectionPolicy {
+
+    /**
+     * @param detected what `VideoDecoder.detectCodecType` made of the first packet, or null when it
+     *   found no parameter set it recognised.
+     * @param requested the codec type implied by `Settings.videoCodec`.
+     * @param hevcDetectable true when the sniff can positively identify HEVC, i.e.
+     *   [VideoDecoder.isHevcSupported]. When false the sniff's H.264 answer may be a misread H.265
+     *   stream and carries no information.
+     * @param hevcUsable true when an HEVC decoder exists by some route - hardware, or an explicitly
+     *   selected software one. Mirrors `hevcAvailableForUserChoice` in the announcement, which is
+     *   what decided the codec the phone is actually sending.
+     */
+    fun select(
+        detected: VideoDecoder.CodecType?,
+        requested: VideoDecoder.CodecType,
+        hevcDetectable: Boolean,
+        hevcUsable: Boolean,
+    ): VideoDecoder.CodecType {
+        // Nothing here can play H.265, so the announcement asked for H.264 and that is what is
+        // arriving. Honouring a stale "H.265" setting builds a decoder that cannot decode anything.
+        if (!hevcUsable) return VideoDecoder.CodecType.H264
+
+        // The sniff saw both codecs' parameter sets and picked one: it is looking at the stream,
+        // the setting is not.
+        if (detected != null && hevcDetectable) return detected
+
+        // Either the packet carried no parameter set, or the sniff was half-blind. The setting is
+        // the better guess, and on the software-HEVC path it is the only correct one.
+        return requested
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/DecoderCapabilityReport.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/DecoderCapabilityReport.kt
@@ -1,0 +1,153 @@
+package com.andrerinas.openheadunit.decoder
+
+import android.media.MediaCodecInfo
+import android.media.MediaCodecList
+import android.os.Build
+
+/**
+ * What a decoder claims about a picture, asked in two places for two different reasons.
+ *
+ * **At configure time**, of the component already chosen: does it manage the stream it is about to
+ * be handed? **At negotiation time**, of whatever component would be chosen: is the profile we are
+ * about to ask the phone for one this device can carry?
+ *
+ * The second question is the one nothing has ever asked. `ServiceDiscoveryResponse` overrides the
+ * user's codec choice and forces H.265 whenever the negotiated resolution is 1440p, without
+ * consulting any decoder - and a #219 reporter's Galaxy Tab S7 FE runs exactly that: 2560x1440 HEVC
+ * on `c2.qti.hevc.decoder`, shedding frames in bursts with up to 2019ms of a 5s window spent waiting
+ * for an input buffer. No log has ever said whether that component claims to sustain the size and
+ * rate we forced on it.
+ *
+ * Nothing here changes a decision. It produces the line that would justify changing one.
+ */
+object DecoderCapabilityReport {
+
+    /**
+     * One decoder's answer, plus the numbers behind it.
+     *
+     * [sustains] is deliberately nullable and distinct from [rateSupported]: below API 29 there are
+     * no performance points, and "we could not ask" is not "the answer was no".
+     */
+    data class Capability(
+        val codecName: String,
+        val mimeType: String,
+        val width: Int,
+        val height: Int,
+        val fps: Int,
+        val sizeSupported: Boolean,
+        val rateSupported: Boolean,
+        val sustains: Boolean?,
+        val lowLatency: Boolean,
+        val adaptivePlayback: Boolean,
+        val supportedWidths: String,
+        val supportedHeights: String,
+    ) {
+        /**
+         * Whether this decoder claims it can carry the picture.
+         *
+         * An unknown [sustains] counts as adequate. `areSizeAndRateSupported` is the weaker claim -
+         * it says the component accepts the format, not that it keeps up - so treating a missing
+         * performance point as failure would flag every pre-Android-10 device that is working fine.
+         */
+        val adequate: Boolean
+            get() = sizeSupported && rateSupported && sustains != false
+
+        override fun toString(): String =
+            "codec=$codecName mime=$mimeType target=${width}x${height}@$fps " +
+                "sizeSupported=$sizeSupported rateSupported=$rateSupported " +
+                "sustains=${sustains ?: "unknown"} " +
+                "widths=$supportedWidths heights=$supportedHeights " +
+                "featureLowLatency=$lowLatency featureAdaptivePlayback=$adaptivePlayback"
+    }
+
+    /** Raw capabilities of [codecName] for [mimeType], or null when they cannot be read. */
+    fun capabilitiesOf(codecName: String, mimeType: String): MediaCodecInfo.CodecCapabilities? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return null
+        return try {
+            MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos
+                .firstOrNull { it.name == codecName }
+                ?.getCapabilitiesForType(mimeType)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /** Whether the component itself claims Android 11's low-latency feature. */
+    fun advertisesLowLatency(codecName: String, mimeType: String): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return false
+        return try {
+            capabilitiesOf(codecName, mimeType)
+                ?.isFeatureSupported(MediaCodecInfo.CodecCapabilities.FEATURE_LowLatency) == true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /** The configure-time question: what does the component we picked say about this picture? */
+    fun forCodec(codecName: String, mimeType: String, width: Int, height: Int, fps: Int): Capability? {
+        val caps = capabilitiesOf(codecName, mimeType) ?: return null
+        val video = caps.videoCapabilities ?: return null
+        val rate = if (fps > 0) fps else DEFAULT_FPS
+        return Capability(
+            codecName = codecName,
+            mimeType = mimeType,
+            width = width,
+            height = height,
+            fps = rate,
+            sizeSupported = runCatching { video.isSizeSupported(width, height) }.getOrDefault(false),
+            rateSupported = runCatching {
+                video.areSizeAndRateSupported(width, height, rate.toDouble())
+            }.getOrDefault(false),
+            // API 29+ only: a performance point is a claim about sustaining a rate, where
+            // areSizeAndRateSupported is only a claim about accepting it.
+            sustains = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                runCatching {
+                    val target = MediaCodecInfo.VideoCapabilities.PerformancePoint(width, height, rate)
+                    video.supportedPerformancePoints?.any { it.covers(target) }
+                }.getOrNull()
+            } else {
+                null
+            },
+            lowLatency = advertisesLowLatency(codecName, mimeType),
+            adaptivePlayback = runCatching {
+                caps.isFeatureSupported(MediaCodecInfo.CodecCapabilities.FEATURE_AdaptivePlayback)
+            }.getOrDefault(false),
+            supportedWidths = runCatching { video.supportedWidths.toString() }.getOrDefault("?"),
+            supportedHeights = runCatching { video.supportedHeights.toString() }.getOrDefault("?"),
+        )
+    }
+
+    /**
+     * The negotiation-time question: of the decoders this device has for [mimeType], what would the
+     * one we are going to pick say?
+     *
+     * Picks the first hardware component, matching `VideoDecoder.findBestCodec`'s order, and falls
+     * back to the first of any kind so a software-only device still gets a line. The software test
+     * is the same name heuristic `VideoDecoder.isHevcDecoderAvailable` uses - one heuristic, not two.
+     */
+    fun query(mimeType: String, width: Int, height: Int, fps: Int): Capability? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return null
+        val names = try {
+            MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos
+                .filter { !it.isEncoder && it.supportedTypes.any { t -> t.equals(mimeType, true) } }
+                .map { it.name }
+        } catch (e: Exception) {
+            return null
+        }
+        val chosen = names.firstOrNull { !isSoftwareName(it) } ?: names.firstOrNull() ?: return null
+        return forCodec(chosen, mimeType, width, height, fps)
+    }
+
+    /** Same test as `VideoDecoder.isHevcDecoderAvailable`, kept in one place. */
+    fun isSoftwareName(codecName: String): Boolean {
+        val name = codecName.lowercase()
+        return name.startsWith("omx.google.") ||
+            name.startsWith("c2.android.") ||
+            name.startsWith("omx.ffmpeg.") ||
+            name.contains(".sw.") ||
+            name.contains("software")
+    }
+
+    /** What a zero or negative fps setting means when a rate has to be named. */
+    const val DEFAULT_FPS = 30
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/DecoderConfigLadder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/DecoderConfigLadder.kt
@@ -1,0 +1,103 @@
+package com.andrerinas.openheadunit.decoder
+
+/**
+ * The order in which to try optional `MediaFormat` keys when configuring a decoder, and what to fall
+ * back to when one is rejected.
+ *
+ * Every optional key this project ever added was removed again, and the comment in [VideoDecoder.start]
+ * records why: `KEY_PRIORITY` and `KEY_OPERATING_RATE` were measured being answered with
+ * `codec does not support config priority (err -1010)` on the head units they were meant to help. The
+ * problem was never the keys, it was that a rejected key took the whole session with it, so the only
+ * safe number of optional keys was zero.
+ *
+ * A ladder changes that. Configure is attempted with the richest key set first and, if it throws, the
+ * next attempt drops one tier. The last tier is always empty, so the worst case is exactly the
+ * behaviour with no optional keys at all - which is what shipped before this existed. That makes any
+ * future key cheap to try and impossible to regress on.
+ *
+ * The keys themselves come from Moonlight's `MediaCodecHelper`, which carries the only device-attributed
+ * table of them anyone maintains. The official `KEY_LOW_LATENCY` only exists from API 30, and the five
+ * vendor spellings below are what the same feature was called before that - including
+ * `vdec-lowlatency`, which MediaTek's fork of ACodec translates to
+ * `OMX.MTK.index.param.video.LowLatencyDecode`, and which is the decoder in the 1 GB unit from #839.
+ *
+ * Nothing here decides *whether* to try the optional tiers; [VideoDecoder] gates that on a setting
+ * which is off by default, because this project's rule is that no vendor key ships enabled without a
+ * log from a device that accepted it. The ladder's tier log is how that log gets produced.
+ */
+object DecoderConfigLadder {
+
+    /** One rung: a label for the log and the integer keys to set. */
+    data class Tier(val label: String, val integerKeys: Map<String, Int>)
+
+    /** Android 11's official low-latency key. Named here so the string is not repeated. */
+    const val KEY_LOW_LATENCY = "low-latency"
+
+    /** API level at which [KEY_LOW_LATENCY] exists. */
+    const val LOW_LATENCY_API = 30
+
+    /**
+     * MediaTek, via their modified ACodec. Also plumbed on Amazon's Amlogic devices, where per
+     * Moonlight it does more than reduce latency - it is what makes their HEVC decoder emit frames at
+     * all.
+     */
+    const val MTK_LOW_LATENCY = "vdec-lowlatency"
+
+    const val AMLOGIC_LOW_LATENCY = "vendor.low-latency.enable"
+    const val QUALCOMM_LOW_LATENCY = "vendor.qti-ext-dec-low-latency.enable"
+    const val EXYNOS_LOW_LATENCY = "vendor.rtc-ext-dec-low-latency.enable"
+    const val HISILICON_LOW_LATENCY_REQ =
+        "vendor.hisi-ext-low-latency-video-dec.video-scene-for-low-latency-req"
+    const val HISILICON_LOW_LATENCY_RDY =
+        "vendor.hisi-ext-low-latency-video-dec.video-scene-for-low-latency-rdy"
+
+    /** The empty rung. Always last, and always reached, so the fallback is the pre-existing behaviour. */
+    val NO_OPTIONAL_KEYS = Tier("none", emptyMap())
+
+    /**
+     * Vendor low-latency keys for a decoder, matched on its name, or empty if the family is unknown.
+     *
+     * Matched by name rather than by `Build` properties because the decoder name is what the key
+     * belongs to: a device can carry components from more than one vendor, and it is the component
+     * that either understands the key or throws.
+     */
+    fun vendorLowLatencyKeys(codecName: String): Map<String, Int> {
+        val name = codecName.lowercase()
+        return when {
+            name.contains(".mtk.") || name.contains("mediatek") -> mapOf(MTK_LOW_LATENCY to 1)
+            name.contains("amlogic") -> mapOf(AMLOGIC_LOW_LATENCY to 1)
+            name.contains(".qcom.") || name.contains(".qti.") -> mapOf(QUALCOMM_LOW_LATENCY to 1)
+            name.contains("exynos") -> mapOf(EXYNOS_LOW_LATENCY to 1)
+            name.contains(".hisi.") || name.contains("hisilicon") ->
+                mapOf(HISILICON_LOW_LATENCY_REQ to 1, HISILICON_LOW_LATENCY_RDY to -1)
+            else -> emptyMap()
+        }
+    }
+
+    /**
+     * The rungs to try, richest first, always ending in [NO_OPTIONAL_KEYS].
+     *
+     * [lowLatencyRequested] false returns the single empty rung, which is the shipped behaviour. When
+     * it is true, the official key is preferred wherever the component advertises `FEATURE_LowLatency`
+     * and the platform is new enough for the key to mean anything; otherwise the vendor spelling for
+     * that component is tried. The two are never combined - a component that understands the official
+     * key has no need of the older private one, and setting both only widens what a single rejection
+     * can take down.
+     */
+    fun tiers(
+        codecName: String,
+        sdkInt: Int,
+        advertisesLowLatencyFeature: Boolean,
+        lowLatencyRequested: Boolean,
+    ): List<Tier> {
+        if (!lowLatencyRequested) return listOf(NO_OPTIONAL_KEYS)
+
+        if (sdkInt >= LOW_LATENCY_API && advertisesLowLatencyFeature) {
+            return listOf(Tier("low-latency", mapOf(KEY_LOW_LATENCY to 1)), NO_OPTIONAL_KEYS)
+        }
+
+        val vendorKeys = vendorLowLatencyKeys(codecName)
+        if (vendorKeys.isEmpty()) return listOf(NO_OPTIONAL_KEYS)
+        return listOf(Tier("vendor", vendorKeys), NO_OPTIONAL_KEYS)
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/DecoderStallCausePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/DecoderStallCausePolicy.kt
@@ -20,6 +20,15 @@ package com.andrerinas.openheadunit.decoder
  * budget gone, then stalls at 10, 20, 30, 40, 50 and 60 seconds with `rendered=0` throughout while
  * input flowed at ~50fps. Android Auto's own client eventually asked whether its screen was visible.
  *
+ * ### A keyframe that decodes, not one that was fed
+ *
+ * [keyframeDecodedSinceStart] is measured at the codec's output for a reason. An access unit that
+ * lost a fragment in the middle still carries its parameter sets and IDR slice at the head, so it
+ * scans as a keyframe, is fed like one, and produces no picture. Counting that as "the codec has had
+ * what it needs" put this straight back on the rebuild path - and at one middle fragment lost in
+ * three, a later round measured the whole pre-fix signature returning: two exhausted restart ladders
+ * and 90+ seconds of `rendered=0`. See [KeyframeRepairTracker].
+ *
  * Naming the starved case costs nothing on the healthy path and turns the loop into a wait.
  *
  * Pure: no clock, no logging. The caller supplies the elapsed times it already has.
@@ -43,8 +52,8 @@ object DecoderStallCausePolicy {
         PHONE_IDLE,
 
         /**
-         * Input is arriving, but no keyframe has reached this codec since it started, so there is
-         * nothing it could have rendered. Ask for a keyframe; do not rebuild.
+         * Input is arriving, but no keyframe has decoded on this codec since it started, so there
+         * is nothing it could have rendered. Ask for a keyframe; do not rebuild.
          */
         STARVED_OF_KEYFRAME,
 
@@ -56,7 +65,8 @@ object DecoderStallCausePolicy {
      * @param stallGapMs time since the last rendered frame, or since this codec started if none.
      * @param inputIdleGapMs time since the last bytes arrived from the phone.
      * @param inputIdleThresholdMs how long that gap has to be before the phone counts as idle.
-     * @param keyframeFedSinceStart whether a keyframe has been handed to this codec instance.
+     * @param keyframeDecodedSinceStart whether a keyframe has produced output on this codec
+     *   instance. Not whether one was fed - a holed keyframe is fed and decodes to nothing.
      * @param sessionHasRendered whether any frame at all has rendered this session. A cold start that
      *   has never rendered stays on the ordinary path deliberately: there the codec type is still
      *   unproven, and the rebuild is what reaches the one-time fallback to the other codec.
@@ -65,11 +75,11 @@ object DecoderStallCausePolicy {
         stallGapMs: Long,
         inputIdleGapMs: Long,
         inputIdleThresholdMs: Long,
-        keyframeFedSinceStart: Boolean,
+        keyframeDecodedSinceStart: Boolean,
         sessionHasRendered: Boolean,
     ): Cause {
         if (inputIdleGapMs > inputIdleThresholdMs) return Cause.PHONE_IDLE
-        if (keyframeFedSinceStart) return Cause.STALLED
+        if (keyframeDecodedSinceStart) return Cause.STALLED
         if (!sessionHasRendered) return Cause.STALLED
         if (stallGapMs >= KEYFRAME_STARVATION_PATIENCE_MS) return Cause.STALLED
         return Cause.STARVED_OF_KEYFRAME

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/DecoderStallCausePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/DecoderStallCausePolicy.kt
@@ -1,0 +1,77 @@
+package com.andrerinas.openheadunit.decoder
+
+/**
+ * Separates a decoder that is broken from one that has simply not been given a keyframe yet.
+ *
+ * The output-side watchdog fires on "input is arriving and nothing is coming out", and its only
+ * answer is to rebuild the MediaCodec. That answer is wrong for one common case, and wrong in a way
+ * that feeds itself.
+ *
+ * A codec rebuilt mid-session resumes on whatever access unit arrives next, which is almost always a
+ * P-frame. It cannot produce a picture from that, and it will not produce one until an IDR arrives.
+ * Android Auto sends those on a fixed ~69s cadence that `VideoConfiguration` gives us no way to
+ * shorten, and the protocol has no keyframe-request message at all - the release/regain focus cycle
+ * is the only lever that exists. So the decoder is silent for up to a full GOP through no fault of
+ * its own, the watchdog reads that silence as a fault, rebuilds again, and the rebuild resets the
+ * wait. Each pass also runs the transport's decoder-error path, which used to cancel the very clock
+ * that would have escalated to the cycle.
+ *
+ * Measured on a UNISOC MT50 under injected mid-stream corruption: four rebuilds in 33s, the restart
+ * budget gone, then stalls at 10, 20, 30, 40, 50 and 60 seconds with `rendered=0` throughout while
+ * input flowed at ~50fps. Android Auto's own client eventually asked whether its screen was visible.
+ *
+ * Naming the starved case costs nothing on the healthy path and turns the loop into a wait.
+ *
+ * Pure: no clock, no logging. The caller supplies the elapsed times it already has.
+ */
+object DecoderStallCausePolicy {
+
+    /**
+     * How long a keyframe-starved decoder is left alone before the ordinary rebuild path resumes.
+     *
+     * A bound rather than an open wait, because "no keyframe has reached the codec" is also what a
+     * decoder looks like when the fault is somewhere this cannot see. Everything meant to resolve the
+     * starvation is far quicker than this: the escalated focus cycle produces a keyframe 0.52-0.78s
+     * after the release, and the warm-relaunch path escalates after 850ms. Fifteen seconds is well
+     * clear of both and well short of the ~69s GOP, so a decoder that is genuinely dead still reaches
+     * the rebuild - and the codec-type fallback behind it - inside the same session.
+     */
+    const val KEYFRAME_STARVATION_PATIENCE_MS = 15_000L
+
+    enum class Cause {
+        /** The phone has stopped sending. Not a decoder fault and never was; the caller stays silent. */
+        PHONE_IDLE,
+
+        /**
+         * Input is arriving, but no keyframe has reached this codec since it started, so there is
+         * nothing it could have rendered. Ask for a keyframe; do not rebuild.
+         */
+        STARVED_OF_KEYFRAME,
+
+        /** Input is arriving, the codec has had what it needs, and nothing is coming out. */
+        STALLED,
+    }
+
+    /**
+     * @param stallGapMs time since the last rendered frame, or since this codec started if none.
+     * @param inputIdleGapMs time since the last bytes arrived from the phone.
+     * @param inputIdleThresholdMs how long that gap has to be before the phone counts as idle.
+     * @param keyframeFedSinceStart whether a keyframe has been handed to this codec instance.
+     * @param sessionHasRendered whether any frame at all has rendered this session. A cold start that
+     *   has never rendered stays on the ordinary path deliberately: there the codec type is still
+     *   unproven, and the rebuild is what reaches the one-time fallback to the other codec.
+     */
+    fun classify(
+        stallGapMs: Long,
+        inputIdleGapMs: Long,
+        inputIdleThresholdMs: Long,
+        keyframeFedSinceStart: Boolean,
+        sessionHasRendered: Boolean,
+    ): Cause {
+        if (inputIdleGapMs > inputIdleThresholdMs) return Cause.PHONE_IDLE
+        if (keyframeFedSinceStart) return Cause.STALLED
+        if (!sessionHasRendered) return Cause.STALLED
+        if (stallGapMs >= KEYFRAME_STARVATION_PATIENCE_MS) return Cause.STALLED
+        return Cause.STARVED_OF_KEYFRAME
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/DeviceMemoryProfile.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/DeviceMemoryProfile.kt
@@ -1,0 +1,129 @@
+package com.andrerinas.openheadunit.decoder
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Build
+
+/**
+ * How much room this device has for the video pipeline to spend.
+ *
+ * The pipeline's buffers were sized for a unit that has memory to spare, and the same numbers land
+ * very differently on one that does not. A 1 GB MediaTek head unit was measured running a 12-20 MB
+ * Java heap while the app asked for a 2 MB `KEY_MAX_INPUT_SIZE`, which the component answered with
+ * eight buffers of that size - 16 MB of graphics memory for input alone - and while the collector
+ * ran every 5-10 seconds freeing 84-208 large arrays a cycle, once pausing for 1.4 s. The decoder
+ * itself was keeping up throughout (`dropped=0`), so what hurt was the size of the machinery rather
+ * than its speed.
+ *
+ * The classification is deliberately coarse and total-RAM-first. The allocations that matter most
+ * are the codec's own input and output buffers, which come from graphics memory rather than the Java
+ * heap, so the heap limit alone would miss them; and `isLowRamDevice` cannot be relied on because
+ * these units set it as often as they do not.
+ *
+ * Only [classify] holds the rule, so it can be tested without a device.
+ */
+enum class DeviceMemoryProfile {
+    /** Roughly 1 GB units and the like: buffers should be sized down. */
+    CONSTRAINED,
+
+    /** The middle ground. Present behaviour. */
+    NORMAL,
+
+    /** Modern tablets and units with memory to spare. */
+    AMPLE;
+
+    companion object {
+
+        /** At or below this much total RAM, treat the device as constrained. */
+        const val CONSTRAINED_TOTAL_RAM_MB = 1536L
+
+        /** At or below this heap ceiling, treat the device as constrained whatever its total RAM. */
+        const val CONSTRAINED_HEAP_LIMIT_MB = 96L
+
+        /** Both of these are needed before extra buffering is considered free. */
+        const val AMPLE_TOTAL_RAM_MB = 3584L
+        const val AMPLE_HEAP_LIMIT_MB = 192L
+
+        private const val BYTES_PER_MB = 1024L * 1024L
+
+        /**
+         * Classifies a device from three numbers.
+         *
+         * [totalRamMb] is the whole device's physical memory, [heapLimitMb] the app's Java heap
+         * ceiling, and [systemLowRamFlag] whatever `ActivityManager.isLowRamDevice()` reports. The
+         * flag can only push the verdict down, never up: a unit that admits to being low-RAM is
+         * believed, one that does not is still judged on its numbers.
+         *
+         * A non-positive input is treated as unknown and ignored rather than as constrained, so a
+         * platform that fails to report something does not silently shrink the pipeline.
+         */
+        fun classify(totalRamMb: Long, heapLimitMb: Long, systemLowRamFlag: Boolean): DeviceMemoryProfile {
+            if (systemLowRamFlag) return CONSTRAINED
+            if (totalRamMb in 1..CONSTRAINED_TOTAL_RAM_MB) return CONSTRAINED
+            if (heapLimitMb in 1..CONSTRAINED_HEAP_LIMIT_MB) return CONSTRAINED
+            if (totalRamMb >= AMPLE_TOTAL_RAM_MB && heapLimitMb >= AMPLE_HEAP_LIMIT_MB) return AMPLE
+            return NORMAL
+        }
+
+        /**
+         * Reads the device's numbers and classifies them, keeping every input in the result so a bug
+         * report carries what the verdict rested on and not only the verdict.
+         */
+        fun read(context: Context): DeviceMemoryReading {
+            val totalRamMb = readTotalRamMb(context)
+            val heapLimitMb = Runtime.getRuntime().maxMemory() / BYTES_PER_MB
+            val memoryClassMb = runCatching { activityManager(context).memoryClass.toLong() }.getOrDefault(0L)
+            val lowRam = runCatching {
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && activityManager(context).isLowRamDevice
+            }.getOrDefault(false)
+
+            return DeviceMemoryReading(
+                profile = classify(totalRamMb, heapLimitMb, lowRam),
+                totalRamMb = totalRamMb,
+                heapLimitMb = heapLimitMb,
+                memoryClassMb = memoryClassMb,
+                systemLowRamFlag = lowRam,
+            )
+        }
+
+        /**
+         * [read], with [override] replacing the verdict when it is set.
+         *
+         * The override exists so the rig can run the constrained path without a 1 GB device. The
+         * measured numbers are kept in the reading either way, and the reading says it was forced, so
+         * a log from a forced run cannot be mistaken for a log from the hardware it imitates.
+         */
+        fun readWithOverride(context: Context, override: DeviceMemoryProfile?): DeviceMemoryReading {
+            val measured = read(context)
+            return if (override == null) measured else measured.copy(profile = override, forced = true)
+        }
+
+        /** Parses a stored profile name, tolerating anything unrecognised. */
+        fun fromName(name: String?): DeviceMemoryProfile? =
+            name?.let { stored -> entries.firstOrNull { it.name == stored } }
+
+        private fun activityManager(context: Context): ActivityManager =
+            context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+
+        private fun readTotalRamMb(context: Context): Long = runCatching {
+            val info = ActivityManager.MemoryInfo()
+            activityManager(context).getMemoryInfo(info)
+            info.totalMem / BYTES_PER_MB
+        }.getOrDefault(0L)
+    }
+}
+
+/** A [DeviceMemoryProfile] plus the numbers behind it, for logging. */
+data class DeviceMemoryReading(
+    val profile: DeviceMemoryProfile,
+    val totalRamMb: Long,
+    val heapLimitMb: Long,
+    val memoryClassMb: Long,
+    val systemLowRamFlag: Boolean,
+    /** True when [profile] was overridden for testing rather than measured. */
+    val forced: Boolean = false,
+) {
+    override fun toString(): String =
+        "$profile${if (forced) " (FORCED)" else ""} (totalRam=${totalRamMb}MB heapLimit=${heapLimitMb}MB " +
+            "memoryClass=${memoryClassMb}MB lowRamFlag=$systemLowRamFlag)"
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/KeyframeRepairTracker.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/KeyframeRepairTracker.kt
@@ -1,0 +1,142 @@
+package com.andrerinas.openheadunit.decoder
+
+/**
+ * Separates a keyframe that was handed to the codec from one that produced a picture.
+ *
+ * Everything upstream of the codec answers the first question. [com.andrerinas.openheadunit.aap.VideoKeyframeScanner]
+ * reads the first few NAL headers at the *head* of an access unit, so an access unit whose middle
+ * arrived damaged - a fragment lost on the link, the exact shape of the melting-picture reports -
+ * still scans as a keyframe. It is fed, it is logged, and it decodes to nothing.
+ *
+ * That mattered because "a keyframe was fed" was wired to two decisions that both mean "the picture
+ * is fine again":
+ *
+ *  - [DecoderStallCausePolicy] stopped calling the codec starved, so the output watchdog went back
+ *    to rebuilding it - and each rebuild resumes on a P-frame, which is the loop the starvation case
+ *    exists to break.
+ *  - `AapTransport`'s escalation clock was cancelled, so the focus cycle that would have fetched a
+ *    *real* keyframe was pushed back behind the next drop.
+ *
+ * Measured on a UNISOC MT50 under one-in-three middle-fragment loss: roughly a third of keyframes
+ * arrive holed, both resets fire repeatedly, and the picture sits at `rendered=0` for 90+ seconds
+ * while the restart budget is spent twice over.
+ *
+ * So the repair signal is moved to the far side of the codec. A keyframe is pending until a frame
+ * with at least its presentation timestamp comes out.
+ *
+ * ### Why the timestamp and not "the next frame rendered"
+ *
+ * Two reasons, and the first is the one that bites. MediaCodec keeps frames queued ahead of the
+ * feed, so the render that follows a keyframe feed is usually a frame from *before* it - "something
+ * rendered after we fed it" would confirm on output the keyframe had no part in. The second is why
+ * a rendered frame is not the signal on its own: after a shed reference frame the decoder renders
+ * continuously and the picture is wrong the whole time, which is the case the keyframe clock was
+ * written for.
+ *
+ * Presentation timestamps are monotonic within one codec instance and restart near zero when the
+ * codec is reconfigured, so [reset] on every restart is not optional - a pending stamp from the old
+ * codec would be confirmed by the new one's first frame.
+ *
+ * ### The decoder that does not carry timestamps through
+ *
+ * Some components hand every output buffer back with the same presentation timestamp, or zero. On
+ * one of those, a keyframe would stay pending while the picture ran perfectly - the decoder would be
+ * called starved every fifteen seconds and the transport would spend focus cycles on a stream that
+ * never needed them, which is a worse thing to ship than the wedge this replaces. So a keyframe that
+ * is still pending after [RENDERS_BEFORE_TIMESTAMPS_DISBELIEVED] frames have come out is confirmed
+ * anyway, and [timestampsUnusable] says why. The bound is far past any real reorder depth and far
+ * short of the fifteen seconds the starvation path waits, so a working decoder never reaches it.
+ *
+ * Pure and thread-safe: written from the feed thread, read and cleared from the output thread.
+ */
+class KeyframeRepairTracker {
+
+    /** Presentation timestamp of the newest keyframe fed and not yet seen at the output. */
+    private var pendingPtsUs = NONE
+
+    private var decoded = false
+
+    /** Frames rendered since the pending keyframe was fed, none of which reached its timestamp. */
+    private var rendersWhilePending = 0
+
+    private var disbelievedTimestamps = false
+
+    /** Whether any keyframe has produced output since the last [reset]. */
+    val keyframeDecoded: Boolean
+        @Synchronized get() = decoded
+
+    /** Whether a keyframe is fed and still waiting to be seen at the output. Diagnostic. */
+    val awaitingOutput: Boolean
+        @Synchronized get() = pendingPtsUs != NONE
+
+    /**
+     * Whether a keyframe has been confirmed by frame count rather than by timestamp.
+     *
+     * True means this component's output timestamps cannot be used, so every repair from here is
+     * being read from the fact that frames are coming out at all. Worth saying once in a log: it is
+     * the difference between "the picture came back" and "the picture came back and we cannot see
+     * which frame brought it".
+     */
+    val timestampsUnusable: Boolean
+        @Synchronized get() = disbelievedTimestamps
+
+    /**
+     * A keyframe was queued to the codec at [ptsUs].
+     *
+     * The newest one replaces any older pending stamp: confirming the newest confirms every keyframe
+     * before it, since output is monotonic, and holding the oldest would let one holed keyframe be
+     * confirmed by a later good one's picture.
+     */
+    @Synchronized
+    fun onKeyframeFed(ptsUs: Long) {
+        pendingPtsUs = ptsUs
+        rendersWhilePending = 0
+    }
+
+    /**
+     * A frame with [ptsUs] reached the surface.
+     *
+     * @return true exactly once per pending keyframe, on the first frame at or past its timestamp -
+     *   the moment the picture is genuinely repaired.
+     */
+    @Synchronized
+    fun onFrameRendered(ptsUs: Long): Boolean {
+        if (pendingPtsUs == NONE) return false
+        if (ptsUs < pendingPtsUs) {
+            rendersWhilePending++
+            if (rendersWhilePending < RENDERS_BEFORE_TIMESTAMPS_DISBELIEVED) return false
+            // Frames are reaching the screen and none of them ever reports the keyframe's stamp.
+            // The picture is demonstrably back; only the attribution is lost.
+            disbelievedTimestamps = true
+        }
+        pendingPtsUs = NONE
+        rendersWhilePending = 0
+        decoded = true
+        return true
+    }
+
+    /** Drops all state. Call wherever the codec is rebuilt - see the class comment on timestamps. */
+    @Synchronized
+    fun reset() {
+        pendingPtsUs = NONE
+        rendersWhilePending = 0
+        decoded = false
+        // Deliberately not cleared: a component that mangles timestamps still does after a rebuild,
+        // and re-learning it would mean another burst of frames confirmed the slow way each time.
+    }
+
+    companion object {
+        /**
+         * How many rendered frames may pass a pending keyframe's timestamp by before the timestamps
+         * are treated as meaningless.
+         *
+         * Half a second at 60fps, which is orders of magnitude past any reorder depth a projected
+         * stream carries and well short of [DecoderStallCausePolicy.KEYFRAME_STARVATION_PATIENCE_MS],
+         * so the only decoder that reaches it is one whose output stamps say nothing.
+         */
+        const val RENDERS_BEFORE_TIMESTAMPS_DISBELIEVED = 30
+
+        /** No keyframe is waiting. Not a valid timestamp: presentation stamps here are never negative. */
+        private const val NONE = -1L
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/ParameterSetInspector.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/ParameterSetInspector.kt
@@ -1,0 +1,392 @@
+package com.andrerinas.openheadunit.decoder
+
+/**
+ * Reads the fields of an H.264 or H.265 parameter set that decide how a decoder buffers frames.
+ *
+ * This exists to answer one question with a number instead of a guess. Moonlight rewrites the H.264
+ * SPS on every Android 8.0+ device it runs on - forcing `bitstream_restriction` present with
+ * `max_num_reorder_frames = 0` and `max_dec_frame_buffering = num_ref_frames` - because unmodified
+ * NVENC output makes some hardware decoders allocate 16+ reference buffers and adds frames of
+ * latency. We have never looked at what Android Auto actually sends, so we do not know whether that
+ * lever exists for us at all. Log it before writing a bitstream writer for it.
+ *
+ * The reader does its own RBSP unescaping. The dimension-only parser this replaced did not, which was
+ * survivable while it only reached the width and height near the front of the SPS - but every field
+ * this class is here for sits behind the VUI or the profile-tier-level block, far enough in that a
+ * single unremoved `0x03` silently shifts everything after it and turns the answer into noise. A
+ * `0x03` in a High-profile scaling matrix reaches the dimensions too, which is one of the reasons the
+ * old parser is gone rather than kept alongside.
+ *
+ * Everything here is a *reader*. Nothing in this file modifies a bitstream.
+ */
+object ParameterSetInspector {
+
+    /**
+     * Fields of an AVC/H.264 SPS. Nullable members are absent from the bitstream rather than zero,
+     * which is the distinction that matters: `bitstreamRestrictionPresent == false` is exactly the
+     * case Moonlight patches.
+     */
+    data class H264Sps(
+        val profileIdc: Int,
+        val levelIdc: Int,
+        val picOrderCntType: Int,
+        val maxNumRefFrames: Int,
+        val width: Int,
+        val height: Int,
+        val vuiPresent: Boolean,
+        val bitstreamRestrictionPresent: Boolean,
+        val maxNumReorderFrames: Int?,
+        val maxDecFrameBuffering: Int?,
+    ) {
+        override fun toString(): String =
+            "profile=$profileIdc level=$levelIdc poc_type=$picOrderCntType " +
+                "num_ref_frames=$maxNumRefFrames size=${width}x$height vui=$vuiPresent " +
+                "bitstream_restriction=$bitstreamRestrictionPresent " +
+                "num_reorder_frames=${maxNumReorderFrames ?: "absent"} " +
+                "max_dec_frame_buffering=${maxDecFrameBuffering ?: "absent"}"
+    }
+
+    /**
+     * Fields of an HEVC/H.265 SPS.
+     *
+     * Stops at the sub-layer ordering info. `sps_temporal_mvp_enabled_flag` sits behind the
+     * short-term reference picture sets, whose parsing is long enough that getting it wrong is more
+     * likely than the field is useful, and nothing planned reads it.
+     */
+    data class HevcSps(
+        val generalProfileIdc: Int,
+        val generalLevelIdc: Int,
+        val chromaFormatIdc: Int,
+        val bitDepthLuma: Int,
+        val width: Int,
+        val height: Int,
+        val maxDecPicBuffering: Int,
+        val maxNumReorderPics: Int,
+    ) {
+        override fun toString(): String =
+            "profile=$generalProfileIdc level=$generalLevelIdc chroma_format=$chromaFormatIdc " +
+                "bit_depth=$bitDepthLuma size=${width}x$height " +
+                "max_dec_pic_buffering=$maxDecPicBuffering max_num_reorder_pics=$maxNumReorderPics"
+    }
+
+    /**
+     * Parses an H.264 SPS.
+     *
+     * [nalHeaderOffset] points at the NAL header byte, i.e. just past the Annex B start code - the
+     * same convention `VideoDecoder.scanAndApplyConfig` already uses. Returns null if the bitstream
+     * runs out or does not parse, never a partly-filled result.
+     */
+    fun parseH264Sps(data: ByteArray, nalHeaderOffset: Int, length: Int): H264Sps? {
+        return try {
+            // Skip nal_unit_header: 1 byte for AVC.
+            val r = RbspReader(data, nalHeaderOffset + 1, length - 1)
+
+            val profileIdc = r.u(8)
+            r.skip(8)                       // constraint_set0..5 (6) + reserved_zero_2bits (2)
+            val levelIdc = r.u(8)
+            r.ue()                          // seq_parameter_set_id
+
+            var chromaFormatIdc = 1
+            if (profileIdc in HIGH_PROFILES) {
+                chromaFormatIdc = r.ue()
+                if (chromaFormatIdc == 3) r.skip(1)   // separate_colour_plane_flag
+                r.ue()                                // bit_depth_luma_minus8
+                r.ue()                                // bit_depth_chroma_minus8
+                r.skip(1)                             // qpprime_y_zero_transform_bypass_flag
+                if (r.u(1) == 1) {                    // seq_scaling_matrix_present_flag
+                    val lists = if (chromaFormatIdc != 3) 8 else 12
+                    for (i in 0 until lists) {
+                        if (r.u(1) == 1) skipScalingList(r, if (i < 6) 16 else 64)
+                    }
+                }
+            }
+
+            r.ue()                                    // log2_max_frame_num_minus4
+            val picOrderCntType = r.ue()
+            when (picOrderCntType) {
+                0 -> r.ue()                           // log2_max_pic_order_cnt_lsb_minus4
+                1 -> {
+                    // The case the dimension-only parser in VideoDecoder gets wrong. Rare in
+                    // practice, but a desync here would put a plausible wrong number in the log,
+                    // which is worse than no number.
+                    r.skip(1)                         // delta_pic_order_always_zero_flag
+                    r.se()                            // offset_for_non_ref_pic
+                    r.se()                            // offset_for_top_to_bottom_field
+                    val cycle = r.ue()                // num_ref_frames_in_pic_order_cnt_cycle
+                    if (cycle > MAX_POC_CYCLE) return null
+                    repeat(cycle) { r.se() }
+                }
+            }
+
+            val maxNumRefFrames = r.ue()
+            r.skip(1)                                 // gaps_in_frame_num_value_allowed_flag
+            val widthInMbsMinus1 = r.ue()
+            val heightInMapUnitsMinus1 = r.ue()
+            val frameMbsOnly = r.u(1)
+            if (frameMbsOnly == 0) r.skip(1)          // mb_adaptive_frame_field_flag
+            r.skip(1)                                 // direct_8x8_inference_flag
+
+            var width = (widthInMbsMinus1 + 1) * 16
+            var height = (2 - frameMbsOnly) * (heightInMapUnitsMinus1 + 1) * 16
+            if (r.u(1) == 1) {                        // frame_cropping_flag
+                val left = r.ue(); val right = r.ue(); val top = r.ue(); val bottom = r.ue()
+                // Crop units are chroma samples; 2 horizontally and 2 * (2 - frame_mbs_only)
+                // vertically for the 4:2:0 that Android Auto negotiates.
+                val subWidth = if (chromaFormatIdc == 3) 1 else 2
+                val subHeight = if (chromaFormatIdc == 1) 2 else 1
+                width -= (left + right) * subWidth
+                height -= (top + bottom) * subHeight * (2 - frameMbsOnly)
+            }
+
+            val vuiPresent = r.u(1) == 1
+            var bitstreamRestrictionPresent = false
+            var maxNumReorderFrames: Int? = null
+            var maxDecFrameBuffering: Int? = null
+            if (vuiPresent) {
+                if (r.u(1) == 1) {                    // aspect_ratio_info_present_flag
+                    if (r.u(8) == 255) r.skip(32)     // aspect_ratio_idc == Extended_SAR
+                }
+                if (r.u(1) == 1) r.skip(1)            // overscan_info_present -> overscan_appropriate
+                if (r.u(1) == 1) {                    // video_signal_type_present_flag
+                    r.skip(4)                         // video_format (3) + video_full_range_flag (1)
+                    if (r.u(1) == 1) r.skip(24)       // colour_description -> primaries/transfer/matrix
+                }
+                if (r.u(1) == 1) { r.ue(); r.ue() }   // chroma_loc_info_present_flag
+                if (r.u(1) == 1) {                    // timing_info_present_flag
+                    r.skip(32)                        // num_units_in_tick
+                    r.skip(32)                        // time_scale
+                    r.skip(1)                         // fixed_frame_rate_flag
+                }
+                val nalHrd = r.u(1) == 1
+                if (nalHrd && !skipHrdParameters(r)) return null
+                val vclHrd = r.u(1) == 1
+                if (vclHrd && !skipHrdParameters(r)) return null
+                if (nalHrd || vclHrd) r.skip(1)       // low_delay_hrd_flag
+                r.skip(1)                             // pic_struct_present_flag
+                bitstreamRestrictionPresent = r.u(1) == 1
+                if (bitstreamRestrictionPresent) {
+                    r.skip(1)                         // motion_vectors_over_pic_boundaries_flag
+                    r.ue()                            // max_bytes_per_pic_denom
+                    r.ue()                            // max_bits_per_mb_denom
+                    r.ue()                            // log2_max_mv_length_horizontal
+                    r.ue()                            // log2_max_mv_length_vertical
+                    maxNumReorderFrames = r.ue()
+                    maxDecFrameBuffering = r.ue()
+                }
+            }
+
+            if (r.overran) return null
+
+            H264Sps(
+                profileIdc = profileIdc,
+                levelIdc = levelIdc,
+                picOrderCntType = picOrderCntType,
+                maxNumRefFrames = maxNumRefFrames,
+                width = width,
+                height = height,
+                vuiPresent = vuiPresent,
+                bitstreamRestrictionPresent = bitstreamRestrictionPresent,
+                maxNumReorderFrames = maxNumReorderFrames,
+                maxDecFrameBuffering = maxDecFrameBuffering,
+            )
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Parses an HEVC SPS. [nalHeaderOffset] points at the first of the two NAL header bytes.
+     */
+    fun parseHevcSps(data: ByteArray, nalHeaderOffset: Int, length: Int): HevcSps? {
+        return try {
+            // Skip nal_unit_header: 2 bytes for HEVC.
+            val r = RbspReader(data, nalHeaderOffset + 2, length - 2)
+
+            r.skip(4)                                 // sps_video_parameter_set_id
+            val maxSubLayersMinus1 = r.u(3)
+            r.skip(1)                                 // sps_temporal_id_nesting_flag
+
+            // profile_tier_level(profilePresentFlag = 1, maxSubLayersMinus1)
+            r.skip(2)                                 // general_profile_space
+            r.skip(1)                                 // general_tier_flag
+            val generalProfileIdc = r.u(5)
+            r.skip(32)                                // general_profile_compatibility_flag[32]
+            r.skip(4)                                 // progressive/interlaced/non_packed/frame_only
+            r.skip(43)                                // general_reserved_zero_43bits
+            r.skip(1)                                 // general_inbld_flag / reserved_zero_bit
+            val generalLevelIdc = r.u(8)
+
+            val subLayerProfilePresent = BooleanArray(maxSubLayersMinus1)
+            val subLayerLevelPresent = BooleanArray(maxSubLayersMinus1)
+            for (i in 0 until maxSubLayersMinus1) {
+                subLayerProfilePresent[i] = r.u(1) == 1
+                subLayerLevelPresent[i] = r.u(1) == 1
+            }
+            if (maxSubLayersMinus1 > 0) r.skip(2 * (8 - maxSubLayersMinus1))
+            for (i in 0 until maxSubLayersMinus1) {
+                if (subLayerProfilePresent[i]) r.skip(88)
+                if (subLayerLevelPresent[i]) r.skip(8)
+            }
+
+            r.ue()                                    // sps_seq_parameter_set_id
+            val chromaFormatIdc = r.ue()
+            if (chromaFormatIdc == 3) r.skip(1)       // separate_colour_plane_flag
+            var width = r.ue()                        // pic_width_in_luma_samples
+            var height = r.ue()                       // pic_height_in_luma_samples
+            if (r.u(1) == 1) {                        // conformance_window_flag
+                val left = r.ue(); val right = r.ue(); val top = r.ue(); val bottom = r.ue()
+                val subWidth = if (chromaFormatIdc == 1 || chromaFormatIdc == 2) 2 else 1
+                val subHeight = if (chromaFormatIdc == 1) 2 else 1
+                width -= (left + right) * subWidth
+                height -= (top + bottom) * subHeight
+            }
+            val bitDepthLuma = r.ue() + 8             // bit_depth_luma_minus8
+            r.ue()                                    // bit_depth_chroma_minus8
+            r.ue()                                    // log2_max_pic_order_cnt_lsb_minus4
+
+            val subLayerOrderingInfoPresent = r.u(1) == 1
+            var maxDecPicBuffering = 0
+            var maxNumReorderPics = 0
+            val firstLayer = if (subLayerOrderingInfoPresent) 0 else maxSubLayersMinus1
+            for (i in firstLayer..maxSubLayersMinus1) {
+                maxDecPicBuffering = r.ue() + 1       // sps_max_dec_pic_buffering_minus1
+                maxNumReorderPics = r.ue()            // sps_max_num_reorder_pics
+                r.ue()                                // sps_max_latency_increase_plus1
+            }
+
+            if (r.overran) return null
+
+            HevcSps(
+                generalProfileIdc = generalProfileIdc,
+                generalLevelIdc = generalLevelIdc,
+                chromaFormatIdc = chromaFormatIdc,
+                bitDepthLuma = bitDepthLuma,
+                width = width,
+                height = height,
+                maxDecPicBuffering = maxDecPicBuffering,
+                maxNumReorderPics = maxNumReorderPics,
+            )
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun skipScalingList(r: RbspReader, sizeOfList: Int) {
+        var lastScale = 8
+        var nextScale = 8
+        for (j in 0 until sizeOfList) {
+            if (nextScale != 0) {
+                val delta = r.se()
+                nextScale = (lastScale + delta + 256) % 256
+            }
+            if (nextScale != 0) lastScale = nextScale
+        }
+    }
+
+    /** Returns false if the bitstream declares an implausible CPB count, i.e. we have desynced. */
+    private fun skipHrdParameters(r: RbspReader): Boolean {
+        val cpbCntMinus1 = r.ue()
+        if (cpbCntMinus1 > MAX_CPB_CNT_MINUS1) return false
+        r.skip(4)                                     // bit_rate_scale
+        r.skip(4)                                     // cpb_size_scale
+        for (i in 0..cpbCntMinus1) {
+            r.ue()                                    // bit_rate_value_minus1
+            r.ue()                                    // cpb_size_value_minus1
+            r.skip(1)                                 // cbr_flag
+        }
+        r.skip(20)                                    // the four *_length_minus1 / time_offset_length
+        return !r.overran
+    }
+
+    /** Profiles whose SPS carries the chroma/scaling-matrix block (H.264 7.3.2.1.1). */
+    private val HIGH_PROFILES = intArrayOf(100, 110, 122, 244, 44, 83, 86, 118, 128, 138, 139, 134, 135)
+
+    /** Spec maximum is 255; anything larger means the reader has lost its place. */
+    private const val MAX_CPB_CNT_MINUS1 = 31
+
+    /** Spec maximum is 255; a larger cycle means the reader has lost its place. */
+    private const val MAX_POC_CYCLE = 255
+
+    /**
+     * Bit reader over an RBSP, i.e. one that removes emulation-prevention bytes as it goes.
+     *
+     * A `0x03` following two zero bytes is inserted by the encoder so a payload can never contain a
+     * start code, and it is not part of the syntax. Reading it as if it were shifts every field
+     * after it.
+     *
+     * [overran] latches instead of throwing, so a caller can parse to the end and then decide the
+     * whole result is untrustworthy - a half-read field is worse than no field.
+     */
+    private class RbspReader(private val buf: ByteArray, offset: Int, length: Int) {
+        private val end = offset + length
+        private var bytePos = offset
+        private var bitInByte = 0
+        private var zeroRun = 0
+
+        var overran: Boolean = false
+            private set
+
+        private fun currentByte(): Int {
+            if (bytePos >= end || bytePos >= buf.size) {
+                overran = true
+                return 0
+            }
+            return buf[bytePos].toInt() and 0xFF
+        }
+
+        private fun advanceByte() {
+            val consumed = currentByte()
+            bytePos++
+            zeroRun = if (consumed == 0) zeroRun + 1 else 0
+            // Two zero bytes then 0x03: the 0x03 is not payload. Skip it and restart the run, so
+            // 00 00 03 00 00 03 is handled as well as a single occurrence.
+            if (zeroRun >= 2 && bytePos < end && bytePos < buf.size &&
+                (buf[bytePos].toInt() and 0xFF) == 0x03
+            ) {
+                bytePos++
+                zeroRun = 0
+            }
+        }
+
+        fun u(count: Int): Int {
+            var result = 0
+            repeat(count) { result = (result shl 1) or bit() }
+            return result
+        }
+
+        fun skip(count: Int) {
+            repeat(count) { bit() }
+        }
+
+        /** Unsigned Exp-Golomb, ue(v). */
+        fun ue(): Int {
+            var leadingZeros = 0
+            while (bit() == 0) {
+                leadingZeros++
+                if (overran || leadingZeros > 32) {
+                    overran = true
+                    return 0
+                }
+            }
+            if (leadingZeros == 0) return 0
+            return (1 shl leadingZeros) - 1 + u(leadingZeros)
+        }
+
+        /** Signed Exp-Golomb, se(v). */
+        fun se(): Int {
+            val k = ue()
+            return if (k % 2 == 0) -(k / 2) else (k + 1) / 2
+        }
+
+        private fun bit(): Int {
+            val b = currentByte()
+            val value = (b shr (7 - bitInByte)) and 1
+            bitInByte++
+            if (bitInByte == 8) {
+                bitInByte = 0
+                advanceByte()
+            }
+            return value
+        }
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/ParameterSetTracker.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/ParameterSetTracker.kt
@@ -1,0 +1,84 @@
+package com.andrerinas.openheadunit.decoder
+
+/**
+ * Notices when the stream's parameter sets stop being the ones the codec was configured from.
+ *
+ * `VideoDecoder` reads VPS/SPS/PPS exactly once, while it is deciding how to configure the codec,
+ * and then stops looking: the scan is inside `if (codec == null)` and gated on `!codecConfigured`.
+ * Every parameter set after the first is discarded unread. Both reference implementations do the
+ * opposite - VLC stores them by id, compares the bytes and bumps a config version on a genuine
+ * difference; Moonlight resubmits CSD - and neither could tell you whether it matters here, because
+ * no log this project has ever collected carries the answer.
+ *
+ * So this measures it and nothing else. It does not touch the stored CSD, the configured size or the
+ * codec: a mid-session reconfiguration is a behaviour change to make once there is evidence one
+ * happens, and this is the evidence.
+ *
+ * ### Why the change is latched
+ *
+ * Parameter sets are re-sent with every keyframe, so "the sets arrived again" is the ordinary case
+ * and says nothing. Only a difference counts, and a difference counts once: VLC latches its version
+ * on read for exactly this reason. Without that, one genuine change would be re-reported on every
+ * keyframe for the rest of the session.
+ *
+ * One slot per kind rather than VLC's by-id table. A stream that alternates parameter-set ids would
+ * defeat this, and Android Auto is not known to send one; if a capture ever shows a change reported
+ * on every keyframe with the bytes flipping between two values, that is what it means.
+ *
+ * Pure: no clock, no logging, no Android. Copies what it stores, because the caller's buffer is
+ * reused.
+ */
+class ParameterSetTracker {
+
+    enum class Kind { VPS, SPS, PPS }
+
+    /**
+     * A genuine difference, reported once.
+     *
+     * [ordinal] counts changes on this tracker, so a log line can say which one it is rather than
+     * leaving a reader to count lines. [kinds] is what actually differed, in VPS/SPS/PPS order.
+     */
+    data class Change(val ordinal: Int, val kinds: List<Kind>)
+
+    private val stored = arrayOfNulls<ByteArray>(Kind.entries.size)
+    private val pending = LinkedHashSet<Kind>()
+    private var changesReported = 0
+
+    /**
+     * Offers one parameter set.
+     *
+     * Returns true when it differs from the one held for that kind. The first of each kind is not a
+     * change - there was nothing to differ from - which is what keeps a fresh session silent.
+     */
+    fun offer(kind: Kind, data: ByteArray, offset: Int, length: Int): Boolean {
+        if (length <= 0 || offset < 0 || offset + length > data.size) return false
+        val previous = stored[kind.ordinal]
+        val copy = data.copyOfRange(offset, offset + length)
+        stored[kind.ordinal] = copy
+        if (previous == null) return false
+        if (previous.contentEquals(copy)) return false
+        pending.add(kind)
+        return true
+    }
+
+    /**
+     * The change since the last call, or null.
+     *
+     * Reading clears it. That is the whole reason a caller can run this on every access unit that
+     * carries parameter sets without a change being reported on every keyframe that follows it.
+     */
+    fun takeChange(): Change? {
+        if (pending.isEmpty()) return null
+        changesReported++
+        val kinds = Kind.entries.filter { it in pending }
+        pending.clear()
+        return Change(changesReported, kinds)
+    }
+
+    /** Forgets everything. For a new session, not for a codec restart - the stream is unchanged. */
+    fun reset() {
+        stored.fill(null)
+        pending.clear()
+        changesReported = 0
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoBackpressurePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoBackpressurePolicy.kt
@@ -1,0 +1,55 @@
+package com.andrerinas.openheadunit.decoder
+
+/**
+ * Separates "the decoder could not keep up" from every other reason a frame goes missing.
+ *
+ * `VideoDecoder` already prints both numbers on every throughput line - `dropped=` and
+ * `inputWait=` - and nothing reads them. Deciding what they mean has been a manual step in every
+ * artifact investigation so far, and it is the step that has gone wrong: #830's round 6 could not
+ * tell a rising drop count caused by a slow codec from one caused by a bursty link, and #219 has
+ * been read as a reassembly fault for five months.
+ *
+ * `inputWait` is time the feed thread spent inside `dequeueInputBuffer`. When frames are shed *and*
+ * that wait is a large share of the window, the codec is the bottleneck: it is not returning input
+ * buffers fast enough, the feed queue fills, and the queue sheds. When frames are shed with the wait
+ * near zero, the loss is upstream and the decoder is not the file to look in.
+ *
+ * ### Where the threshold comes from
+ *
+ * A #219 reporter's Galaxy Tab S7 FE, 2560x1440 HEVC on `c2.qti.hevc.decoder`, four captures. Of the
+ * five 5s windows that shed frames, four waited 2019ms, 1333ms, 804ms and 705ms - 40%, 27%, 16% and
+ * 14% of the window - and the fifth waited 180ms (3.6%). Across all 288 windows the median wait was
+ * 188ms and the 90th percentile 587ms. Ten percent sits above the healthy median and below every
+ * burst but one, so it separates the two populations that capture actually contains rather than a
+ * number chosen for looking round.
+ */
+object VideoBackpressurePolicy {
+
+    /** Share of a throughput window spent waiting for an input buffer before the codec is suspect. */
+    const val WAIT_PERCENT = 10
+
+    /**
+     * Windows that both shed and waited before the codec is named.
+     *
+     * Two rather than one because a single window can be a scheduling hiccup, and more than two
+     * because the bursts are isolated - they do not arrive consecutively, so anything demanding a
+     * run of them would never fire on the capture this was built from.
+     */
+    const val WINDOWS_BEFORE_REPORT = 2
+
+    /**
+     * Whether this window's losses are attributable to the codec.
+     *
+     * Both halves are required. Waiting without shedding is a decoder under load that is still
+     * keeping up, which is ordinary; shedding without waiting is a loss that happened somewhere
+     * else entirely.
+     */
+    fun isBackpressureWindow(windowMs: Long, inputWaitMs: Long, dropped: Long): Boolean {
+        if (dropped <= 0 || windowMs <= 0 || inputWaitMs <= 0) return false
+        return inputWaitMs * 100 >= windowMs * WAIT_PERCENT
+    }
+
+    /** Whether enough of those windows have been seen to say so, once per decoder session. */
+    fun shouldReport(backpressureWindows: Int, alreadyReported: Boolean): Boolean =
+        !alreadyReported && backpressureWindows >= WINDOWS_BEFORE_REPORT
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -382,15 +382,19 @@ class VideoDecoder(
     // The transport wires it to the same gain-only keyframe nudge corrupt-frame recovery uses.
     var onFrameDropped: (() -> Unit)? = null
 
-    // Fired when a keyframe is handed to the codec, which is the only evidence a shed reference
-    // frame has been repaired. Read where the frame is fed rather than where it arrives: a keyframe
-    // the queue sheds never reaches the picture, so it repairs nothing and must not count.
+    // Fired when a keyframe has produced a picture, which is the only evidence a shed reference
+    // frame has been repaired. Driven from the output side rather than the arrival or the feed: a
+    // keyframe the queue sheds never reaches the codec, and one whose access unit lost a fragment
+    // on the way reaches it and decodes to nothing. Neither repairs anything, and both used to
+    // count - see [KeyframeRepairTracker].
     var onKeyframeObserved: (() -> Unit)? = null
 
-    // True once a keyframe has been fed to *this* codec instance. A codec rebuilt mid-session
-    // resumes on a P-frame and can produce nothing until an IDR arrives, so this is what separates
-    // "the decoder is broken" from "the decoder has been given nothing it could decode".
-    @Volatile private var keyframeFedSinceStart = false
+    // Whether a keyframe has produced a picture on *this* codec instance. A codec rebuilt
+    // mid-session resumes on a P-frame and can produce nothing until an IDR arrives, so this is what
+    // separates "the decoder is broken" from "the decoder has been given nothing it could decode" -
+    // and it counts the output rather than the feed, because a keyframe that arrived with a hole in
+    // it is fed like any other and decodes to nothing. See [KeyframeRepairTracker].
+    private val keyframeRepair = KeyframeRepairTracker()
 
     // Throttle stamp for onFrameDropped. Both drop sites feed it: the transport read thread on
     // queue overflow and the feed thread on input-buffer exhaustion. A race between them costs
@@ -399,6 +403,10 @@ class VideoDecoder(
 
     /** Throttle stamp for [onKeyframeStarved], on the output thread only. */
     private var lastKeyframeStarvedAskMs = 0L
+
+    /** Said once per process: this component's output timestamps mean nothing. Not session-scoped,
+     * because it is a property of the decoder rather than of the stream. */
+    private var loggedUnusableOutputTimestamps = false
 
     /** Diagnostic only - see [ParameterSetTracker]. Feed-thread confined, like the scan that feeds it. */
     private val parameterSetTracker = ParameterSetTracker()
@@ -497,7 +505,7 @@ class VideoDecoder(
             stop(DecoderStopPolicy.REASON_NEW_SURFACE)
             mSurface = surface
             lastFrameRenderedMs = 0L
-            keyframeFedSinceStart = false
+            keyframeRepair.reset()
         }
     }
 
@@ -617,7 +625,9 @@ class VideoDecoder(
                 loggedContentKinds.clear()
             }
             lastFrameRenderedMs = 0L
-            keyframeFedSinceStart = false
+            // Presentation timestamps restart near zero on the next configure, so a stamp left
+            // pending here would be confirmed by the new codec's very first frame.
+            keyframeRepair.reset()
             lastKeyframeStarvedAskMs = 0L
             loggedFirstSoftwareFrame = false
             loggedFirstHardwareFrame = false
@@ -743,11 +753,22 @@ class VideoDecoder(
                 } else {
                     val detectedType = detectCodecType(frameData, frameOffset, size)
                     val requestedType = if (codecName.contains("265")) CodecType.H265 else CodecType.H264
-                    if (requestedType == CodecType.H265) {
-                        CodecType.H265
-                    } else {
-                        detectedType ?: requestedType
+                    val hevcDetectable = isHevcSupported()
+                    val hevcUsable = hevcDetectable || bundledHevcSelected()
+                    val selected = CodecTypeSelectionPolicy.select(
+                        detected = detectedType,
+                        requested = requestedType,
+                        hevcDetectable = hevcDetectable,
+                        hevcUsable = hevcUsable,
+                    )
+                    if (selected != requestedType) {
+                        AppLog.i(
+                            "Building a $selected decoder although the setting asks for " +
+                                "$requestedType (stream says ${detectedType ?: "nothing yet"}, " +
+                                "HEVC detectable=$hevcDetectable usable=$hevcUsable)"
+                        )
                     }
+                    selected
                 }
                 currentCodecType = typeToUse
 
@@ -960,6 +981,18 @@ class VideoDecoder(
                 settings.softwareVideoDecoder == Settings.SoftwareVideoDecoder.BUNDLED_FFMPEG &&
                 FfmpegHevcDecoder.isAvailable()
     }
+
+    /**
+     * True when an explicitly selected software HEVC decoder is available, i.e. H.265 is playable
+     * here even though [isHevcSupported] - which is hardware-only - says no. Mirrors the
+     * `explicitSoftwareHevc` half of the announcement, so the decoder and the codec we asked the
+     * phone for agree about whether H.265 was ever on the table.
+     */
+    private fun bundledHevcSelected(): Boolean =
+        settings.forceSoftwareDecoding && when (settings.softwareVideoDecoder) {
+            Settings.SoftwareVideoDecoder.BUNDLED_FFMPEG -> isBundledHevcDecoderAvailable()
+            Settings.SoftwareVideoDecoder.DEVICE_MEDIACODEC -> isHevcDecoderAvailable(includeSoftware = true)
+        }
 
     private fun startBundledHevc(width: Int, height: Int) {
         try {
@@ -1641,9 +1674,10 @@ class VideoDecoder(
 
             currentCodec.queueInputBuffer(inputIndex, 0, inputBuffer.limit(), pts, flags)
             if (isKeyframe) {
-                keyframeFedSinceStart = true
+                // Fed, not yet repaired. The picture counts as repaired at the output side, where
+                // a keyframe that arrived holed is told apart from one that decodes.
+                keyframeRepair.onKeyframeFed(pts)
                 AppLog.i("VideoDecoder: keyframe reached the codec (${inputBuffer.limit()} bytes)")
-                onKeyframeObserved?.invoke()
             }
             return FeedResult.FED
         } catch (e: Exception) {
@@ -1803,6 +1837,22 @@ class VideoDecoder(
                     lastFrameRenderedMs = SystemClock.elapsedRealtime()
                     renderedThisSession = true
                     lastOutputMs = lastFrameRenderedMs
+                    // bufferInfo carries the last successful dequeue, which is renderIndex. The
+                    // frames released ahead of it in this pass decoded earlier and so have smaller
+                    // timestamps, and the ones the catch-up branch discarded decoded too - so this
+                    // one stamp answers for the whole pass either way.
+                    if (keyframeRepair.onFrameRendered(bufferInfo.presentationTimeUs)) {
+                        if (keyframeRepair.timestampsUnusable && !loggedUnusableOutputTimestamps) {
+                            loggedUnusableOutputTimestamps = true
+                            AppLog.w(
+                                "$currentCodecName never carries a keyframe's timestamp through to its " +
+                                    "output, so a repaired picture is read from frames arriving rather " +
+                                    "than from the frame that repaired it."
+                            )
+                        }
+                        AppLog.i("VideoDecoder: keyframe decoded - the picture is repaired")
+                        onKeyframeObserved?.invoke()
+                    }
                     framesRenderedThisSession++
                     consecutiveErrors = 0
                     // The one landmark that says video actually reached the screen on the path
@@ -1854,7 +1904,7 @@ class VideoDecoder(
                         stallGapMs = stallGap,
                         inputIdleGapMs = inputIdleGap,
                         inputIdleThresholdMs = SYNC_STALL_THRESHOLD_MS,
-                        keyframeFedSinceStart = keyframeFedSinceStart,
+                        keyframeDecodedSinceStart = keyframeRepair.keyframeDecoded,
                         sessionHasRendered = renderedThisSession,
                     )
                     if (cause == DecoderStallCausePolicy.Cause.PHONE_IDLE) {

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -6,6 +6,7 @@ import android.media.MediaCodecList
 import android.media.MediaFormat
 import android.os.Build
 import android.view.Surface
+import com.andrerinas.openheadunit.aap.CodecConfigScanner
 import com.andrerinas.openheadunit.aap.VideoKeyframeScanner
 import com.andrerinas.openheadunit.aap.VideoRecoveryPolicy
 import com.andrerinas.openheadunit.utils.AppLog
@@ -25,8 +26,16 @@ interface VideoDimensionsListener {
 /**
  * Main video decoding engine.
  * Handles H.264/H.265 streams via MediaCodec.
+ *
+ * [memoryReading] is resolved once at construction and reported with the codec configuration, so
+ * that every bug report carries what the device actually has. Nothing is sized from it yet.
  */
-class VideoDecoder(private val settings: Settings) {
+class VideoDecoder(
+    private val settings: Settings,
+    private val memoryReading: DeviceMemoryReading = DeviceMemoryReading(
+        DeviceMemoryProfile.NORMAL, totalRamMb = 0, heapLimitMb = 0, memoryClassMb = 0, systemLowRamFlag = false
+    ),
+) {
     companion object {
         private const val TIMEOUT_US = 10000L
         private const val MAX_RESTARTS_WITHOUT_FRAME = 3
@@ -68,8 +77,29 @@ class VideoDecoder(private val settings: Settings) {
         // drifting apart is what cost #830 its reference frames.
         private const val FEED_POLL_MS = 200L
         // Floor for pooled frame buffers, so the pool settles at a reusable size instead of
-        // reallocating around whatever the first few frames happened to measure.
+        // reallocating around whatever the first few frames happened to measure. Smaller on a
+        // constrained device, where the floor alone accounts for a measurable slice of the heap:
+        // 42 slots at 64KB is 2.7MB before a single real frame has been held.
         private const val MIN_POOLED_FRAME_BYTES = 64 * 1024
+        private const val MIN_POOLED_FRAME_BYTES_CONSTRAINED = 16 * 1024
+
+        /**
+         * Soft ceiling on the bytes the frame pool may retain, on a constrained device only.
+         *
+         * The pool holds capacity+2 buffers and each grows to the largest frame it has ever held,
+         * never shrinking, so a pool that has seen a few keyframes settles at tens of slots times
+         * keyframe size - several megabytes on a device whose whole heap is twenty. This bounds that
+         * without touching the queue depth, which is load-bearing (see VideoFeedQueuePolicy): a
+         * buffer that would push the pool past the ceiling is simply not kept, and the next frame
+         * that needs one allocates it again.
+         *
+         * 2MB holds every slot at the constrained floor with room left for several keyframe-sized
+         * buffers, so the steady state stays pooled and only the largest ones churn.
+         */
+        private const val CONSTRAINED_POOL_BUDGET_BYTES = 2 * 1024 * 1024
+
+        /** Spacing of the per-frame input-buffer-full report. The throughput line carries the rate. */
+        private const val FEED_DROP_LOG_INTERVAL_MS = 1000L
 
         // Throttle for reporting a stall the watchdog saw but declined to act on. Once the
         // cooldown or the restart cap below suppresses a restart, that branch takes no action
@@ -81,6 +111,14 @@ class VideoDecoder(private val settings: Settings) {
         // check a reported crop rectangle against the buffer geometry: a real crop is at most
         // this far below the buffer, so anything further off is not describing this stream.
         private const val MAX_ALIGNMENT_PADDING = 64
+
+        // Bounds on a picture size read out of a parameter set. Android Auto projects between
+        // 800x480 and 3840x2160; these are wide enough to accept anything a head unit could
+        // plausibly be sent and narrow enough that a desynced parse is caught rather than
+        // configured into the codec.
+        private const val MIN_PLAUSIBLE_DIMENSION = 160
+        private const val MAX_PLAUSIBLE_WIDTH = 7680
+        private const val MAX_PLAUSIBLE_HEIGHT = 4320
 
         /**
          * Checks if H.265 (HEVC) hardware decoding is supported on the current device.
@@ -182,6 +220,29 @@ class VideoDecoder(private val settings: Settings) {
     // (e.g. nal_unit_type=1/nal_ref_idc=2 -> byte 0x41 -> 0x41 >> 1 == 32), and re-detecting on
     // every restart let that false positive hijack an otherwise-working H.264 session.
     private var codecTypePinned = false
+    // One-shot per session: the parameter sets are re-sent on every keyframe, and the fields we
+    // want out of them do not change mid-stream, so logging them once keeps the diagnostic out of
+    // the hot path while still putting it in every bug report.
+    private var loggedParameterSet = false
+    // One-shot per codec start: what we asked KEY_MAX_INPUT_SIZE for, and what the component
+    // actually handed back. #839 measured a 2MB request answered with eight buffers of that size,
+    // 16MB of graphics memory for input alone on a 1GB unit, and nothing in our own log said so.
+    private var requestedMaxInputSize = 0
+    private var loggedInputBufferCapacity = false
+    private var loggedDecoderCapability = false
+
+    /**
+     * What the component claimed at configure time, kept so the backpressure line can quote it.
+     *
+     * "The codec is the bottleneck" and "the codec said it could do this" are only worth anything
+     * together: the first without the second reads as a slow device, and the pair says the profile
+     * we negotiated was never one this hardware could carry.
+     */
+    private var decoderCapability: DecoderCapabilityReport.Capability? = null
+
+    /** Windows that both shed frames and spent a large share waiting - see [VideoBackpressurePolicy]. */
+    private var backpressureWindows = 0
+    private var reportedBackpressure = false
     private var restartsSinceLastFrame = 0
     private var codecFallbackUsed = false
     private var decoderPermanentlyFailed = false
@@ -237,6 +298,30 @@ class VideoDecoder(private val settings: Settings) {
     private val frameQueueCapacity = VideoFeedQueuePolicy.capacityFor(settings.fpsLimit)
     private val frameQueue = ArrayBlockingQueue<PendingFrame>(frameQueueCapacity)
     private val framePool = ArrayBlockingQueue<PendingFrame>(frameQueueCapacity + 2)
+
+    private val constrained = memoryReading.profile == DeviceMemoryProfile.CONSTRAINED
+    private val minPooledFrameBytes =
+        if (constrained) MIN_POOLED_FRAME_BYTES_CONSTRAINED else MIN_POOLED_FRAME_BYTES
+    private val pooledByteBudget = if (constrained) CONSTRAINED_POOL_BUDGET_BYTES else Int.MAX_VALUE
+
+    /**
+     * Bytes currently held by [framePool]. Atomic because frames are returned from both the feed
+     * thread and the transport thread, and the ceiling it guards is only useful if it is not raced
+     * away.
+     */
+    private val pooledBytes = java.util.concurrent.atomic.AtomicInteger(0)
+
+    /**
+     * Last time a per-frame drop was reported, and how many were suppressed since.
+     *
+     * The two drop lines below used to print once per frame, which on a saturated link is 30-60 a
+     * second - and every AppLog line builds a Throwable and walks its stack to derive the caller,
+     * so on a device already collecting every five seconds the reporting costs more than the thing
+     * being reported. The counters in the throughput line carry the rate; these lines only need to
+     * say it is happening.
+     */
+    private var lastFeedDropLogMs = 0L
+    private var suppressedFeedDropLogs = 0
     // Volatile and identity-checked by the loop itself: interrupt() does not abort a MediaCodec
     // call, so a feed thread parked in dequeueInputBuffer can outlive the join() below. If it
     // does, stop() goes on to release the codec and a later start() sets running back to true -
@@ -283,8 +368,15 @@ class VideoDecoder(private val settings: Settings) {
     @Volatile private var decoderNeedsRestart = false
     @Volatile private var decoderRestartReason: String? = null
 
-    // Callback for transport layer integration
-    var onDecoderError: (() -> Unit)? = null
+    // Callback for transport layer integration. Carries the restart reason because the transport
+    // answers a decoder rebuild by asking the phone for a keyframe, and only some rebuilds are its
+    // to answer - see AapTransport's wiring of it.
+    var onDecoderError: ((reason: String) -> Unit)? = null
+
+    // Fired, throttled, while the codec is waiting for a keyframe it has no way to ask for itself.
+    // Separate from onDecoderError because the whole point of the starved case is that nothing is
+    // being rebuilt: the codec is fine and the stream has nothing it can decode yet.
+    var onKeyframeStarved: (() -> Unit)? = null
 
     // Fired, throttled, when a frame is shed with the picture live - see notifyFrameDropped().
     // The transport wires it to the same gain-only keyframe nudge corrupt-frame recovery uses.
@@ -295,10 +387,24 @@ class VideoDecoder(private val settings: Settings) {
     // the queue sheds never reaches the picture, so it repairs nothing and must not count.
     var onKeyframeObserved: (() -> Unit)? = null
 
+    // True once a keyframe has been fed to *this* codec instance. A codec rebuilt mid-session
+    // resumes on a P-frame and can produce nothing until an IDR arrives, so this is what separates
+    // "the decoder is broken" from "the decoder has been given nothing it could decode".
+    @Volatile private var keyframeFedSinceStart = false
+
     // Throttle stamp for onFrameDropped. Both drop sites feed it: the transport read thread on
     // queue overflow and the feed thread on input-buffer exhaustion. A race between them costs
     // at most one extra nudge, so a volatile check-then-set is enough.
     @Volatile private var lastDropKeyframeRequestMs = 0L
+
+    /** Throttle stamp for [onKeyframeStarved], on the output thread only. */
+    private var lastKeyframeStarvedAskMs = 0L
+
+    /** Diagnostic only - see [ParameterSetTracker]. Feed-thread confined, like the scan that feeds it. */
+    private val parameterSetTracker = ParameterSetTracker()
+
+    /** Config-scanner answers already reported this session, so each is said once. */
+    private val loggedContentKinds = HashSet<CodecConfigScanner.Content>()
 
     val videoWidth: Int get() = mWidth
     val videoHeight: Int get() = mHeight
@@ -391,6 +497,7 @@ class VideoDecoder(private val settings: Settings) {
             stop(DecoderStopPolicy.REASON_NEW_SURFACE)
             mSurface = surface
             lastFrameRenderedMs = 0L
+            keyframeFedSinceStart = false
         }
     }
 
@@ -454,6 +561,7 @@ class VideoDecoder(private val settings: Settings) {
             // Pooled frames grow to the largest ever seen and never shrink, so a 4K session would
             // otherwise pin that size for the life of the process.
             framePool.clear()
+            pooledBytes.set(0)
 
             try {
                 codec?.stop()
@@ -501,10 +609,23 @@ class VideoDecoder(private val settings: Settings) {
                 mWidth = 0
                 mHeight = 0
                 codecConfigured = false
+                loggedParameterSet = false
+                // Session-scoped, like everything else in this block: a restart does not change what
+                // the phone is sending, so a change reported across one would be reporting the
+                // tracker's own amnesia.
+                parameterSetTracker.reset()
+                loggedContentKinds.clear()
             }
             lastFrameRenderedMs = 0L
+            keyframeFedSinceStart = false
+            lastKeyframeStarvedAskMs = 0L
             loggedFirstSoftwareFrame = false
             loggedFirstHardwareFrame = false
+            loggedInputBufferCapacity = false
+            loggedDecoderCapability = false
+            decoderCapability = null
+            backpressureWindows = 0
+            reportedBackpressure = false
             // The FPS window and the throughput counters must not straddle a restart, or the
             // first sample afterwards is averaged over the whole teardown and reads near zero.
             frameCount = 0
@@ -586,10 +707,11 @@ class VideoDecoder(private val settings: Settings) {
                     restartsSinceLastFrame = 0
                 }
 
-                stop("restart: $decoderRestartReason")
+                val restartReason = decoderRestartReason ?: "unknown"
+                stop("restart: $restartReason")
                 decoderNeedsRestart = false
                 decoderRestartReason = null
-                onDecoderError?.invoke()
+                onDecoderError?.invoke(restartReason)
             }
 
             if (decoderPermanentlyFailed) return
@@ -681,10 +803,7 @@ class VideoDecoder(private val settings: Settings) {
         // the fed count that the throughput line uses to say whether frames arrived.
         if (size <= 0) return
 
-        val frame = framePool.poll()?.let { pooled ->
-            if (pooled.data.size < size) pooled.data = ByteArray(maxOf(size, MIN_POOLED_FRAME_BYTES))
-            pooled
-        } ?: PendingFrame(ByteArray(maxOf(size, MIN_POOLED_FRAME_BYTES)), 0, 0L)
+        val frame = borrowFrame(size)
 
         System.arraycopy(frameData, frameOffset, frame.data, 0, size)
         frame.size = size
@@ -701,9 +820,33 @@ class VideoDecoder(private val settings: Settings) {
             // The frame shed here is still a reference for what follows it, though, so ask for
             // that keyframe rather than waiting out the phone's own cadence - see
             // notifyFrameDropped().
-            framePool.offer(frame)
+            recycleFrame(frame)
             notifyFrameDropped()
         }
+    }
+
+    /** Takes a buffer from the pool, growing it if this frame does not fit, or allocates one. */
+    private fun borrowFrame(size: Int): PendingFrame {
+        val pooled = framePool.poll()
+        if (pooled != null) {
+            pooledBytes.addAndGet(-pooled.data.size)
+            if (pooled.data.size < size) pooled.data = ByteArray(maxOf(size, minPooledFrameBytes))
+            return pooled
+        }
+        return PendingFrame(ByteArray(maxOf(size, minPooledFrameBytes)), 0, 0L)
+    }
+
+    /**
+     * Returns a buffer to the pool, unless keeping it would push the pool past [pooledByteBudget].
+     *
+     * Dropping it on the floor is safe and deliberate - the next frame that needs a buffer allocates
+     * one. Above a constrained device the budget is effectively unlimited, so this is the previous
+     * behaviour exactly.
+     */
+    private fun recycleFrame(frame: PendingFrame) {
+        val bytes = frame.data.size
+        if (pooledBytes.get().toLong() + bytes > pooledByteBudget.toLong()) return
+        if (framePool.offer(frame)) pooledBytes.addAndGet(bytes)
     }
 
     /**
@@ -772,7 +915,7 @@ class VideoDecoder(private val settings: Settings) {
                             // of the decoder starting, while the component is merely draining its
                             // first buffers. A decoder that is genuinely stuck rather than busy
                             // is still caught by the sync_stall watchdog.
-                            AppLog.w("Input buffer full. Dropping frame.")
+                            logFeedDrop("")
                             notifyFrameDropped()
                         }
                     }
@@ -780,17 +923,34 @@ class VideoDecoder(private val settings: Settings) {
             } catch (e: Exception) {
                 AppLog.w("Feed thread error: ${e.message}")
             } finally {
-                framePool.offer(frame)
+                recycleFrame(frame)
             }
         }
         AppLog.i("Feed thread stopped")
+    }
+
+    /**
+     * Reports a frame the codec had no room for, at most once per [FEED_DROP_LOG_INTERVAL_MS].
+     *
+     * Called from the feed thread only, so the counters need no synchronisation.
+     */
+    private fun logFeedDrop(detail: String) {
+        val now = SystemClock.elapsedRealtime()
+        if (lastFeedDropLogMs != 0L && now - lastFeedDropLogMs < FEED_DROP_LOG_INTERVAL_MS) {
+            suppressedFeedDropLogs++
+            return
+        }
+        lastFeedDropLogMs = now
+        val alsoSuppressed = if (suppressedFeedDropLogs > 0) " (+$suppressedFeedDropLogs more since the last line)" else ""
+        suppressedFeedDropLogs = 0
+        AppLog.w("Input buffer full. Dropping frame.%s%s", detail, alsoSuppressed)
     }
 
     /** Empties the feed queue back into the pool. Anything still waiting is stale after a stop. */
     private fun clearFrameQueue() {
         while (true) {
             val frame = frameQueue.poll() ?: break
-            framePool.offer(frame)
+            recycleFrame(frame)
         }
     }
 
@@ -931,6 +1091,83 @@ class VideoDecoder(private val settings: Settings) {
     }
 
     /**
+     * Reads this session's sequence parameter set: picture size for the codec, and the buffering
+     * fields for the log.
+     *
+     * One parser for both codecs, because there were two and one of them was wrong. The H.264
+     * dimension parser this replaces walked `pic_order_cnt_type == 1` as though it were type 0 - it
+     * read the POC LSB field that only type 0 has - and every field after that, including the width
+     * and height, came out of the wrong bits. It also had no RBSP unescaping, so a `0x03` anywhere in
+     * the scaling matrix of a High-profile SPS shifted the same fields. [ParameterSetInspector]
+     * handles both, is covered by vectors, and discards the whole result rather than returning half
+     * of one.
+     *
+     * The logged fields are the ones that decide how many frames a decoder holds before it emits one,
+     * and we have never recorded what Android Auto actually sends. Moonlight rewrites the H.264 SPS on
+     * every Android 8.0+ device it runs on because unmodified encoder output makes some hardware
+     * decoders allocate 16+ reference buffers and adds frames of latency; whether that lever exists
+     * here is a question about `num_ref_frames` and `bitstream_restriction`, so print them rather
+     * than assume either way. Read-only - nothing modifies the bitstream.
+     */
+    private fun applyParameterSet(nalData: ByteArray, headerLen: Int, type: CodecType) {
+        val length = nalData.size - headerLen
+        val summary: String?
+        val parsedWidth: Int
+        val parsedHeight: Int
+        if (type == CodecType.H264) {
+            val parsed = ParameterSetInspector.parseH264Sps(nalData, headerLen, length)
+            summary = parsed?.toString()
+            parsedWidth = parsed?.width ?: 0
+            parsedHeight = parsed?.height ?: 0
+        } else {
+            val parsed = ParameterSetInspector.parseHevcSps(nalData, headerLen, length)
+            summary = parsed?.toString()
+            parsedWidth = parsed?.width ?: 0
+            parsedHeight = parsed?.height ?: 0
+        }
+
+        applyStreamDimensions(parsedWidth, parsedHeight, type)
+
+        if (loggedParameterSet) return
+        loggedParameterSet = true
+        if (summary != null) {
+            AppLog.i("Stream SPS (${type.settingsValue}): $summary")
+        } else {
+            AppLog.w("Stream SPS (${type.settingsValue}): could not be parsed ($length bytes)")
+        }
+    }
+
+    /**
+     * Takes the picture size from the stream rather than from what was negotiated.
+     *
+     * H.265 had no parser at all, so `mWidth` stayed zero and every H.265 session configured its
+     * codec from `HeadUnitScreenConfig`'s negotiated size - which is what the phone was *asked* for,
+     * not necessarily what it sent. That is what the "Fallback to negotiated dimensions" line reports,
+     * and on an H.265 session it was reporting every time.
+     *
+     * Bounded rather than trusted, in the same spirit as the crop-rectangle check: a parse that comes
+     * back with something outside any resolution a head unit projects is more likely a desync than a
+     * discovery, and the negotiated size is the better guess in that case. Nothing here is final
+     * either way - [handleOutputFormatChange] corrects the size again from the component's own output
+     * format once frames start, which is the authority when they disagree.
+     */
+    private fun applyStreamDimensions(width: Int, height: Int, type: CodecType) {
+        if (width <= 0 || height <= 0) return
+        if (width !in MIN_PLAUSIBLE_DIMENSION..MAX_PLAUSIBLE_WIDTH ||
+            height !in MIN_PLAUSIBLE_DIMENSION..MAX_PLAUSIBLE_HEIGHT
+        ) {
+            AppLog.w("${type.settingsValue} SPS reported an implausible ${width}x$height - ignoring it")
+            return
+        }
+        if (mWidth == width && mHeight == height) return
+        val negotiated = "${HeadUnitScreenConfig.getNegotiatedWidth()}x${HeadUnitScreenConfig.getNegotiatedHeight()}"
+        AppLog.i("${type.settingsValue} SPS parsed: ${width}x$height (negotiated $negotiated)")
+        mWidth = width
+        mHeight = height
+        dimensionsListener?.onVideoDimensionsChanged(mWidth, mHeight)
+    }
+
+    /**
      * Extracts SPS/PPS/VPS data for the decoder configuration (CSD).
      */
     private fun scanAndApplyConfig(buffer: ByteArray, offset: Int, size: Int, type: CodecType) {
@@ -940,16 +1177,7 @@ class VideoDecoder(private val settings: Settings) {
                 val nalType = nalFirstByte and 0x1F
                 if (nalType == 7) { // SPS
                     sps = nalData
-                    try {
-                        val offsetInNal = if (sps!![2].toInt() == 1) 3 else 4
-                        SpsParser.parse(sps!!, offsetInNal, sps!!.size - offsetInNal)?.let {
-                            if (mWidth != it.width || mHeight != it.height) {
-                                AppLog.i("H.264 SPS parsed: ${it.width}x${it.height}")
-                                mWidth = it.width; mHeight = it.height
-                                dimensionsListener?.onVideoDimensionsChanged(mWidth, mHeight)
-                            }
-                        }
-                    } catch (e: Exception) { AppLog.e("Failed to parse SPS data", e) }
+                    applyParameterSet(nalData, headerLen, CodecType.H264)
                 } else if (nalType == 8) pps = nalData // PPS
 
                 // H.264 requires at least SPS to start
@@ -957,12 +1185,137 @@ class VideoDecoder(private val settings: Settings) {
             } else {
                 val nalType = (nalFirstByte and 0x7E) shr 1
                 if (nalType == 32) vps = nalData
-                else if (nalType == 33) sps = nalData
-                else if (nalType == 34) pps = nalData
+                else if (nalType == 33) {
+                    sps = nalData
+                    applyParameterSet(nalData, headerLen, CodecType.H265)
+                } else if (nalType == 34) pps = nalData
 
                 // H.265 requires VPS and SPS to start reliably
                 if (vps != null && sps != null) codecConfigured = true
             }
+        }
+    }
+
+    /**
+     * Builds the mandatory part of the decoder format: parameter sets, input size and the per-vendor
+     * stability patches. Everything here has to be set for the session to work at all, so none of it
+     * takes part in the configure ladder - only [DecoderConfigLadder]'s optional keys do.
+     */
+    private fun buildFormat(mimeType: String, width: Int, height: Int, bestCodec: String): MediaFormat {
+        val format = MediaFormat.createVideoFormat(mimeType, width, height)
+
+        // Deliberately no KEY_PRIORITY / KEY_OPERATING_RATE / KEY_FRAME_RATE / KEY_MAX_B_FRAMES
+        // here. They were added as latency hints and measured to do nothing: the OMX components
+        // on the head units they were meant to help answer with
+        // "codec does not support config priority (err -1010)" and the same for the operating
+        // rate. The frame-rate keys are worse than inert, because the only frame rate this
+        // class knows is settings.fpsLimit - the user's cap, not the rate the phone negotiated
+        // - and KEY_MAX_B_FRAMES is an encoder key. Any replacement needs a log from a device
+        // where the codec actually accepts it.
+        //
+        // The ladder is how such a replacement gets tried safely: an optional key that the
+        // component rejects now costs one retry instead of the session.
+
+        // Apply Codec Specific Data (CSD) from parsed SPS/PPS/VPS
+        if (mimeType == CodecType.H265.mimeType) {
+            val combined = (vps ?: byteArrayOf()) + (sps ?: byteArrayOf()) + (pps ?: byteArrayOf())
+            if (combined.isNotEmpty()) {
+                format.setByteBuffer("csd-0", ByteBuffer.wrap(combined))
+            }
+            // [BUG_FIX] Dynamic buffer size based on resolution.
+            // 8MB is too large for many older 1080p decoders (Allwinner/Rockchip),
+            // but we need it for 4K.
+            //
+            // These two figures are now a ceiling rather than the request. A component sizes its
+            // whole input port from KEY_MAX_INPUT_SIZE, so asking for 2MB at 720p cost a 1GB unit
+            // eight buffers of that size - 16MB of graphics memory - for a picture whose largest
+            // legal coded frame is about 675KB. CodecInputSizePolicy derives the request from the
+            // picture and clamps it here, so this can only ever ask for less than it used to.
+            val cap = if (width * height > 1920 * 1080) {
+                8 * 1024 * 1024
+            } else {
+                2 * 1024 * 1024
+            }
+            val maxInputSize = CodecInputSizePolicy.maxInputSizeFor(width, height, cap)
+            format.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, maxInputSize)
+            requestedMaxInputSize = maxInputSize
+        } else {
+            if (sps != null) format.setByteBuffer("csd-0", ByteBuffer.wrap(sps!!))
+            if (pps != null) format.setByteBuffer("csd-1", ByteBuffer.wrap(pps!!))
+
+            // [BUG_FIX] Lower buffer for legacy devices (Android < 9) to prevent startup stalls.
+            // Kept as a ceiling; see the H.265 branch above for why the request itself is now
+            // derived from the picture.
+            val cap = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+                1 * 1024 * 1024 // 1MB for legacy
+            } else {
+                2 * 1024 * 1024 // 2MB for modern
+            }
+            val maxInputSize = CodecInputSizePolicy.maxInputSizeFor(width, height, cap)
+            format.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, maxInputSize)
+            requestedMaxInputSize = maxInputSize
+        }
+
+        val isAllwinner = bestCodec.lowercase(Locale.ROOT).contains("allwinner")
+        if (isAllwinner) {
+            // [BUG_FIX] Allwinner decoders often fail on adaptive playback initialization,
+            // leading to a SIGABRT in CodecLooper when the surface reconfigures for padding (e.g. 1080->1088).
+            AppLog.i("Decoder: Applying Allwinner stability patches.")
+            format.setInteger("adaptive-playback", 0)
+
+            if (mimeType == CodecType.H265.mimeType) {
+                AppLog.w("CAUTION: Allwinner H.265 is known to be unstable. If the app crashes, please switch to H.264 in settings.")
+                // Force macroblock alignment (multiple of 16) to prevent re-padding crash
+                val alignedHeight = ((height + 15) / 16) * 16
+                if (alignedHeight != height) {
+                    AppLog.i("Decoder: Aligning Allwinner H.265 height to $alignedHeight (was $height)")
+                    format.setInteger(MediaFormat.KEY_HEIGHT, alignedHeight)
+                }
+            }
+
+            // Explicitly set color format to surface to help ACodec
+            format.setInteger(MediaFormat.KEY_COLOR_FORMAT, android.media.MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface)
+        }
+
+        return format
+    }
+
+    /**
+     * Reports whether the chosen decoder can actually carry the picture it is about to be handed.
+     *
+     * Nothing acts on this. Codec selection stays where it was - the SoC allowlist in
+     * [isHevcReliable] decides whether Auto mode offers H.265 at all - because overriding a codec the
+     * user chose explicitly, or one already negotiated with the phone, is a bigger change than the
+     * evidence supports. What was missing is the evidence: the artifact reports in #219 are mostly
+     * from units where H.265 was selected by hand, and no log has ever said whether the component
+     * that got it claims to manage that resolution and rate, or only to accept it.
+     *
+     * A WARN here on a unit that reports melting is the thing that would settle it.
+     */
+    private fun logDecoderCapability(codecName: String, mimeType: String, width: Int, height: Int) {
+        if (loggedDecoderCapability) return
+        loggedDecoderCapability = true
+        // Silent below Lollipop, as before: there is no capability API to ask, and a WARN every
+        // session on a device that can never answer is noise rather than a finding.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return
+        try {
+            // Held for the throughput line: when the codec turns out to be the bottleneck, what it
+            // claimed beforehand is the other half of the finding.
+            val capability = DecoderCapabilityReport.forCodec(
+                codecName, mimeType, width, height, settings.fpsLimit
+            )
+            decoderCapability = capability
+            if (capability == null) {
+                AppLog.w("Decoder $codecName reported no video capabilities for $mimeType")
+                return
+            }
+            if (capability.adequate) {
+                AppLog.i("Decoder capability: $capability")
+            } else {
+                AppLog.w("Decoder may not manage this stream: $capability")
+            }
+        } catch (e: Exception) {
+            AppLog.w("Decoder capability check failed for $codecName: ${e.message}")
         }
     }
 
@@ -975,76 +1328,61 @@ class VideoDecoder(private val settings: Settings) {
             val bestCodec = findBestCodec(mimeType, !forceSoftware)
                 ?: throw IllegalStateException("No decoder available for $mimeType")
             this.currentCodecName = bestCodec
+            logDecoderCapability(bestCodec, mimeType, width, height)
 
-            codec = MediaCodec.createByCodecName(bestCodec)
-            codecBufferInfo = MediaCodec.BufferInfo()
+            // Richest key set first, always ending in none. The last rung is exactly the format this
+            // built before the ladder existed, so a component that rejects everything optional lands
+            // on the previous behaviour rather than on a failed session.
+            val tiers = DecoderConfigLadder.tiers(
+                codecName = bestCodec,
+                sdkInt = Build.VERSION.SDK_INT,
+                // From the same report the capability line printed, so the ladder and that line can
+                // no longer disagree about what the component advertises.
+                advertisesLowLatencyFeature = decoderCapability?.lowLatency
+                    ?: DecoderCapabilityReport.advertisesLowLatency(bestCodec, mimeType),
+                lowLatencyRequested = settings.debugVideoLowLatency,
+            )
 
-            val format = MediaFormat.createVideoFormat(mimeType, width, height)
+            var started = false
+            var lastFailure: Exception? = null
+            for ((attempt, tier) in tiers.withIndex()) {
+                // A configure() that throws leaves the component unusable, so each rung needs its own
+                // instance - and the old one has to be released rather than dropped, because on head
+                // units with a single hardware decoder instance every leaked one makes the next create
+                // fail until the process dies.
+                try { codec?.release() } catch (ignore: Exception) {}
+                codec = null
 
-            // Deliberately no KEY_PRIORITY / KEY_OPERATING_RATE / KEY_FRAME_RATE / KEY_MAX_B_FRAMES
-            // here. They were added as latency hints and measured to do nothing: the OMX components
-            // on the head units they were meant to help answer with
-            // "codec does not support config priority (err -1010)" and the same for the operating
-            // rate. The frame-rate keys are worse than inert, because the only frame rate this
-            // class knows is settings.fpsLimit - the user's cap, not the rate the phone negotiated
-            // - and KEY_MAX_B_FRAMES is an encoder key. Any replacement needs a log from a device
-            // where the codec actually accepts it.
+                if (mSurface?.isValid != true) throw IllegalStateException("Surface not valid")
 
-            // Apply Codec Specific Data (CSD) from parsed SPS/PPS/VPS
-            if (mimeType == CodecType.H265.mimeType) {
-                val combined = (vps ?: byteArrayOf()) + (sps ?: byteArrayOf()) + (pps ?: byteArrayOf())
-                if (combined.isNotEmpty()) {
-                    format.setByteBuffer("csd-0", ByteBuffer.wrap(combined))
-                }
-                // [BUG_FIX] Dynamic buffer size based on resolution.
-                // 8MB is too large for many older 1080p decoders (Allwinner/Rockchip),
-                // but we need it for 4K.
-                val maxInputSize = if (width * height > 1920 * 1080) {
-                    8 * 1024 * 1024
-                } else {
-                    2 * 1024 * 1024
-                }
-                format.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, maxInputSize)
-            } else {
-                if (sps != null) format.setByteBuffer("csd-0", ByteBuffer.wrap(sps!!))
-                if (pps != null) format.setByteBuffer("csd-1", ByteBuffer.wrap(pps!!))
+                codec = MediaCodec.createByCodecName(bestCodec)
+                codecBufferInfo = MediaCodec.BufferInfo()
+                val format = buildFormat(mimeType, width, height, bestCodec)
+                for ((key, value) in tier.integerKeys) format.setInteger(key, value)
 
-                // [BUG_FIX] Lower buffer for legacy devices (Android < 9) to prevent startup stalls
-                val maxInputSize = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
-                    1 * 1024 * 1024 // 1MB for legacy
-                } else {
-                    2 * 1024 * 1024 // 2MB for modern
-                }
-                format.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, maxInputSize)
-            }
-
-            if (!mSurface!!.isValid) throw IllegalStateException("Surface not valid")
-
-            val isAllwinner = bestCodec.lowercase(Locale.ROOT).contains("allwinner")
-            if (isAllwinner) {
-                // [BUG_FIX] Allwinner decoders often fail on adaptive playback initialization,
-                // leading to a SIGABRT in CodecLooper when the surface reconfigures for padding (e.g. 1080->1088).
-                AppLog.i("Decoder: Applying Allwinner stability patches.")
-                format.setInteger("adaptive-playback", 0)
-
-                if (mimeType == CodecType.H265.mimeType) {
-                    AppLog.w("CAUTION: Allwinner H.265 is known to be unstable. If the app crashes, please switch to H.264 in settings.")
-                    // Force macroblock alignment (multiple of 16) to prevent re-padding crash
-                    val alignedHeight = ((height + 15) / 16) * 16
-                    if (alignedHeight != height) {
-                        AppLog.i("Decoder: Aligning Allwinner H.265 height to $alignedHeight (was $height)")
-                        format.setInteger(MediaFormat.KEY_HEIGHT, alignedHeight)
+                val keyDetail = if (tier.integerKeys.isEmpty()) "" else " ${tier.integerKeys.keys}"
+                AppLog.i(
+                    "Configuring decoder: $bestCodec for ${width}x${height}, " +
+                        "max-input-size=${requestedMaxInputSize / 1024}KB, memory=$memoryReading, " +
+                        "queue=$frameQueueCapacity frames, optionalKeys=${tier.label}$keyDetail"
+                )
+                try {
+                    codec?.configure(format, mSurface, null, 0)
+                    try { codec?.setVideoScalingMode(MediaCodec.VIDEO_SCALING_MODE_SCALE_TO_FIT) } catch (e: Exception) {}
+                    codec?.start()
+                    started = true
+                    if (attempt > 0) {
+                        AppLog.w("Decoder accepted the format only with optionalKeys=${tier.label}")
                     }
+                    break
+                } catch (e: Exception) {
+                    lastFailure = e
+                    AppLog.w("Decoder rejected optionalKeys=${tier.label}: ${e.message}")
                 }
-
-                // Explicitly set color format to surface to help ACodec
-                format.setInteger(MediaFormat.KEY_COLOR_FORMAT, android.media.MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface)
             }
-
-            AppLog.i("Configuring decoder: $bestCodec for ${width}x${height}")
-            codec?.configure(format, mSurface, null, 0)
-            try { codec?.setVideoScalingMode(MediaCodec.VIDEO_SCALING_MODE_SCALE_TO_FIT) } catch (e: Exception) {}
-            codec?.start()
+            if (!started) {
+                throw lastFailure ?: IllegalStateException("Decoder configure failed for $bestCodec")
+            }
 
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
                 @Suppress("DEPRECATION") inputBuffers = codec?.inputBuffers
@@ -1096,40 +1434,94 @@ class VideoDecoder(private val settings: Settings) {
     }
 
     /**
-     * Logic to identify chipsets that require constant flagging
+     * Says once, per distinct answer, what the config scanner made of an access unit.
+     *
+     * Which units get `BUFFER_FLAG_CODEC_CONFIG` is decided per unit now rather than per chipset, so
+     * a device that never used to receive a mid-stream config buffer may now receive one. That is a
+     * real change in what reaches the component and it was previously invisible: three lines a
+     * session make it a fact in the capture instead of an argument about the code.
      */
-    private fun shouldAlwaysFlagConfig(): Boolean {
-        val name = currentCodecName?.lowercase(Locale.ROOT) ?: return false
-        return name.contains(".rk.") ||       // Rockchip
-                name.contains("allwinner") ||
-                name.contains(".tcc.")      // Telechips
+    private fun reportContentOnce(content: CodecConfigScanner.Content) {
+        if (!loggedContentKinds.add(content)) return
+        val consequence = when (content) {
+            CodecConfigScanner.Content.PARAMETER_SETS_ONLY -> "flagged to the codec as configuration"
+            CodecConfigScanner.Content.PARAMETER_SETS_WITH_PICTURE -> "carries a picture too, so not flagged"
+            CodecConfigScanner.Content.NO_PARAMETER_SETS -> "an ordinary frame"
+        }
+        AppLog.i("VideoDecoder: access unit classified $content - $consequence (first this session)")
     }
 
     /**
-     * Checks if the data contains SPS/PPS/VPS configuration data.
+     * Reads the parameter sets of an access unit that carries them and reports a genuine change.
+     *
+     * Diagnostic only - see [ParameterSetTracker] for why nothing here writes to the stored CSD or
+     * the configured size. Runs only on units the config scanner says carry parameter sets, which is
+     * keyframes and config messages, so the per-NAL copying [forEachNalUnit] does is paid a few times
+     * a minute rather than sixty times a second.
      */
-    private fun isCodecConfigData(data: ByteArray, offset: Int, size: Int): Boolean {
-        if (size < 5) return false
-        for (i in offset until (offset + size - 4).coerceAtMost(offset + 32)) {
-            if (data[i].toInt() == 0 && data[i + 1].toInt() == 0) {
-                val headerPos: Int
-                if (data[i + 2].toInt() == 0 && data[i + 3].toInt() == 1) {
-                    headerPos = i + 4
-                } else if (data[i + 2].toInt() == 1) {
-                    headerPos = i + 3
-                } else continue
-                if (headerPos >= offset + size) return false
-                val b = data[headerPos].toInt()
-                if (currentCodecType == CodecType.H265) {
-                    val nalType = (b and 0x7E) shr 1
-                    return nalType in 32..34
-                } else {
-                    val nalType = b and 0x1F
-                    return nalType == 7 || nalType == 8
+    private fun trackParameterSets(data: ByteArray, offset: Int, size: Int) {
+        val hevc = currentCodecType == CodecType.H265
+        var spsNal: ByteArray? = null
+        var spsHeaderLen = 0
+        forEachNalUnit(data, offset, size) { nalData, headerLen ->
+            val first = nalData[headerLen].toInt()
+            val kind = if (hevc) {
+                when ((first and 0x7E) shr 1) {
+                    32 -> ParameterSetTracker.Kind.VPS
+                    33 -> ParameterSetTracker.Kind.SPS
+                    34 -> ParameterSetTracker.Kind.PPS
+                    else -> null
+                }
+            } else {
+                when (first and 0x1F) {
+                    7 -> ParameterSetTracker.Kind.SPS
+                    8 -> ParameterSetTracker.Kind.PPS
+                    else -> null
+                }
+            }
+            if (kind != null) {
+                parameterSetTracker.offer(kind, nalData, headerLen, nalData.size - headerLen)
+                if (kind == ParameterSetTracker.Kind.SPS) {
+                    spsNal = nalData
+                    spsHeaderLen = headerLen
                 }
             }
         }
-        return false
+
+        val change = parameterSetTracker.takeChange() ?: return
+        val kinds = change.kinds.joinToString(" ")
+        // Snapshotted because the lambda above assigns it; a captured var is not smart-castable.
+        val sps = spsNal
+        val sizeNote = if (sps != null) describeSizeChange(sps, spsHeaderLen, hevc) else "size unread"
+        AppLog.w(
+            "VideoDecoder: parameter sets changed mid-session ($kinds, $sizeNote) - change #${change.ordinal}"
+        )
+    }
+
+    /**
+     * The size the new SPS describes, against the one the codec is configured for. Read-only: the
+     * configured size is corrected by the component's own output format, and second-guessing it from
+     * here is the behaviour change this measurement exists to justify or rule out.
+     */
+    private fun describeSizeChange(nalData: ByteArray, headerLen: Int, hevc: Boolean): String {
+        val length = nalData.size - headerLen
+        val width: Int
+        val height: Int
+        if (hevc) {
+            val parsed = ParameterSetInspector.parseHevcSps(nalData, headerLen, length) ?: return "size unparsed"
+            width = parsed.width
+            height = parsed.height
+        } else {
+            val parsed = ParameterSetInspector.parseH264Sps(nalData, headerLen, length) ?: return "size unparsed"
+            width = parsed.width
+            height = parsed.height
+        }
+        if (width <= 0 || height <= 0) return "size unparsed"
+        return if (width == mWidth && height == mHeight) {
+            "size unchanged ${width}x$height"
+        } else {
+            "size ${mWidth}x$mHeight -> ${width}x$height"
+        }
     }
 
     /** Outcome of [feedInputBuffer] for one frame. */
@@ -1176,9 +1568,10 @@ class VideoDecoder(private val settings: Settings) {
             inputWaitMs += SystemClock.elapsedRealtime() - waitStart
 
             if (inputIndex < 0) {
-                // Silent when the wait was cut short by a teardown: that exit is ordinary and the
-                // frame is moot, while "full" would blame the codec on every stop.
-                if (running) AppLog.e("Input buffer feed failed (full)")
+                // Silent here on purpose. A wait cut short by a teardown is ordinary and the frame
+                // is moot, so "full" would blame the codec on every stop; and the caller reports the
+                // genuine case through logFeedDrop, which throttles it. Printing at ERROR here as
+                // well doubled the per-frame logging cost of a saturated link for no information.
                 return FeedResult.NO_INPUT_BUFFER
             }
 
@@ -1192,15 +1585,41 @@ class VideoDecoder(private val settings: Settings) {
             inputBuffer.clear()
 
             val capacity = inputBuffer.capacity()
+            if (!loggedInputBufferCapacity) {
+                loggedInputBufferCapacity = true
+                AppLog.i(
+                    "Codec input buffer: requested ${requestedMaxInputSize / 1024}KB, " +
+                        "got ${capacity / 1024}KB per buffer"
+                )
+            }
 
-            // Always set BUFFER_FLAG_CODEC_CONFIG for config data (VPS/SPS/PPS).
-            // Some decoders (Rockchip/Allwinner) require this flag for every config packet
-            // even after the stream has already started.
-            val isConfig = buffer.hasArray() && isCodecConfigData(buffer.array(), buffer.position(), buffer.remaining())
+            val content = if (buffer.hasArray()) {
+                CodecConfigScanner.classify(
+                    buffer.array(), buffer.position(), buffer.remaining(), currentCodecType == CodecType.H265
+                )
+            } else {
+                CodecConfigScanner.Content.NO_PARAMETER_SETS
+            }
+            reportContentOnce(content)
+            if (content != CodecConfigScanner.Content.NO_PARAMETER_SETS && buffer.hasArray()) {
+                trackParameterSets(buffer.array(), buffer.position(), buffer.remaining())
+            }
             val isKeyframe = buffer.hasArray() && VideoKeyframeScanner.containsKeyframe(
                 buffer.array(), buffer.position(), buffer.remaining(), currentCodecType == CodecType.H265
             )
-            val flags = if (isConfig && (shouldAlwaysFlagConfig() || !codecConfigured)) {
+            // BUFFER_FLAG_CODEC_CONFIG says the buffer is codec-specific data and nothing else, so a
+            // component may consume it and produce no output. Set it only for a unit that really is
+            // only parameter sets: on a keyframe that leads with SPS/PPS and continues into its IDR
+            // slice, this flag risks the slice - and with it the repair the keyframe was for.
+            //
+            // Chipset name no longer decides this. The three families that were listed here
+            // (Rockchip, Allwinner, Telechips) were the only ones that flagged config mid-stream at
+            // all, and they were also the only ones that could flag a fused keyframe as
+            // configuration, because the old check read the first NAL and answered for the whole
+            // unit. Getting the classification right makes the list unnecessary in both directions:
+            // every device now gets the flag on genuine config, which Moonlight's errata says some
+            // decoders crash without, and no device gets it on a picture.
+            val flags = if (content == CodecConfigScanner.Content.PARAMETER_SETS_ONLY) {
                 MediaCodec.BUFFER_FLAG_CODEC_CONFIG
             } else 0
 
@@ -1222,6 +1641,7 @@ class VideoDecoder(private val settings: Settings) {
 
             currentCodec.queueInputBuffer(inputIndex, 0, inputBuffer.limit(), pts, flags)
             if (isKeyframe) {
+                keyframeFedSinceStart = true
                 AppLog.i("VideoDecoder: keyframe reached the codec (${inputBuffer.limit()} bytes)")
                 onKeyframeObserved?.invoke()
             }
@@ -1275,6 +1695,37 @@ class VideoDecoder(private val settings: Settings) {
             "Throughput over ${elapsed}ms: rendered=$rendered (${renderedFps}fps), " +
                 "fed=$fed (${fedFps}fps), dropped=$dropped, skipped=$skipped, " +
                 "inputWait=${inputWait}ms, codec=$currentCodecName"
+        )
+        reportBackpressure(elapsed, inputWait, dropped)
+    }
+
+    /**
+     * Says once, in the reporter's own log, that the codec is what is losing the frames.
+     *
+     * Both numbers this reads have been printed on every throughput line for a long time and
+     * nothing has ever interpreted them, which left the interpretation to whoever read the log by
+     * hand - and that step is where two investigations went wrong. #219 was read as a reassembly
+     * fault for five months on a device whose captures show shedding only in windows that also
+     * spent up to 2019ms of 5000 waiting for an input buffer.
+     *
+     * The capability line from configure time is quoted alongside, because "the codec cannot keep
+     * up" and "the codec said it could" only mean something together.
+     */
+    private fun reportBackpressure(elapsedMs: Long, inputWaitMs: Long, dropped: Long) {
+        // Early out for cost only; the once-per-session rule itself lives in shouldReport below.
+        if (reportedBackpressure) return
+        if (!VideoBackpressurePolicy.isBackpressureWindow(elapsedMs, inputWaitMs, dropped)) return
+        backpressureWindows++
+        if (!VideoBackpressurePolicy.shouldReport(backpressureWindows, reportedBackpressure)) return
+        reportedBackpressure = true
+        val claim = decoderCapability?.let {
+            if (it.adequate) " It claimed it could: $it" else " It said it might not: $it"
+        } ?: ""
+        AppLog.w(
+            "VideoDecoder: the codec is the bottleneck - $backpressureWindows windows shed frames " +
+                "while waiting >=${VideoBackpressurePolicy.WAIT_PERCENT}% of the window for an input " +
+                "buffer (${mWidth}x$mHeight@${settings.fpsLimit} on $currentCodecName). The negotiated " +
+                "size and rate are more than this decoder is keeping up with.$claim"
         )
     }
 
@@ -1399,13 +1850,37 @@ class VideoDecoder(private val settings: Settings) {
                 }
                 if (stallGap > stallThreshold) {
                     val inputIdleGap = now - lastInputBytesReceivedMs
-                    if (inputIdleGap > SYNC_STALL_THRESHOLD_MS) {
+                    val cause = DecoderStallCausePolicy.classify(
+                        stallGapMs = stallGap,
+                        inputIdleGapMs = inputIdleGap,
+                        inputIdleThresholdMs = SYNC_STALL_THRESHOLD_MS,
+                        keyframeFedSinceStart = keyframeFedSinceStart,
+                        sessionHasRendered = renderedThisSession,
+                    )
+                    if (cause == DecoderStallCausePolicy.Cause.PHONE_IDLE) {
                         // Stream is idle on the phone side (no new video frames arriving).
                         // Deliberately silent: this branch used to fall through to the
                         // "restart suppressed" line below, which read as a decoder fault for a
                         // phone that had simply stopped sending, and misled a whole hardware
                         // round with "0/4 used" printed every 10s for an idle stream.
                         lastOutputMs = now
+                    } else if (cause == DecoderStallCausePolicy.Cause.STARVED_OF_KEYFRAME) {
+                        // Nothing is wrong with the codec: it has been given no keyframe since it
+                        // started, so it has nothing it could render. Rebuilding it here is what
+                        // turned one corrupt access unit into a permanent black screen - each
+                        // rebuild restarts the wait and spends a restart the real stall path needs.
+                        // Ask instead, on the same throttle the suppressed report uses.
+                        if (now - lastSyncStallSuppressedLogMs >= SYNC_STALL_SUPPRESSED_LOG_INTERVAL_MS) {
+                            lastSyncStallSuppressedLogMs = now
+                            AppLog.w("Decoder has had no keyframe since it started ${stallGap}ms ago - waiting for one instead of rebuilding.")
+                        }
+                        // The ask runs on the shorter of the two clocks. This loop turns over every
+                        // 10ms, so it needs its own throttle rather than the report's - the same
+                        // one every other keyframe request in the app is held to.
+                        if (VideoRecoveryPolicy.canRequestKeyframe(now, lastKeyframeStarvedAskMs)) {
+                            lastKeyframeStarvedAskMs = now
+                            onKeyframeStarved?.invoke()
+                        }
                     } else {
                         // Input bytes ARE arriving, but decoder produces no output -> REAL DECODER STALL!
                         // A device that is merely marginal — renders fine for stretches, then
@@ -1477,78 +1952,5 @@ class VideoDecoder(private val settings: Settings) {
         val lower = info.name.lowercase(Locale.ROOT)
         return !(lower.startsWith("omx.google.") || lower.startsWith("c2.android.") ||
                 lower.startsWith("omx.ffmpeg.") || lower.contains(".sw.") || lower.contains("software"))
-    }
-}
-
-/**
- * Helper to parse Bitstreams for SPS data.
- */
-private class BitReader(private val buffer: ByteArray, private val offset: Int, private val size: Int) {
-    private var bitPosition = offset * 8
-    private val bitLimit = (offset + size) * 8
-
-    fun readBit(): Int {
-        if (bitPosition >= bitLimit) return 0
-        return (buffer[bitPosition / 8].toInt() shr (7 - (bitPosition++ % 8))) and 1
-    }
-
-    fun readBits(count: Int): Int {
-        var res = 0
-        repeat(count) { res = (res shl 1) or readBit() }
-        return res
-    }
-
-    fun readUE(): Int {
-        var zeros = 0
-        while (readBit() == 0 && bitPosition < bitLimit) zeros++
-        return if (zeros == 0) 0 else (1 shl zeros) - 1 + readBits(zeros)
-    }
-}
-
-data class SpsData(val width: Int, val height: Int)
-
-/**
- * Parses AVC/H.264 Sequence Parameter Sets to extract video dimensions.
- */
-private object SpsParser {
-    fun parse(sps: ByteArray, offset: Int, size: Int): SpsData? {
-        try {
-            val reader = BitReader(sps, offset, size)
-            reader.readBits(8)
-            val profileIdc = reader.readBits(8)
-            reader.readBits(16)
-            reader.readUE()
-            if (profileIdc in listOf(100, 110, 122, 244, 44, 83, 86, 118, 128)) {
-                val chroma = reader.readUE()
-                if (chroma == 3) reader.readBit()
-                reader.readUE(); reader.readUE(); reader.readBit()
-                if (reader.readBit() == 1) {
-                    repeat(if (chroma != 3) 8 else 12) {
-                        if (reader.readBit() == 1) {
-                            var last = 8; var next = 8
-                            repeat(if (it < 6) 16 else 64) {
-                                if (next != 0) next = (last + reader.readUE() + 256) % 256
-                                if (next != 0) last = next
-                            }
-                        }
-                    }
-                }
-            }
-            reader.readUE()
-            if (reader.readUE() == 0) reader.readUE()
-            reader.readUE(); reader.readBit()
-            val w = (reader.readUE() + 1) * 16
-            val hMap = reader.readUE()
-            val mbs = reader.readBit()
-            var h = (2 - mbs) * (hMap + 1) * 16
-            if (mbs == 0) reader.readBit()
-            reader.readBit()
-            if (reader.readBit() == 1) {
-                val l = reader.readUE(); val r = reader.readUE()
-                val t = reader.readUE(); val b = reader.readUE()
-                return SpsData(w - (l + r) * 2, h - (t + b) * 2)
-            }
-            return SpsData(w, h)
-        } catch (e: Exception) { return null }
     }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -1853,6 +1853,51 @@ class SettingsFragment : Fragment() {
             }
         ))
 
+        // Puts the Native AA P2P group on 2.4 GHz, which the rig can otherwise never run: the group
+        // is requested as 5 GHz and any group that lands on 2.4 GHz is torn down and remade. Both of
+        // those come off together - see NativeGroupBandPolicy. Applies on the next connection.
+        items.add(SettingItem.ToggleSettingEntry(
+            stableId = "debugForceP2pBand24",
+            nameResId = R.string.debug_force_p2p_band_24,
+            descriptionResId = R.string.debug_force_p2p_band_24_description,
+            isChecked = settings.debugForceP2pBand24,
+            searchKeywords = "2.4 ghz band wifi direct p2p group native link outage",
+            onCheckedChanged = { isChecked ->
+                settings.debugForceP2pBand24 = isChecked
+                updateSettingsList()
+            }
+        ))
+
+        // Below Android 10 there is no band request at all, so this is the only lever those units
+        // have. Off by default: the request is a frequency whitelist, so a unit that cannot host a
+        // 5 GHz group owner fails to create one rather than falling back - see the retry in
+        // WifiDirectManager. Applies on the next connection.
+        items.add(SettingItem.ToggleSettingEntry(
+            stableId = "p2pLegacyFiveGhz",
+            nameResId = R.string.p2p_legacy_5ghz,
+            descriptionResId = R.string.p2p_legacy_5ghz_description,
+            isChecked = settings.p2pLegacyFiveGhz,
+            searchKeywords = "5 ghz band wifi direct legacy android 9 channel 36 stutter",
+            onCheckedChanged = { isChecked ->
+                settings.p2pLegacyFiveGhz = isChecked
+                updateSettingsList()
+            }
+        ))
+
+        if (settings.p2pLegacyFiveGhz) {
+            items.add(SettingItem.ToggleSettingEntry(
+                stableId = "p2pLegacyFiveGhzUpperBand",
+                nameResId = R.string.p2p_legacy_5ghz_upper,
+                descriptionResId = R.string.p2p_legacy_5ghz_upper_description,
+                isChecked = settings.p2pLegacyFiveGhzUpperBand,
+                searchKeywords = "channel 149 upper 5 ghz unii region",
+                onCheckedChanged = { isChecked ->
+                    settings.p2pLegacyFiveGhzUpperBand = isChecked
+                    updateSettingsList()
+                }
+            ))
+        }
+
         // Deliberately corrupts the video stream so the reassembler's failure paths can be
         // exercised on a working unit. Applies on the next connection, and every injected fault is
         // logged loudly - see VideoFaultInjector. Applied immediately rather than through the

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -27,6 +27,8 @@ import com.andrerinas.openheadunit.R
 import com.andrerinas.openheadunit.aap.AapService
 import com.andrerinas.openheadunit.aap.MediaKeyRoutingPolicy
 import com.andrerinas.openheadunit.aap.PlaybackFocusPolicy
+import com.andrerinas.openheadunit.aap.VideoFaultInjector
+import com.andrerinas.openheadunit.decoder.DeviceMemoryProfile
 import com.andrerinas.openheadunit.main.settings.SettingItem
 import com.andrerinas.openheadunit.main.settings.SettingsAdapter
 import com.andrerinas.openheadunit.utils.AppLog
@@ -1808,6 +1810,91 @@ class SettingsFragment : Fragment() {
                 updateSettingsList()
             }
         ))
+
+        // Applied immediately, like the two below it: the configure ladder falls back on its own if
+        // the decoder rejects the key, so there is nothing to confirm before trying it.
+        items.add(SettingItem.ToggleSettingEntry(
+            stableId = "debugVideoLowLatency",
+            nameResId = R.string.debug_video_low_latency,
+            descriptionResId = R.string.debug_video_low_latency_description,
+            isChecked = settings.debugVideoLowLatency,
+            searchKeywords = "low latency vendor key decoder mediatek amlogic qualcomm exynos",
+            onCheckedChanged = { isChecked ->
+                settings.debugVideoLowLatency = isChecked
+                updateSettingsList()
+            }
+        ))
+
+        // Lets a well-provisioned rig run the constrained video pipeline, which is otherwise only
+        // reachable on 1GB hardware we do not have. Applies on the next connection; the configure
+        // line reports the profile and marks it FORCED.
+        val memoryProfileNames = listOf("Measure") +
+            DeviceMemoryProfile.entries.map { it.name.lowercase().replaceFirstChar { c -> c.uppercase() } }
+        val memoryProfileValues = listOf<DeviceMemoryProfile?>(null) + DeviceMemoryProfile.entries
+        items.add(SettingItem.SettingEntry(
+            stableId = "debugForceMemoryProfile",
+            nameResId = R.string.debug_force_memory_profile,
+            value = memoryProfileNames[memoryProfileValues.indexOf(settings.debugForceMemoryProfile).coerceAtLeast(0)],
+            searchKeywords = "memory profile low ram constrained buffers queue",
+            onClick = {
+                val currentIndex = memoryProfileValues.indexOf(settings.debugForceMemoryProfile).coerceAtLeast(0)
+                MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
+                    .setTitle(R.string.debug_force_memory_profile)
+                    .setSingleChoiceItems(memoryProfileNames.toTypedArray(), currentIndex) { dialog, which ->
+                        settings.debugForceMemoryProfile = memoryProfileValues[which]
+                        dialog.dismiss()
+                        updateSettingsList()
+                    }
+                    .show()
+            }
+        ))
+
+        // Deliberately corrupts the video stream so the reassembler's failure paths can be
+        // exercised on a working unit. Applies on the next connection, and every injected fault is
+        // logged loudly - see VideoFaultInjector. Applied immediately rather than through the
+        // pending/save flow, like the log level below: this is a tool, not a preference.
+        val faultModes = VideoFaultInjector.Mode.entries
+        val faultModeNames = faultModes
+            .map { it.name.lowercase().replace('_', ' ').replaceFirstChar { c -> c.uppercase() } }
+            .toTypedArray()
+        items.add(SettingItem.SettingEntry(
+            stableId = "debugVideoFaultInjection",
+            nameResId = R.string.debug_video_fault_injection,
+            value = faultModeNames[faultModes.indexOf(settings.debugVideoFaultInjection).coerceAtLeast(0)],
+            searchKeywords = "fault injection corrupt fragment reassembly test",
+            onClick = {
+                val currentIndex = faultModes.indexOf(settings.debugVideoFaultInjection).coerceAtLeast(0)
+                MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
+                    .setTitle(R.string.debug_video_fault_injection)
+                    .setSingleChoiceItems(faultModeNames, currentIndex) { dialog, which ->
+                        settings.debugVideoFaultInjection = faultModes[which]
+                        dialog.dismiss()
+                        updateSettingsList()
+                    }
+                    .show()
+            }
+        ))
+
+        if (settings.debugVideoFaultInjection != VideoFaultInjector.Mode.OFF) {
+            val faultRates = listOf(10, 30, 100, 300, 1000, 3000)
+            val faultRateNames = faultRates.map { "1 in " + it }.toTypedArray()
+            items.add(SettingItem.SettingEntry(
+                stableId = "debugVideoFaultRate",
+                nameResId = R.string.debug_video_fault_rate,
+                value = "1 in " + settings.debugVideoFaultRate,
+                onClick = {
+                    val currentIndex = faultRates.indexOf(settings.debugVideoFaultRate).coerceAtLeast(0)
+                    MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
+                        .setTitle(R.string.debug_video_fault_rate)
+                        .setSingleChoiceItems(faultRateNames, currentIndex) { dialog, which ->
+                            settings.debugVideoFaultRate = faultRates[which]
+                            dialog.dismiss()
+                            updateSettingsList()
+                        }
+                        .show()
+                }
+            ))
+        }
 
         val logLevels = LogExporter.LogLevel.entries
         val logLevelNames = logLevels.map { it.name.lowercase().replaceFirstChar { c -> c.uppercase() } }.toTypedArray()

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -663,6 +663,10 @@ class SettingsFragment : Fragment() {
         updateSaveButtonState()
     }
 
+    /** Reads a fault budget for the settings row, so 0 says what it means rather than showing "0". */
+    private fun describeFaultBudget(budget: Int): String =
+        if (budget == VideoFaultInjector.UNLIMITED_BUDGET) "Whole session" else "$budget faults"
+
     private fun updateSettingsList() {
         val app = App.provide(requireContext())
         val scrollState = settingsRecyclerView.layoutManager?.onSaveInstanceState()
@@ -1888,6 +1892,25 @@ class SettingsFragment : Fragment() {
                         .setTitle(R.string.debug_video_fault_rate)
                         .setSingleChoiceItems(faultRateNames, currentIndex) { dialog, which ->
                             settings.debugVideoFaultRate = faultRates[which]
+                            dialog.dismiss()
+                            updateSettingsList()
+                        }
+                        .show()
+                }
+            ))
+
+            val faultBudgets = listOf(VideoFaultInjector.UNLIMITED_BUDGET, 5, 10, 30, 100)
+            val faultBudgetNames = faultBudgets.map { describeFaultBudget(it) }.toTypedArray()
+            items.add(SettingItem.SettingEntry(
+                stableId = "debugVideoFaultBudget",
+                nameResId = R.string.debug_video_fault_budget,
+                value = describeFaultBudget(settings.debugVideoFaultBudget),
+                onClick = {
+                    val currentIndex = faultBudgets.indexOf(settings.debugVideoFaultBudget).coerceAtLeast(0)
+                    MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
+                        .setTitle(R.string.debug_video_fault_budget)
+                        .setSingleChoiceItems(faultBudgetNames, currentIndex) { dialog, which ->
+                            settings.debugVideoFaultBudget = faultBudgets[which]
                             dialog.dismiss()
                             updateSettingsList()
                         }

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -351,6 +351,52 @@ class Settings(private val context: Context) {
         set(value) { prefs.edit().putString("debug-force-memory-profile", value?.name).apply() }
 
     /**
+     * Puts the Native AA WiFi Direct group on 2.4 GHz instead of asking for 5 GHz.
+     *
+     * Off by default, and it is a rig lever rather than a preference: 5 GHz is what a working
+     * session runs on and nothing here recommends moving off it. What it exists for is that the
+     * link-outage reports come from 2.4 GHz head units and the rig could never be put on that band
+     * - the group is requested as 5 GHz and any group that lands on 2.4 GHz is torn down and
+     * remade. Both of those are turned off together by this one flag; see
+     * [com.andrerinas.openheadunit.aap.NativeGroupBandPolicy], which is where the coupling lives.
+     *
+     * Applies to the next group, so it needs a reconnect rather than only a settings write.
+     */
+    var debugForceP2pBand24: Boolean
+        get() = prefs.getBoolean("debug-force-p2p-band-24", false)
+        set(value) { prefs.edit().putBoolean("debug-force-p2p-band-24", value).apply() }
+
+    /**
+     * On a device with no band API, asks the P2P stack for a 5 GHz operating channel.
+     *
+     * Below API 29 there is no `WifiP2pConfig.Builder`, so the group's band is the driver's choice
+     * and this app has never had a say in it - which is every pre-Android-10 head unit, including
+     * both units in the periodic-outage reports. The hidden `setWifiP2pChannels` is the one lever
+     * left; see [com.andrerinas.openheadunit.aap.P2pOperatingChannelPolicy].
+     *
+     * **Off by default, and it should stay off until a unit reports back.** The request is a
+     * disallowed-frequency list, so a unit whose P2P firmware cannot host a 5 GHz group owner is not
+     * left on 2.4 GHz - it is left unable to form a group at all. The bring-up clears the restriction
+     * and retries once when that happens, but an opt-in costs nothing and a wrong default costs
+     * every pre-Q unit its connection.
+     *
+     * Ignored from API 29 up, where the supported band request does this properly.
+     */
+    var p2pLegacyFiveGhz: Boolean
+        get() = prefs.getBoolean("p2p-legacy-5ghz", false)
+        set(value) { prefs.edit().putBoolean("p2p-legacy-5ghz", value).apply() }
+
+    /**
+     * Asks for UNII-3 (channel 149) instead of UNII-1 (channel 36) when [p2pLegacyFiveGhz] is on.
+     *
+     * Both are non-DFS and channel 36 is what the reference implementations use, so this exists only
+     * for a regulatory domain that refuses the lower range.
+     */
+    var p2pLegacyFiveGhzUpperBand: Boolean
+        get() = prefs.getBoolean("p2p-legacy-5ghz-upper", false)
+        set(value) { prefs.edit().putBoolean("p2p-legacy-5ghz-upper", value).apply() }
+
+    /**
      * Asks the decoder for low-latency mode, through whichever key its vendor understands.
      *
      * Off by default, and it stays off until a log from a real device shows a component accepting the

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -8,6 +8,8 @@ import android.content.pm.PackageManager
 import android.location.Location
 import android.os.Build
 import com.andrerinas.openheadunit.aap.MediaKeyRoutingPolicy
+import com.andrerinas.openheadunit.aap.VideoFaultInjector
+import com.andrerinas.openheadunit.decoder.DeviceMemoryProfile
 import com.andrerinas.openheadunit.aap.PlaybackFocusPolicy
 import com.andrerinas.openheadunit.aap.protocol.proto.Control
 import com.andrerinas.openheadunit.app.UsbAttachedActivity
@@ -321,6 +323,54 @@ class Settings(private val context: Context) {
             return SoftwareVideoDecoder.fromInt(value) ?: SoftwareVideoDecoder.BUNDLED_FFMPEG
         }
         set(value) { prefs.edit().putInt("software-video-decoder", value.value).apply() }
+
+    /**
+     * Deliberately corrupts the projected video stream, for testing the reassembler's failure paths.
+     *
+     * Off, and meant to stay off. The artifact reports this exists for come from units we do not
+     * have, and a healthy rig never produces the conditions that cause them - so without this there
+     * is no way to show a fix works except to wait for a reporter's next drive. Every injected fault
+     * is logged, so a log captured with this left on cannot be mistaken for a log of a real fault.
+     */
+    var debugVideoFaultInjection: VideoFaultInjector.Mode
+        get() {
+            val value = prefs.getInt("debug-video-fault-injection", VideoFaultInjector.Mode.OFF.value)
+            return VideoFaultInjector.Mode.fromInt(value) ?: VideoFaultInjector.Mode.OFF
+        }
+        set(value) { prefs.edit().putInt("debug-video-fault-injection", value.value).apply() }
+
+    /**
+     * Overrides how much memory the video pipeline believes this device has.
+     *
+     * Null means measure it. Set, it lets a well-provisioned rig run the constrained path, which is
+     * otherwise only reachable on hardware we do not have. Stored by name rather than by ordinal so
+     * reordering the enum cannot silently change what a stored value means.
+     */
+    var debugForceMemoryProfile: DeviceMemoryProfile?
+        get() = DeviceMemoryProfile.fromName(prefs.getString("debug-force-memory-profile", null))
+        set(value) { prefs.edit().putString("debug-force-memory-profile", value?.name).apply() }
+
+    /**
+     * Asks the decoder for low-latency mode, through whichever key its vendor understands.
+     *
+     * Off by default, and it stays off until a log from a real device shows a component accepting the
+     * key - which is this project's standing rule about vendor MediaFormat keys, written after
+     * KEY_PRIORITY and KEY_OPERATING_RATE were both measured being rejected outright. The configure
+     * ladder is what makes turning it on cheap to try: a rejected key now costs one retry instead of
+     * the session. See [com.andrerinas.openheadunit.decoder.DecoderConfigLadder].
+     */
+    var debugVideoLowLatency: Boolean
+        get() = prefs.getBoolean("debug-video-low-latency", false)
+        set(value) { prefs.edit().putBoolean("debug-video-low-latency", value).apply() }
+
+    /** One in this many of the targeted messages is faulted. See [debugVideoFaultInjection]. */
+    var debugVideoFaultRate: Int
+        get() = prefs.getInt("debug-video-fault-rate", VideoFaultInjector.DEFAULT_RATE)
+        set(value) {
+            prefs.edit()
+                .putInt("debug-video-fault-rate", value.coerceIn(VideoFaultInjector.MIN_RATE, VideoFaultInjector.MAX_RATE))
+                .apply()
+        }
 
     var rightHandDrive: Boolean
         get() = prefs.getBoolean("right-hand-drive", false)

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -372,6 +372,21 @@ class Settings(private val context: Context) {
                 .apply()
         }
 
+    /**
+     * Stop injecting after this many faults, or 0 to keep going for the whole session.
+     *
+     * What a bounded run buys is the second half of the measurement: a stream that is still being
+     * corrupted stays broken no matter what the recovery code does, so only a run that stops can
+     * show whether the picture comes back. See [VideoFaultInjector.budget].
+     */
+    var debugVideoFaultBudget: Int
+        get() = prefs.getInt("debug-video-fault-budget", VideoFaultInjector.UNLIMITED_BUDGET)
+        set(value) {
+            prefs.edit()
+                .putInt("debug-video-fault-budget", value.coerceAtLeast(VideoFaultInjector.UNLIMITED_BUDGET))
+                .apply()
+        }
+
     var rightHandDrive: Boolean
         get() = prefs.getBoolean("right-hand-drive", false)
         set(value) { prefs.edit().putBoolean("right-hand-drive", value).apply() }

--- a/app/src/main/java/com/andrerinas/openheadunit/view/GlProjectionView.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/view/GlProjectionView.kt
@@ -105,8 +105,14 @@ class GlProjectionView(context: Context) : GLSurfaceView(context), IProjectionVi
         private var mScaleX = 1.0f
         private var mScaleY = 1.0f
 
+        /**
+         * Resizes the texture's default buffer, on the GL thread.
+         *
+         * Called from the main thread when the video dimensions change, and it used to touch the
+         * SurfaceTexture straight from there while the GL thread was inside updateTexImage.
+         */
         fun updateBufferSize(width: Int, height: Int) {
-            surfaceTexture?.setDefaultBufferSize(width, height)
+            queueEvent { surfaceTexture?.setDefaultBufferSize(width, height) }
         }
 
         fun setScale(x: Float, y: Float) {
@@ -236,6 +242,38 @@ class GlProjectionView(context: Context) : GLSurfaceView(context), IProjectionVi
         private var updateSurface = false
         private var hasYuvFrame = false
         private var pendingYuvFrame = false
+
+        /**
+         * Which of the two frame sources produced something most recently.
+         *
+         * This renderer can be fed two ways: the decoder renders into [surfaceTexture] and the GL
+         * thread samples it as an external texture, or the bundled software decoder hands over YUV
+         * planes and the GL thread uploads them itself. [hasYuvFrame] used to latch true on the first
+         * YUV frame and never clear, so once a single software-decoded frame had been drawn the
+         * external-texture path was dead for the life of the renderer - and any later hardware output
+         * went into the SurfaceTexture and was never sampled. Turning software decoding off without
+         * reconnecting left a frozen or black picture.
+         *
+         * Comparing sequence numbers instead of latching a flag makes the choice self-healing: the
+         * source that is actually producing frames wins, and a switch either way is corrected on the
+         * next draw without anything having to tell the renderer it happened.
+         */
+        private var frameSequence = 0L
+        private var lastOesFrameSeq = 0L
+        private var lastYuvFrameSeq = 0L
+
+        /**
+         * Set once the direct upload has missed its deadline, after which only the staged path is used.
+         *
+         * The direct path hands the codec's own buffers to the GL thread and waits up to
+         * [directUploadTimeoutMs] for the upload to finish, which saves a CPU copy of three planes when
+         * the GL thread is keeping up. When it is not, the caller - the decoder thread - pays the full
+         * timeout *and then does the staged copy anyway*, which is the worst of both and was happening
+         * per frame. A GL thread slow enough to miss the deadline once is not going to start making it,
+         * so stop asking: the cost becomes one missed deadline a session instead of one per frame.
+         */
+        @Volatile
+        private var directUploadTimedOut = false
         private var yuvWidth = 0
         private var yuvHeight = 0
         private val uploadedPlaneWidths = IntArray(3)
@@ -278,6 +316,7 @@ class GlProjectionView(context: Context) : GLSurfaceView(context), IProjectionVi
                 yuvHeight = height
                 hasYuvFrame = true
                 pendingYuvFrame = true
+                lastYuvFrameSeq = ++frameSequence
                 if (!loggedFirstYuvFrame) {
                     loggedFirstYuvFrame = true
                     AppLog.i("GlProjectionView: first YUV420 frame queued ${width}x$height strides=$yStride/$uStride/$vStride")
@@ -298,6 +337,7 @@ class GlProjectionView(context: Context) : GLSurfaceView(context), IProjectionVi
             vStride: Int
         ): Boolean {
             if (width <= 0 || height <= 0) return false
+            if (directUploadTimedOut) return false
             val chromaWidth = width / 2
             val chromaHeight = height / 2
             if (yStride < width || uStride < chromaWidth || vStride < chromaWidth) return false
@@ -343,6 +383,11 @@ class GlProjectionView(context: Context) : GLSurfaceView(context), IProjectionVi
 
                 if (!completed.await(directUploadTimeoutMs, TimeUnit.MILLISECONDS)) {
                     if (state.compareAndSet(directPending, directCancelled)) {
+                        directUploadTimedOut = true
+                        AppLog.w(
+                            "GlProjectionView: direct YUV upload missed its ${directUploadTimeoutMs}ms deadline; " +
+                                "using the staged copy for the rest of this session"
+                        )
                         return false
                     }
                     completed.await()
@@ -419,13 +464,19 @@ class GlProjectionView(context: Context) : GLSurfaceView(context), IProjectionVi
             uploadYuvPlane(1, yuvTextureIds[1], uPlane, uStride, chromaHeight)
             uploadYuvPlane(2, yuvTextureIds[2], vPlane, vStride, chromaHeight)
 
-            yuvWidth = width
-            yuvHeight = height
-            yTextureScaleX = width.toFloat() / yStride.toFloat()
-            uTextureScaleX = chromaWidth.toFloat() / uStride.toFloat()
-            vTextureScaleX = chromaWidth.toFloat() / vStride.toFloat()
-            hasYuvFrame = true
-            pendingYuvFrame = false
+            // Under the monitor: queueYuv420Frame and drawYuvFrame read exactly these fields under
+            // it, and this path wrote them all bare. The GL uploads above stay outside, so the
+            // decoder thread is not held for the length of a texture upload.
+            synchronized(this) {
+                yuvWidth = width
+                yuvHeight = height
+                yTextureScaleX = width.toFloat() / yStride.toFloat()
+                uTextureScaleX = chromaWidth.toFloat() / uStride.toFloat()
+                vTextureScaleX = chromaWidth.toFloat() / vStride.toFloat()
+                hasYuvFrame = true
+                pendingYuvFrame = false
+                lastYuvFrameSeq = ++frameSequence
+            }
 
             if (!loggedFirstDirectYuvFrame) {
                 loggedFirstDirectYuvFrame = true
@@ -434,14 +485,26 @@ class GlProjectionView(context: Context) : GLSurfaceView(context), IProjectionVi
             return true
         }
 
+        /**
+         * Tears the render target down, telling the decoder before the Surface is actually gone.
+         *
+         * The notification has to be posted to the main looper because that is where every other
+         * surface callback is delivered from, and it used to be posted *and then* followed by two
+         * synchronous release() calls - so for one looper turn the decoder still held a Surface that
+         * had already been released. Releasing inside the same post closes that window; the fields are
+         * cleared first so a second call cannot release twice.
+         */
         fun release() {
-            surface?.let { s ->
-                Handler(Looper.getMainLooper()).post {
-                    callbacks.forEach { it.onSurfaceDestroyed(s) }
-                }
+            val doomedSurface = surface
+            val doomedTexture = surfaceTexture
+            surface = null
+            surfaceTexture = null
+            if (doomedSurface == null && doomedTexture == null) return
+            Handler(Looper.getMainLooper()).post {
+                doomedSurface?.let { s -> callbacks.forEach { it.onSurfaceDestroyed(s) } }
+                doomedSurface?.release()
+                doomedTexture?.release()
             }
-            surface?.release()
-            surfaceTexture?.release()
         }
 
         override fun onSurfaceCreated(gl: GL10?, config: EGLConfig?) {
@@ -556,7 +619,8 @@ class GlProjectionView(context: Context) : GLSurfaceView(context), IProjectionVi
             GLES20.glClearColor(0.0f, 0.0f, 0.0f, 1.0f)
             GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT)
 
-            val shouldDrawYuv = synchronized(this) { hasYuvFrame }
+            // Whichever source produced a frame more recently. See lastOesFrameSeq.
+            val shouldDrawYuv = synchronized(this) { hasYuvFrame && lastYuvFrameSeq >= lastOesFrameSeq }
             if (shouldDrawYuv) {
                 drawYuvFrame()
                 return
@@ -678,6 +742,7 @@ class GlProjectionView(context: Context) : GLSurfaceView(context), IProjectionVi
         override fun onFrameAvailable(surfaceTexture: SurfaceTexture?) {
             synchronized(this) {
                 updateSurface = true
+                lastOesFrameSeq = ++frameSequence
             }
             requestRender()
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -688,6 +688,7 @@
          purpose - it is a developer tool and the terms are protocol terms. -->
     <string name="debug_video_fault_injection" translatable="false">Video fault injection</string>
     <string name="debug_video_fault_rate" translatable="false">Fault rate (one in N)</string>
+    <string name="debug_video_fault_budget" translatable="false">Fault budget</string>
     <string name="debug_force_memory_profile" translatable="false">Force memory profile</string>
     <string name="debug_video_low_latency" translatable="false">Request decoder low-latency mode</string>
     <string name="debug_video_low_latency_description" translatable="false">Sets the vendor low-latency MediaFormat key when configuring the video decoder. Falls back automatically if the decoder rejects it.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -683,6 +683,14 @@
     <string name="nav_action_ferry_train">Ferry / train</string>
     <string name="nav_action_destination">Arrival</string>
     <string name="show_fps_counter">Show FPS Counter</string>
+    <!-- Debug-only: deliberately corrupts the projected video stream so the reassembler's
+         failure paths can be exercised on a unit that is working correctly. Not translated on
+         purpose - it is a developer tool and the terms are protocol terms. -->
+    <string name="debug_video_fault_injection" translatable="false">Video fault injection</string>
+    <string name="debug_video_fault_rate" translatable="false">Fault rate (one in N)</string>
+    <string name="debug_force_memory_profile" translatable="false">Force memory profile</string>
+    <string name="debug_video_low_latency" translatable="false">Request decoder low-latency mode</string>
+    <string name="debug_video_low_latency_description" translatable="false">Sets the vendor low-latency MediaFormat key when configuring the video decoder. Falls back automatically if the decoder rejects it.</string>
     <string name="show_fps_counter_description">Display a real-time FPS overlay in the top-left corner during projection.</string>
 
     <!-- Auto-start permission strings -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -690,6 +690,12 @@
     <string name="debug_video_fault_rate" translatable="false">Fault rate (one in N)</string>
     <string name="debug_video_fault_budget" translatable="false">Fault budget</string>
     <string name="debug_force_memory_profile" translatable="false">Force memory profile</string>
+    <string name="debug_force_p2p_band_24" translatable="false">Force WiFi Direct onto 2.4 GHz</string>
+    <string name="p2p_legacy_5ghz" translatable="false">Ask for 5 GHz on Android 9 and older</string>
+    <string name="p2p_legacy_5ghz_description" translatable="false">Below Android 10 there is no way to request a band, so the WiFi Direct group lands wherever the driver puts it — often 2.4 GHz, shared with Bluetooth. This asks for a 5 GHz channel instead. Leave it off unless the picture or sound stutters: a unit whose WiFi Direct cannot host 5 GHz will fail to create a group, and the app then clears the request and retries once. No effect on Android 10 and newer.</string>
+    <string name="p2p_legacy_5ghz_upper" translatable="false">Use the upper 5 GHz range</string>
+    <string name="p2p_legacy_5ghz_upper_description" translatable="false">Asks for channel 149 instead of channel 36. Try this only if channel 36 fails — some regions allow one range and not the other.</string>
+    <string name="debug_force_p2p_band_24_description" translatable="false">Native AA hosts its group on 2.4 GHz instead of asking for 5 GHz, and stops remaking a group that lands there. For reproducing 2.4 GHz link faults on a 5 GHz rig; leave off otherwise. Applies on the next connection.</string>
     <string name="debug_video_low_latency" translatable="false">Request decoder low-latency mode</string>
     <string name="debug_video_low_latency_description" translatable="false">Sets the vendor low-latency MediaFormat key when configuring the video decoder. Falls back automatically if the decoder rejects it.</string>
     <string name="show_fps_counter_description">Display a real-time FPS overlay in the top-left corner during projection.</string>

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/AapReadRecoveryPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/AapReadRecoveryPolicyTest.kt
@@ -1,0 +1,90 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.AapReadRecoveryPolicy.Outcome
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The table is spelled out per read site because the four sites used to answer the same way -
+ * "skip this message and carry on" - and that answer is only correct for one of them.
+ *
+ * The case that matters is a short read of a body: it leaves an unknown number of bytes consumed,
+ * so nothing downstream can find the next header. A reporter's capture measured exactly that,
+ * followed by 69 `WRONG FLAG` and 63 `SSL Decrypt failed` lines in half a second.
+ */
+class AapReadRecoveryPolicyTest {
+
+    private val headerSize = 4
+
+    @Test
+    fun `a complete read of any field continues`() {
+        assertEquals(Outcome.CONTINUE, AapReadRecoveryPolicy.afterHeaderRead(headerSize, headerSize, true))
+        assertEquals(Outcome.CONTINUE, AapReadRecoveryPolicy.afterFragmentTotalRead(4, 4))
+        assertEquals(Outcome.CONTINUE, AapReadRecoveryPolicy.afterBodyRead(8231, 8231))
+    }
+
+    @Test
+    fun `end of stream is an ordinary disconnect at every site`() {
+        assertEquals(Outcome.DISCONNECT_EOF, AapReadRecoveryPolicy.afterHeaderRead(-1, headerSize, true))
+        assertEquals(Outcome.DISCONNECT_EOF, AapReadRecoveryPolicy.afterFragmentTotalRead(-1, 4))
+        assertEquals(Outcome.DISCONNECT_EOF, AapReadRecoveryPolicy.afterBodyRead(-1, 8231))
+    }
+
+    @Test
+    fun `a header that never arrived took no bytes, so only the socket gives up`() {
+        // Nothing was consumed either way - this is a liveness rule, not an alignment one. USB
+        // tolerates a quiet bus; a socket silent for its whole timeout is gone.
+        assertEquals(Outcome.DISCONNECT_IDLE, AapReadRecoveryPolicy.afterHeaderRead(0, headerSize, true))
+        assertEquals(Outcome.CONTINUE, AapReadRecoveryPolicy.afterHeaderRead(0, headerSize, false))
+    }
+
+    @Test
+    fun `a partial header cannot be resumed`() {
+        assertEquals(Outcome.DISCONNECT_DESYNC, AapReadRecoveryPolicy.afterHeaderRead(1, headerSize, true))
+        assertEquals(Outcome.DISCONNECT_DESYNC, AapReadRecoveryPolicy.afterHeaderRead(3, headerSize, false))
+    }
+
+    @Test
+    fun `a short fragment total is fatal even though the field is four bytes`() {
+        // The header before it is already consumed, so continuing would read the body as a header.
+        assertEquals(Outcome.DISCONNECT_DESYNC, AapReadRecoveryPolicy.afterFragmentTotalRead(0, 4))
+        assertEquals(Outcome.DISCONNECT_DESYNC, AapReadRecoveryPolicy.afterFragmentTotalRead(2, 4))
+    }
+
+    @Test
+    fun `a body that timed out reports zero but consumed an unknown amount`() {
+        // The reporter's line read "Expected 8231, got 0" and the stream was already unframed. The
+        // zero is the timeout catch's return value, not a count of what readFully took.
+        assertEquals(Outcome.DISCONNECT_DESYNC, AapReadRecoveryPolicy.afterBodyRead(0, 8231))
+        assertEquals(Outcome.DISCONNECT_DESYNC, AapReadRecoveryPolicy.afterBodyRead(4096, 8231))
+    }
+
+    @Test
+    fun `a declared length inside the buffer continues, including an empty body`() {
+        val capacity = 4 * 1024 * 1024
+        assertEquals(Outcome.CONTINUE, AapReadRecoveryPolicy.afterDeclaredLength(0, capacity))
+        assertEquals(Outcome.CONTINUE, AapReadRecoveryPolicy.afterDeclaredLength(8231, capacity))
+        assertEquals(Outcome.CONTINUE, AapReadRecoveryPolicy.afterDeclaredLength(capacity, capacity))
+    }
+
+    @Test
+    fun `a declared length outside the buffer is a desync, not a big message`() {
+        // Both shapes come from reading garbage as a header, which is what a previous skip produces.
+        val capacity = 4 * 1024 * 1024
+        assertEquals(Outcome.DISCONNECT_DESYNC, AapReadRecoveryPolicy.afterDeclaredLength(capacity + 1, capacity))
+        assertEquals(Outcome.DISCONNECT_DESYNC, AapReadRecoveryPolicy.afterDeclaredLength(-120, capacity))
+    }
+
+    @Test
+    fun `no site answers CONTINUE once bytes have gone missing`() {
+        // The regression guard for the whole change: the only CONTINUE on a short read is the
+        // header case that consumed nothing.
+        val shortReads = listOf(
+            AapReadRecoveryPolicy.afterFragmentTotalRead(1, 4),
+            AapReadRecoveryPolicy.afterBodyRead(1, 2),
+            AapReadRecoveryPolicy.afterHeaderRead(2, 4, true),
+            AapReadRecoveryPolicy.afterHeaderRead(2, 4, false),
+        )
+        shortReads.forEach { assertEquals(Outcome.DISCONNECT_DESYNC, it) }
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/AuditRecoveryPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/AuditRecoveryPolicyTest.kt
@@ -1,0 +1,70 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.FragmentedMessageAudit.Outcome
+import com.andrerinas.openheadunit.aap.protocol.Channel
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The framing audit was built as an instrument and wired like one: it computed its finding, the
+ * reader printed it, and nothing acted on it. This is the rule that decides which of its findings
+ * are worth more than a log line.
+ *
+ * The cost of getting it wrong runs both ways. Too narrow and the one corruption mode nothing else
+ * can see goes on being seen and ignored - a hardware round measured 37 and 59 injected
+ * middle-fragment faults producing zero keyframe requests. Too broad and a fault that already has a
+ * reporter gets asked about twice, which also stamps the corruption clock twice and makes one lost
+ * fragment look like a wire that is still breaking.
+ */
+class AuditRecoveryPolicyTest {
+
+    @Test
+    fun `a hole in a video run is asked about, because nothing else will`() {
+        // DELTA_CHANGED means the run's byte total cannot be explained by its fragment count, i.e.
+        // a fragment is missing. When it is a middle fragment, VideoFragmentAssembler still sees a
+        // first, some middles and a last in order and assembles the frame around the hole. This is
+        // the only outcome with no second reporter.
+        assertTrue(AuditRecoveryPolicy.shouldRequestKeyframe(Outcome.DELTA_CHANGED, Channel.ID_VID))
+    }
+
+    @Test
+    fun `the outcomes the reassembler already reports are left to it`() {
+        // TRUNCATED_RUN surfaces downstream as Anomaly.TRUNCATED_PREVIOUS and ORPHANED_FRAGMENT as
+        // Anomaly.ORPHANED_FRAGMENT, both of which already call requestKeyframe. Asking here too
+        // would spend two requests on one fault and, worse, stamp lastWireCorruptionMs twice - so a
+        // single lost fragment would read as a wire still losing them and hold off the focus cycle.
+        assertFalse(AuditRecoveryPolicy.shouldRequestKeyframe(Outcome.TRUNCATED_RUN, Channel.ID_VID))
+        assertFalse(AuditRecoveryPolicy.shouldRequestKeyframe(Outcome.ORPHANED_FRAGMENT, Channel.ID_VID))
+    }
+
+    @Test
+    fun `the first run on a channel is a baseline, not a fault`() {
+        // FIRST_OBSERVATION is how the audit learns the channel's convention. It fires once per
+        // channel per session and on a perfectly healthy stream.
+        assertFalse(AuditRecoveryPolicy.shouldRequestKeyframe(Outcome.FIRST_OBSERVATION, Channel.ID_VID))
+    }
+
+    @Test
+    fun `a hole in another channel's run is real but not repairable this way`() {
+        // The audit runs per channel because runs interleave, and MUSIC_PLAYBACK fragments enough to
+        // have its own accounting - two hardware rounds established a convention on it alongside
+        // VIDEO. A keyframe repairs video and nothing else, and the protocol has no equivalent ask.
+        for (channel in listOf(Channel.ID_CTR, Channel.ID_SEN, Channel.ID_INP, Channel.ID_AUD, Channel.ID_MPB, Channel.ID_MIC)) {
+            assertFalse(
+                "${Channel.name(channel)} has no keyframe to ask for",
+                AuditRecoveryPolicy.shouldRequestKeyframe(Outcome.DELTA_CHANGED, channel)
+            )
+        }
+    }
+
+    @Test
+    fun `no outcome on a non-video channel ever asks`() {
+        for (outcome in Outcome.entries) {
+            assertFalse(
+                "$outcome on MUSIC_PLAYBACK must not ask for a video keyframe",
+                AuditRecoveryPolicy.shouldRequestKeyframe(outcome, Channel.ID_MPB)
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/AuditReportPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/AuditReportPolicyTest.kt
@@ -1,0 +1,63 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The rule that failed in the field: the audit spent its whole ten-line budget in 200ms on
+ * false positives and was silent for the remaining five minutes, including both windows in which a
+ * reporter's artifact was on screen.
+ */
+class AuditReportPolicyTest {
+
+    private val burst = AuditReportPolicy.BURST_REPORTS
+    private val interval = AuditReportPolicy.SUMMARY_INTERVAL_MS
+
+    @Test
+    fun `the first reports print immediately, however fast they arrive`() {
+        // The connect-time burst is worth seeing in full - it is where a systematic fault shows up.
+        for (printed in 0 until burst) {
+            assertTrue(AuditReportPolicy.shouldReport(printed, lastReportMs = 1000, nowMs = 1000))
+        }
+    }
+
+    @Test
+    fun `the budget refills instead of running out`() {
+        // The whole point. Under the old hard cap this was false forever.
+        assertFalse(AuditReportPolicy.shouldReport(burst, lastReportMs = 1000, nowMs = 1000))
+        assertTrue(AuditReportPolicy.shouldReport(burst, lastReportMs = 1000, nowMs = 1000 + interval))
+        assertTrue(AuditReportPolicy.shouldReport(10_000, lastReportMs = 1000, nowMs = 1000 + interval))
+    }
+
+    @Test
+    fun `a fault that starts in minute nine is still reported`() {
+        // The failure this exists to prevent, stated as the case: budget long gone, hours later,
+        // something starts going wrong.
+        val nineMinutes = 9 * 60_000L
+        assertTrue(AuditReportPolicy.shouldReport(burst, lastReportMs = 500, nowMs = nineMinutes))
+    }
+
+    @Test
+    fun `a storm is bounded to roughly one line per interval`() {
+        // Replay a fault firing every 100ms for ten minutes and count what would be printed.
+        var printed = 0
+        var lastReport = 0L
+        var now = 0L
+        while (now < 10 * 60_000L) {
+            if (AuditReportPolicy.shouldReport(printed, lastReport, now)) {
+                printed++
+                lastReport = now
+            }
+            now += 100
+        }
+        // The burst, plus one per interval afterwards.
+        assertTrue("expected the burst plus ~10 summaries, got $printed", printed in burst + 8..burst + 11)
+    }
+
+    @Test
+    fun `the interval is not so long that a report is lost in the noise of a drive`() {
+        assertTrue("a summary every minute at most", interval <= 60_000L)
+        assertTrue("but not so often it floods", interval >= 10_000L)
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/CodecConfigScannerTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/CodecConfigScannerTest.kt
@@ -1,0 +1,191 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.CodecConfigScanner.Content
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * What may and may not be flagged BUFFER_FLAG_CODEC_CONFIG.
+ *
+ * The case that matters is [a keyframe leading with its parameter sets is not configuration]: that
+ * flag tells MediaCodec the buffer holds codec-specific data and nothing else, so a component may
+ * consume it and return no picture. On the three chipset families that flagged every config packet,
+ * the old first-NAL-only check answered "configuration" for exactly that unit.
+ */
+class CodecConfigScannerTest {
+
+    // H.264 NAL header byte: (nal_ref_idc shl 5) or nal_unit_type.
+    private val avcSps = 0x67       // type 7, ref_idc 3
+    private val avcPps = 0x68       // type 8
+    private val avcIdr = 0x65       // type 5
+    private val avcNonIdr = 0x41    // type 1, ref_idc 2
+    private val avcSei = 0x06       // type 6
+    private val avcAud = 0x09       // type 9
+    private val avcSpsExt = 0x6D    // type 13
+
+    // H.265 NAL header, first byte: nal_unit_type shl 1.
+    private val hevcVps = 0x40      // type 32
+    private val hevcSps = 0x42      // type 33
+    private val hevcPps = 0x44      // type 34
+    private val hevcIdr = 0x26      // type 19, IDR_W_RADL
+    private val hevcTrail = 0x02    // type 1, TRAIL_N
+    private val hevcAud = 0x46      // type 35
+    private val hevcSei = 0x4E      // type 39, PREFIX_SEI
+
+    /** An Annex B access unit: a 4-byte start code and some payload per NAL. */
+    private fun unit(vararg headerBytes: Int, threeByteStartCodes: Boolean = false): ByteArray {
+        val out = ArrayList<Byte>()
+        for (h in headerBytes) {
+            if (!threeByteStartCodes) out.add(0)
+            out.add(0); out.add(0); out.add(1)
+            out.add(h.toByte())
+            // Some payload, chosen so it contains no accidental start code.
+            for (b in listOf(0x42, 0x99, 0x11, 0x77)) out.add(b.toByte())
+        }
+        return out.toByteArray()
+    }
+
+    private fun classifyAvc(data: ByteArray) = CodecConfigScanner.classify(data, 0, data.size, isHevc = false)
+    private fun classifyHevc(data: ByteArray) = CodecConfigScanner.classify(data, 0, data.size, isHevc = true)
+
+    // ---- the case this class exists for ----
+
+    @Test
+    fun `a keyframe leading with its parameter sets is not configuration`() {
+        assertEquals(
+            Content.PARAMETER_SETS_WITH_PICTURE,
+            classifyAvc(unit(avcSps, avcPps, avcIdr))
+        )
+        assertEquals(
+            Content.PARAMETER_SETS_WITH_PICTURE,
+            classifyHevc(unit(hevcVps, hevcSps, hevcPps, hevcIdr))
+        )
+    }
+
+    @Test
+    fun `parameter sets on their own are configuration`() {
+        assertEquals(Content.PARAMETER_SETS_ONLY, classifyAvc(unit(avcSps, avcPps)))
+        assertEquals(Content.PARAMETER_SETS_ONLY, classifyHevc(unit(hevcVps, hevcSps, hevcPps)))
+    }
+
+    @Test
+    fun `parameter sets are found behind a delimiter or an SEI`() {
+        // The other half of the old check's failure: a unit that does not *lead* with a parameter set
+        // was reported as carrying none, so decoders that require the flag never got it.
+        assertEquals(Content.PARAMETER_SETS_ONLY, classifyAvc(unit(avcAud, avcSps, avcPps)))
+        assertEquals(Content.PARAMETER_SETS_ONLY, classifyAvc(unit(avcSei, avcSps)))
+        assertEquals(Content.PARAMETER_SETS_ONLY, classifyHevc(unit(hevcAud, hevcVps, hevcSps, hevcPps)))
+        assertEquals(Content.PARAMETER_SETS_ONLY, classifyHevc(unit(hevcSei, hevcSps)))
+    }
+
+    @Test
+    fun `an ordinary frame carries no parameter sets`() {
+        assertEquals(Content.NO_PARAMETER_SETS, classifyAvc(unit(avcNonIdr)))
+        assertEquals(Content.NO_PARAMETER_SETS, classifyAvc(unit(avcAud, avcNonIdr)))
+        assertEquals(Content.NO_PARAMETER_SETS, classifyHevc(unit(hevcTrail)))
+        assertEquals(Content.NO_PARAMETER_SETS, classifyHevc(unit(hevcAud, hevcTrail)))
+    }
+
+    @Test
+    fun `an IDR with no parameter sets is still just a frame`() {
+        // Nothing to configure with, so nothing to flag - and it must not be treated as config.
+        assertEquals(Content.NO_PARAMETER_SETS, classifyAvc(unit(avcIdr)))
+        assertEquals(Content.NO_PARAMETER_SETS, classifyHevc(unit(hevcIdr)))
+    }
+
+    // ---- details of the walk ----
+
+    @Test
+    fun `three-byte start codes are read too`() {
+        assertEquals(
+            Content.PARAMETER_SETS_WITH_PICTURE,
+            classifyAvc(unit(avcSps, avcPps, avcIdr, threeByteStartCodes = true))
+        )
+        assertEquals(
+            Content.PARAMETER_SETS_ONLY,
+            classifyHevc(unit(hevcVps, hevcSps, threeByteStartCodes = true))
+        )
+    }
+
+    @Test
+    fun `the H264 SPS extensions count as parameter sets`() {
+        assertEquals(Content.PARAMETER_SETS_ONLY, classifyAvc(unit(avcSpsExt)))
+    }
+
+    @Test
+    fun `the answer is read against the pinned codec, because the same byte means two things`() {
+        // 0x41 is an H.264 non-IDR slice; read as HEVC its type is (0x41 and 0x7E) shr 1 == 32, which
+        // is a VPS. This is the documented false positive that once let a keyframe latch read an
+        // ordinary P-slice as configuration - which is why the caller passes the type the decoder
+        // pinned and never the user's preference.
+        val ambiguous = unit(avcNonIdr)
+        assertEquals(Content.NO_PARAMETER_SETS, classifyAvc(ambiguous))
+        assertEquals(Content.PARAMETER_SETS_ONLY, classifyHevc(ambiguous))
+    }
+
+    @Test
+    fun `a unit too short to hold a NAL is not configuration`() {
+        for (size in 0..4) {
+            val data = ByteArray(size)
+            assertEquals(Content.NO_PARAMETER_SETS, CodecConfigScanner.classify(data, 0, size, isHevc = false))
+            assertEquals(Content.NO_PARAMETER_SETS, CodecConfigScanner.classify(data, 0, size, isHevc = true))
+        }
+    }
+
+    @Test
+    fun `bytes outside the offset and size are not read`() {
+        // The frame is a window into a larger buffer on every path that reaches this.
+        val payload = unit(avcSps, avcPps)
+        val padded = ByteArray(payload.size + 16)
+        System.arraycopy(payload, 0, padded, 8, payload.size)
+        // A keyframe sitting in the padding must not be seen.
+        val trailer = unit(avcIdr)
+        System.arraycopy(trailer, 0, padded, 8 + payload.size, minOf(trailer.size, 8))
+        assertEquals(
+            Content.PARAMETER_SETS_ONLY,
+            CodecConfigScanner.classify(padded, 8, payload.size, isHevc = false)
+        )
+    }
+
+    @Test
+    fun `a large frame is not walked past the byte bound`() {
+        // A P-frame contains no start code after its first, so an unbounded walk reads all of it -
+        // 60 times a second, on the feed thread. The bound is what stops that.
+        val big = ByteArray(400 * 1024) { 0x5A }
+        assertEquals(Content.NO_PARAMETER_SETS, CodecConfigScanner.classify(big, 0, big.size, isHevc = false))
+    }
+
+    @Test
+    fun `stopping at the bound withholds the flag rather than guessing`() {
+        // Parameter sets found, and then a stretch too long to see the end of. The unit may or may not
+        // contain a picture, and the safe answer is the one that does not flag it as configuration.
+        val head = unit(avcSps, avcPps)
+        val padded = ByteArray(CodecConfigScanner.MAX_BYTES_SCANNED * 2)
+        System.arraycopy(head, 0, padded, 0, head.size)
+        for (i in head.size until padded.size) padded[i] = 0x5A
+        assertEquals(
+            Content.PARAMETER_SETS_WITH_PICTURE,
+            CodecConfigScanner.classify(padded, 0, padded.size, isHevc = false)
+        )
+    }
+
+    @Test
+    fun `a real parameter-set unit finishes well inside the bound`() {
+        // Which is why bounding the walk cannot cost the config flag on the units that need it: SPS
+        // and PPS together are tens of bytes.
+        val sets = unit(avcSps, avcPps)
+        org.junit.Assert.assertTrue(
+            "a parameter-set unit is ${sets.size} bytes, the bound is ${CodecConfigScanner.MAX_BYTES_SCANNED}",
+            sets.size < CodecConfigScanner.MAX_BYTES_SCANNED
+        )
+        assertEquals(Content.PARAMETER_SETS_ONLY, classifyAvc(sets))
+    }
+
+    @Test
+    fun `a picture found after the parameter sets settles the answer immediately`() {
+        // Sixteen headers is the bound, so a unit with more NALs than that still has to come out right
+        // as long as the picture is not beyond it - which it never is, since slices follow the sets.
+        val headers = IntArray(20) { if (it == 0) avcSps else if (it == 1) avcPps else avcIdr }
+        assertEquals(Content.PARAMETER_SETS_WITH_PICTURE, classifyAvc(unit(*headers)))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/FocusCycleLeverTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/FocusCycleLeverTest.kt
@@ -1,0 +1,62 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FocusCycleLeverTest {
+
+    @Test
+    fun `the first claim wins and the second is refused`() {
+        val lever = FocusCycleLever()
+        assertTrue(lever.tryClaim())
+        assertFalse(lever.tryClaim())
+        assertTrue(lever.isHeld)
+    }
+
+    @Test
+    fun `releasing lets the next cycle through`() {
+        val lever = FocusCycleLever()
+        assertTrue(lever.tryClaim())
+        lever.release()
+        assertFalse(lever.isHeld)
+        assertTrue(lever.tryClaim())
+    }
+
+    @Test
+    fun `releasing twice is safe`() {
+        // A cycle can be completed early by a settle path and then again by its own delayed regain.
+        val lever = FocusCycleLever()
+        lever.tryClaim()
+        lever.release()
+        lever.release()
+        assertTrue(lever.tryClaim())
+    }
+
+    @Test
+    fun `releasing what was never claimed does not open a second cycle`() {
+        val lever = FocusCycleLever()
+        lever.release()
+        assertTrue(lever.tryClaim())
+        assertFalse(lever.tryClaim())
+    }
+
+    @Test
+    fun `only one of many concurrent claims succeeds`() {
+        // The two callers live on different handlers - the transport's send thread and the
+        // projection activity's watchdog - so this is a real race, not a theoretical one.
+        val lever = FocusCycleLever()
+        val winners = java.util.concurrent.atomic.AtomicInteger(0)
+        val start = java.util.concurrent.CountDownLatch(1)
+        val threads = (1..8).map {
+            Thread {
+                start.await()
+                if (lever.tryClaim()) winners.incrementAndGet()
+            }
+        }
+        threads.forEach { it.start() }
+        start.countDown()
+        threads.forEach { it.join() }
+        org.junit.Assert.assertEquals(1, winners.get())
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/FragmentedMessageAuditTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/FragmentedMessageAuditTest.kt
@@ -1,0 +1,293 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.FragmentedMessageAudit.Outcome
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The cross-check that catches the one corruption mode nothing else can see.
+ *
+ * A missing *middle* fragment leaves the run looking intact to [VideoFragmentAssembler] - first,
+ * middles, last, in order - so the frame is assembled with a hole in it and decoded as though it were
+ * whole. The total size the first fragment declares is the only thing that disagrees.
+ *
+ * The numbers in the "measured" cases are the real fragment counts and deltas measured on a
+ * UNISOC MT50. They are pinned here because the first version of this class
+ * compared every run against the establishing run's *whole* difference, so every run with a
+ * different fragment count reported - which then exhausted the print budget and left the check dead
+ * for the rest of the session.
+ */
+class FragmentedMessageAuditTest {
+
+    private val vid = 2
+    private val aud = 6
+
+    private val first = FragmentedMessageAudit.FLAG_BIT_FIRST
+    private val last = FragmentedMessageAudit.FLAG_BIT_LAST
+    private val middle = 0
+    private val single = first or last
+
+    /** Flags as they appear on the wire, with the encryption bit that every payload message carries. */
+    private val encrypted = 0x08
+
+    @Test
+    fun `a healthy run reports once and then stays quiet`() {
+        val a = FragmentedMessageAudit()
+        // Declared total is the sum of the three fragment lengths, whatever the convention turns out
+        // to be - the class learns whichever offset the stream uses.
+        assertNull(a.onMessage(vid, first or encrypted, encLen = 100, declaredTotal = 300))
+        assertNull(a.onMessage(vid, middle or encrypted, encLen = 100, declaredTotal = 0))
+        val firstRun = a.onMessage(vid, last or encrypted, encLen = 100, declaredTotal = 0)
+        assertNotNull(firstRun)
+        assertEquals(Outcome.FIRST_OBSERVATION, firstRun!!.outcome)
+        assertEquals(0, firstRun.delta)
+        assertEquals(3, firstRun.fragments)
+
+        // Every identical run afterwards is silent.
+        repeat(5) {
+            assertNull(a.onMessage(vid, first or encrypted, 100, 300))
+            assertNull(a.onMessage(vid, middle or encrypted, 100, 0))
+            assertNull(a.onMessage(vid, last or encrypted, 100, 0))
+        }
+    }
+
+    @Test
+    fun `the convention is learned, not assumed`() {
+        // Same stream shape, but the declared total counts something we do not model - here it is
+        // 12 bytes larger than the fragment bodies. The first run establishes that and the rest are
+        // silent, so a convention we guessed wrong cannot flood the log.
+        val a = FragmentedMessageAudit()
+        a.onMessage(vid, first or encrypted, 100, 312)
+        a.onMessage(vid, middle or encrypted, 100, 0)
+        val established = a.onMessage(vid, last or encrypted, 100, 0)!!
+        assertEquals(Outcome.FIRST_OBSERVATION, established.outcome)
+        assertEquals(12, established.delta)
+
+        assertNull(a.onMessage(vid, first or encrypted, 100, 312))
+        assertNull(a.onMessage(vid, middle or encrypted, 100, 0))
+        assertNull(a.onMessage(vid, last or encrypted, 100, 0))
+    }
+
+    @Test
+    fun `a missing middle fragment is reported, and it is the case nothing else sees`() {
+        val a = FragmentedMessageAudit()
+        // Establish the convention on a good run.
+        a.onMessage(vid, first or encrypted, 100, 300)
+        a.onMessage(vid, middle or encrypted, 100, 0)
+        a.onMessage(vid, last or encrypted, 100, 0)
+
+        // Now the middle never arrives. The assembler sees first-then-last, which is a legal run.
+        a.onMessage(vid, first or encrypted, 100, 300)
+        val result = a.onMessage(vid, last or encrypted, 100, 0)
+        assertNotNull("a 100-byte hole must not pass unreported", result)
+        assertEquals(Outcome.DELTA_CHANGED, result!!.outcome)
+        assertEquals(100, result.delta)
+        assertEquals(0, result.expectedDelta)
+        assertEquals(2, result.fragments)
+    }
+
+    @Test
+    fun `a run that never ends is reported when the next message starts`() {
+        val a = FragmentedMessageAudit()
+        a.onMessage(vid, first or encrypted, 100, 300)
+        a.onMessage(vid, middle or encrypted, 100, 0)
+        val result = a.onMessage(vid, first or encrypted, 100, 300)
+        assertNotNull(result)
+        assertEquals(Outcome.TRUNCATED_RUN, result!!.outcome)
+        assertEquals(2, result.fragments)
+    }
+
+    @Test
+    fun `an unfragmented message also ends an open run`() {
+        val a = FragmentedMessageAudit()
+        a.onMessage(vid, first or encrypted, 100, 300)
+        val result = a.onMessage(vid, single or encrypted, 500, 0)
+        assertEquals(Outcome.TRUNCATED_RUN, result!!.outcome)
+        // And leaves nothing open behind it.
+        assertEquals(Outcome.ORPHANED_FRAGMENT, a.onMessage(vid, last or encrypted, 100, 0)!!.outcome)
+    }
+
+    @Test
+    fun `unfragmented messages on their own are never reported`() {
+        val a = FragmentedMessageAudit()
+        repeat(20) { assertNull(a.onMessage(vid, single or encrypted, 500, 0)) }
+    }
+
+    @Test
+    fun `a fragment with no run open is an orphan`() {
+        val a = FragmentedMessageAudit()
+        assertEquals(Outcome.ORPHANED_FRAGMENT, a.onMessage(vid, middle or encrypted, 100, 0)!!.outcome)
+        assertEquals(Outcome.ORPHANED_FRAGMENT, a.onMessage(vid, last or encrypted, 100, 0)!!.outcome)
+    }
+
+    @Test
+    fun `channels are audited independently because their runs interleave`() {
+        // Video and audio fragments share one connection, so a run on one must not be closed,
+        // extended or blamed by traffic on the other.
+        val a = FragmentedMessageAudit()
+        a.onMessage(vid, first or encrypted, 100, 200)
+        a.onMessage(aud, first or encrypted, 50, 150)
+        a.onMessage(vid, last or encrypted, 100, 0)
+        a.onMessage(aud, middle or encrypted, 50, 0)
+        val audioRun = a.onMessage(aud, last or encrypted, 50, 0)
+        assertNotNull(audioRun)
+        assertEquals(Outcome.FIRST_OBSERVATION, audioRun!!.outcome)
+        assertEquals(aud, audioRun.channel)
+        assertEquals(3, audioRun.fragments)
+        assertEquals(0, audioRun.delta)
+    }
+
+    @Test
+    fun `an out of range channel is ignored rather than crashing`() {
+        val a = FragmentedMessageAudit()
+        assertNull(a.onMessage(-1, first or encrypted, 100, 300))
+        assertNull(a.onMessage(FragmentedMessageAudit.DEFAULT_CHANNEL_COUNT, first or encrypted, 100, 300))
+        assertNull(a.onMessage(9999, last or encrypted, 100, 0))
+    }
+
+    @Test
+    fun `reset forgets both the open run and the learned convention`() {
+        val a = FragmentedMessageAudit()
+        a.onMessage(vid, first or encrypted, 100, 312)
+        a.onMessage(vid, last or encrypted, 100, 0)
+        a.onMessage(vid, first or encrypted, 100, 312)
+        a.reset()
+
+        assertEquals(
+            "a fragment after a reset has no run to belong to",
+            Outcome.ORPHANED_FRAGMENT,
+            a.onMessage(vid, last or encrypted, 100, 0)!!.outcome
+        )
+        a.onMessage(vid, first or encrypted, 100, 200)
+        assertEquals(
+            "and the convention has to be learned again",
+            Outcome.FIRST_OBSERVATION,
+            a.onMessage(vid, last or encrypted, 100, 0)!!.outcome
+        )
+    }
+
+    @Test
+    fun `the report carries the numbers a reader would need`() {
+        val a = FragmentedMessageAudit()
+        a.onMessage(vid, first or encrypted, 100, 300)
+        a.onMessage(vid, middle or encrypted, 100, 0)
+        a.onMessage(vid, last or encrypted, 100, 0)
+        a.onMessage(vid, first or encrypted, 100, 300)
+        val text = a.onMessage(vid, last or encrypted, 100, 0)!!.toString()
+        for (field in listOf("channel=2", "fragments=2", "declaredTotal=300", "observed=200", "delta=100", "expectedDelta=0")) {
+            org.junit.Assert.assertTrue("report is missing $field: $text", text.contains(field))
+        }
+    }
+
+    @Test
+    fun `the learned convention scales with the fragment count`() {
+        // The bug this pins: an establishing run of 3 fragments must not make a run of 7 look wrong.
+        val a = FragmentedMessageAudit()
+        run(a, fragments = 3, perFragment = -29)
+        for (count in listOf(2, 4, 5, 7, 8, 3, 2)) {
+            assertNull(
+                "a $count-fragment run is not an anomaly just because the first run had 3",
+                run(a, fragments = count, perFragment = -29)
+            )
+        }
+    }
+
+    @Test
+    fun `the measured fragment counts and deltas from the rig report nothing`() {
+        // Every DELTA_CHANGED line the rig printed, replayed. All twenty were false.
+        val a = FragmentedMessageAudit()
+        val established = run(a, fragments = 3, perFragment = -29)!!
+        assertEquals(Outcome.FIRST_OBSERVATION, established.outcome)
+        assertEquals(-87, established.delta)
+        assertEquals(-29, established.perFragmentDelta)
+
+        for (count in listOf(7, 8, 8, 7, 7, 4, 2, 2, 2, 2, 3, 5, 4, 8, 4, 4, 3, 3, 3, 3)) {
+            assertNull(run(a, fragments = count, perFragment = -29))
+        }
+    }
+
+    @Test
+    fun `a hole is still caught once the expectation scales`() {
+        // The check has to survive the fix: establish on 3, then lose one fragment out of 5.
+        val a = FragmentedMessageAudit()
+        run(a, fragments = 3, perFragment = -29)
+
+        // A five-fragment message whose third fragment never arrives: declared covers all five,
+        // only four are seen.
+        val body = 1000
+        val declared = 5 * body
+        a.onMessage(vid, first or encrypted, body + 29, declared)
+        a.onMessage(vid, middle or encrypted, body + 29, 0)
+        a.onMessage(vid, middle or encrypted, body + 29, 0)
+        val result = a.onMessage(vid, last or encrypted, body + 29, 0)
+
+        assertNotNull("a 1000-byte hole must not pass unreported", result)
+        assertEquals(Outcome.DELTA_CHANGED, result!!.outcome)
+        assertEquals(4, result.fragments)
+        // Expected -116 for four fragments; the missing fragment's body is the whole difference.
+        assertEquals(-116, result.expectedDelta)
+        assertEquals(body - 116, result.delta)
+    }
+
+    @Test
+    fun `a convention that does not divide evenly still scales exactly`() {
+        // Nothing requires the per-fragment overhead to divide; the comparison cross-multiplies.
+        // Establish 10 over 4 fragments, then a run of 2 must expect exactly 5.
+        val a = FragmentedMessageAudit()
+        a.onMessage(vid, first or encrypted, 100, 410)
+        repeat(2) { a.onMessage(vid, middle or encrypted, 100, 0) }
+        val established = a.onMessage(vid, last or encrypted, 100, 0)!!
+        assertEquals(10, established.delta)
+        assertNull("10 over 4 fragments is not a whole number", established.perFragmentDelta)
+
+        a.onMessage(vid, first or encrypted, 100, 205)
+        assertNull("2 fragments should expect exactly half of 10", a.onMessage(vid, last or encrypted, 100, 0))
+
+        a.onMessage(vid, first or encrypted, 100, 206)
+        val off = a.onMessage(vid, last or encrypted, 100, 0)!!
+        assertEquals(Outcome.DELTA_CHANGED, off.outcome)
+        assertEquals(5, off.expectedDelta)
+        assertEquals(6, off.delta)
+    }
+
+    @Test
+    fun `an orphan quotes no expectation, because there is nothing to expect`() {
+        val a = FragmentedMessageAudit()
+        run(a, fragments = 3, perFragment = -29)
+        val orphan = a.onMessage(vid, last or encrypted, 100, 0)!!
+        assertEquals(Outcome.ORPHANED_FRAGMENT, orphan.outcome)
+        assertNull(orphan.expectedDelta)
+        assertNull(orphan.perFragmentDelta)
+    }
+
+    @Test
+    fun `a truncated run quotes the expectation for what it did see`() {
+        val a = FragmentedMessageAudit()
+        run(a, fragments = 3, perFragment = -29)
+        a.onMessage(vid, first or encrypted, 129, 3000)
+        a.onMessage(vid, middle or encrypted, 129, 0)
+        val truncated = a.onMessage(vid, first or encrypted, 129, 3000)!!
+        assertEquals(Outcome.TRUNCATED_RUN, truncated.outcome)
+        assertEquals(2, truncated.fragments)
+        assertEquals("scaled to the two fragments that arrived, not to the three of the first run",
+            -58, truncated.expectedDelta)
+    }
+
+    /**
+     * One complete run of [fragments] fragments whose declared total is short by [perFragment] per
+     * fragment - the shape the rig measured. Returns whatever the audit made of it.
+     */
+    private fun run(
+        audit: FragmentedMessageAudit,
+        fragments: Int,
+        perFragment: Int,
+        body: Int = 1000,
+    ): FragmentedMessageAudit.Result? {
+        val declared = fragments * (body + perFragment)
+        audit.onMessage(vid, first or encrypted, body, declared)
+        repeat(fragments - 2) { audit.onMessage(vid, middle or encrypted, body, 0) }
+        return audit.onMessage(vid, last or encrypted, body, 0)
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicyTest.kt
@@ -1,7 +1,9 @@
 package com.andrerinas.openheadunit.aap
 
 import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.Action
+import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.CORRUPTION_QUIET_MS
 import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.CYCLE_COOLDOWN_MS
+import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.DEFER_FOR_QUIET_LIMIT_MS
 import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.ESCALATE_AFTER_UNREPAIRED_MS
 import com.andrerinas.openheadunit.aap.WarmRelaunchKeyframePolicy.ESCALATE_AFTER_SURFACE_MS
 import com.andrerinas.openheadunit.aap.WarmRelaunchKeyframePolicy.FOCUS_CYCLE_GAP_MS
@@ -24,7 +26,10 @@ class KeyframeCycleEscalationPolicyTest {
         unrepairedSinceMs: Long,
         cyclesUsedThisSession: Int = 0,
         lastCycleMs: Long = 0L,
-    ) = KeyframeCycleEscalationPolicy.decide(nowMs, unrepairedSinceMs, cyclesUsedThisSession, lastCycleMs)
+        lastWireCorruptionMs: Long = 0L,
+    ) = KeyframeCycleEscalationPolicy.decide(
+        nowMs, unrepairedSinceMs, cyclesUsedThisSession, lastCycleMs, lastWireCorruptionMs
+    )
 
     // --- The trigger ------------------------------------------------------------------------
 
@@ -189,6 +194,286 @@ class KeyframeCycleEscalationPolicyTest {
             "re-check window ${ESCALATE_AFTER_UNREPAIRED_MS}ms no longer outlasts the regain gap " +
                 "${FOCUS_CYCLE_GAP_MS}ms plus the measured 557ms keyframe turnaround",
             ESCALATE_AFTER_UNREPAIRED_MS > FOCUS_CYCLE_GAP_MS + 557
+        )
+    }
+
+    // --- The wire's own quiet ---------------------------------------------------------------
+
+    @Test
+    fun `an isolated dropped frame still cycles at exactly the same instant it always has`() {
+        // The fault this escalation was written for is one lost frame on an otherwise clean wire.
+        // There the corruption stamp and the unrepaired stamp are the same moment, so nothing is
+        // deferred and the cycle goes out on the first check. This is the guard on that: if it ever
+        // fails, the deferral has started taxing the common case to pay for the sustained-loss one.
+        //
+        // Both orderings, because which stamp lands first is not fixed: AapVideo reports the corrupt
+        // access unit and the decoder sheds the reference frame, and the gap between them is however
+        // long the decoder takes to fail on it. The quiet window outlasts the escalation window now,
+        // so an ordering-sensitive gate here would defer this case for thirteen seconds.
+        val broken = 10_000L
+        for (corruptionAt in listOf(broken - 250L, broken, broken + 1L)) {
+            assertEquals(
+                "isolated drop deferred with the corruption stamped at ${corruptionAt - broken}ms",
+                Action.CYCLE_FOCUS,
+                decide(
+                    nowMs = broken + ESCALATE_AFTER_UNREPAIRED_MS,
+                    unrepairedSinceMs = broken,
+                    lastWireCorruptionMs = corruptionAt,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `the quiet window outlasts a fault interval without outlasting the ceiling`() {
+        // Sized against how far apart faults land, not against the report throttle. The first
+        // version was two seconds - twice the throttle - and asked its question two seconds after
+        // each arming, so on a wire losing a frame every ~12s it could only ever catch corruption
+        // by coincidence: one hold in six checks, and the budget gone 207s before the loss stopped.
+        //
+        // The ceiling is the other side. A quiet window at or past it would mean a wire that never
+        // settles never reaches the lever, which is the failure DEFER_FOR_QUIET_LIMIT_MS exists to
+        // prevent.
+        assertTrue(
+            "quiet window ${CORRUPTION_QUIET_MS}ms does not outlast the escalation window " +
+                "${ESCALATE_AFTER_UNREPAIRED_MS}ms it is checked on",
+            CORRUPTION_QUIET_MS > ESCALATE_AFTER_UNREPAIRED_MS
+        )
+        assertTrue(
+            "quiet window ${CORRUPTION_QUIET_MS}ms reaches the ${DEFER_FOR_QUIET_LIMIT_MS}ms " +
+                "ceiling, so a wire that never settles would never reach the lever",
+            CORRUPTION_QUIET_MS < DEFER_FOR_QUIET_LIMIT_MS
+        )
+    }
+
+    @Test
+    fun `the quiet window clears two throttle windows`() {
+        // Corrupt-frame reports are paced by VideoRecoveryPolicy, so one missing report is only
+        // silence. Two in a row is the shortest gap that means the wire has actually settled.
+        assertTrue(
+            "quiet window ${CORRUPTION_QUIET_MS}ms does not clear two " +
+                "${VideoRecoveryPolicy.KEYFRAME_REQUEST_THROTTLE_MS}ms throttle windows",
+            CORRUPTION_QUIET_MS >= VideoRecoveryPolicy.KEYFRAME_REQUEST_THROTTLE_MS * 2
+        )
+    }
+
+    @Test
+    fun `a wire that is still losing frames holds the cycle instead of spending it`() {
+        val broken = 10_000L
+        val now = broken + 3_000L
+        assertEquals(
+            Action.WAIT_FOR_QUIET,
+            decide(
+                nowMs = now,
+                unrepairedSinceMs = broken,
+                lastWireCorruptionMs = now - 500L,
+            )
+        )
+    }
+
+    @Test
+    fun `the cycle goes out on the first check after the wire settles`() {
+        // The same broken picture, the same budget, one quiet window later. This is the measured
+        // case: the run that stopped its injected corruption recovered 0.96s after the first cycle
+        // fired on a clean wire, having wasted the previous one 60s earlier on a noisy one.
+        val broken = 10_000L
+        val lastCorruption = broken + 3_000L
+        assertEquals(
+            Action.WAIT_FOR_QUIET,
+            decide(
+                nowMs = lastCorruption + CORRUPTION_QUIET_MS - 1,
+                unrepairedSinceMs = broken,
+                lastWireCorruptionMs = lastCorruption,
+            )
+        )
+        assertEquals(
+            Action.CYCLE_FOCUS,
+            decide(
+                nowMs = lastCorruption + CORRUPTION_QUIET_MS,
+                unrepairedSinceMs = broken,
+                lastWireCorruptionMs = lastCorruption,
+            )
+        )
+    }
+
+    @Test
+    fun `a wire that never settles still reaches the lever`() {
+        // Light continuous loss may still be repairable by a keyframe, and a deferral with no
+        // ceiling would put the only lever that exists permanently out of reach.
+        val broken = 10_000L
+        val now = broken + DEFER_FOR_QUIET_LIMIT_MS
+        assertEquals(
+            Action.CYCLE_FOCUS,
+            decide(
+                nowMs = now,
+                unrepairedSinceMs = broken,
+                lastWireCorruptionMs = now - 1L,
+            )
+        )
+    }
+
+    @Test
+    fun `the deferral ceiling is never cheaper to abandon than to keep`() {
+        // A cycle spent on a wire that is still breaking costs a whole cooldown: the keyframe it
+        // buys arrives broken, and the next cycle - the one that would have worked - is a minute
+        // away. So giving up on the wait sooner than that can lose more time than the wait itself,
+        // which is the exact fault this gate exists to stop. Measured: a run whose loss stopped ten
+        // seconds into an unrepaired stretch recovered in ~5s; the same run with the loss stopping
+        // twenty seconds in would have burned its cycle first and waited out the full sixty.
+        assertTrue(
+            "deferral ceiling ${DEFER_FOR_QUIET_LIMIT_MS}ms is shorter than the " +
+                "${CYCLE_COOLDOWN_MS}ms a wasted cycle costs",
+            DEFER_FOR_QUIET_LIMIT_MS >= CYCLE_COOLDOWN_MS
+        )
+    }
+
+    // --- The last cycle is kept back ---------------------------------------------------------
+
+    @Test
+    fun `the last cycle is held on a wire that the earlier ones would have been spent on`() {
+        // The same wire, the same broken picture, the same instant - and a different answer purely
+        // because of how much budget is left. Cycles 1 and 2 are worth spending speculatively on a
+        // stream that may never settle; the last one is worth only what it buys at the moment the
+        // loss stops, so it waits for that moment.
+        val broken = 10_000L
+        val now = broken + DEFER_FOR_QUIET_LIMIT_MS + 30_000L
+        val stillLosing = now - 1_000L
+        assertEquals(
+            "an earlier cycle should still reach the lever on a wire that never settles",
+            Action.CYCLE_FOCUS,
+            decide(
+                nowMs = now,
+                unrepairedSinceMs = broken,
+                cyclesUsedThisSession = 0,
+                lastWireCorruptionMs = stillLosing,
+            )
+        )
+        assertEquals(
+            Action.WAIT_FOR_QUIET,
+            decide(
+                nowMs = now,
+                unrepairedSinceMs = broken,
+                cyclesUsedThisSession = MAX_CYCLES_PER_SESSION - 1,
+                lastWireCorruptionMs = stillLosing,
+            )
+        )
+    }
+
+    @Test
+    fun `the deferral ceiling does not apply to the last cycle`() {
+        // The ceiling trades a possibly-wasted cycle for the chance that a lightly-broken wire is
+        // repairable anyway. With one cycle left that trade is the wrong way round: the measured
+        // cost of taking it was a picture dead for 207 seconds with nothing left to spend when the
+        // wire finally went quiet.
+        val broken = 10_000L
+        val now = broken + DEFER_FOR_QUIET_LIMIT_MS
+        assertEquals(
+            Action.WAIT_FOR_QUIET,
+            decide(
+                nowMs = now,
+                unrepairedSinceMs = broken,
+                cyclesUsedThisSession = MAX_CYCLES_PER_SESSION - 1,
+                lastWireCorruptionMs = now - 1L,
+            )
+        )
+    }
+
+    @Test
+    fun `the last cycle goes out on the first check after the wire settles`() {
+        // What the hold is for. A cycle fired on a quiet wire has been measured repairing the
+        // picture in 0.96s and in 1.5-1.6s; the whole point of keeping one back is that it is
+        // available at the instant this becomes true.
+        val broken = 10_000L
+        val lastCorruption = broken + 120_000L
+        assertEquals(
+            Action.WAIT_FOR_QUIET,
+            decide(
+                nowMs = lastCorruption + CORRUPTION_QUIET_MS - 1,
+                unrepairedSinceMs = broken,
+                cyclesUsedThisSession = MAX_CYCLES_PER_SESSION - 1,
+                lastWireCorruptionMs = lastCorruption,
+            )
+        )
+        assertEquals(
+            Action.CYCLE_FOCUS,
+            decide(
+                nowMs = lastCorruption + CORRUPTION_QUIET_MS,
+                unrepairedSinceMs = broken,
+                cyclesUsedThisSession = MAX_CYCLES_PER_SESSION - 1,
+                lastWireCorruptionMs = lastCorruption,
+            )
+        )
+    }
+
+    @Test
+    fun `a hold that lasts for minutes stays a bounded number of log lines`() {
+        // A held last cycle is re-checked every ESCALATE_AFTER_UNREPAIRED_MS, which has to stay
+        // short so the cycle lands promptly once the wire settles. Unthrottled that is one line
+        // every two seconds for as long as the loss runs - about a hundred across the injection run
+        // that motivated the reserve, all saying the same thing. AapTransport prints it through the
+        // same budget the framing audit uses, so the first ones say so in full and the rest are
+        // counted into a summary.
+        var printed = 0
+        var lastPrintMs = 0L
+        val holdMs = 5 * 60_000L
+        var now = 0L
+        while (now < holdMs) {
+            if (AuditReportPolicy.shouldReport(printed, lastPrintMs, now)) {
+                printed++
+                lastPrintMs = now
+            }
+            now += ESCALATE_AFTER_UNREPAIRED_MS
+        }
+        assertTrue(
+            "a five-minute hold printed $printed lines, which is not bounded by the budget",
+            printed <= AuditReportPolicy.BURST_REPORTS + holdMs / AuditReportPolicy.SUMMARY_INTERVAL_MS
+        )
+        assertTrue(
+            "a five-minute hold printed $printed lines, so the first ones are not getting through",
+            printed >= AuditReportPolicy.BURST_REPORTS
+        )
+    }
+
+    @Test
+    fun `a spent budget and a running cooldown answer before the quiet check does`() {
+        // Both are reasons to stop asking for a minute; the quiet check clears in two seconds, and
+        // the caller re-arms on a correspondingly shorter clock. Returning WAIT_FOR_QUIET for either
+        // of these would put that fast re-check behind a gate that cannot move.
+        val broken = 100_000L
+        val now = broken + 3_000L
+        assertEquals(
+            Action.NUDGE,
+            decide(
+                nowMs = now,
+                unrepairedSinceMs = broken,
+                cyclesUsedThisSession = MAX_CYCLES_PER_SESSION,
+                lastWireCorruptionMs = now - 1L,
+            )
+        )
+        assertEquals(
+            Action.NUDGE,
+            decide(
+                nowMs = now,
+                unrepairedSinceMs = broken,
+                cyclesUsedThisSession = 1,
+                lastCycleMs = now - 1L,
+                lastWireCorruptionMs = now - 1L,
+            )
+        )
+    }
+
+    @Test
+    fun `a session that has never seen wire corruption never defers`() {
+        // Zero means "none this session", not "one at time zero" - the same reading lastCycleMs
+        // gets, and the same bug if it were read the other way.
+        val broken = 10_000L
+        assertEquals(
+            Action.CYCLE_FOCUS,
+            decide(
+                nowMs = broken + ESCALATE_AFTER_UNREPAIRED_MS,
+                unrepairedSinceMs = broken,
+                lastWireCorruptionMs = 0L,
+            )
         )
     }
 }

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicyTest.kt
@@ -3,6 +3,7 @@ package com.andrerinas.openheadunit.aap
 import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.Action
 import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.CYCLE_COOLDOWN_MS
 import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.ESCALATE_AFTER_UNREPAIRED_MS
+import com.andrerinas.openheadunit.aap.WarmRelaunchKeyframePolicy.ESCALATE_AFTER_SURFACE_MS
 import com.andrerinas.openheadunit.aap.WarmRelaunchKeyframePolicy.FOCUS_CYCLE_GAP_MS
 import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.MAX_CYCLES_PER_SESSION
 import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.NATURAL_CADENCE_MIN_OBSERVED_MS
@@ -159,6 +160,35 @@ class KeyframeCycleEscalationPolicyTest {
         assertTrue(
             "cooldown ${CYCLE_COOLDOWN_MS}ms is not comfortably clear of the ${FOCUS_CYCLE_GAP_MS}ms regain gap",
             CYCLE_COOLDOWN_MS >= FOCUS_CYCLE_GAP_MS * 10
+        )
+    }
+
+    @Test
+    fun `the surface escalation always gets to the lever first`() {
+        // Both policies can want a cycle at once - a decoder rebuilt under a surface that has never
+        // shown a frame satisfies each of them - and only one release may go out. The lever refuses
+        // the second claim, so nothing breaks either way, but the ordering decides which policy's
+        // budget pays: the surface path is the one with the measured 3.0-3.2s recovery behind it and
+        // should win, so it must stay the shorter window.
+        assertTrue(
+            "surface escalation ${ESCALATE_AFTER_SURFACE_MS}ms no longer precedes the unrepaired " +
+                "escalation ${ESCALATE_AFTER_UNREPAIRED_MS}ms",
+            ESCALATE_AFTER_SURFACE_MS < ESCALATE_AFTER_UNREPAIRED_MS
+        )
+    }
+
+    @Test
+    fun `a refused claim is re-checked only after the winning cycle has had its chance`() {
+        // When the lever is already held, AapTransport re-arms its check at this window instead of
+        // returning and leaving the clock latched. That is only correct while the window outlasts the
+        // whole of the other cycle: FOCUS_CYCLE_GAP_MS to send the regain, plus the phone's own
+        // turnaround - measured at 544ms and 557ms from the release line to the keyframe reaching the
+        // codec, on the rig, on the two cycles a corrupt-access-unit run produced. 400 + 557 is
+        // comfortably inside 2000; shortening either constant has to argue with those numbers.
+        assertTrue(
+            "re-check window ${ESCALATE_AFTER_UNREPAIRED_MS}ms no longer outlasts the regain gap " +
+                "${FOCUS_CYCLE_GAP_MS}ms plus the measured 557ms keyframe turnaround",
+            ESCALATE_AFTER_UNREPAIRED_MS > FOCUS_CYCLE_GAP_MS + 557
         )
     }
 }

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/LinkGapMonitorTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/LinkGapMonitorTest.kt
@@ -1,0 +1,199 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The monitor exists because two reporters' captures said the same thing and only one of them could
+ * be read. Both waveforms are replayed here in the numbers their captures produced, so that what the
+ * app prints can be checked against what the offline script printed for the same link.
+ *
+ * The tests that matter most are the ones asserting silence. An instrument that speaks on a healthy
+ * session gets ignored on an unhealthy one, and that is not hypothetical here: it is what happened
+ * to the framing audit, which spent its whole print budget on false positives in the first 200 ms
+ * and was then switched off for the five minutes that mattered.
+ */
+class LinkGapMonitorTest {
+
+    /**
+     * Feed traffic at [fps] for [durationMs] starting at [startMs], collecting any reports.
+     * Returns the timestamp of the last message sent.
+     */
+    private fun stream(
+        monitor: LinkGapMonitor,
+        startMs: Long,
+        durationMs: Long,
+        fps: Int,
+        reports: MutableList<LinkGapMonitor.Report>
+    ): Long {
+        val step = 1000L / fps
+        var t = startMs
+        val end = startMs + durationMs
+        while (t <= end) {
+            monitor.onMessage(t)?.let { reports.add(it) }
+            t += step
+        }
+        return t - step
+    }
+
+    @Test
+    fun `a healthy link says nothing at all`() {
+        val monitor = LinkGapMonitor()
+        val reports = mutableListOf<LinkGapMonitor.Report>()
+        // Sixty seconds at 50 fps - two full windows, nothing anywhere near the threshold.
+        stream(monitor, 10_000L, 60_000L, 50, reports)
+        assertTrue("a clean link must print nothing, got $reports", reports.isEmpty())
+    }
+
+    @Test
+    fun `the waveform one reporter's verbose capture measured`() {
+        // 1.59s of silence every 11.57s, sustained - profiled at 14.1% dead over 487.7s. A 30s
+        // window holds two or three of those cycles depending on where it falls, so the counts
+        // quantise; the two fields that identify the waveform do not.
+        val monitor = LinkGapMonitor()
+        val reports = mutableListOf<LinkGapMonitor.Report>()
+        var t = 0L
+        monitor.onMessage(t)
+        repeat(12) {
+            t = stream(monitor, t, 9_980L, 50, reports)   // the quiet interval, carrying traffic
+            t += 1_590L                                   // the silence
+            monitor.onMessage(t)?.let { r -> reports.add(r) }
+        }
+
+        assertTrue("expected several reports, got ${reports.size}", reports.size >= 3)
+        reports.forEach {
+            assertEquals("every gap in this waveform is the same length", 1_590L, it.longestMs)
+            assertTrue(
+                "dead time should read near the 14% the script measured, got ${it.deadPercent}%",
+                it.deadPercent in 9..16
+            )
+        }
+        assertTrue(
+            "the cadence must show up as the start-to-start interval",
+            reports.any { it.medianPeriodMs == 11_570L }
+        )
+    }
+
+    @Test
+    fun `the waveform the second reporter's capture measured`() {
+        // 5-6s of silence every ~10.5s, each long gap trailed by a short one, with only two or
+        // three seconds of picture in between. Far more severe than the first: most of that session
+        // is dead air, which is what "it did nothing, no improvements at all" was describing.
+        val monitor = LinkGapMonitor()
+        val reports = mutableListOf<LinkGapMonitor.Report>()
+        var t = 0L
+        monitor.onMessage(t)
+        repeat(8) {
+            t = stream(monitor, t, 2_500L, 50, reports)
+            t += 5_960L                                   // the long gap
+            monitor.onMessage(t)?.let { r -> reports.add(r) }
+            t = stream(monitor, t, 20L, 50, reports)
+            t += 2_130L                                   // the short one trailing it
+            monitor.onMessage(t)?.let { r -> reports.add(r) }
+        }
+
+        assertTrue("expected at least two reports, got ${reports.size}", reports.size >= 2)
+        reports.forEach {
+            assertEquals("the long gap is the longest", 5_960L, it.longestMs)
+            assertTrue(
+                "a link this bad must read as mostly dead, got ${it.deadPercent}%",
+                it.deadPercent > 60
+            )
+            assertNotNull("paired gaps give an interval to report", it.medianPeriodMs)
+        }
+    }
+
+    @Test
+    fun `only the window holding a gap speaks`() {
+        val monitor = LinkGapMonitor()
+        val reports = mutableListOf<LinkGapMonitor.Report>()
+        monitor.onMessage(0L)
+        monitor.onMessage(2_000L)?.let { reports.add(it) }   // one gap, early in the window
+        stream(monitor, 2_000L, 90_000L, 50, reports)        // three clean windows after it
+
+        assertEquals("exactly one window held the single gap", 1, reports.size)
+        assertEquals(1, reports[0].gaps)
+        assertEquals(2_000L, reports[0].longestMs)
+        assertNull("one gap has no start-to-start interval", reports[0].medianPeriodMs)
+    }
+
+    @Test
+    fun `the threshold is exclusive`() {
+        val exactly = LinkGapMonitor()
+        val atThreshold = mutableListOf<LinkGapMonitor.Report>()
+        exactly.onMessage(0L)
+        exactly.onMessage(LinkGapMonitor.GAP_THRESHOLD_MS)
+        stream(exactly, LinkGapMonitor.GAP_THRESHOLD_MS, 35_000L, 50, atThreshold)
+        assertTrue("a gap of exactly the threshold is not a gap", atThreshold.isEmpty())
+
+        val overByOne = LinkGapMonitor()
+        val overThreshold = mutableListOf<LinkGapMonitor.Report>()
+        overByOne.onMessage(0L)
+        overByOne.onMessage(LinkGapMonitor.GAP_THRESHOLD_MS + 1)
+        stream(overByOne, LinkGapMonitor.GAP_THRESHOLD_MS + 1, 35_000L, 50, overThreshold)
+        assertEquals("one millisecond over is", 1, overThreshold.size)
+        assertEquals(LinkGapMonitor.GAP_THRESHOLD_MS + 1, overThreshold[0].longestMs)
+    }
+
+    @Test
+    fun `the first message after a reset opens no gap`() {
+        val monitor = LinkGapMonitor()
+        val reports = mutableListOf<LinkGapMonitor.Report>()
+        stream(monitor, 0L, 40_000L, 50, reports)
+        monitor.reset()
+
+        // A new session an hour later on the same monotonic clock. The interval across the reset is
+        // enormous and must not be measured - the transport outliving a session is why reset exists.
+        monitor.onMessage(3_600_000L)
+        stream(monitor, 3_600_000L, 40_000L, 50, reports)
+        assertTrue(
+            "a re-armed monitor must not report the gap between sessions, got $reports",
+            reports.isEmpty()
+        )
+    }
+
+    @Test
+    fun `a gap spanning a window boundary is counted once`() {
+        val monitor = LinkGapMonitor()
+        val reports = mutableListOf<LinkGapMonitor.Report>()
+        monitor.onMessage(0L)
+        stream(monitor, 0L, 29_000L, 50, reports)
+        // Silence starting inside the window and ending well past its nominal close. A window can
+        // only end on a message, so this one runs long and has to say so.
+        monitor.onMessage(45_000L)?.let { reports.add(it) }
+        stream(monitor, 45_000L, 40_000L, 50, reports)
+
+        assertEquals("one gap, reported in one window", 1, reports.size)
+        assertEquals(1, reports[0].gaps)
+        assertEquals(45_000L, reports[0].windowMs)
+        assertEquals(16_000L, reports[0].deadMs)
+        assertEquals("the percentage is against the elapsed window, not the nominal one",
+            35, reports[0].deadPercent)
+    }
+
+    @Test
+    fun `the report reads as the offline script's fields`() {
+        val periodic = LinkGapMonitor.Report(
+            gaps = 3, windowMs = 30_412L, deadMs = 17_240L,
+            longestMs = 6_110L, medianPeriodMs = 10_520L
+        )
+        assertEquals(56, periodic.deadPercent)
+        assertEquals(
+            "inbound link quiet 3 times in 30412ms: dead=17240ms (56%), longest=6110ms, " +
+                "period~10520ms",
+            periodic.toString()
+        )
+
+        val single = LinkGapMonitor.Report(
+            gaps = 1, windowMs = 30_000L, deadMs = 1_310L,
+            longestMs = 1_310L, medianPeriodMs = null
+        )
+        assertEquals(
+            "inbound link quiet 1 time in 30000ms: dead=1310ms (4%), longest=1310ms",
+            single.toString()
+        )
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/NativeGroupBandPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/NativeGroupBandPolicyTest.kt
@@ -1,0 +1,63 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.NativeGroupBandPolicy.Band
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The frequencies are real ones: 2437 and 2462 are the 2.4 GHz channels this rig's groups have come
+ * up on, 5180 and 5745 the 5 GHz ones.
+ */
+class NativeGroupBandPolicyTest {
+
+    @Test
+    fun `the default is unchanged - 5GHz is what Native AA asks for`() {
+        assertEquals(Band.GHZ_5, NativeGroupBandPolicy.bandFor(force24Ghz = false))
+    }
+
+    @Test
+    fun `the override asks for 2_4GHz`() {
+        assertEquals(Band.GHZ_2_4, NativeGroupBandPolicy.bandFor(force24Ghz = true))
+    }
+
+    @Test
+    fun `a 5GHz request that came up on 2_4GHz is remade`() {
+        assertTrue(NativeGroupBandPolicy.shouldRetryFor5Ghz(Band.GHZ_5, 2437, retriesSoFar = 0, maxRetries = 2))
+        assertTrue(NativeGroupBandPolicy.shouldRetryFor5Ghz(Band.GHZ_5, 2462, retriesSoFar = 1, maxRetries = 2))
+    }
+
+    @Test
+    fun `a group deliberately put on 2_4GHz is never remade - the round would measure nothing otherwise`() {
+        assertFalse(NativeGroupBandPolicy.shouldRetryFor5Ghz(Band.GHZ_2_4, 2437, retriesSoFar = 0, maxRetries = 2))
+        assertFalse(NativeGroupBandPolicy.shouldRetryFor5Ghz(Band.GHZ_2_4, 2462, retriesSoFar = 1, maxRetries = 2))
+    }
+
+    @Test
+    fun `a 5GHz request that came up on 5GHz is left alone`() {
+        assertFalse(NativeGroupBandPolicy.shouldRetryFor5Ghz(Band.GHZ_5, 5180, retriesSoFar = 0, maxRetries = 2))
+        assertFalse(NativeGroupBandPolicy.shouldRetryFor5Ghz(Band.GHZ_5, 5745, retriesSoFar = 0, maxRetries = 2))
+    }
+
+    @Test
+    fun `the retry budget still bounds it`() {
+        assertFalse(NativeGroupBandPolicy.shouldRetryFor5Ghz(Band.GHZ_5, 2437, retriesSoFar = 2, maxRetries = 2))
+    }
+
+    @Test
+    fun `an unknown frequency is not a mismatch`() {
+        assertFalse(NativeGroupBandPolicy.shouldRetryFor5Ghz(Band.GHZ_5, 0, retriesSoFar = 0, maxRetries = 2))
+    }
+
+    @Test
+    fun `a standard-fallback group is never remade - nobody asked for a band`() {
+        assertFalse(NativeGroupBandPolicy.shouldRetryFor5Ghz(Band.UNSPECIFIED, 2437, retriesSoFar = 0, maxRetries = 2))
+    }
+
+    @Test
+    fun `the labels are the ones the log and the briefs grep for`() {
+        assertEquals("2.4GHz", NativeGroupBandPolicy.label(Band.GHZ_2_4))
+        assertEquals("5GHz", NativeGroupBandPolicy.label(Band.GHZ_5))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/P2pOperatingChannelPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/P2pOperatingChannelPolicyTest.kt
@@ -1,0 +1,123 @@
+package com.andrerinas.openheadunit.aap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The frequencies are the ones the platform derives, not ones chosen here: `SupplicantP2pIfaceHal`
+ * turns an operating channel into `(channel <= 14 ? 2407 : 5000) + channel * 5` and disallows
+ * everything either side of it. If these numbers are wrong the driver is asked for the wrong band.
+ */
+class P2pOperatingChannelPolicyTest {
+
+    private val api27 = 27
+    private val api29 = 29
+    private val api34 = 34
+
+    @Test
+    fun `channel 36 is 5180 MHz, which is what makes this worth doing`() {
+        assertEquals(5180, P2pOperatingChannelPolicy.frequencyMhzFor(36))
+    }
+
+    @Test
+    fun `the upper band channel is 5745 MHz`() {
+        assertEquals(5745, P2pOperatingChannelPolicy.frequencyMhzFor(149))
+    }
+
+    @Test
+    fun `the 2_4 GHz channels use the other base, so a mix-up would be visible`() {
+        assertEquals(2412, P2pOperatingChannelPolicy.frequencyMhzFor(1))
+        assertEquals(2437, P2pOperatingChannelPolicy.frequencyMhzFor(6))
+        assertEquals(2462, P2pOperatingChannelPolicy.frequencyMhzFor(11))
+        // 13 then 14 pins the discontinuity: the linear formula holds up to 13 and then stops, so a
+        // converter that lost the special case would answer 2477 here and pass every other case.
+        assertEquals(2472, P2pOperatingChannelPolicy.frequencyMhzFor(13))
+        assertEquals(2484, P2pOperatingChannelPolicy.frequencyMhzFor(14))
+    }
+
+    @Test
+    fun `the 2_4 GHz conversion agrees with the one that reads a group's frequency back`() {
+        // P2pChannelPolicy converts frequency to channel and this converts channel to frequency, so
+        // a round trip has to close. It did not: this policy was written with a flat 5 MHz step and
+        // answered 2477 for channel 14, which the other object would have read back as no channel
+        // at all. Any future divergence between the two shows up here first.
+        for (channel in 1..14) {
+            assertEquals(
+                channel,
+                P2pChannelPolicy.channelFor(P2pOperatingChannelPolicy.frequencyMhzFor(channel)),
+            )
+        }
+    }
+
+    @Test
+    fun `a channel the platform would reject has no frequency`() {
+        assertEquals(0, P2pOperatingChannelPolicy.frequencyMhzFor(0))
+        assertEquals(0, P2pOperatingChannelPolicy.frequencyMhzFor(166))
+        assertEquals(0, P2pOperatingChannelPolicy.frequencyMhzFor(-1))
+    }
+
+    @Test
+    fun `this applies only below the API that has a band request`() {
+        assertTrue(P2pOperatingChannelPolicy.appliesTo(21))
+        assertTrue(P2pOperatingChannelPolicy.appliesTo(api27))
+        assertTrue(P2pOperatingChannelPolicy.appliesTo(28))
+        assertFalse(P2pOperatingChannelPolicy.appliesTo(api29))
+        assertFalse(P2pOperatingChannelPolicy.appliesTo(api34))
+    }
+
+    @Test
+    fun `a modern device is never given a channel, because it has the supported band request`() {
+        assertEquals(
+            P2pOperatingChannelPolicy.CHANNEL_UNRESTRICTED,
+            P2pOperatingChannelPolicy.operatingChannel(api29, requestFiveGhz = true),
+        )
+        assertEquals(
+            P2pOperatingChannelPolicy.CHANNEL_UNRESTRICTED,
+            P2pOperatingChannelPolicy.operatingChannel(api34, requestFiveGhz = true, useUpperBand = true),
+        )
+    }
+
+    @Test
+    fun `the default is to ask for nothing, so an untouched install behaves as it always did`() {
+        assertEquals(
+            P2pOperatingChannelPolicy.CHANNEL_UNRESTRICTED,
+            P2pOperatingChannelPolicy.operatingChannel(api27, requestFiveGhz = false),
+        )
+    }
+
+    @Test
+    fun `opting in on an old device asks for channel 36`() {
+        assertEquals(36, P2pOperatingChannelPolicy.operatingChannel(api27, requestFiveGhz = true))
+    }
+
+    @Test
+    fun `the upper band is only reached when it is asked for`() {
+        assertEquals(
+            149,
+            P2pOperatingChannelPolicy.operatingChannel(api27, requestFiveGhz = true, useUpperBand = true),
+        )
+        assertEquals(
+            P2pOperatingChannelPolicy.CHANNEL_UNRESTRICTED,
+            P2pOperatingChannelPolicy.operatingChannel(api27, requestFiveGhz = false, useUpperBand = true),
+        )
+    }
+
+    @Test
+    fun `every channel this policy can return is one the platform accepts`() {
+        assertTrue(P2pOperatingChannelPolicy.isRequestable(P2pOperatingChannelPolicy.CHANNEL_LOWER))
+        assertTrue(P2pOperatingChannelPolicy.isRequestable(P2pOperatingChannelPolicy.CHANNEL_UPPER))
+        assertTrue(P2pOperatingChannelPolicy.isRequestable(P2pOperatingChannelPolicy.CHANNEL_UNRESTRICTED))
+        assertFalse(P2pOperatingChannelPolicy.isRequestable(166))
+        assertFalse(P2pOperatingChannelPolicy.isRequestable(-1))
+    }
+
+    @Test
+    fun `both offered channels are outside the DFS range a group owner may not use`() {
+        // wpa_supplicant marks operating classes 118-123 (channels 52-140) NO_P2P_SUPP, so a group
+        // owner asked for one of those cannot start at all. Both channels here sit outside it.
+        assertTrue(P2pOperatingChannelPolicy.CHANNEL_LOWER < 52)
+        assertTrue(P2pOperatingChannelPolicy.CHANNEL_UPPER > 140)
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/ProjectionWatchdogPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/ProjectionWatchdogPolicyTest.kt
@@ -10,6 +10,12 @@ import org.junit.Test
  * HandshakeComplete — a state the session passes through once, briefly — and returned without
  * re-posting, so it died on the first tick of every session. TransportStarted being live is the
  * regression this table pins.
+ *
+ * The overlay and recovery tables pin the other half of that history. Reviving the watchdog made its
+ * frame-only criterion reachable for the first time, and it promptly called an idle Android Auto
+ * screen a lost connection (issue #852). The two decisions were split rather than retuned, so the
+ * cases that matter are the asymmetric ones: a stopped picture on a live link must produce recovery
+ * and no overlay, and neither signal alone is enough for the overlay.
  */
 class ProjectionWatchdogPolicyTest {
 
@@ -29,10 +35,85 @@ class ProjectionWatchdogPolicyTest {
     }
 
     @Test
-    fun `no request without the reconnecting overlay`() {
-        // The overlay is the watchdog's own 10s-frame-gap signal; without it the picture is fine
+    fun `no request while the picture is still arriving`() {
+        // The gate is the frame gap, not the overlay: a picture that is still coming needs nothing,
         // and a focus request would only disturb a healthy stream.
         assertFalse(ProjectionWatchdogPolicy.shouldRequestVideoFocus(false, nowMs = 100_000, lastRequestMs = 0))
+    }
+
+    @Test
+    fun `recovery still fires on a stopped picture with a live link`() {
+        // The #852 regression guard, in the other direction. The overlay now needs the link to have
+        // gone quiet too, and tying recovery to the overlay after that split would leave a genuinely
+        // stalled stream with nothing asking for video back - which is what the watchdog exists for.
+        val nowMs = VideoRecoveryPolicy.KEYFRAME_REQUEST_THROTTLE_MS + 1
+        assertTrue(ProjectionWatchdogPolicy.shouldRequestVideoFocus(true, nowMs = nowMs, lastRequestMs = 0))
+        assertFalse(
+            ProjectionWatchdogPolicy.shouldShowReconnecting(
+                frameGapMs = ProjectionWatchdogPolicy.FRAME_GAP_MS + 1,
+                linkQuietMs = 0
+            )
+        )
+    }
+
+    @Test
+    fun `a picture that stops while the link keeps talking is not a lost connection`() {
+        // Issue #852: Android Auto sends no video at all while nothing on screen animates, so a
+        // paused full-screen music player produces an arbitrarily long frame gap on a healthy link.
+        assertFalse(
+            ProjectionWatchdogPolicy.shouldShowReconnecting(
+                frameGapMs = 10L * 60 * 1000,
+                linkQuietMs = ProjectionWatchdogPolicy.LINK_QUIET_MS
+            )
+        )
+    }
+
+    @Test
+    fun `a stopped picture on a silent link is a lost connection`() {
+        assertTrue(
+            ProjectionWatchdogPolicy.shouldShowReconnecting(
+                frameGapMs = ProjectionWatchdogPolicy.FRAME_GAP_MS + 1,
+                linkQuietMs = ProjectionWatchdogPolicy.LINK_QUIET_MS + 1
+            )
+        )
+    }
+
+    @Test
+    fun `a silent link alone is not enough while frames are arriving`() {
+        assertFalse(
+            ProjectionWatchdogPolicy.shouldShowReconnecting(
+                frameGapMs = 0,
+                linkQuietMs = ProjectionWatchdogPolicy.LINK_QUIET_MS + 1
+            )
+        )
+    }
+
+    @Test
+    fun `both thresholds are exclusive at the boundary`() {
+        assertFalse(
+            ProjectionWatchdogPolicy.shouldShowReconnecting(
+                frameGapMs = ProjectionWatchdogPolicy.FRAME_GAP_MS,
+                linkQuietMs = ProjectionWatchdogPolicy.LINK_QUIET_MS
+            )
+        )
+    }
+
+    @Test
+    fun `never having heard from the phone reads as silent, and still needs a frame gap`() {
+        // AapProjectionActivity maps "no message yet" to Long.MAX_VALUE rather than letting
+        // `now - 0` stand in for it, which would have read as a *silent* link on a session that had
+        // merely not started. Pinned here because the activity's own frame-gap guard makes the value
+        // unreachable in practice - a frame can only have rendered if a message arrived first - so
+        // nothing else would catch it if that guard were ever relaxed.
+        assertTrue(
+            ProjectionWatchdogPolicy.shouldShowReconnecting(
+                frameGapMs = ProjectionWatchdogPolicy.FRAME_GAP_MS + 1,
+                linkQuietMs = Long.MAX_VALUE
+            )
+        )
+        assertFalse(
+            ProjectionWatchdogPolicy.shouldShowReconnecting(frameGapMs = 0, linkQuietMs = Long.MAX_VALUE)
+        )
     }
 
     @Test
@@ -42,5 +123,63 @@ class ProjectionWatchdogPolicyTest {
         assertFalse(ProjectionWatchdogPolicy.shouldRequestVideoFocus(true, nowMs = throttle, lastRequestMs = 0))
         // Past it: allowed.
         assertTrue(ProjectionWatchdogPolicy.shouldRequestVideoFocus(true, nowMs = throttle + 1, lastRequestMs = 0))
+    }
+
+
+    // --- The first-frame nudge loop ---------------------------------------------------------
+
+    private fun nudge(
+        sessionLive: Boolean = true,
+        surfaceSet: Boolean = true,
+        renderedSinceSurfaceSet: Boolean = false,
+        warmRelaunchCycleSpent: Boolean = false,
+    ) = ProjectionWatchdogPolicy.shouldNudgeForFirstFrame(
+        sessionLive, surfaceSet, renderedSinceSurfaceSet, warmRelaunchCycleSpent
+    )
+
+    @Test
+    fun `a surface that has never shown a picture is nudged for`() {
+        assertTrue(nudge())
+    }
+
+    @Test
+    fun `a picture on the current surface ends the loop`() {
+        assertFalse(nudge(renderedSinceSurfaceSet = true))
+    }
+
+    @Test
+    fun `nothing is asked for before there is a surface to ask about`() {
+        assertFalse(nudge(surfaceSet = false))
+    }
+
+    @Test
+    fun `a dead session is not nudged`() {
+        assertFalse(nudge(sessionLive = false))
+    }
+
+    @Test
+    fun `the escalation taking over ends the loop`() {
+        // Without a bound this would nudge every window forever on a screen that simply has nothing
+        // to draw. The overlay used to supply that bound incidentally, being up only before a
+        // session's first frame; once the cycle is spent, WarmRelaunchKeyframePolicy's own throttled
+        // nudge is what continues, and two unthrottled askers on one clock is what this avoids.
+        assertFalse(nudge(warmRelaunchCycleSpent = true))
+    }
+
+    @Test
+    fun `the loop is decided by the picture, never by what is drawn over it`() {
+        // The whole defect this rule replaces. The nudge loop was gated on the loading overlay being
+        // visible, and onCreate hides that overlay whenever the *previous* activity instance had
+        // rendered - a stamp the surface handoff zeroes moments later. The runnable does not re-post
+        // when it declines, so one relaunch in two lost the loop on its first tick and sat black
+        // with nothing asking for video. Measured on a reporter's capture: four relaunches,
+        // alternating, two of them silent for 11.8s and 23s.
+        //
+        // There is deliberately no overlay parameter to pass. If one is ever added, this fails to
+        // compile, which is the point.
+        assertTrue(
+            "the rule must depend only on session, surface, picture and the escalation's claim",
+            nudge(sessionLive = true, surfaceSet = true, renderedSinceSurfaceSet = false)
+        )
     }
 }

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/VideoFaultInjectorTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/VideoFaultInjectorTest.kt
@@ -2,6 +2,7 @@ package com.andrerinas.openheadunit.aap
 
 import com.andrerinas.openheadunit.aap.VideoFaultInjector.Effect
 import com.andrerinas.openheadunit.aap.VideoFaultInjector.Mode
+import com.andrerinas.openheadunit.aap.VideoFaultInjector.Stage
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -119,14 +120,129 @@ class VideoFaultInjectorTest {
     }
 
     @Test
+    fun `a budget stops injection at exactly N faults`() {
+        val injector = VideoFaultInjector(Mode.DROP_MIDDLE_FRAGMENT, rate = 2, budget = 3)
+        assertEquals(3, injector.budget)
+        // Six targeted messages at one in two is three faults, which is the whole budget.
+        repeat(6) { injector.effectFor(middleFlag) }
+        assertEquals(3L, injector.injectedCount)
+        assertTrue(injector.budgetSpent)
+        // Everything after it goes through untouched, however long the run continues.
+        repeat(50) { assertEquals(Effect.NONE, injector.effectFor(middleFlag)) }
+        assertEquals(3L, injector.injectedCount)
+    }
+
+    @Test
+    fun `a spent budget still counts candidates`() {
+        // The clean half of a bounded run has to be visible as traffic that went by untouched, or
+        // the summary reads like a stream that stopped fragmenting.
+        val injector = VideoFaultInjector(Mode.DROP_MIDDLE_FRAGMENT, rate = 2, budget = 1)
+        repeat(10) { injector.effectFor(middleFlag) }
+        assertEquals(10L, injector.matchingCount)
+        assertEquals(1L, injector.injectedCount)
+    }
+
+    @Test
+    fun `no budget means the whole session, and a negative one is not a budget`() {
+        val unlimited = VideoFaultInjector(Mode.DROP_MIDDLE_FRAGMENT, rate = 2)
+        repeat(40) { unlimited.effectFor(middleFlag) }
+        assertEquals(20L, unlimited.injectedCount)
+        assertFalse(unlimited.budgetSpent)
+
+        // Clamped rather than read as "stop immediately", which would silently turn a mistyped
+        // setting into a run that injects nothing and looks like a rate that never took.
+        val negative = VideoFaultInjector(Mode.DROP_MIDDLE_FRAGMENT, rate = 2, budget = -4)
+        assertEquals(VideoFaultInjector.UNLIMITED_BUDGET, negative.budget)
+        repeat(10) { negative.effectFor(middleFlag) }
+        assertEquals(5L, negative.injectedCount)
+    }
+
+    @Test
     fun `the summary carries the setting and both counts`() {
         val injector = VideoFaultInjector(Mode.DROP_MIDDLE_FRAGMENT, rate = 20)
         repeat(8) { injector.effectFor(middleFlag) }
         val text = injector.describe()
         // The exact shape a five-minute run that injected nothing produced, which is the case this
         // line exists for: eight candidates at one in twenty is zero faults and no defect.
-        listOf("DROP_MIDDLE_FRAGMENT", "1-in-20", "8 candidates", "0 injected").forEach {
+        listOf("DROP_MIDDLE_FRAGMENT", "1-in-20", "8 candidates", "0 injected", "no budget").forEach {
             assertTrue("missing '$it' in: $text", text.contains(it))
         }
+    }
+
+    @Test
+    fun `the summary says how much of a budget is left`() {
+        val injector = VideoFaultInjector(Mode.DROP_MIDDLE_FRAGMENT, rate = 2, budget = 5)
+        repeat(4) { injector.effectFor(middleFlag) }
+        assertTrue(injector.describe(), injector.describe().contains("budget 2/5"))
+    }
+
+    // --- Which stage a mode belongs to ------------------------------------------------------
+
+    @Test
+    fun `each mode belongs to exactly one stage, and only one site applies it`() {
+        // The two injection sites - AapVideo.process and the readers - both ask isActiveAt rather
+        // than comparing modes, so a mode can never be applied twice or land at neither site. This
+        // pins that: for every mode, at most one stage claims it, and OFF is claimed by none.
+        for (mode in Mode.entries) {
+            val injector = VideoFaultInjector(mode, rate = 2)
+            val claims = Stage.entries.count { injector.isActiveAt(it) }
+            if (mode == Mode.OFF) {
+                assertEquals("OFF must be applied nowhere", 0, claims)
+            } else {
+                assertEquals("$mode must be applied at exactly one stage", 1, claims)
+            }
+        }
+    }
+
+    @Test
+    fun `only the reader mode runs in the reader`() {
+        // The distinction the whole reader stage exists for. An assembler-stage drop happens after
+        // the framing audit has already counted the fragment, so the audit sees a complete run and
+        // the one corruption mode nothing else can see stays invisible. A hardware round measured
+        // that cost: 37 and 59 injected middle-fragment faults, zero keyframe requests.
+        assertTrue(
+            VideoFaultInjector(Mode.DROP_MIDDLE_FRAGMENT_IN_READER, rate = 2).isActiveAt(Stage.READER)
+        )
+        for (mode in Mode.entries - Mode.DROP_MIDDLE_FRAGMENT_IN_READER) {
+            assertFalse(
+                "$mode must not be applied in the reader",
+                VideoFaultInjector(mode, rate = 2).isActiveAt(Stage.READER)
+            )
+        }
+    }
+
+    @Test
+    fun `the reader mode attacks middle fragments, like the assembler-stage mode it mirrors`() {
+        // Same fault, injected one step earlier. If these ever target different flags the pair stops
+        // being a controlled comparison, which is the only reason to keep both.
+        assertEquals(
+            VideoFaultInjector.targetFlag(Mode.DROP_MIDDLE_FRAGMENT),
+            VideoFaultInjector.targetFlag(Mode.DROP_MIDDLE_FRAGMENT_IN_READER)
+        )
+        assertEquals(middleFlag, VideoFaultInjector.targetFlag(Mode.DROP_MIDDLE_FRAGMENT_IN_READER))
+    }
+
+    @Test
+    fun `the reader mode honours the rate and the budget like every other`() {
+        val injector = VideoFaultInjector(Mode.DROP_MIDDLE_FRAGMENT_IN_READER, rate = 3, budget = 2)
+        val effects = (1..12).map { injector.effectFor(middleFlag) }
+        assertEquals(
+            "two faults at one in three, then the budget stops it",
+            listOf(Effect.DROP, Effect.DROP),
+            effects.filter { it != Effect.NONE }
+        )
+        assertTrue(injector.budgetSpent)
+        // Candidates keep being counted past the budget, so the summary still says how much of the
+        // stream went by untouched - what the recovery half of a bounded run is measured against.
+        assertEquals(12L, injector.matchingCount)
+    }
+
+    @Test
+    fun `the reader mode leaves every other flag alone`() {
+        val injector = VideoFaultInjector(Mode.DROP_MIDDLE_FRAGMENT_IN_READER, rate = 2)
+        for (flags in listOf(first, lastFlag, single)) {
+            repeat(10) { assertEquals(Effect.NONE, injector.effectFor(flags)) }
+        }
+        assertEquals(0L, injector.injectedCount)
     }
 }

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/VideoFaultInjectorTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/VideoFaultInjectorTest.kt
@@ -1,0 +1,132 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.VideoFaultInjector.Effect
+import com.andrerinas.openheadunit.aap.VideoFaultInjector.Mode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The test tool that makes the reassembly fixes measurable on a unit that is working correctly.
+ *
+ * Its own correctness matters as much as the code it exercises: a brief that says "a fault every six
+ * seconds" has to be true, or the results cannot be compared between builds.
+ */
+class VideoFaultInjectorTest {
+
+    private val first = VideoFragmentAssembler.FLAG_FIRST
+    private val middleFlag = VideoFragmentAssembler.FLAG_MIDDLE
+    private val lastFlag = VideoFragmentAssembler.FLAG_LAST
+    private val single = VideoFragmentAssembler.FLAG_SINGLE
+
+    @Test
+    fun `off does nothing to anything`() {
+        val injector = VideoFaultInjector(Mode.OFF, rate = 2)
+        assertFalse(injector.isActive)
+        for (flags in listOf(first, middleFlag, lastFlag, single)) {
+            repeat(10) { assertEquals(Effect.NONE, injector.effectFor(flags)) }
+        }
+        assertEquals(0L, injector.injectedCount)
+    }
+
+    @Test
+    fun `every Nth targeted message is faulted, and nothing else is touched`() {
+        val injector = VideoFaultInjector(Mode.DROP_FIRST_FRAGMENT, rate = 3)
+        assertTrue(injector.isActive)
+
+        val effects = (1..9).map { injector.effectFor(first) }
+        assertEquals(
+            "one in three, deterministically",
+            listOf(Effect.NONE, Effect.NONE, Effect.DROP, Effect.NONE, Effect.NONE, Effect.DROP, Effect.NONE, Effect.NONE, Effect.DROP),
+            effects
+        )
+        assertEquals(3L, injector.injectedCount)
+    }
+
+    @Test
+    fun `the rate counts only the flag being attacked`() {
+        // A frame is often three or four messages, so counting all video traffic would make the rate
+        // mean something three times rarer than the brief says.
+        val injector = VideoFaultInjector(Mode.DROP_LAST_FRAGMENT, rate = 2)
+        // A full frame's worth of messages that are not the target.
+        repeat(20) {
+            injector.effectFor(first)
+            injector.effectFor(middleFlag)
+            injector.effectFor(single)
+        }
+        assertEquals("untargeted traffic must not advance the counter", 0L, injector.injectedCount)
+        assertEquals(Effect.NONE, injector.effectFor(lastFlag))
+        assertEquals(Effect.DROP, injector.effectFor(lastFlag))
+    }
+
+    @Test
+    fun `each mode attacks the flag it says it does`() {
+        assertEquals(null, VideoFaultInjector.targetFlag(Mode.OFF))
+        assertEquals(first, VideoFaultInjector.targetFlag(Mode.DROP_FIRST_FRAGMENT))
+        assertEquals(first, VideoFaultInjector.targetFlag(Mode.HIDE_START_CODE))
+        assertEquals(middleFlag, VideoFaultInjector.targetFlag(Mode.DROP_MIDDLE_FRAGMENT))
+        assertEquals(lastFlag, VideoFaultInjector.targetFlag(Mode.DROP_LAST_FRAGMENT))
+    }
+
+    @Test
+    fun `hiding the start code is not a drop`() {
+        // The distinction matters: the bytes arrive, so the framing audit sees a complete run and
+        // only the reassembler should object.
+        val injector = VideoFaultInjector(Mode.HIDE_START_CODE, rate = 2)
+        assertEquals(Effect.NONE, injector.effectFor(first))
+        assertEquals(Effect.HIDE_START_CODE, injector.effectFor(first))
+    }
+
+    @Test
+    fun `the rate is clamped to something that can still produce a picture`() {
+        assertEquals(VideoFaultInjector.MIN_RATE, VideoFaultInjector(Mode.DROP_FIRST_FRAGMENT, rate = 1).rate)
+        assertEquals(VideoFaultInjector.MIN_RATE, VideoFaultInjector(Mode.DROP_FIRST_FRAGMENT, rate = 0).rate)
+        assertEquals(VideoFaultInjector.MIN_RATE, VideoFaultInjector(Mode.DROP_FIRST_FRAGMENT, rate = -5).rate)
+        assertEquals(VideoFaultInjector.MAX_RATE, VideoFaultInjector(Mode.DROP_FIRST_FRAGMENT, rate = Int.MAX_VALUE).rate)
+        assertEquals(300, VideoFaultInjector(Mode.DROP_FIRST_FRAGMENT, rate = 300).rate)
+    }
+
+    @Test
+    fun `every mode round-trips through the value stored in settings`() {
+        for (mode in Mode.entries) {
+            assertEquals(mode, Mode.fromInt(mode.value))
+        }
+        assertEquals("an unknown stored value must not throw", null, Mode.fromInt(-1))
+        assertEquals(null, Mode.fromInt(99))
+    }
+
+    @Test
+    fun `the default rate is rare enough to leave a fair sample of normal behaviour`() {
+        // At the ~50 messages per second a healthy link carries, one in 300 is a fault every few
+        // seconds. If this ever changes, the test brief's timings change with it.
+        assertTrue(VideoFaultInjector.DEFAULT_RATE >= 100)
+        assertTrue(VideoFaultInjector.DEFAULT_RATE in VideoFaultInjector.MIN_RATE..VideoFaultInjector.MAX_RATE)
+    }
+
+    @Test
+    fun `the candidate count follows the targeted flag and nothing else`() {
+        // The denominator the log needs. A run can inject nothing because the rate is high or because
+        // the stream never fragmented, and only this number tells those apart.
+        val injector = VideoFaultInjector(Mode.DROP_MIDDLE_FRAGMENT, rate = 4)
+        repeat(20) { injector.effectFor(first) }
+        repeat(20) { injector.effectFor(single) }
+        assertEquals("untargeted flags are not candidates", 0L, injector.matchingCount)
+
+        repeat(7) { injector.effectFor(middleFlag) }
+        assertEquals(7L, injector.matchingCount)
+        assertEquals(1L, injector.injectedCount)
+    }
+
+    @Test
+    fun `the summary carries the setting and both counts`() {
+        val injector = VideoFaultInjector(Mode.DROP_MIDDLE_FRAGMENT, rate = 20)
+        repeat(8) { injector.effectFor(middleFlag) }
+        val text = injector.describe()
+        // The exact shape a five-minute run that injected nothing produced, which is the case this
+        // line exists for: eight candidates at one in twenty is zero faults and no defect.
+        listOf("DROP_MIDDLE_FRAGMENT", "1-in-20", "8 candidates", "0 injected").forEach {
+            assertTrue("missing '$it' in: $text", text.contains(it))
+        }
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/VideoFragmentAssemblerTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/VideoFragmentAssemblerTest.kt
@@ -1,0 +1,271 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.VideoFragmentAssembler.Action
+import com.andrerinas.openheadunit.aap.VideoFragmentAssembler.Anomaly
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The transition table for video fragment reassembly.
+ *
+ * Issue #219 - the melting/smearing picture - is what reaching the codec with something that is not
+ * a whole access unit looks like, and the three ways the stream can produce that are all in here.
+ * The case worth naming is `a first fragment with no start code`: it used to leave the run open and
+ * silently assemble the frame without its own beginning.
+ */
+class VideoFragmentAssemblerTest {
+
+    private val single = VideoFragmentAssembler.FLAG_SINGLE
+    private val first = VideoFragmentAssembler.FLAG_FIRST
+    private val middle = VideoFragmentAssembler.FLAG_MIDDLE
+    private val last = VideoFragmentAssembler.FLAG_LAST
+
+    private val atTimestamp = VideoFragmentAssembler.OFFSET_TIMESTAMP_INDICATION
+    private val atMedia = VideoFragmentAssembler.OFFSET_MEDIA_INDICATION
+
+    /** A message whose payload begins at offset 10. */
+    private fun VideoFragmentAssembler.timestampIndication(flags: Int) =
+        onMessage(flags, payloadStartsAt10 = true, payloadStartsAt2 = false)
+
+    /** A message whose payload begins at offset 2. */
+    private fun VideoFragmentAssembler.mediaIndication(flags: Int) =
+        onMessage(flags, payloadStartsAt10 = false, payloadStartsAt2 = true)
+
+    /** A continuation fragment: no start code is expected anywhere in it. */
+    private fun VideoFragmentAssembler.continuation(flags: Int) =
+        onMessage(flags, payloadStartsAt10 = false, payloadStartsAt2 = false)
+
+    // ---- the happy paths ----
+
+    @Test
+    fun `a complete frame decodes from the timestamp offset`() {
+        val a = VideoFragmentAssembler()
+        val d = a.timestampIndication(single)
+        assertEquals(Action.DecodeWhole(atTimestamp), d.action)
+        assertNull(d.anomaly)
+        assertFalse("a single-message frame opens no run", a.isAssembling)
+    }
+
+    @Test
+    fun `the timestamp offset wins when both offsets look like a start code`() {
+        // Offset 2 can hold a false positive because a media indication and a timestamp indication
+        // are the same message with different headers. 10 is checked first, as it always was.
+        val d = VideoFragmentAssembler().onMessage(single, payloadStartsAt10 = true, payloadStartsAt2 = true)
+        assertEquals(Action.DecodeWhole(atTimestamp), d.action)
+    }
+
+    @Test
+    fun `a complete frame decodes from the media offset when there is nothing at ten`() {
+        assertEquals(Action.DecodeWhole(atMedia), VideoFragmentAssembler().mediaIndication(single).action)
+    }
+
+    @Test
+    fun `a two-fragment frame assembles and decodes`() {
+        val a = VideoFragmentAssembler()
+        assertEquals(Action.BeginAssembly(atTimestamp), a.timestampIndication(first).action)
+        assertTrue(a.isAssembling)
+        assertEquals(Action.AppendAndDecode, a.continuation(last).action)
+        assertFalse("the run closes on its last fragment", a.isAssembling)
+        assertFalse(a.hasAnomalies())
+    }
+
+    @Test
+    fun `a long frame appends every middle fragment`() {
+        val a = VideoFragmentAssembler()
+        a.mediaIndication(first)
+        repeat(5) { assertEquals(Action.Append, a.continuation(middle).action) }
+        assertEquals(Action.AppendAndDecode, a.continuation(last).action)
+        assertFalse(a.hasAnomalies())
+    }
+
+    @Test
+    fun `back to back frames leave no state behind`() {
+        val a = VideoFragmentAssembler()
+        repeat(3) {
+            a.timestampIndication(first)
+            a.continuation(middle)
+            assertEquals(Action.AppendAndDecode, a.continuation(last).action)
+        }
+        assertFalse(a.hasAnomalies())
+        assertFalse(a.isFrameCorrupt)
+    }
+
+    // ---- truncation: a run that never gets its last fragment ----
+
+    @Test
+    fun `a first fragment during an open run reports the previous frame truncated`() {
+        val a = VideoFragmentAssembler()
+        a.timestampIndication(first)
+        val d = a.timestampIndication(first)
+        assertEquals(Anomaly.TRUNCATED_PREVIOUS, d.anomaly)
+        assertEquals("the new frame still starts normally", Action.BeginAssembly(atTimestamp), d.action)
+        assertTrue("and its run is open", a.isAssembling)
+        assertFalse("the new frame is not itself corrupt", a.isFrameCorrupt)
+    }
+
+    @Test
+    fun `a complete frame during an open run reports the previous frame truncated`() {
+        val a = VideoFragmentAssembler()
+        a.mediaIndication(first)
+        val d = a.timestampIndication(single)
+        assertEquals(Anomaly.TRUNCATED_PREVIOUS, d.anomaly)
+        assertEquals(Action.DecodeWhole(atTimestamp), d.action)
+        assertFalse(a.isAssembling)
+    }
+
+    @Test
+    fun `a middle fragment does not itself count as truncation`() {
+        val a = VideoFragmentAssembler()
+        a.timestampIndication(first)
+        assertNull(a.continuation(middle).anomaly)
+    }
+
+    // ---- orphans: a fragment with no run open ----
+
+    @Test
+    fun `a middle fragment with no run open is an orphan and is discarded`() {
+        val a = VideoFragmentAssembler()
+        val d = a.continuation(middle)
+        assertEquals(Anomaly.ORPHANED_FRAGMENT, d.anomaly)
+        assertEquals(Action.Discard(consumed = true), d.action)
+        assertTrue(a.isFrameCorrupt)
+    }
+
+    @Test
+    fun `a last fragment with no run open is an orphan and closes nothing`() {
+        val a = VideoFragmentAssembler()
+        val d = a.continuation(last)
+        assertEquals(Anomaly.ORPHANED_FRAGMENT, d.anomaly)
+        assertEquals(Action.Discard(consumed = true), d.action)
+        assertFalse(a.isAssembling)
+    }
+
+    @Test
+    fun `the rest of a corrupt frame is discarded, and the next frame recovers`() {
+        val a = VideoFragmentAssembler()
+        a.continuation(middle) // orphan, marks the frame corrupt
+        assertEquals(Action.Discard(consumed = true), a.continuation(middle).action)
+        assertEquals(Action.Discard(consumed = true), a.continuation(last).action)
+
+        val recovered = a.timestampIndication(first)
+        assertEquals(Action.BeginAssembly(atTimestamp), recovered.action)
+        assertFalse("a new frame clears the mark", a.isFrameCorrupt)
+        assertEquals(Action.AppendAndDecode, a.continuation(last).action)
+    }
+
+    // ---- the silent hole this class was extracted to close ----
+
+    @Test
+    fun `a first fragment with no start code is discarded, not assembled headless`() {
+        val a = VideoFragmentAssembler()
+        val d = a.continuation(first)
+
+        assertEquals(Anomaly.HEADLESS_FIRST_FRAGMENT, d.anomaly)
+        assertEquals(Action.Discard(consumed = false), d.action)
+        assertFalse("the run must stay closed, or the followers get assembled without it", a.isAssembling)
+        assertTrue(a.isFrameCorrupt)
+    }
+
+    @Test
+    fun `the followers of a headless first fragment never reach the decoder`() {
+        // The whole point. Before this class, these three appended into the reassembly buffer and
+        // the 10 handed the codec an access unit missing its own first fragment, with nothing
+        // logged. Now each is an orphan and each is discarded.
+        val a = VideoFragmentAssembler()
+        a.continuation(first)
+        for (flags in listOf(middle, middle, last)) {
+            val d = a.continuation(flags)
+            assertEquals("flag $flags must not be appended", Action.Discard(consumed = true), d.action)
+            assertEquals("flag $flags must be reported", Anomaly.ORPHANED_FRAGMENT, d.anomaly)
+        }
+    }
+
+    @Test
+    fun `a headless first fragment does not consume the message`() {
+        // Preserved from the original: process() returned false here, which is what decides whether
+        // a media ack goes out and whether the other channel handlers get a look.
+        val a = VideoFragmentAssembler()
+        assertEquals(Action.Discard(consumed = false), a.continuation(first).action)
+    }
+
+    @Test
+    fun `a complete frame with no start code is dropped without asking for a keyframe`() {
+        // Small ones are control traffic on the video channel, not lost picture - len=4 and len=6
+        // arrive at session start on real units. No anomaly, so no keyframe request during setup.
+        val a = VideoFragmentAssembler()
+        val d = a.continuation(single)
+        assertEquals(Action.Discard(consumed = false), d.action)
+        assertNull(d.anomaly)
+        assertFalse(a.hasAnomalies())
+    }
+
+    // ---- overflow, and the counters ----
+
+    @Test
+    fun `overflow marks the frame corrupt so the rest of it is skipped`() {
+        val a = VideoFragmentAssembler()
+        a.timestampIndication(first)
+        assertEquals(Anomaly.OVERFLOW, a.onOverflow())
+        assertTrue(a.isFrameCorrupt)
+        assertEquals(Action.Discard(consumed = true), a.continuation(middle).action)
+        assertEquals(Action.Discard(consumed = true), a.continuation(last).action)
+    }
+
+    @Test
+    fun `every anomaly is counted and the counters reset independently of the state`() {
+        val a = VideoFragmentAssembler()
+        a.continuation(middle)      // orphan
+        a.continuation(first)       // headless
+        a.timestampIndication(first)
+        a.timestampIndication(first) // truncated
+        a.onOverflow()
+
+        assertEquals(1, a.countOf(Anomaly.ORPHANED_FRAGMENT))
+        assertEquals(1, a.countOf(Anomaly.HEADLESS_FIRST_FRAGMENT))
+        assertEquals(1, a.countOf(Anomaly.TRUNCATED_PREVIOUS))
+        assertEquals(1, a.countOf(Anomaly.OVERFLOW))
+        assertTrue(a.hasAnomalies())
+
+        a.resetCounts()
+        assertFalse(a.hasAnomalies())
+        assertTrue("resetCounts must not reopen or close the run", a.isAssembling)
+    }
+
+    @Test
+    fun `a headless first fragment during an open run counts both anomalies`() {
+        val a = VideoFragmentAssembler()
+        a.timestampIndication(first)
+        val d = a.continuation(first)
+        assertEquals("the caller is told about the one that decides the action", Anomaly.HEADLESS_FIRST_FRAGMENT, d.anomaly)
+        assertEquals(1, a.countOf(Anomaly.TRUNCATED_PREVIOUS))
+        assertEquals(1, a.countOf(Anomaly.HEADLESS_FIRST_FRAGMENT))
+    }
+
+    @Test
+    fun `reset returns the machine to its start state`() {
+        val a = VideoFragmentAssembler()
+        a.timestampIndication(first)
+        a.onOverflow()
+        a.reset()
+        assertFalse(a.isAssembling)
+        assertFalse(a.isFrameCorrupt)
+        assertFalse(a.hasAnomalies())
+        assertEquals("a 10 after a reset is an orphan, not a completion", Anomaly.ORPHANED_FRAGMENT, a.continuation(last).anomaly)
+    }
+
+    // ---- flags that are not video payload ----
+
+    @Test
+    fun `an unhandled flag is passed on without touching the run`() {
+        val a = VideoFragmentAssembler()
+        a.timestampIndication(first)
+        val d = a.onMessage(0, payloadStartsAt10 = false, payloadStartsAt2 = false)
+        assertEquals(Action.Discard(consumed = false), d.action)
+        assertNull(d.anomaly)
+        assertTrue("an unrelated flag must not close an open run", a.isAssembling)
+        assertFalse(a.hasAnomalies())
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/WarmRelaunchKeyframePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/WarmRelaunchKeyframePolicyTest.kt
@@ -10,18 +10,18 @@ import org.junit.Test
  * away from a stream that is working. A release across a healthy stream is a known way to drop one
  * to a few fps permanently, so the escalation is only ever correct in the one situation these
  * arguments describe together: a decoder rebuilt under a surface that has never shown a frame, on a
- * session that already proved itself, with the phone still sending.
+ * session that already proved itself, with the phone still on the link.
  */
 class WarmRelaunchKeyframePolicyTest {
 
-    /** A relaunch that has gone 2s without a picture while the phone streams: the whole point. */
+    /** A relaunch that has gone 5s without a picture while the phone is on the link: the whole point. */
     private fun warmRelaunch(
         sessionHasRendered: Boolean = true,
         renderedSinceSurfaceSet: Boolean = false,
         transportStarted: Boolean = true,
         msSinceSurfaceSet: Long = 5_000,
-        msSincePhoneBytes: Long = 100,
-        phoneAliveThresholdMs: Long = 1_500,
+        msSinceLinkActivity: Long = 100,
+        linkQuietThresholdMs: Long = ProjectionWatchdogPolicy.LINK_QUIET_MS,
         cycleAlreadySpent: Boolean = false,
         msSinceLastRequest: Long = 60_000
     ) = WarmRelaunchKeyframePolicy.decide(
@@ -29,8 +29,8 @@ class WarmRelaunchKeyframePolicyTest {
         renderedSinceSurfaceSet = renderedSinceSurfaceSet,
         transportStarted = transportStarted,
         msSinceSurfaceSet = msSinceSurfaceSet,
-        msSincePhoneBytes = msSincePhoneBytes,
-        phoneAliveThresholdMs = phoneAliveThresholdMs,
+        msSinceLinkActivity = msSinceLinkActivity,
+        linkQuietThresholdMs = linkQuietThresholdMs,
         cycleAlreadySpent = cycleAlreadySpent,
         msSinceLastRequest = msSinceLastRequest
     )
@@ -86,15 +86,32 @@ class WarmRelaunchKeyframePolicyTest {
     }
 
     @Test
-    fun `a phone that stopped sending is a pause, not a stall`() {
+    fun `a phone that has left the link is a disconnect, not a stall`() {
         assertEquals(
             Action.NONE,
-            warmRelaunch(msSincePhoneBytes = 1_501, phoneAliveThresholdMs = 1_500)
+            warmRelaunch(msSinceLinkActivity = ProjectionWatchdogPolicy.LINK_QUIET_MS + 1)
         )
         assertEquals(
             Action.CYCLE_FOCUS,
-            warmRelaunch(msSincePhoneBytes = 1_500, phoneAliveThresholdMs = 1_500)
+            warmRelaunch(msSinceLinkActivity = ProjectionWatchdogPolicy.LINK_QUIET_MS)
         )
+    }
+
+    @Test
+    fun `a phone that is silent on video but present on the link still gets the cycle`() {
+        // This gate used to read the age of the last *video* bytes against a 1.5s window. Android
+        // Auto sends no video at all while nothing on screen animates, so on a paused full-screen
+        // player it shut within seconds and stayed shut - and took the only escalation with it. A
+        // reporter's capture then has the cycle repairing that exact stream: paused upstream for
+        // minutes, keyframe 0.68s after the release. Video silence is not evidence of anything.
+        assertEquals(Action.CYCLE_FOCUS, warmRelaunch(msSinceLinkActivity = 2_000))
+    }
+
+    @Test
+    fun `a session with no link activity at all is never escalated`() {
+        // The caller reports "nothing has ever arrived" as Long.MAX_VALUE, and that must read as
+        // gone rather than as zero.
+        assertEquals(Action.NONE, warmRelaunch(msSinceLinkActivity = Long.MAX_VALUE))
     }
 
     @Test

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/WirelessServerRestartPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/WirelessServerRestartPolicyTest.kt
@@ -1,0 +1,179 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.WirelessServerRestartPolicy.Action
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The case these exist for: a reporter whose head unit hosted its network, woke the phone, handed
+ * out credentials, and then aborted every handshake with "nothing is listening on port 5288",
+ * repeatedly, for as long as the capture ran. The server object was assigned and not listening, and
+ * the old guard read "assigned" as "running".
+ */
+class WirelessServerRestartPolicyTest {
+
+    private val now = 1_000_000L
+    private val never = 0L
+
+    @Test
+    fun `a listening server is left alone`() {
+        assertEquals(
+            Action.NO_OP,
+            WirelessServerRestartPolicy.decide(
+                assigned = true, alive = true, listening = true, nowMs = now,
+                lastRebuildAtMs = never, rebuildsInWindow = 0, windowStartedAtMs = never,
+            ),
+        )
+    }
+
+    @Test
+    fun `nothing assigned yet means start, not rebuild`() {
+        assertEquals(
+            Action.START,
+            WirelessServerRestartPolicy.decide(
+                assigned = false, alive = false, listening = false, nowMs = now,
+                lastRebuildAtMs = never, rebuildsInWindow = 0, windowStartedAtMs = never,
+            ),
+        )
+    }
+
+    @Test
+    fun `assigned but not listening is the whole bug, and it rebuilds`() {
+        // The old code returned early here because the field was non-null, so the port stayed
+        // unbound for the life of the mode and every handshake aborted against it.
+        assertEquals(
+            Action.REBUILD,
+            WirelessServerRestartPolicy.decide(
+                assigned = true, alive = false, listening = false, nowMs = now,
+                lastRebuildAtMs = never, rebuildsInWindow = 0, windowStartedAtMs = never,
+            ),
+        )
+    }
+
+    @Test
+    fun `a handshake retrying every few seconds cannot drive a rebuild per attempt`() {
+        // The observed cadence in the reporter's log is a fresh handshake roughly every 4 s. Each
+        // one asks; only the first may act.
+        var lastRebuild = now
+        for (attempt in 1..5) {
+            val at = now + attempt * 4_000L
+            val action = WirelessServerRestartPolicy.decide(
+                assigned = true, alive = false, listening = false, nowMs = at,
+                lastRebuildAtMs = lastRebuild, rebuildsInWindow = 1, windowStartedAtMs = now,
+            )
+            if (at - lastRebuild < WirelessServerRestartPolicy.REBUILD_COOLDOWN_MS) {
+                assertEquals("attempt $attempt at +${at - now}ms", Action.BACKOFF, action)
+            } else {
+                assertEquals("attempt $attempt at +${at - now}ms", Action.REBUILD, action)
+                lastRebuild = at
+            }
+        }
+    }
+
+    @Test
+    fun `a port that will never bind stops being retried`() {
+        val action = WirelessServerRestartPolicy.decide(
+            assigned = true, alive = false, listening = false, nowMs = now + 30_000L,
+            lastRebuildAtMs = now, rebuildsInWindow = WirelessServerRestartPolicy.MAX_REBUILDS_PER_WINDOW,
+            windowStartedAtMs = now,
+        )
+        assertEquals(Action.BACKOFF, action)
+    }
+
+    @Test
+    fun `a unit that fails once an hour is never talked out of trying`() {
+        // The exhausted count must not be permanent: the window ages out and the next failure is
+        // treated as the first one again.
+        val muchLater = now + WirelessServerRestartPolicy.REBUILD_WINDOW_MS + 1
+        assertFalse(WirelessServerRestartPolicy.windowIsOpen(muchLater, now))
+        assertEquals(
+            Action.REBUILD,
+            WirelessServerRestartPolicy.decide(
+                assigned = true, alive = false, listening = false, nowMs = muchLater,
+                lastRebuildAtMs = now, rebuildsInWindow = WirelessServerRestartPolicy.MAX_REBUILDS_PER_WINDOW,
+                windowStartedAtMs = now,
+            ),
+        )
+        assertEquals(1, WirelessServerRestartPolicy.nextRebuildCount(muchLater, now, 3))
+        assertEquals(muchLater, WirelessServerRestartPolicy.nextWindowStart(muchLater, now))
+    }
+
+    @Test
+    fun `counting inside one window accumulates rather than resetting`() {
+        val soon = now + 5_000L
+        assertTrue(WirelessServerRestartPolicy.windowIsOpen(soon, now))
+        assertEquals(2, WirelessServerRestartPolicy.nextRebuildCount(soon, now, 1))
+        assertEquals(now, WirelessServerRestartPolicy.nextWindowStart(soon, now))
+    }
+
+    @Test
+    fun `a first ever rebuild is not held back by an unset timestamp`() {
+        // lastRebuildAtMs of 0 means "never", not "at time zero, so 1000000ms ago".
+        assertEquals(
+            Action.REBUILD,
+            WirelessServerRestartPolicy.decide(
+                assigned = true, alive = false, listening = false, nowMs = 500L,
+                lastRebuildAtMs = never, rebuildsInWindow = 0, windowStartedAtMs = never,
+            ),
+        )
+    }
+
+    @Test
+    fun `every action says why, because that is the point of the change`() {
+        for (action in Action.values()) {
+            val text = WirelessServerRestartPolicy.describe(action, assigned = true, listening = false)
+            assertTrue("$action has no reason text", text.isNotBlank())
+        }
+        assertEquals(
+            "a server exists but its port is not bound",
+            WirelessServerRestartPolicy.describe(Action.REBUILD, assigned = true, listening = false),
+        )
+    }
+
+    @Test
+    fun `a server still binding is waited for, never torn down`() {
+        // The bind is retried inside the coroutine, so assigned-and-not-listening is a normal
+        // transient state for a second or so. Reading it as dead would replace a server that was
+        // about to succeed, and the replacement would race the original for the same port -
+        // SO_REUSEADDR does not cover a live listener, only one in TIME_WAIT.
+        assertEquals(
+            Action.AWAIT,
+            WirelessServerRestartPolicy.decide(
+                assigned = true, alive = true, listening = false, nowMs = now,
+                lastRebuildAtMs = never, rebuildsInWindow = 0, windowStartedAtMs = never,
+            ),
+        )
+    }
+
+    @Test
+    fun `a live session is never disturbed`() {
+        // A projection session arrived over this socket. Replacing it can only do harm, and the
+        // phone is already connected, so nothing here needs repairing.
+        assertEquals(
+            Action.NO_OP,
+            WirelessServerRestartPolicy.decide(
+                assigned = true, alive = false, listening = false, nowMs = now, sessionBusy = true,
+                lastRebuildAtMs = never, rebuildsInWindow = 0, windowStartedAtMs = never,
+            ),
+        )
+    }
+
+    @Test
+    fun `every state maps to exactly one action, and none is left undecided`() {
+        val seen = mutableSetOf<Action>()
+        for (assigned in listOf(false, true)) {
+            for (alive in listOf(false, true)) {
+                for (listening in listOf(false, true)) {
+                    seen += WirelessServerRestartPolicy.decide(
+                        assigned = assigned, alive = alive, listening = listening, nowMs = now,
+                        lastRebuildAtMs = never, rebuildsInWindow = 0, windowStartedAtMs = never,
+                    )
+                }
+            }
+        }
+        // BACKOFF needs a prior attempt to be reachable, so it is not expected from this sweep.
+        assertEquals(setOf(Action.NO_OP, Action.START, Action.AWAIT, Action.REBUILD), seen)
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/CodecInputSizePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/CodecInputSizePolicyTest.kt
@@ -1,0 +1,96 @@
+package com.andrerinas.openheadunit.decoder
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The buffer request that decides how much graphics memory a decoder's input port takes.
+ *
+ * The measurement this exists for: a 2 MB request at 1280x720 was answered with eight buffers of
+ * that size - 16 MB - on a unit with a 12-20 MB Java heap.
+ */
+class CodecInputSizePolicyTest {
+
+    private val mb = 1024 * 1024
+    private val h265Cap = 2 * mb
+    private val h265CapAbove1080p = 8 * mb
+    private val h264LegacyCap = 1 * mb
+
+    @Test
+    fun `720p asks for well under the tier it used to take`() {
+        val size = CodecInputSizePolicy.maxInputSizeFor(1280, 720, h265Cap)
+        // 80 x 45 macroblocks, 921600 samples, 3/(2*2) of that.
+        assertEquals(691200, size)
+        assertTrue("must be a real saving over the 2MB tier", size < h265Cap / 2)
+    }
+
+    @Test
+    fun `1080p stays inside the tier and still saves`() {
+        val size = CodecInputSizePolicy.maxInputSizeFor(1920, 1080, h265Cap)
+        // 120 x 68 macroblocks - 1080 rounds up to 1088 - so 2088960 samples.
+        assertEquals(1566720, size)
+        assertTrue(size < h265Cap)
+    }
+
+    @Test
+    fun `800x480 saves too, and the floor does not bind there`() {
+        val size = CodecInputSizePolicy.maxInputSizeFor(800, 480, h265Cap)
+        assertEquals(288000, size)
+        assertTrue(
+            "the floor must not decide the answer at the smallest resolution Android Auto negotiates",
+            size > CodecInputSizePolicy.MIN_INPUT_SIZE_BYTES
+        )
+    }
+
+    @Test
+    fun `4K needs most of its tier, which is why the tier exists`() {
+        val size = CodecInputSizePolicy.maxInputSizeFor(3840, 2160, h265CapAbove1080p)
+        assertEquals(6220800, size)
+        assertTrue(size < h265CapAbove1080p)
+    }
+
+    @Test
+    fun `the cap is never exceeded, whatever the resolution claims`() {
+        // A stream that claims 8K on a device whose tier is 2MB must still get 2MB, not 25MB.
+        assertEquals(h265Cap, CodecInputSizePolicy.maxInputSizeFor(7680, 4320, h265Cap))
+        assertEquals(h264LegacyCap, CodecInputSizePolicy.maxInputSizeFor(1920, 1080, h264LegacyCap))
+    }
+
+    @Test
+    fun `unknown dimensions leave the cap alone`() {
+        // Shrinking a buffer on a guess is how a working unit stops working.
+        for (bad in listOf(0 to 720, 1280 to 0, 0 to 0, -1 to -1)) {
+            assertEquals(
+                "dimensions ${bad.first}x${bad.second} must not shrink anything",
+                h265Cap,
+                CodecInputSizePolicy.maxInputSizeFor(bad.first, bad.second, h265Cap)
+            )
+        }
+    }
+
+    @Test
+    fun `a tiny picture still gets a usable buffer`() {
+        val size = CodecInputSizePolicy.maxInputSizeFor(320, 240, h265Cap)
+        assertEquals(CodecInputSizePolicy.MIN_INPUT_SIZE_BYTES, size)
+    }
+
+    @Test
+    fun `the floor cannot push a request past its cap`() {
+        // A cap smaller than the floor is a device tier we have measured and must respect.
+        val tinyCap = 128 * 1024
+        assertEquals(tinyCap, CodecInputSizePolicy.maxInputSizeFor(320, 240, tinyCap))
+        assertEquals(tinyCap, CodecInputSizePolicy.maxInputSizeFor(1920, 1080, tinyCap))
+    }
+
+    @Test
+    fun `the request never grows with resolution beyond its cap and never shrinks with it`() {
+        var previous = 0
+        for (height in listOf(240, 480, 600, 720, 1080)) {
+            val width = height * 16 / 9
+            val size = CodecInputSizePolicy.maxInputSizeFor(width, height, h265CapAbove1080p)
+            assertTrue("size must be monotonic in resolution", size >= previous)
+            previous = size
+        }
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/CodecTypeSelectionPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/CodecTypeSelectionPolicyTest.kt
@@ -1,0 +1,108 @@
+package com.andrerinas.openheadunit.decoder
+
+import com.andrerinas.openheadunit.decoder.VideoDecoder.CodecType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The four inputs are named after what produces them on a device, so a case here maps onto a unit
+ * you could hold: `hevcDetectable` is hardware HEVC, `hevcUsable` adds the explicitly selected
+ * software decoder, and `detected` is what the first packet's parameter sets said.
+ */
+class CodecTypeSelectionPolicyTest {
+
+    private fun select(
+        detected: CodecType?,
+        requested: CodecType,
+        hevcDetectable: Boolean,
+        hevcUsable: Boolean,
+    ) = CodecTypeSelectionPolicy.select(detected, requested, hevcDetectable, hevcUsable)
+
+    // --- the defect this policy exists for -------------------------------------------------
+
+    @Test
+    fun `an H264 stream gets an H264 decoder even when the setting says H265`() {
+        // A unit with real hardware HEVC, set to H.265, on a session the phone opened as H.264.
+        // Read off a reporter capture: 52 codec rebuilds and 48 ACodec errors in 275s.
+        assertEquals(
+            CodecType.H264,
+            select(CodecType.H264, CodecType.H265, hevcDetectable = true, hevcUsable = true)
+        )
+    }
+
+    @Test
+    fun `a unit that cannot decode HEVC at all ignores an H265 setting`() {
+        // The announcement already downgraded this unit to H.264, so H.264 is what is arriving.
+        // Both with and without a usable sniff.
+        assertEquals(
+            CodecType.H264,
+            select(CodecType.H264, CodecType.H265, hevcDetectable = false, hevcUsable = false)
+        )
+        assertEquals(
+            CodecType.H264,
+            select(null, CodecType.H265, hevcDetectable = false, hevcUsable = false)
+        )
+    }
+
+    // --- what must not regress -------------------------------------------------------------
+
+    @Test
+    fun `software HEVC keeps the setting, because the sniff cannot see HEVC there`() {
+        // No hardware HEVC, so detectCodecType walks past the VPS/SPS/PPS and can misread an HEVC
+        // IDR_N_LP header as an H.264 PPS. Its answer is not evidence; the setting is.
+        assertEquals(
+            CodecType.H265,
+            select(CodecType.H264, CodecType.H265, hevcDetectable = false, hevcUsable = true)
+        )
+        assertEquals(
+            CodecType.H265,
+            select(null, CodecType.H265, hevcDetectable = false, hevcUsable = true)
+        )
+    }
+
+    @Test
+    fun `a packet with no parameter set falls back to the setting`() {
+        assertEquals(
+            CodecType.H265,
+            select(null, CodecType.H265, hevcDetectable = true, hevcUsable = true)
+        )
+        assertEquals(
+            CodecType.H264,
+            select(null, CodecType.H264, hevcDetectable = true, hevcUsable = true)
+        )
+    }
+
+    @Test
+    fun `an H265 stream still gets an H265 decoder when the setting says H264`() {
+        // Pre-existing behaviour: the sniff already won this direction and must keep winning.
+        assertEquals(
+            CodecType.H265,
+            select(CodecType.H265, CodecType.H264, hevcDetectable = true, hevcUsable = true)
+        )
+    }
+
+    @Test
+    fun `the ordinary agreeing cases are unchanged`() {
+        assertEquals(
+            CodecType.H264,
+            select(CodecType.H264, CodecType.H264, hevcDetectable = true, hevcUsable = true)
+        )
+        assertEquals(
+            CodecType.H265,
+            select(CodecType.H265, CodecType.H265, hevcDetectable = true, hevcUsable = true)
+        )
+    }
+
+    @Test
+    fun `H264 is never overridden into H265 by the setting alone when the stream disagrees`() {
+        // The whole failure mode in one assertion: on any unit where the sniff can tell the two
+        // apart, a positively-identified H.264 stream is never handed an HEVC decoder.
+        for (usable in listOf(true, false)) {
+            assertEquals(
+                "hevcUsable=$usable",
+                CodecType.H264,
+                select(CodecType.H264, CodecType.H265, hevcDetectable = true, hevcUsable = usable)
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/DecoderCapabilityReportTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/DecoderCapabilityReportTest.kt
@@ -1,0 +1,101 @@
+package com.andrerinas.openheadunit.decoder
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the two halves of [DecoderCapabilityReport] that need no device: the verdict and the name
+ * heuristic. The queries themselves need `MediaCodecList` and are exercised on hardware.
+ */
+class DecoderCapabilityReportTest {
+
+    private fun capability(
+        sizeSupported: Boolean = true,
+        rateSupported: Boolean = true,
+        sustains: Boolean? = true,
+    ) = DecoderCapabilityReport.Capability(
+        codecName = "c2.qti.hevc.decoder",
+        mimeType = "video/hevc",
+        width = 2560,
+        height = 1440,
+        fps = 60,
+        sizeSupported = sizeSupported,
+        rateSupported = rateSupported,
+        sustains = sustains,
+        lowLatency = true,
+        adaptivePlayback = true,
+        supportedWidths = "[64, 4096]",
+        supportedHeights = "[64, 4096]",
+    )
+
+    @Test
+    fun `a decoder that claims all three is adequate`() {
+        assertTrue(capability().adequate)
+    }
+
+    @Test
+    fun `an unknown performance point does not count against the decoder`() {
+        // Below API 29 there are no performance points at all. Treating "we could not ask" as "no"
+        // would flag every pre-Android-10 unit that is working perfectly well.
+        assertTrue(capability(sustains = null).adequate)
+    }
+
+    @Test
+    fun `a performance point that says no is decisive`() {
+        // The case worth catching: the component accepts the format but does not claim to sustain
+        // the rate, which is exactly the gap areSizeAndRateSupported cannot express.
+        assertFalse(capability(sustains = false).adequate)
+    }
+
+    @Test
+    fun `size or rate failing is enough on its own`() {
+        assertFalse(capability(sizeSupported = false).adequate)
+        assertFalse(capability(rateSupported = false).adequate)
+    }
+
+    @Test
+    fun `the summary carries every number a report needs`() {
+        val text = capability(sustains = false).toString()
+        listOf(
+            "codec=c2.qti.hevc.decoder",
+            "mime=video/hevc",
+            "target=2560x1440@60",
+            "sizeSupported=true",
+            "rateSupported=true",
+            "sustains=false",
+            "featureLowLatency=true",
+        ).forEach { assertTrue("missing '$it' in: $text", text.contains(it)) }
+    }
+
+    @Test
+    fun `an unknown performance point prints as unknown, not null`() {
+        assertTrue(capability(sustains = null).toString().contains("sustains=unknown"))
+    }
+
+    @Test
+    fun `software components are recognised by the same names VideoDecoder uses`() {
+        listOf(
+            "OMX.google.hevc.decoder",
+            "c2.android.hevc.decoder",
+            "OMX.ffmpeg.hevc.decoder",
+            "OMX.qcom.video.decoder.sw.hevc",
+            "some.software.decoder",
+        ).forEach { assertTrue(it, DecoderCapabilityReport.isSoftwareName(it)) }
+    }
+
+    @Test
+    fun `hardware components are not`() {
+        listOf(
+            "c2.qti.hevc.decoder",
+            "OMX.MTK.VIDEO.DECODER.HEVC",
+            "OMX.rk.video_decoder.hevc",
+        ).forEach { assertFalse(it, DecoderCapabilityReport.isSoftwareName(it)) }
+    }
+
+    @Test
+    fun `a missing fps setting falls back to a named default rather than zero`() {
+        assertEquals(30, DecoderCapabilityReport.DEFAULT_FPS)
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/DecoderConfigLadderTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/DecoderConfigLadderTest.kt
@@ -1,0 +1,119 @@
+package com.andrerinas.openheadunit.decoder
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The rules for trying optional decoder keys.
+ *
+ * The property that matters more than any individual key: the last rung is always empty, so whatever
+ * the ladder decides, the fallback is the behaviour that shipped before it existed.
+ */
+class DecoderConfigLadderTest {
+
+    private val mtk = "OMX.MTK.VIDEO.DECODER.HEVC"
+    private val qcom = "OMX.qcom.video.decoder.avc"
+    private val exynos = "OMX.Exynos.avc.dec"
+    private val amlogic = "OMX.amlogic.hevc.decoder"
+    private val hisi = "OMX.hisi.video.decoder.avc"
+    private val unknown = "OMX.rk.video_decoder.avc"
+
+    @Test
+    fun `the last rung is always empty, whatever else is offered`() {
+        val cases = listOf(mtk, qcom, exynos, amlogic, hisi, unknown, "")
+        for (name in cases) {
+            for (sdk in listOf(16, 21, 27, 29, 30, 34)) {
+                for (feature in listOf(true, false)) {
+                    for (requested in listOf(true, false)) {
+                        val tiers = DecoderConfigLadder.tiers(name, sdk, feature, requested)
+                        assertTrue("$name/$sdk: no rungs at all", tiers.isNotEmpty())
+                        assertEquals(
+                            "$name/$sdk/feature=$feature/requested=$requested must end with no optional keys",
+                            DecoderConfigLadder.NO_OPTIONAL_KEYS,
+                            tiers.last()
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `not asking for low latency is exactly the shipped behaviour`() {
+        val tiers = DecoderConfigLadder.tiers(mtk, 34, advertisesLowLatencyFeature = true, lowLatencyRequested = false)
+        assertEquals(listOf(DecoderConfigLadder.NO_OPTIONAL_KEYS), tiers)
+    }
+
+    @Test
+    fun `the official key is preferred where the component advertises it`() {
+        val tiers = DecoderConfigLadder.tiers(qcom, 34, advertisesLowLatencyFeature = true, lowLatencyRequested = true)
+        assertEquals(2, tiers.size)
+        assertEquals(mapOf(DecoderConfigLadder.KEY_LOW_LATENCY to 1), tiers[0].integerKeys)
+    }
+
+    @Test
+    fun `the official key is not used below the API that has it, even if the feature is claimed`() {
+        val tiers = DecoderConfigLadder.tiers(qcom, 29, advertisesLowLatencyFeature = true, lowLatencyRequested = true)
+        assertEquals(
+            "should fall back to the vendor spelling",
+            mapOf(DecoderConfigLadder.QUALCOMM_LOW_LATENCY to 1),
+            tiers[0].integerKeys
+        )
+    }
+
+    @Test
+    fun `the vendor spelling is used when the component does not advertise the feature`() {
+        // The case that matters for #839: a MediaTek component on API 27, where the official key does
+        // not exist at all.
+        val tiers = DecoderConfigLadder.tiers(mtk, 27, advertisesLowLatencyFeature = false, lowLatencyRequested = true)
+        assertEquals(2, tiers.size)
+        assertEquals(mapOf(DecoderConfigLadder.MTK_LOW_LATENCY to 1), tiers[0].integerKeys)
+    }
+
+    @Test
+    fun `the two spellings are never combined`() {
+        for (name in listOf(mtk, qcom, exynos, amlogic, hisi)) {
+            for (sdk in listOf(27, 30, 34)) {
+                for (feature in listOf(true, false)) {
+                    val rich = DecoderConfigLadder.tiers(name, sdk, feature, lowLatencyRequested = true).first()
+                    assertTrue(
+                        "$name/$sdk/feature=$feature set both spellings: ${rich.integerKeys.keys}",
+                        !(rich.integerKeys.containsKey(DecoderConfigLadder.KEY_LOW_LATENCY) &&
+                            rich.integerKeys.keys.any { it != DecoderConfigLadder.KEY_LOW_LATENCY })
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `an unknown vendor gets nothing rather than a guess`() {
+        val tiers = DecoderConfigLadder.tiers(unknown, 27, advertisesLowLatencyFeature = false, lowLatencyRequested = true)
+        assertEquals(listOf(DecoderConfigLadder.NO_OPTIONAL_KEYS), tiers)
+        assertTrue(DecoderConfigLadder.vendorLowLatencyKeys(unknown).isEmpty())
+        assertTrue(DecoderConfigLadder.vendorLowLatencyKeys("").isEmpty())
+    }
+
+    @Test
+    fun `each vendor family is matched by its component name`() {
+        assertEquals(mapOf(DecoderConfigLadder.MTK_LOW_LATENCY to 1), DecoderConfigLadder.vendorLowLatencyKeys(mtk))
+        assertEquals(mapOf(DecoderConfigLadder.QUALCOMM_LOW_LATENCY to 1), DecoderConfigLadder.vendorLowLatencyKeys(qcom))
+        assertEquals(mapOf(DecoderConfigLadder.EXYNOS_LOW_LATENCY to 1), DecoderConfigLadder.vendorLowLatencyKeys(exynos))
+        assertEquals(mapOf(DecoderConfigLadder.AMLOGIC_LOW_LATENCY to 1), DecoderConfigLadder.vendorLowLatencyKeys(amlogic))
+        assertEquals(
+            mapOf(
+                DecoderConfigLadder.HISILICON_LOW_LATENCY_REQ to 1,
+                DecoderConfigLadder.HISILICON_LOW_LATENCY_RDY to -1,
+            ),
+            DecoderConfigLadder.vendorLowLatencyKeys(hisi)
+        )
+    }
+
+    @Test
+    fun `the Codec2 spellings of the same families are matched too`() {
+        assertEquals(mapOf(DecoderConfigLadder.MTK_LOW_LATENCY to 1), DecoderConfigLadder.vendorLowLatencyKeys("c2.mtk.hevc.decoder"))
+        assertEquals(mapOf(DecoderConfigLadder.QUALCOMM_LOW_LATENCY to 1), DecoderConfigLadder.vendorLowLatencyKeys("c2.qti.avc.decoder"))
+        assertEquals(mapOf(DecoderConfigLadder.EXYNOS_LOW_LATENCY to 1), DecoderConfigLadder.vendorLowLatencyKeys("c2.exynos.hevc.decoder"))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/DecoderStallCausePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/DecoderStallCausePolicyTest.kt
@@ -17,10 +17,10 @@ class DecoderStallCausePolicyTest {
     private fun classify(
         stallGapMs: Long = 10_000L,
         inputIdleGapMs: Long = 0L,
-        keyframeFedSinceStart: Boolean = false,
+        keyframeDecodedSinceStart: Boolean = false,
         sessionHasRendered: Boolean = true,
     ) = DecoderStallCausePolicy.classify(
-        stallGapMs, inputIdleGapMs, idleThreshold, keyframeFedSinceStart, sessionHasRendered
+        stallGapMs, inputIdleGapMs, idleThreshold, keyframeDecodedSinceStart, sessionHasRendered
     )
 
     @Test
@@ -29,7 +29,7 @@ class DecoderStallCausePolicyTest {
         // Decided before anything else, so it holds whatever the codec's own state looks like.
         assertEquals(
             Cause.PHONE_IDLE,
-            classify(inputIdleGapMs = 30_000L, keyframeFedSinceStart = true, sessionHasRendered = false)
+            classify(inputIdleGapMs = 30_000L, keyframeDecodedSinceStart = true, sessionHasRendered = false)
         )
     }
 
@@ -43,7 +43,26 @@ class DecoderStallCausePolicyTest {
 
     @Test
     fun `a codec that has had its keyframe and still produces nothing is stalled`() {
-        assertEquals(Cause.STALLED, classify(keyframeFedSinceStart = true))
+        assertEquals(Cause.STALLED, classify(keyframeDecodedSinceStart = true))
+    }
+
+    @Test
+    fun `a keyframe that was fed but never decoded still counts as starvation`() {
+        // The case that reopened the wedge: an access unit that lost a middle fragment keeps its
+        // parameter sets and IDR slice at the head, so it scans as a keyframe and is fed like one,
+        // and the codec produces nothing from it. The caller passes what came *out*, so this reads
+        // exactly like the codec never having had one - which is the answer that asks for a real
+        // keyframe instead of rebuilding for it.
+        assertEquals(Cause.STARVED_OF_KEYFRAME, classify(keyframeDecodedSinceStart = false))
+        // And the patience bound still applies to it, so a codec that is genuinely dead is not
+        // waited on forever just because every keyframe it was handed arrived broken.
+        assertEquals(
+            Cause.STALLED,
+            classify(
+                keyframeDecodedSinceStart = false,
+                stallGapMs = DecoderStallCausePolicy.KEYFRAME_STARVATION_PATIENCE_MS
+            )
+        )
     }
 
     @Test

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/DecoderStallCausePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/DecoderStallCausePolicyTest.kt
@@ -1,0 +1,75 @@
+package com.andrerinas.openheadunit.decoder
+
+import com.andrerinas.openheadunit.decoder.DecoderStallCausePolicy.Cause
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The three causes and the two gates. The numbers in the "measured" cases are the UNISOC MT50 round
+ * that motivated the class - a stall detected 4s after the codec was rebuilt, then every ten seconds
+ * after that.
+ */
+class DecoderStallCausePolicyTest {
+
+    private val idleThreshold = 2000L
+
+    private fun classify(
+        stallGapMs: Long = 10_000L,
+        inputIdleGapMs: Long = 0L,
+        keyframeFedSinceStart: Boolean = false,
+        sessionHasRendered: Boolean = true,
+    ) = DecoderStallCausePolicy.classify(
+        stallGapMs, inputIdleGapMs, idleThreshold, keyframeFedSinceStart, sessionHasRendered
+    )
+
+    @Test
+    fun `a phone that has stopped sending is not a decoder fault`() {
+        assertEquals(Cause.PHONE_IDLE, classify(inputIdleGapMs = idleThreshold + 1))
+        // Decided before anything else, so it holds whatever the codec's own state looks like.
+        assertEquals(
+            Cause.PHONE_IDLE,
+            classify(inputIdleGapMs = 30_000L, keyframeFedSinceStart = true, sessionHasRendered = false)
+        )
+    }
+
+    @Test
+    fun `a rebuilt codec that has had no keyframe is starved, not stalled`() {
+        // The measured shape: 2s, then 5.5s, then 10s of nothing out while input flowed at ~50fps.
+        listOf(2005L, 5524L, 10_001L).forEach {
+            assertEquals("stallGap=$it", Cause.STARVED_OF_KEYFRAME, classify(stallGapMs = it))
+        }
+    }
+
+    @Test
+    fun `a codec that has had its keyframe and still produces nothing is stalled`() {
+        assertEquals(Cause.STALLED, classify(keyframeFedSinceStart = true))
+    }
+
+    @Test
+    fun `a cold start stays on the rebuild path`() {
+        // Deliberate. Before anything has rendered the codec type is still a guess, and the rebuild
+        // is what reaches the one-time fallback to the other codec. Calling that starvation would
+        // leave a device with a broken HEVC component waiting fifteen seconds for a keyframe it
+        // could not decode anyway.
+        assertEquals(Cause.STALLED, classify(sessionHasRendered = false))
+    }
+
+    @Test
+    fun `patience runs out and the ordinary path resumes`() {
+        val patience = DecoderStallCausePolicy.KEYFRAME_STARVATION_PATIENCE_MS
+        assertEquals(Cause.STARVED_OF_KEYFRAME, classify(stallGapMs = patience - 1))
+        assertEquals(Cause.STALLED, classify(stallGapMs = patience))
+    }
+
+    @Test
+    fun `patience clears every mechanism meant to resolve the starvation`() {
+        // If it did not, the rebuild would pre-empt the repair it is waiting for. The focus cycle
+        // produces a keyframe 0.52-0.78s after the release and the warm-relaunch path escalates at
+        // 850ms; both have room to spare inside this.
+        assertTrue(DecoderStallCausePolicy.KEYFRAME_STARVATION_PATIENCE_MS >= 10_000L)
+        // And well short of the phone's own ~69s cadence, so this is a wait for a keyframe we asked
+        // for, never a wait for the scheduled one.
+        assertTrue(DecoderStallCausePolicy.KEYFRAME_STARVATION_PATIENCE_MS < 60_000L)
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/DeviceMemoryProfileTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/DeviceMemoryProfileTest.kt
@@ -1,0 +1,131 @@
+package com.andrerinas.openheadunit.decoder
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The classification that decides how much memory the video pipeline is allowed to hold.
+ *
+ * The two anchors worth naming: the 1 GB MediaTek unit from #839 has to come out CONSTRAINED, and
+ * the tablets this app is tested on must not - shrinking the pipeline on a device that was fine is
+ * how a fix for one report becomes a regression for everyone else.
+ */
+class DeviceMemoryProfileTest {
+
+    @Test
+    fun `the 1GB head unit this exists for is constrained`() {
+        assertEquals(
+            DeviceMemoryProfile.CONSTRAINED,
+            DeviceMemoryProfile.classify(totalRamMb = 1024, heapLimitMb = 96, systemLowRamFlag = false)
+        )
+    }
+
+    @Test
+    fun `a modern tablet is ample and its buffers are left alone`() {
+        assertEquals(
+            DeviceMemoryProfile.AMPLE,
+            DeviceMemoryProfile.classify(totalRamMb = 8192, heapLimitMb = 512, systemLowRamFlag = false)
+        )
+    }
+
+    @Test
+    fun `a mid-range unit is normal, which is today's behaviour`() {
+        assertEquals(
+            DeviceMemoryProfile.NORMAL,
+            DeviceMemoryProfile.classify(totalRamMb = 2048, heapLimitMb = 192, systemLowRamFlag = false)
+        )
+    }
+
+    @Test
+    fun `the low-RAM flag is believed when it is set`() {
+        assertEquals(
+            DeviceMemoryProfile.CONSTRAINED,
+            DeviceMemoryProfile.classify(totalRamMb = 8192, heapLimitMb = 512, systemLowRamFlag = true)
+        )
+    }
+
+    @Test
+    fun `a small heap ceiling is constraining whatever the total RAM says`() {
+        // Units that report a lot of RAM and then hand the app a 64MB heap exist; the heap is what
+        // the reassembly and pool buffers come out of.
+        assertEquals(
+            DeviceMemoryProfile.CONSTRAINED,
+            DeviceMemoryProfile.classify(totalRamMb = 4096, heapLimitMb = 64, systemLowRamFlag = false)
+        )
+    }
+
+    @Test
+    fun `ample needs both numbers, not one`() {
+        assertEquals(
+            "plenty of RAM but a modest heap is not ample",
+            DeviceMemoryProfile.NORMAL,
+            DeviceMemoryProfile.classify(totalRamMb = 8192, heapLimitMb = 128, systemLowRamFlag = false)
+        )
+        assertEquals(
+            "a large heap on a small device is not ample",
+            DeviceMemoryProfile.NORMAL,
+            DeviceMemoryProfile.classify(totalRamMb = 2048, heapLimitMb = 512, systemLowRamFlag = false)
+        )
+    }
+
+    @Test
+    fun `an unreadable number is unknown rather than constraining`() {
+        // A platform that fails to report totalMem must not silently shrink the pipeline; zero means
+        // "we do not know", and the decision falls to whatever else was readable.
+        assertEquals(
+            DeviceMemoryProfile.NORMAL,
+            DeviceMemoryProfile.classify(totalRamMb = 0, heapLimitMb = 256, systemLowRamFlag = false)
+        )
+        assertEquals(
+            DeviceMemoryProfile.NORMAL,
+            DeviceMemoryProfile.classify(totalRamMb = 0, heapLimitMb = 0, systemLowRamFlag = false)
+        )
+        assertEquals(
+            "a readable small heap still counts",
+            DeviceMemoryProfile.CONSTRAINED,
+            DeviceMemoryProfile.classify(totalRamMb = 0, heapLimitMb = 64, systemLowRamFlag = false)
+        )
+    }
+
+    @Test
+    fun `the boundaries fall on the documented side`() {
+        assertEquals(
+            DeviceMemoryProfile.CONSTRAINED,
+            DeviceMemoryProfile.classify(DeviceMemoryProfile.CONSTRAINED_TOTAL_RAM_MB, 256, false)
+        )
+        assertEquals(
+            DeviceMemoryProfile.NORMAL,
+            DeviceMemoryProfile.classify(DeviceMemoryProfile.CONSTRAINED_TOTAL_RAM_MB + 1, 256, false)
+        )
+        assertEquals(
+            DeviceMemoryProfile.AMPLE,
+            DeviceMemoryProfile.classify(
+                DeviceMemoryProfile.AMPLE_TOTAL_RAM_MB,
+                DeviceMemoryProfile.AMPLE_HEAP_LIMIT_MB,
+                false
+            )
+        )
+        assertEquals(
+            DeviceMemoryProfile.NORMAL,
+            DeviceMemoryProfile.classify(
+                DeviceMemoryProfile.AMPLE_TOTAL_RAM_MB,
+                DeviceMemoryProfile.AMPLE_HEAP_LIMIT_MB - 1,
+                false
+            )
+        )
+    }
+
+    @Test
+    fun `the reading carries every input it decided from`() {
+        val text = DeviceMemoryReading(
+            profile = DeviceMemoryProfile.CONSTRAINED,
+            totalRamMb = 1024,
+            heapLimitMb = 96,
+            memoryClassMb = 96,
+            systemLowRamFlag = false,
+        ).toString()
+        for (field in listOf("CONSTRAINED", "totalRam=1024MB", "heapLimit=96MB", "memoryClass=96MB", "lowRamFlag=false")) {
+            org.junit.Assert.assertTrue("reading is missing $field: $text", text.contains(field))
+        }
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/KeyframeRepairTrackerTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/KeyframeRepairTrackerTest.kt
@@ -1,0 +1,111 @@
+package com.andrerinas.openheadunit.decoder
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The one distinction this class exists for: a keyframe that was fed against one that decoded.
+ *
+ * The timestamps below are microseconds, the units the decoder's synthetic monotonic PTS is in.
+ */
+class KeyframeRepairTrackerTest {
+
+    private val tracker = KeyframeRepairTracker()
+
+    @Test
+    fun `feeding a keyframe is not a repair`() {
+        tracker.onKeyframeFed(1_000)
+        assertTrue(tracker.awaitingOutput)
+        assertFalse(tracker.keyframeDecoded)
+    }
+
+    @Test
+    fun `a frame at or past the keyframe confirms it, once`() {
+        tracker.onKeyframeFed(1_000)
+        assertTrue(tracker.onFrameRendered(1_000))
+        assertTrue(tracker.keyframeDecoded)
+        assertFalse(tracker.awaitingOutput)
+        // Every later frame is ordinary output, not another repair - the escalation clock is
+        // already stopped and re-firing would only cost log lines.
+        assertFalse(tracker.onFrameRendered(1_016))
+    }
+
+    @Test
+    fun `output the codec already had queued does not confirm anything`() {
+        // The reason this is a timestamp comparison and not "the next frame rendered". MediaCodec
+        // holds frames ahead of the feed, so the renders right after a keyframe is queued are
+        // usually frames from before it.
+        tracker.onKeyframeFed(5_000)
+        assertFalse(tracker.onFrameRendered(4_800))
+        assertFalse(tracker.onFrameRendered(4_950))
+        assertFalse(tracker.keyframeDecoded)
+        assertTrue(tracker.onFrameRendered(5_000))
+    }
+
+    @Test
+    fun `renders with nothing pending are not repairs`() {
+        // After a shed reference frame the decoder renders continuously and the picture is wrong
+        // the whole time, which is why a rendered frame on its own can never be the signal.
+        assertFalse(tracker.onFrameRendered(2_000))
+        assertFalse(tracker.keyframeDecoded)
+    }
+
+    @Test
+    fun `a newer keyframe replaces an older pending one`() {
+        // A holed keyframe stays pending because nothing decodes from it. Holding the older stamp
+        // would let the next good keyframe's picture confirm the broken one - and confirming the
+        // newest confirms everything before it anyway, output being monotonic.
+        tracker.onKeyframeFed(1_000)
+        tracker.onKeyframeFed(70_000)
+        assertFalse(tracker.onFrameRendered(1_500))
+        assertTrue(tracker.onFrameRendered(70_000))
+    }
+
+    @Test
+    fun `a decoder whose output timestamps say nothing still reports a repair`() {
+        // Some components hand every buffer back with the same stamp, or zero. Waiting for a stamp
+        // that never comes would have such a decoder called starved every fifteen seconds and spend
+        // focus cycles on a picture that is running perfectly - worse than the wedge this replaces.
+        val bound = KeyframeRepairTracker.RENDERS_BEFORE_TIMESTAMPS_DISBELIEVED
+        tracker.onKeyframeFed(500_000)
+        repeat(bound - 1) { assertFalse(tracker.onFrameRendered(0)) }
+        assertFalse(tracker.timestampsUnusable)
+        assertTrue(tracker.onFrameRendered(0))
+        assertTrue(tracker.timestampsUnusable)
+        assertTrue(tracker.keyframeDecoded)
+    }
+
+    @Test
+    fun `the bound is far past any real reorder depth and far short of the starvation patience`() {
+        // Half a second at 60fps. Below this it would fire on an ordinary pipeline; above it, the
+        // rebuild path would pre-empt it and the guard would never be reached.
+        val bound = KeyframeRepairTracker.RENDERS_BEFORE_TIMESTAMPS_DISBELIEVED
+        assertTrue(bound >= 10)
+        assertTrue(bound / 60.0 * 1000 < DecoderStallCausePolicy.KEYFRAME_STARVATION_PATIENCE_MS)
+    }
+
+    @Test
+    fun `a run of stale frames does not carry over to the next keyframe`() {
+        val bound = KeyframeRepairTracker.RENDERS_BEFORE_TIMESTAMPS_DISBELIEVED
+        tracker.onKeyframeFed(1_000)
+        repeat(bound - 1) { tracker.onFrameRendered(0) }
+        // A new keyframe is a new question; the frames that missed the old one say nothing about it.
+        tracker.onKeyframeFed(2_000)
+        assertFalse(tracker.onFrameRendered(0))
+        assertTrue(tracker.onFrameRendered(2_000))
+        assertFalse(tracker.timestampsUnusable)
+    }
+
+    @Test
+    fun `reset drops a pending keyframe and the decoded flag`() {
+        // Presentation stamps restart near zero when the codec is reconfigured, so a stamp carried
+        // across a rebuild would be confirmed by the new codec's very first frame.
+        tracker.onKeyframeFed(90_000)
+        tracker.onFrameRendered(90_000)
+        tracker.reset()
+        assertFalse(tracker.keyframeDecoded)
+        assertFalse(tracker.awaitingOutput)
+        assertFalse(tracker.onFrameRendered(0))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/ParameterSetInspectorTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/ParameterSetInspectorTest.kt
@@ -1,0 +1,221 @@
+package com.andrerinas.openheadunit.decoder
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Vectors for the parameter-set reader.
+ *
+ * Each was assembled field by field from the syntax in H.264 7.3.2.1.1 / Annex E.1.1 and
+ * H.265 7.3.2.2.1, with the field values chosen first and the bits emitted from them, so the
+ * expectations below are the inputs rather than a recording of what the parser happens to do.
+ * Emulation-prevention bytes were then inserted the way an encoder inserts them, which is why the
+ * two HEVC vectors carry `00 00 03` runs - they are the reason this class does its own RBSP
+ * unescaping, which the dimension-only parser it replaced did not.
+ */
+class ParameterSetInspectorTest {
+
+    private fun bytes(hex: String): ByteArray =
+        hex.trim().split(" ").map { it.toInt(16).toByte() }.toByteArray()
+
+    /** H.264 SPS, baseline profile, level 3.1, 1280x720, one reference frame, no VUI. */
+    private val h264Baseline720p = bytes("67 42 80 1F F4 02 80 2D C8")
+
+    /**
+     * H.264 SPS, high profile, level 4.0, 1920x1080 via a bottom crop of 4 on a 1088 frame,
+     * four reference frames, VUI carrying bitstream_restriction with reorder 0 / max_dec 4.
+     */
+    private val h264High1080pRestricted =
+        bytes("67 64 00 28 AC E5 01 E0 08 9F 96 01 B4 11 08 CB")
+
+    /**
+     * H.264 SPS with pic_order_cnt_type 1, 1280x720.
+     *
+     * The dimension parser this class replaced walked type 1 as though it were type 0 - it read the
+     * POC LSB field that only type 0 has, and then everything after it came out of the wrong bits.
+     * On this exact vector it reported **176x48** for a 1280x720 stream, which is the size the codec
+     * would then have been configured at.
+     */
+    private val h264PocType1 = bytes("67 42 00 1F D7 44 40 28 02 DC 80")
+
+    /**
+     * H.264 SPS with timing info and nal_hrd_parameters before the bitstream restriction, so the
+     * hrd_parameters skip has to be exactly right or reorder/max_dec come out wrong.
+     * Two reference frames, reorder 1, max_dec 3.
+     */
+    private val h264WithHrd = bytes(
+        "67 42 00 1F F6 02 80 2D D0 80 00 01 F4 00 00 75 30 74 30 07 D2 00 7D " +
+            "15 EF 7C 0D A0 80 41 12"
+    )
+
+    /** HEVC SPS, Main profile, level 3.1, 1280x720, max_dec 4, reorder 0. Contains 00 00 03 runs. */
+    private val hevcMain720p =
+        bytes("42 01 01 01 00 00 03 00 00 80 00 00 03 00 00 03 00 5D A0 02 80 80 2D 16 59 38")
+
+    /**
+     * HEVC SPS with two sub-layers and a conformance window: 1920x1080 from a 1088 frame, and the
+     * sub-layer ordering info absent so only the top layer's values are read.
+     */
+    private val hevc1080pTwoSubLayers = bytes(
+        "42 01 03 01 00 00 03 00 00 80 00 00 03 00 00 03 00 78 C0 00 00 03 00 00 03 00 " +
+            "00 03 00 00 03 00 00 03 00 00 78 A0 03 C0 80 11 07 CB 94 67 80"
+    )
+
+    // ---- H.264 ----
+
+    @Test
+    fun `reads a baseline SPS with no VUI`() {
+        val sps = ParameterSetInspector.parseH264Sps(h264Baseline720p, 0, h264Baseline720p.size)
+        assertNotNull(sps)
+        sps!!
+        assertEquals(66, sps.profileIdc)
+        assertEquals(31, sps.levelIdc)
+        assertEquals(0, sps.picOrderCntType)
+        assertEquals(1, sps.maxNumRefFrames)
+        assertEquals(1280, sps.width)
+        assertEquals(720, sps.height)
+        assertFalse(sps.vuiPresent)
+        assertFalse(sps.bitstreamRestrictionPresent)
+        assertNull("absent must read as absent, not as zero", sps.maxNumReorderFrames)
+        assertNull(sps.maxDecFrameBuffering)
+    }
+
+    @Test
+    fun `reads a high profile SPS through the VUI to the bitstream restriction`() {
+        val sps = ParameterSetInspector.parseH264Sps(h264High1080pRestricted, 0, h264High1080pRestricted.size)
+        assertNotNull(sps)
+        sps!!
+        assertEquals(100, sps.profileIdc)
+        assertEquals(40, sps.levelIdc)
+        assertEquals(4, sps.maxNumRefFrames)
+        assertEquals(1920, sps.width)
+        assertEquals("the bottom crop of 4 must take 1088 down to 1080", 1080, sps.height)
+        assertTrue(sps.vuiPresent)
+        assertTrue(sps.bitstreamRestrictionPresent)
+        assertEquals(0, sps.maxNumReorderFrames)
+        assertEquals(4, sps.maxDecFrameBuffering)
+    }
+
+    @Test
+    fun `pic_order_cnt_type 1 does not desync the fields behind it`() {
+        val sps = ParameterSetInspector.parseH264Sps(h264PocType1, 0, h264PocType1.size)
+        assertNotNull(sps)
+        sps!!
+        assertEquals(1, sps.picOrderCntType)
+        assertEquals("the old parser read 176 here", 1280, sps.width)
+        assertEquals("the old parser read 48 here", 720, sps.height)
+        assertEquals(1, sps.maxNumRefFrames)
+        assertFalse(sps.vuiPresent)
+    }
+
+    @Test
+    fun `walks hrd_parameters without losing its place`() {
+        // The one field group long enough that getting its length wrong still yields plausible
+        // numbers further on. If the skip is off, reorder and max_dec come out as something else.
+        val sps = ParameterSetInspector.parseH264Sps(h264WithHrd, 0, h264WithHrd.size)
+        assertNotNull(sps)
+        sps!!
+        assertEquals(2, sps.maxNumRefFrames)
+        assertEquals(1280, sps.width)
+        assertEquals(720, sps.height)
+        assertTrue(sps.bitstreamRestrictionPresent)
+        assertEquals(1, sps.maxNumReorderFrames)
+        assertEquals(3, sps.maxDecFrameBuffering)
+    }
+
+    @Test
+    fun `every truncation of an SPS reads as no answer rather than a wrong one`() {
+        // The reader latches an overrun rather than throwing, so the whole result is discarded when
+        // any field ran past the end. A half-read SPS reported as fact would put a plausible wrong
+        // number in a log we intend to make a decision from, which is worse than no number.
+        for (cut in 1 until h264High1080pRestricted.size) {
+            val short = h264High1080pRestricted.copyOfRange(0, cut)
+            assertNull(
+                "a $cut-byte prefix produced an answer",
+                ParameterSetInspector.parseH264Sps(short, 0, short.size)
+            )
+        }
+    }
+
+    @Test
+    fun `empty input is rejected`() {
+        assertNull(ParameterSetInspector.parseH264Sps(ByteArray(0), 0, 0))
+        assertNull(ParameterSetInspector.parseHevcSps(ByteArray(0), 0, 0))
+    }
+
+    // ---- H.265 ----
+
+    @Test
+    fun `reads an HEVC SPS past its emulation-prevention bytes`() {
+        // This vector contains three inserted 0x03 bytes. A reader that does not remove them shifts
+        // every field after the first one, so the exact values here are the proof the unescaping
+        // works, not just that the walk is the right length.
+        val sps = ParameterSetInspector.parseHevcSps(hevcMain720p, 0, hevcMain720p.size)
+        assertNotNull(sps)
+        sps!!
+        assertEquals("Main profile", 1, sps.generalProfileIdc)
+        assertEquals("level 3.1", 93, sps.generalLevelIdc)
+        assertEquals("4:2:0", 1, sps.chromaFormatIdc)
+        assertEquals(8, sps.bitDepthLuma)
+        assertEquals(1280, sps.width)
+        assertEquals(720, sps.height)
+        assertEquals(4, sps.maxDecPicBuffering)
+        assertEquals(0, sps.maxNumReorderPics)
+    }
+
+    @Test
+    fun `reads an HEVC SPS with sub-layers and a conformance window`() {
+        val sps = ParameterSetInspector.parseHevcSps(hevc1080pTwoSubLayers, 0, hevc1080pTwoSubLayers.size)
+        assertNotNull(sps)
+        sps!!
+        assertEquals(1, sps.generalProfileIdc)
+        assertEquals(120, sps.generalLevelIdc)
+        assertEquals(1920, sps.width)
+        assertEquals("the conformance window must take 1088 down to 1080", 1080, sps.height)
+        assertEquals(6, sps.maxDecPicBuffering)
+        assertEquals(2, sps.maxNumReorderPics)
+    }
+
+    @Test
+    fun `a truncated HEVC SPS reads as no answer`() {
+        val short = hevcMain720p.copyOfRange(0, 8)
+        assertNull(ParameterSetInspector.parseHevcSps(short, 0, short.size))
+    }
+
+    // ---- the shape of the log line ----
+
+    @Test
+    fun `the H264 summary names every field a decision would rest on`() {
+        val text = ParameterSetInspector.parseH264Sps(h264High1080pRestricted, 0, h264High1080pRestricted.size)!!.toString()
+        for (field in listOf(
+            "profile=", "level=", "poc_type=", "num_ref_frames=", "size=", "vui=",
+            "bitstream_restriction=", "num_reorder_frames=", "max_dec_frame_buffering="
+        )) {
+            assertTrue("summary is missing $field: $text", text.contains(field))
+        }
+    }
+
+    @Test
+    fun `an absent restriction says absent rather than zero`() {
+        // The distinction the whole diagnostic turns on: Moonlight patches the SPS precisely when
+        // bitstream_restriction is missing, and "0" would read as already-optimal.
+        val text = ParameterSetInspector.parseH264Sps(h264Baseline720p, 0, h264Baseline720p.size)!!.toString()
+        assertTrue(text, text.contains("num_reorder_frames=absent"))
+        assertTrue(text, text.contains("max_dec_frame_buffering=absent"))
+    }
+
+    @Test
+    fun `the HEVC summary names every field a decision would rest on`() {
+        val text = ParameterSetInspector.parseHevcSps(hevcMain720p, 0, hevcMain720p.size)!!.toString()
+        for (field in listOf(
+            "profile=", "level=", "chroma_format=", "bit_depth=", "size=",
+            "max_dec_pic_buffering=", "max_num_reorder_pics="
+        )) {
+            assertTrue("summary is missing $field: $text", text.contains(field))
+        }
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/ParameterSetTrackerTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/ParameterSetTrackerTest.kt
@@ -1,0 +1,116 @@
+package com.andrerinas.openheadunit.decoder
+
+import com.andrerinas.openheadunit.decoder.ParameterSetTracker.Kind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ParameterSetTrackerTest {
+
+    private fun bytes(vararg v: Int) = ByteArray(v.size) { v[it].toByte() }
+
+    private fun ParameterSetTracker.offer(kind: Kind, data: ByteArray) =
+        offer(kind, data, 0, data.size)
+
+    @Test
+    fun `the first of a kind is not a change`() {
+        val t = ParameterSetTracker()
+        assertFalse(t.offer(Kind.SPS, bytes(1, 2, 3)))
+        assertNull(t.takeChange())
+        // Stored all the same, which only a differing set can prove: had the first offer been
+        // dropped, this one would be a first of a kind too and would report no change.
+        assertTrue(t.offer(Kind.SPS, bytes(1, 2, 4)))
+    }
+
+    @Test
+    fun `the same bytes again are not a change`() {
+        // The ordinary case: parameter sets ride along with every keyframe, so this is what the
+        // tracker sees a few hundred times a session and it must stay silent for all of them.
+        val t = ParameterSetTracker()
+        t.offer(Kind.SPS, bytes(1, 2, 3))
+        repeat(5) { assertFalse(t.offer(Kind.SPS, bytes(1, 2, 3))) }
+        assertNull(t.takeChange())
+    }
+
+    @Test
+    fun `different bytes are a change, reported once`() {
+        val t = ParameterSetTracker()
+        t.offer(Kind.SPS, bytes(1, 2, 3))
+        assertTrue(t.offer(Kind.SPS, bytes(1, 2, 4)))
+
+        val change = t.takeChange()!!
+        assertEquals(1, change.ordinal)
+        assertEquals(listOf(Kind.SPS), change.kinds)
+
+        // Latched: the same set arriving again on the next keyframe is not a second change.
+        assertFalse(t.offer(Kind.SPS, bytes(1, 2, 4)))
+        assertNull(t.takeChange())
+    }
+
+    @Test
+    fun `a length change is a change`() {
+        val t = ParameterSetTracker()
+        t.offer(Kind.PPS, bytes(9, 9))
+        assertTrue(t.offer(Kind.PPS, bytes(9, 9, 9)))
+        assertEquals(listOf(Kind.PPS), t.takeChange()!!.kinds)
+    }
+
+    @Test
+    fun `several kinds changing in one access unit are one report`() {
+        val t = ParameterSetTracker()
+        listOf(Kind.VPS, Kind.SPS, Kind.PPS).forEach { t.offer(it, bytes(it.ordinal)) }
+        t.offer(Kind.PPS, bytes(7))
+        t.offer(Kind.VPS, bytes(8))
+
+        val change = t.takeChange()!!
+        assertEquals(1, change.ordinal)
+        // Reported in VPS/SPS/PPS order whatever order they arrived in.
+        assertEquals(listOf(Kind.VPS, Kind.PPS), change.kinds)
+        assertNull(t.takeChange())
+    }
+
+    @Test
+    fun `changes are counted across the session`() {
+        val t = ParameterSetTracker()
+        t.offer(Kind.SPS, bytes(1))
+        t.offer(Kind.SPS, bytes(2))
+        assertEquals(1, t.takeChange()!!.ordinal)
+        t.offer(Kind.SPS, bytes(3))
+        assertEquals(2, t.takeChange()!!.ordinal)
+    }
+
+    @Test
+    fun `it reads only the slice it was given`() {
+        // The caller hands it a NAL inside a frame buffer that is reused, so a tracker that kept the
+        // array instead of a copy would compare the next frame against itself.
+        val t = ParameterSetTracker()
+        val frame = bytes(0, 0, 1, 0x67, 0x42, 0x00)
+        assertFalse(t.offer(Kind.SPS, frame, 3, 3))
+        frame[3] = 0x68
+        frame[4] = 0x43
+        assertTrue(t.offer(Kind.SPS, frame, 3, 3))
+    }
+
+    @Test
+    fun `a nonsense slice is ignored rather than stored`() {
+        val t = ParameterSetTracker()
+        assertFalse(t.offer(Kind.SPS, bytes(1, 2), 0, 0))
+        assertFalse(t.offer(Kind.SPS, bytes(1, 2), 1, 5))
+        assertFalse(t.offer(Kind.SPS, bytes(1, 2), -1, 2))
+        // Nothing was stored, so a real set is still the first of its kind. Had any of the three
+        // been kept, these bytes would differ from it and this would report a change.
+        assertFalse(t.offer(Kind.SPS, bytes(1, 2)))
+    }
+
+    @Test
+    fun `reset forgets everything`() {
+        val t = ParameterSetTracker()
+        t.offer(Kind.SPS, bytes(1))
+        t.offer(Kind.SPS, bytes(2))
+        t.reset()
+        assertNull(t.takeChange())
+        assertFalse(t.offer(Kind.SPS, bytes(3)))
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/VideoBackpressurePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/VideoBackpressurePolicyTest.kt
@@ -1,0 +1,78 @@
+package com.andrerinas.openheadunit.decoder
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The numbers in the "measured" cases come from a #219 reporter's Galaxy Tab S7 FE running
+ * 2560x1440 HEVC on `c2.qti.hevc.decoder`. They are the reason the threshold is where it is, so
+ * they are pinned here rather than described in a comment somewhere.
+ */
+class VideoBackpressurePolicyTest {
+
+    private val window = 5000L
+
+    @Test
+    fun `shedding while waiting a large share of the window is backpressure`() {
+        // The four measured drop bursts: 40%, 27%, 16% and 14% of a 5s window.
+        listOf(2019L to 29L, 1333L to 18L, 804L to 11L, 705L to 2L).forEach { (wait, dropped) ->
+            assertTrue(
+                "wait=${wait}ms dropped=$dropped should be attributed to the codec",
+                VideoBackpressurePolicy.isBackpressureWindow(window, wait, dropped)
+            )
+        }
+    }
+
+    @Test
+    fun `shedding with a small wait is not the codec`() {
+        // The fifth measured burst: 9 frames shed after only 180ms of waiting - 3.6% of the window.
+        // Something else lost those, and calling it a slow decoder would send the next reader to
+        // the wrong file.
+        assertFalse(VideoBackpressurePolicy.isBackpressureWindow(window, 180, 9))
+    }
+
+    @Test
+    fun `waiting without shedding is a decoder under load that is still keeping up`() {
+        // The median healthy window in that capture waited 188ms; the 90th percentile waited 587ms.
+        // Neither shed anything, and neither is a fault.
+        assertFalse(VideoBackpressurePolicy.isBackpressureWindow(window, 188, 0))
+        assertFalse(VideoBackpressurePolicy.isBackpressureWindow(window, 587, 0))
+        assertFalse(VideoBackpressurePolicy.isBackpressureWindow(window, 4000, 0))
+    }
+
+    @Test
+    fun `the threshold is inclusive at exactly the share`() {
+        val exact = window * VideoBackpressurePolicy.WAIT_PERCENT / 100
+        assertTrue(VideoBackpressurePolicy.isBackpressureWindow(window, exact, 1))
+        assertFalse(VideoBackpressurePolicy.isBackpressureWindow(window, exact - 1, 1))
+    }
+
+    @Test
+    fun `degenerate windows are never backpressure`() {
+        assertFalse(VideoBackpressurePolicy.isBackpressureWindow(0, 4000, 10))
+        assertFalse(VideoBackpressurePolicy.isBackpressureWindow(window, 0, 10))
+        assertFalse(VideoBackpressurePolicy.isBackpressureWindow(window, 4000, 0))
+        assertFalse(VideoBackpressurePolicy.isBackpressureWindow(window, -1, 10))
+    }
+
+    @Test
+    fun `one window is not a verdict`() {
+        assertFalse(VideoBackpressurePolicy.shouldReport(1, alreadyReported = false))
+        assertTrue(VideoBackpressurePolicy.shouldReport(2, alreadyReported = false))
+    }
+
+    @Test
+    fun `the report is once per decoder session`() {
+        assertFalse(VideoBackpressurePolicy.shouldReport(2, alreadyReported = true))
+        assertFalse(VideoBackpressurePolicy.shouldReport(50, alreadyReported = true))
+    }
+
+    @Test
+    fun `the required windows do not have to be consecutive`() {
+        // Deliberate: in the capture this was built from the bursts were isolated windows, so a rule
+        // demanding a run of them would never have fired on the device that motivated it.
+        assertEquals(2, VideoBackpressurePolicy.WINDOWS_BEFORE_REPORT)
+    }
+}


### PR DESCRIPTION
# Video pipeline, WiFi Direct and Native AA wireless: rebuild from the stream, and stop latching on failure

**This is a large PR: 74 files, +9224/-535, five commits.** It is big because the video path, the P2P group's lifecycle and the Native AA handshake turned out to be one investigation, and splitting them would have left each half untestable against the reporter logs that drove it. Commits are grouped by component and each stands alone, so reviewing commit by commit is the intended route. Coverage goes from 312 to 565 JVM tests across 22 new test files, and every decision that can be made without Android is extracted into a pure policy object with a transition table in its tests.

**Fixes:** #219 (fragment reassembly), #830 (dropped reference frames), #839 (the announced codec treated as a decoder command), #852 (an idle screen read as a lost connection), #854 (the 5288 server latching dead), plus the decoder wedge on a corrupt access unit, low-RAM pipeline sizing, four WiFi Direct lifecycle latches, the `SO_REUSEADDR` no-op, the credential torn read, and the manual poke button that woke the phone with nothing listening.

The video half stops guessing. `AapVideo` reassembles fragments against the total the protocol carries on flag 9, which the old code discarded, so a lost middle fragment is now visible instead of being decoded as a holed access unit. Buffers are sized from the device rather than from a constant the 1 GB units in the reports could not hold, and the decoder is configured from the stream's own parameter sets and chosen by capability rather than by a name match. A codec rebuilt mid-session no longer rebuilds again while waiting for an IDR: `DecoderStallCausePolicy` names the starved case and asks through a video focus cycle, since AAP has no keyframe request and the phone's GOP is around 69 s. Alongside that: an idle screen is no longer a fault or a lost connection, a keyframe counts as a repair only once a frame decodes, a read that loses bytes ends the session instead of desynchronising the socket, and `videoCodec` is a preference announced to the phone, not a command to the decoder.

The wireless half removes six ways the app stayed broken after one failure. `WifiDirectManager.stop()` left `isReceiverRegistered` and `checkGroupAndCreateInFlight` set, so the P2P receiver never re-registered and no group was ever created again; in-flight `ActionListener` continuations could create a group after `stop()`; and the credential-delivery thread could overwrite live credentials with a dead group's. On the handshake path, `SO_REUSEADDR` was set after the constructor had already bound, where it does nothing; the four credential fields were unsynchronised `var`s whose torn read hands the phone a mismatched SSID and BSSID; and `startWirelessServer()` read "assigned" as "running", so a server that failed to bind once stayed dead for the life of the mode while the phone was woken every few seconds and handed nothing. `WirelessServerRestartPolicy` repairs that, bounded at three rebuilds per 60 s, and every outcome of a server start now logs.

**Verification and review focus.** 
The video half is hardware-validated on a UNISOC MT50: the previously wedging case ran 2 faults, 2 rebuilds, 2 focus cycles with keyframes 0.544 s and 0.557 s later and `rendered` never zero, against 90+ s of `rendered=0` before, and a control with the focus cycle swapped for the inert focus mode 4 reproduced the wedge at full severity. 

APK for testing
https://github.com/o-jcardenass/open-headunit/releases/download/v.3.2.0-fixes/OHU3.2.5_Experimental.apk