### PR TITLE
Fix/settings UI crash and dpi input

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -105,3 +105,60 @@ jobs:
             app/build/reports/tests/testGithubDebugUnitTest
             app/build/test-results/testGithubDebugUnitTest
           if-no-files-found: warn
+
+  lint:
+    name: Lint (NewApi)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      # See the build job for why NDK/CMake are pinned and the install is retried.
+      - name: Install pinned NDK and CMake
+        run: |
+          for attempt in 1 2 3; do
+            sdkmanager "ndk;27.0.12077973" "cmake;3.22.1" && exit 0
+            echo "sdkmanager attempt $attempt failed; retrying in 15s..." >&2
+            sleep 15
+          done
+          echo "sdkmanager failed after 3 attempts" >&2
+          exit 1
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run Android lint
+        run: ./gradlew :app:lintGithubDebug --stacktrace
+
+      # abortOnError is false in app/build.gradle.kts so ordinary lint findings do not
+      # block CI. NewApi is different: on a minSdk 16 app it is not a warning, it is a
+      # NoSuchMethodError on somebody's head unit the moment that code path is reached.
+      - name: Fail on NewApi findings
+        run: |
+          report=app/build/reports/lint-results-githubDebug.xml
+          if [ ! -f "$report" ]; then
+            echo "::error::lint report not found at $report"
+            exit 1
+          fi
+          if grep -q 'id="NewApi"' "$report"; then
+            echo "::error::NewApi: an API above minSdk is called unguarded"
+            grep -B2 -A4 'id="NewApi"' "$report"
+            exit 1
+          fi
+
+      - name: Upload lint report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-report
+          path: app/build/reports/lint-results-githubDebug.*
+          if-no-files-found: warn

--- a/app/src/main/java/com/andrerinas/openheadunit/main/DpiSettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/DpiSettingsFragment.kt
@@ -118,6 +118,9 @@ class DpiSettingsFragment : Fragment() {
     }
 
     private fun saveSettings() {
+        // Save lives in the toolbar and takes no focus, so a value typed into the picker is still
+        // sitting in the text field at this point.
+        picker.commitPendingInput()
         val value = currentValue()
         settings.dpiPixelDensity = value
         settings.commit()
@@ -129,6 +132,8 @@ class DpiSettingsFragment : Fragment() {
     }
 
     private fun handleBackPress() {
+        // So the unsaved-changes prompt weighs the value the user typed, not the one it replaced.
+        picker.commitPendingInput()
         if (currentValue() != initialValue) {
             MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
                 .setTitle(R.string.unsaved_changes)

--- a/app/src/main/java/com/andrerinas/openheadunit/main/OnboardingActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/OnboardingActivity.kt
@@ -654,6 +654,9 @@ class OnboardingActivity : BaseActivity() {
             // If we changed the renderer, confirm the picture on the first projection.
             if (settings.viewMode != previousViewMode) settings.pendingRendererConfirm = true
         }
+        // Next is a button, so it never takes focus off the DPI field; without this a value the
+        // user typed and did not confirm would be dropped in favour of the previous one.
+        dpiPicker?.commitPendingInput()
         settings.dpiPixelDensity = dpiPicker?.dpi ?: result.recommendedDpi
         settings.commit()
         updateDpiOverPanelWarning()

--- a/app/src/main/java/com/andrerinas/openheadunit/main/VehicleInfoFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/VehicleInfoFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -296,7 +297,9 @@ class VehicleInfoFragment : Fragment() {
                 setText(messageResId)
                 val textColorAttr = android.util.TypedValue()
                 context.theme.resolveAttribute(android.R.attr.textColorSecondary, textColorAttr, true)
-                setTextColor(context.resources.getColor(textColorAttr.resourceId, context.theme))
+                // Resources.getColor(int, Theme) is API 23; this app runs down to 16, where the
+                // two-argument overload does not exist and the call is a NoSuchMethodError.
+                setTextColor(ContextCompat.getColor(context, textColorAttr.resourceId))
                 textSize = 13f
                 setPadding(0, 0, 0, 24)
             }

--- a/app/src/main/java/com/andrerinas/openheadunit/view/DpiPickerView.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/view/DpiPickerView.kt
@@ -4,10 +4,13 @@ import android.animation.ValueAnimator
 import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.MotionEvent
+import android.view.View
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
 import android.widget.LinearLayout
 import com.andrerinas.openheadunit.R
 import com.google.android.material.button.MaterialButtonToggleGroup
@@ -38,6 +41,9 @@ class DpiPickerView @JvmOverloads constructor(
 
     private var isBinding = false
     private var onDpiChanged: ((Int) -> Unit)? = null
+    // onVisibilityChanged can be reached from View's own constructor, before the children below
+    // have been found; nothing here is usable until init has finished.
+    private var ready = false
 
     // Self-running demo that sweeps only the preview illustration (not the slider or the number), so
     // the user sees what DPI does before touching anything. It stops for good the moment the user
@@ -50,6 +56,10 @@ class DpiPickerView @JvmOverloads constructor(
 
     init {
         orientation = VERTICAL
+        // Somewhere for focus to land when the value field gives it up: clearFocus() on the only
+        // focusable view in a hierarchy hands focus straight back to it. This also keeps the field
+        // from taking focus — and opening the keyboard — the moment the picker is first shown.
+        isFocusableInTouchMode = true
         LayoutInflater.from(context).inflate(R.layout.view_dpi_picker, this, true)
         preview = findViewById(R.id.dpi_preview)
         slider = findViewById(R.id.dpi_slider)
@@ -77,8 +87,15 @@ class DpiPickerView @JvmOverloads constructor(
                 applyDpi(rep, fromSlider = false)
             }
         }
-        input.setOnEditorActionListener { _, actionId, _ ->
-            if (actionId == EditorInfo.IME_ACTION_DONE) { commitInput(); true } else false
+        // Consuming the action (returning true) skips TextView's own handling of DONE, which is
+        // what would otherwise lower the keyboard — so the dismissal has to be explicit, and the
+        // repo already prefers it that way (see hideKeyboard in SettingsFragment: some head units
+        // will not put the keyboard away on their own). IME_NULL is the hardware Enter key and the
+        // OEM keyboards that report no action id at all.
+        input.setOnEditorActionListener { _, actionId, event ->
+            val done = actionId == EditorInfo.IME_ACTION_DONE ||
+                (actionId == EditorInfo.IME_NULL && (event == null || event.action == KeyEvent.ACTION_DOWN))
+            if (done) { commitInput(); dismissKeyboard(); true } else false
         }
         input.setOnFocusChangeListener { _, hasFocus ->
             if (hasFocus) stopDemo(userDriven = true) else commitInput()
@@ -86,8 +103,17 @@ class DpiPickerView @JvmOverloads constructor(
 
         // Initialise the field/preview/tab from the slider's default value.
         applyDpi(slider.value.toInt(), fromSlider = true, silent = true)
+        ready = true
     }
 
+    /**
+     * The chosen DPI. A value typed into the field but not yet confirmed does not appear here —
+     * call [commitPendingInput] first.
+     *
+     * The commit deliberately does not live in this getter: it would run
+     * commitInput -> applyDpi -> onDpiChanged -> a listener that reads [dpi] -> commitInput, which
+     * does not terminate.
+     */
     var dpi: Int
         // While the demo sweeps, report the intended value, not the animated frame.
         get() = if (demoAnimator != null) committedDpi else slider.value.toInt()
@@ -97,6 +123,13 @@ class DpiPickerView @JvmOverloads constructor(
         get() = userInteracted
 
     fun setOnDpiChanged(cb: (Int) -> Unit) { onDpiChanged = cb }
+
+    /**
+     * Folds a value typed into the field into the picker. Call this before reading [dpi] from a
+     * button handler: buttons do not take focus in touch mode, so tapping Next or Save never moves
+     * focus off the field and the typed number would otherwise be dropped. Safe to call repeatedly.
+     */
+    fun commitPendingInput() = commitInput()
 
     fun setPanelResolution(widthPx: Int, heightPx: Int) = preview.setPanelResolution(widthPx, heightPx)
 
@@ -140,6 +173,28 @@ class DpiPickerView @JvmOverloads constructor(
         stopDemo(userDriven = false)
     }
 
+    /**
+     * The wizard swaps steps through a ViewFlipper and the DPI screen hides the picker when
+     * Automatic is switched on, so both leave through here: keep whatever was typed, and do not
+     * leave the keyboard covering the screen that comes next.
+     */
+    override fun onVisibilityChanged(changedView: View, visibility: Int) {
+        super.onVisibilityChanged(changedView, visibility)
+        if (ready && visibility != VISIBLE) {
+            commitPendingInput()
+            dismissKeyboard()
+        }
+    }
+
+    private fun dismissKeyboard() {
+        // No token once the view is off the window, and this is also reached from teardown.
+        windowToken?.let { token ->
+            val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+            imm?.hideSoftInputFromWindow(token, 0)
+        }
+        input.clearFocus()
+    }
+
     fun setPickerEnabled(enabled: Boolean) {
         slider.isEnabled = enabled
         input.isEnabled = enabled
@@ -173,6 +228,7 @@ class DpiPickerView @JvmOverloads constructor(
         if (!silent) onDpiChanged?.invoke(v)
     }
 
+    /** Rounds to a value the slider can actually hold, then clamps into range. */
     private fun snap(value: Int): Int {
         val stepped = ((value - MIN) / STEP.toFloat()).roundToInt() * STEP + MIN
         return stepped.coerceIn(MIN, MAX)
@@ -193,7 +249,10 @@ class DpiPickerView @JvmOverloads constructor(
     companion object {
         private const val MIN = 110
         private const val MAX = 640
-        private const val STEP = 2
+        // Must stay equal to android:stepSize on dpi_slider in view_dpi_picker.xml: applyDpi
+        // assigns slider.value, and a Slider throws IllegalStateException for a value that is not
+        // valueFrom plus a whole number of steps. 1 so a typed 175 stays 175 rather than snapping.
+        private const val STEP = 1
         private const val SMALL_REP = 132
         private const val MEDIUM_REP = 175
         private const val LARGE_REP = 218

--- a/app/src/main/res/layout/view_dpi_picker.xml
+++ b/app/src/main/res/layout/view_dpi_picker.xml
@@ -14,7 +14,7 @@
         android:layout_marginTop="10dp"
         android:valueFrom="110"
         android:valueTo="640"
-        android:stepSize="2"
+        android:stepSize="1"
         android:value="160" />
 
     <com.google.android.material.textfield.TextInputLayout


### PR DESCRIPTION
# Settings: fix a crash on Android 5.1, and make a typed DPI value survive

Two unrelated UI faults on the settings and onboarding screens, plus the CI job that would have caught the first one. Six files, +132/-5, no behaviour change outside these screens.

**The crash.** Tapping Vehicle ID or Head Unit Make killed the app on Android 5.1. The dialog those fields open colours an explanatory note with `Resources.getColor(int, Theme)`, an API 23 method on an app whose `minSdk` is 16, so below Android 6 it throws `NoSuchMethodError`. Fields with no note pass `messageResId = null` and skip the branch, which is why Display name, Model and Year were unaffected and the report reads as two specific fields rather than a broken page. Since Vehicle Make gained a note in `8dda5c19`, 3.2.4 onward has a third crash site on the same devices; one line covers all three, and `DialogUtils` already had the correct form of the same helper. Reported in #858 on an MT6735 unit.

**The DPI picker.** Tapping the DPI value in the setup wizard opened the keyboard with no way to put it away, and Back then left the previously saved DPI in place rather than the number just typed. Both faults are in the shared picker. The check key did nothing because the editor-action listener returned `true`, and consuming `IME_ACTION_DONE` skips the `TextView` handling that lowers the keyboard; it now dismisses explicitly and also accepts `IME_NULL`, for hardware Enter and the OEM keyboards that send no action id. The typed value was dropped because the only paths folding the field into the picker were that dead handler and a focus-loss listener, and buttons take no focus in touch mode, so neither Next nor Save ever moved focus off the field. Both call sites now commit first and the picker commits itself when it stops being visible. The commit stays a separate call rather than living in the `dpi` getter, which would recurse without bound. The slider's step also drops from 2 to 1 so a typed 175 stays 175, with the Kotlin constant and `android:stepSize` moved together because `Slider` throws for a value off the step grid.

**CI and verification.** Neither existing workflow ran lint and `abortOnError` is off, so `NewApi` had no way to fail anything: a third job now runs lint and fails on `NewApi` alone, with other findings left non-blocking. An API above `minSdk` is a crash on a user's head unit, not a warning.
