### PR TITLE
Video: stop dropping 1-byte tail fragments, and conceal corruption within what AAP allows

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapMessageFraming.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapMessageFraming.kt
@@ -1,0 +1,68 @@
+package com.andrerinas.openheadunit.aap
+
+/**
+ * What an AAP message's flag byte says about the bytes behind it.
+ *
+ * The flag byte is a bitfield, not an enum, and the four values the payload channels actually use
+ * are the two low bits plus the encryption bit that [AapMessageIncoming.decrypt] already tests:
+ *
+ * | flags | bit 0 | bit 1 | meaning | 2-byte message type at offset 0 |
+ * |---|---|---|---|---|
+ * | `0x0b` (11) | 1 | 1 | complete message | yes |
+ * | `0x09` (9) | 1 | 0 | first fragment | yes |
+ * | `0x08` (8) | 0 | 0 | middle fragment | **no** |
+ * | `0x0a` (10) | 0 | 1 | last fragment | **no** |
+ *
+ * Bit 0 means "this message begins an AAP message", so it is the bit that says whether there is a
+ * message type to read. A continuation fragment is raw payload from its first byte, and **any**
+ * length is legal there, including one byte and zero.
+ *
+ * ### Why this exists as its own object
+ *
+ * The rule was already implemented twice, from opposite ends of the app, and written down nowhere.
+ * [AapVideo.process] copies `Append` and `AppendAndDecode` fragments from offset 0 while
+ * `BeginAssembly` and `DecodeWhole` start at offset 10 or 2; `AapMediaPlayback.processMetadataPacket`
+ * does the same on MUSIC_PLAYBACK, taking the first fragment from `dataOffset` and the middle and
+ * last from 0. Both are right. The place that got it wrong was the one that never had the rule in
+ * front of it.
+ *
+ * ### The bug this was extracted for
+ *
+ * `AapMessageIncoming.decrypt` rejected every payload shorter than two bytes, on every channel and
+ * every flag, because it wanted to read a message type at offset 0. The check began as a real
+ * crash fix - the SSL layer then returned an exactly sized per-message array, so reading two bytes
+ * out of a one-byte payload threw - but the remedy was wrong rather than the diagnosis: it dropped
+ * the message instead of declining to read a type that was never there. On the video channel,
+ * video fragments are 16KB, so any access unit whose size mod 16384 is 1 ends in a legal one-byte
+ * tail; dropping it costs the whole access unit, the reassembler reports `TRUNCATED_PREVIOUS`, and
+ * the picture drifts until a keyframe repairs it. That signature - short-payload line, truncation,
+ * and a silent framing audit - is how the fault was identified in the field.
+ *
+ * The crash the old guard prevented can no longer happen. `AapSslContext.plaintextBuffer` is sized
+ * to the session's `rxBuffer` capacity and reused per message, so offsets 0 and 1 are in bounds
+ * whatever the payload length is.
+ *
+ * Pure: no clock, no logging, no Android. Its test is the record of the table above.
+ */
+object AapMessageFraming {
+
+    /** Set when this message begins an AAP message, so a 2-byte type follows at offset 0. */
+    const val FLAG_BIT_FIRST = 0x01
+
+    /** Set when this message ends one. Both bits set is a message that was never fragmented. */
+    const val FLAG_BIT_LAST = 0x02
+
+    /**
+     * Set on every message that arrives encrypted, which after the handshake is all of them.
+     * Named here so the table above is complete; [AapMessageIncoming.decrypt] owns the check.
+     */
+    const val FLAG_BIT_ENCRYPTED = 0x08
+
+    /**
+     * Whether [flags] describes a message carrying the 2-byte type at offset 0.
+     *
+     * False for the middle and last fragments of a run, whose payload starts at byte zero. Callers
+     * that read a type, or that guard a read of one, have to ask this first.
+     */
+    fun carriesMessageType(flags: Int): Boolean = flags and FLAG_BIT_FIRST != 0
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapMessageIncoming.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapMessageIncoming.kt
@@ -40,11 +40,32 @@ internal class AapMessageIncoming(header: EncryptedHeader, ba: ByteArrayWithLimi
 
             val ba = ssl.decrypt(offset, header.enc_len, buf) ?: return null
 
+            // Two bytes are the message type read below, and only a message that *begins* an AAP
+            // message has one - see AapMessageFraming. A middle or last fragment is raw payload from
+            // its first byte, so any length is legal there and this guard must not touch it. It used
+            // to, on every channel and every flag, and on the video channel dropping a run's last
+            // fragment costs the whole access unit: the reassembler sees the next frame's first
+            // fragment arrive with the run still open, reports TRUNCATED_PREVIOUS, and the picture
+            // smears until a keyframe.
+            //
             // The payload length is ba.limit, not ba.data.size: the SSL layer hands back one reused
             // buffer whose length is the session ceiling, so data.size is always large enough and
-            // this guard would never fire. Two bytes are needed for the message type read below.
-            if (ba.limit < 2) {
-                AppLog.e("Decrypted payload too short: " + ba.limit)
+            // reading it here would never fire. That reuse is also why relaxing the guard is safe -
+            // the ArrayIndexOutOfBounds this originally existed to prevent needed the exactly sized
+            // per-message array the SSL layer no longer allocates.
+            //
+            // A zero-length continuation now passes too, and is a no-op: AapVideo's append copies
+            // zero bytes. It was the one reason to keep rejecting on length alone, because a run of
+            // `too short: 0` is what an SSL desync looks like from here - but a desync ends the
+            // session in seconds through AapRead's own disconnect paths, which log unconditionally,
+            // so the diagnosis survives without this guard having to guess at it.
+            if (AapMessageFraming.carriesMessageType(header.flags) && ba.limit < 2) {
+                // Carries the framing the same way the WRONG FLAG line above does. What is left here
+                // is a message that claims to begin one and is too short to say what it begins, so
+                // the channel and flag are what separate a phone that sent a malformed message from
+                // a reader that mis-framed one.
+                AppLog.e("Decrypted payload too short: %d  chan: %d %s  flags: 0x%02x  enc_len: %d",
+                        ba.limit, header.chan, Channel.name(header.chan), header.flags, header.enc_len)
                 return null
             }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapProjectionActivity.kt
@@ -176,7 +176,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
                 // hidden (the previous instance had rendered), so its keyframe watchdog never
                 // re-arms, and maybeRequestVideoFocus below is never reached.
                 maybeRecoverWarmRelaunch()
-                watchdogHandler.postDelayed(this, 2000)
+                watchdogHandler.postDelayed(this, ProjectionWatchdogPolicy.WATCHDOG_TICK_MS)
                 return
             }
             val gap = SystemClock.elapsedRealtime() - lastFrame
@@ -202,7 +202,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
                 maybeRecoverFromDisplayStall()
             }
             maybeRequestVideoFocus(pictureStopped)
-            watchdogHandler.postDelayed(this, 2000)
+            watchdogHandler.postDelayed(this, ProjectionWatchdogPolicy.WATCHDOG_TICK_MS)
         }
     }
 
@@ -488,11 +488,10 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
     // Detection is gated on the phone still sending video bytes (videoDecoder.lastInputBytesReceivedMs)
     // so it never fights a genuine phone-side pause (which stops the input too and is left to the
     // reconnecting overlay). It then looks for two failure shapes on the consumer side:
-    //   - a full freeze: nothing drawn for displayFreezeThresholdMs, and
+    //   - a full freeze: nothing drawn for ProjectionWatchdogPolicy.DISPLAY_FREEZE_MS, and
     //   - a throughput collapse: several abnormally long frames within a sliding window. On MediaTek
     //     the GL consumer does not fully stop but drops to 2-5fps with single frames taking ~2s, so
     //     a plain "no frame for N seconds" check misses it (issue #650).
-    private val displayFreezeThresholdMs = 5000L
     // "The phone is still streaming video" - for [maybeRecoverFromDisplayStall] only, where that is
     // the right question: that path is about the display consumer freezing while video flows. The
     // warm-relaunch escalation used to share it and asks about the link instead, because there a
@@ -559,7 +558,7 @@ class AapProjectionActivity : SurfaceActivity(), IProjectionView.Callbacks, Vide
         }
         val effectiveDrawn = if (drawn == 0L) firstUndrawnMs else drawn
 
-        val frozen = effectiveDrawn > 0L && now - effectiveDrawn >= displayFreezeThresholdMs
+        val frozen = effectiveDrawn > 0L && now - effectiveDrawn >= ProjectionWatchdogPolicy.DISPLAY_FREEZE_MS
         val collapsed = longFramesInWindow >= collapseLongFrameFloor
 
         if (!frozen && !collapsed) {

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapRead.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapRead.kt
@@ -15,9 +15,11 @@ internal interface AapRead {
 
     /**
      * @param onVideoRunHoled called when a video fragment run turns out to be short of the bytes it
-     *   declared. A callback rather than an [AapVideo] reference: the reader owes the video path one
-     *   fact and nothing else, and the two are wired together in [Factory] the way every other
-     *   cross-manager coupling in this app is.
+     *   declared; the argument says whether the shortfall is large enough that the assembled unit
+     *   should be discarded rather than decoded ([AuditRecoveryPolicy.shouldDiscardAssembledUnit]).
+     *   A callback rather than an [AapVideo] reference: the reader owes the video path one fact and
+     *   nothing else, and the two are wired together in [Factory] the way every other cross-manager
+     *   coupling in this app is.
      * @param faultInjector reader-stage fault injection, or null. Distinct from the injector
      *   [AapVideo] holds because the two act at different points in the receive path - see
      *   [VideoFaultInjector.Stage]. Only one of the two is ever non-null in a session.
@@ -26,7 +28,7 @@ internal interface AapRead {
             private val connection: AccessoryConnection?,
             internal val ssl: AapSsl,
             internal val handler: AapMessageHandler,
-            private val onVideoRunHoled: () -> Unit = {},
+            private val onVideoRunHoled: (discardAssembledUnit: Boolean) -> Unit = {},
             internal val faultInjector: VideoFaultInjector? = null) : AapRead {
 
         /** Every line [faultInjector] prints. Shared wording with [AapVideo]'s - see the class. */
@@ -123,7 +125,10 @@ internal interface AapRead {
             // *printed*; a suppressed line must not also suppress the repair. The ask has its own
             // throttle in VideoRecoveryPolicy, which every keyframe request in the app is held to.
             if (AuditRecoveryPolicy.shouldRequestKeyframe(result.outcome, result.channel)) {
-                onVideoRunHoled()
+                // The finding is produced on the run's last fragment, which is the very message the
+                // handler is about to complete assembly with - so the discard verdict travels on
+                // the same thread, ahead of it, with nothing to synchronise.
+                onVideoRunHoled(AuditRecoveryPolicy.shouldDiscardAssembledUnit(result))
             }
 
             val channelName = Channel.name(channel)
@@ -186,7 +191,7 @@ internal interface AapRead {
                 settings.debugVideoFaultBudget
             ).takeIf { it.isActiveAt(VideoFaultInjector.Stage.READER) }
 
-            val onVideoRunHoled = { aapVideo.onFragmentRunHoled() }
+            val onVideoRunHoled = { discard: Boolean -> aapVideo.onFragmentRunHoled(discard) }
 
             return if (connection is SocketAccessoryConnection)
                 AapReadSingleMessage(connection, transport.ssl, handler, onVideoRunHoled, readerFaults)

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapReadMultipleMessages.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapReadMultipleMessages.kt
@@ -11,7 +11,7 @@ internal class AapReadMultipleMessages(
         connection: AccessoryConnection,
         ssl: AapSsl,
         handler: AapMessageHandler,
-        onVideoRunHoled: () -> Unit = {},
+        onVideoRunHoled: (discardAssembledUnit: Boolean) -> Unit = {},
         faultInjector: VideoFaultInjector? = null)
     : AapRead.Base(connection, ssl, handler, onVideoRunHoled, faultInjector) {
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapReadSingleMessage.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapReadSingleMessage.kt
@@ -7,7 +7,7 @@ internal class AapReadSingleMessage(
         connection: AccessoryConnection,
         ssl: AapSsl,
         handler: AapMessageHandler,
-        onVideoRunHoled: () -> Unit = {},
+        onVideoRunHoled: (discardAssembledUnit: Boolean) -> Unit = {},
         faultInjector: VideoFaultInjector? = null)
     : AapRead.Base(connection, ssl, handler, onVideoRunHoled, faultInjector) {
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapSslContext.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapSslContext.kt
@@ -1,5 +1,6 @@
 package com.andrerinas.openheadunit.aap
 
+import android.os.SystemClock
 import com.andrerinas.openheadunit.aap.protocol.messages.Messages
 import com.andrerinas.openheadunit.connection.AccessoryConnection
 import com.andrerinas.openheadunit.ssl.ConscryptInitializer
@@ -238,12 +239,26 @@ class AapSslContext(keyManager: SingleKeyKeyManager): AapSsl {
     /** Reused wrapper, so the per-message allocation is zero rather than one small object. */
     private val plaintextHolder = ByteArrayWithLimit(ByteArray(0), 0)
 
+    /**
+     * Print budget for the zero-produce unwrap line, in the shape [AuditReportPolicy] governs.
+     *
+     * A single empty unwrap is legal TLS (a record can carry only handshake or alert bytes), so a
+     * handful at session start are ordinary and an unthrottled WARN would be a storm. A *run* of
+     * them mid-session is the first symptom of a desynced stream, and it used to print only at
+     * DEBUG, below the level reporter captures keep - so the log told that story from the
+     * disconnect instead of from the cause.
+     */
+    private var zeroUnwrapReports = 0
+    private var zeroUnwrapLastLogMs = 0L
+    private var zeroUnwrapSuppressed = 0
+
     override fun decrypt(start: Int, length: Int, buffer: ByteArray): ByteArrayWithLimit? {
         // The status line is built under the lock but emitted outside it. encrypt() takes this same
         // monitor, so logging in here put the whole logging pipeline — formatting, the caller-name
         // stack walk, the file writer — between the poll thread and the send thread once per
         // decrypted packet, which at verbose is several times per video frame.
         var statusLine: String? = null
+        var zeroProduceLine: String? = null
         val decrypted = synchronized(this) {
             if (!::sslEngine.isInitialized || !::rxBuffer.isInitialized || !::plaintextBuffer.isInitialized) {
                 AppLog.w("SSL Decrypt: Not initialized yet")
@@ -255,8 +270,24 @@ class AapSslContext(keyManager: SingleKeyKeyManager): AapSsl {
                 val result = sslEngine.unwrap(encrypted, rxBuffer)
                 runDelegatedTasks(result, sslEngine)
 
-                if (AppLog.LOG_VERBOSE || result.bytesProduced() == 0) {
+                if (AppLog.LOG_VERBOSE) {
                     statusLine = "SSL Decrypt Status: ${result.status}, Produced: ${result.bytesProduced()}, Consumed: ${result.bytesConsumed()}"
+                }
+                if (result.bytesProduced() == 0) {
+                    val now = SystemClock.elapsedRealtime()
+                    if (AuditReportPolicy.shouldReport(zeroUnwrapReports, zeroUnwrapLastLogMs, now)) {
+                        val suppressed = zeroUnwrapSuppressed
+                        zeroUnwrapSuppressed = 0
+                        zeroUnwrapReports++
+                        zeroUnwrapLastLogMs = now
+                        val suffix =
+                            if (suppressed > 0) " (and $suppressed more since the last report)" else ""
+                        zeroProduceLine = "SSL Decrypt: unwrap produced no application data " +
+                            "(status ${result.status}, consumed ${result.bytesConsumed()} of " +
+                            "$length bytes)$suffix"
+                    } else {
+                        zeroUnwrapSuppressed++
+                    }
                 }
 
                 val produced = result.bytesProduced()
@@ -295,6 +326,7 @@ class AapSslContext(keyManager: SingleKeyKeyManager): AapSsl {
             }
         }
         statusLine?.let { AppLog.d(it) }
+        zeroProduceLine?.let { AppLog.w(it) }
         return decrypted
     }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
@@ -178,11 +178,21 @@ class AapTransport(
     }
 
     // Escalation state for KeyframeCycleEscalationPolicy - see triggerFocusCycleRecovery().
-    // unrepairedSinceMs is when the picture was last known good: set by a shed reference frame,
-    // cleared when a keyframe reaches the codec. Zero means nothing is broken.
+    // unrepairedSinceMs is when the picture was last known good: set by a shed reference frame, a
+    // rebuilt or starved codec, or a corrupt access unit off the wire, and cleared when a keyframe
+    // reaches the codec. Zero means nothing is broken.
     private var unrepairedSinceMs = 0L
     private var focusCyclesUsedThisSession = 0
     private var lastFocusCycleMs = 0L
+
+    /**
+     * Lifetime spends and the budget's last movement, for
+     * [KeyframeCycleEscalationPolicy.cyclesToRefund]. The spend counter is what the per-drive
+     * ceiling reads and refunds never touch it; the stamp moves on every spend and every refund,
+     * so refunds accrue one per quiet window rather than all against the first spend.
+     */
+    private var focusCyclesSpentThisSession = 0
+    private var lastBudgetChangeMs = 0L
 
     /**
      * When an access unit last arrived broken on the wire, as opposed to when the decoder last had
@@ -252,26 +262,56 @@ class AapTransport(
      * release can, and has only ever been tested against one phone. It stays the first response.
      *
      * @param escalatable whether this caller's stream is live enough to earn a focus release if the
-     *   nudge goes unanswered. True for the dropped-frame path, which is gated on the decoder having
-     *   rendered, and for both decoder paths - a rebuilt or keyframe-starved codec is the case where
-     *   the picture is most certainly gone and least able to come back on its own. That last pair
-     *   used to pass false, on the grounds that a rebuild belongs to [WarmRelaunchKeyframePolicy]'s
-     *   window and two deciders must not reach for the same lever. The lever now has one owner
-     *   ([com.andrerinas.openheadunit.connection.CommManager.releaseVideoFocusForKeyframe]), so the
-     *   overlap is refused rather than argued about, and the ordering still favours the surface path:
-     *   it escalates at 850ms against this one's 2000ms.
-     *   [AapVideo]'s corruption path stays false only because it has no rendered-frame signal to
-     *   gate on.
+     *   nudge goes unanswered. True for the dropped-frame path, for both decoder paths (a rebuilt
+     *   or keyframe-starved codec is the picture most certainly gone and least able to come back),
+     *   and for [AapVideo]'s corruption path, all behind the same
+     *   [VideoDecoder.hasRenderedThisSession] gate. The corruption path used to pass a hard false,
+     *   which left a wire truncation with only the inert nudge and a picture that stayed broken
+     *   for tens of seconds until the phone's own keyframe, against the escalation's few. Lever
+     *   overlap with [WarmRelaunchKeyframePolicy] is handled by the lever's single owner
+     *   ([com.andrerinas.openheadunit.connection.CommManager.releaseVideoFocusForKeyframe]), and
+     *   the ordering still favours the surface path: 850ms against this one's 2000ms.
+     *
+     * @param wireCorruption whether the caller is reporting an access unit that arrived broken *on
+     *   the wire*, which is what [KeyframeCycleEscalationPolicy]'s quiet gate reads. Its own
+     *   parameter rather than `!escalatable`: those were the same bit inverted only because
+     *   [AapVideo] was the sole non-escalatable caller, so the stamp could not survive that path
+     *   becoming escalatable. Now the decoder paths report a consequence and say so, and the video
+     *   path reports a cause and says so.
      */
     @Synchronized
-    private fun triggerFocusCycleRecovery(escalatable: Boolean) {
+    private fun triggerFocusCycleRecovery(escalatable: Boolean, wireCorruption: Boolean) {
         AppLog.w("AapTransport: Requesting recovery keyframe (unsolicited focus gain).")
         send(VideoFocusEvent(gain = true, unsolicited = true))
 
-        // Stamped before the returns below, and deliberately on the path that returns early: a
-        // stream that is still losing frames is exactly the case where the clock is already running,
-        // and that is the case the stamp exists to let the escalation see.
-        if (!escalatable) lastWireCorruptionMs = SystemClock.elapsedRealtime()
+        // Settled quiet earns spent cycles back, judged before this fault stamps the corruption
+        // clock - the stretch being judged is the one this fault just ended. Granted here, on the
+        // fault that needs it, rather than on a timer: escalateIfStillUnrepaired() only runs while
+        // the clock is armed, and a repaired picture is exactly when a refund becomes possible.
+        val refundNow = SystemClock.elapsedRealtime()
+        val refund = KeyframeCycleEscalationPolicy.cyclesToRefund(
+            refundNow,
+            focusCyclesUsedThisSession,
+            focusCyclesSpentThisSession,
+            lastBudgetChangeMs,
+            lastWireCorruptionMs,
+            unrepairedSinceMs != 0L,
+        )
+        if (refund > 0) {
+            focusCyclesUsedThisSession -= refund
+            lastBudgetChangeMs = refundNow
+            AppLog.w(
+                "AapTransport: quiet stream earned back $refund focus cycle(s) " +
+                    "($focusCyclesUsedThisSession/${KeyframeCycleEscalationPolicy.MAX_CYCLES_PER_SESSION} " +
+                    "used, $focusCyclesSpentThisSession/${KeyframeCycleEscalationPolicy.MAX_CYCLES_PER_DRIVE} " +
+                    "spent this drive)"
+            )
+        }
+
+        // Stamped before the returns below, and deliberately also when this call goes on to arm
+        // nothing: a stream that is still losing frames is exactly the case where the clock is
+        // already running, and that is the case the stamp exists to let the escalation see.
+        if (wireCorruption) lastWireCorruptionMs = SystemClock.elapsedRealtime()
 
         if (!escalatable || unrepairedSinceMs != 0L) return
         // Stamped only once the check is actually armed. Setting it without a handler to run the
@@ -353,7 +393,9 @@ class AapTransport(
                     return
                 }
                 focusCyclesUsedThisSession++
+                focusCyclesSpentThisSession++
                 lastFocusCycleMs = now
+                lastBudgetChangeMs = now
                 AppLog.w(
                     "AapTransport: picture unrepaired for ${now - since}ms - cycling video focus " +
                         "($focusCyclesUsedThisSession/${KeyframeCycleEscalationPolicy.MAX_CYCLES_PER_SESSION})"
@@ -408,8 +450,14 @@ class AapTransport(
     init {
         micRecorder.listener = this
         aapAudio = AapAudio(audioDecoder, audioManager, settings, context)
+        // A corrupt access unit is the one fault the phone cannot heal for us inside a GOP, and
+        // hasRenderedThisSession is the gate that keeps this clear of the warm-up window
+        // [WarmRelaunchKeyframePolicy] owns - the same gate VideoDecoder.notifyFrameDropped uses.
         aapVideo = AapVideo(videoDecoder, settings) {
-            triggerFocusCycleRecovery(escalatable = false)
+            triggerFocusCycleRecovery(
+                escalatable = videoDecoder.hasRenderedThisSession,
+                wireCorruption = true,
+            )
         }
 
         // A rebuilt codec resumes on a P-frame and can render nothing until an IDR arrives, which
@@ -418,16 +466,16 @@ class AapTransport(
         // lever that can repair it was switched off: the old wiring abandoned the escalation clock
         // and armed nothing, so a decoder restarting every ten seconds could never reach a cycle.
         videoDecoder.onDecoderError = { _ ->
-            triggerFocusCycleRecovery(escalatable = true)
+            triggerFocusCycleRecovery(escalatable = true, wireCorruption = false)
         }
 
         // Same ask, from a decoder that is deliberately *not* rebuilding while it waits.
         videoDecoder.onKeyframeStarved = {
-            triggerFocusCycleRecovery(escalatable = true)
+            triggerFocusCycleRecovery(escalatable = true, wireCorruption = false)
         }
 
         videoDecoder.onFrameDropped = {
-            triggerFocusCycleRecovery(escalatable = true)
+            triggerFocusCycleRecovery(escalatable = true, wireCorruption = false)
         }
 
         videoDecoder.onKeyframeObserved = {

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapVideo.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapVideo.kt
@@ -80,9 +80,22 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
      * Runs on the poll thread, which is the thread [process] and every other keyframe request
      * already run on, so it shares their throttle and their ordering without any locking of its own.
      */
-    fun onFragmentRunHoled() = requestKeyframe("fragment run lost bytes")
+    fun onFragmentRunHoled(discardAssembledUnit: Boolean) {
+        // One-shot, consumed by the very next process() call: the audit raises the finding on the
+        // run's last fragment, and that same message is the next thing this class sees. Any other
+        // action arriving instead means the run did not complete normally and the verdict is moot.
+        if (discardAssembledUnit) discardNextAssembly = true
+        requestKeyframe("fragment run lost bytes")
+    }
+
+    private var discardNextAssembly = false
 
     private fun requestKeyframe(reason: String) {
+        // Above the throttle, on purpose: the throttle paces messages on the wire, and the
+        // concealment window this opens is a local render decision with its own hard bound. A
+        // second fault inside the throttle window must still hold the picture even though it
+        // sends nothing.
+        videoDecoder.noteStreamCorrupted(reason)
         val now = android.os.SystemClock.elapsedRealtime()
         if (VideoRecoveryPolicy.canRequestKeyframe(now, lastKeyframeRequestMs)) {
             lastKeyframeRequestMs = now
@@ -240,6 +253,11 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
         decision.anomaly?.let { handleAnomaly(it, message) }
         reportAnomalies()
 
+        // Consumed whatever the action turns out to be, so a verdict against a run that never
+        // completes cannot linger and eat the following healthy frame.
+        val discardCompletedAssembly = discardNextAssembly
+        discardNextAssembly = false
+
         return when (val action = decision.action) {
             is VideoFragmentAssembler.Action.DecodeWhole -> {
                 messageBuffer.clear()
@@ -291,6 +309,19 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
                 messageBuffer.flip()
                 val assembledSize = messageBuffer.limit()
 
+                if (discardCompletedAssembly) {
+                    // The framing audit found this run short by at least a whole fragment. Decoding
+                    // the unit anyway is what used to smear the picture with no anomaly and no
+                    // second reporter; the concealment window the audit's ask opened is already
+                    // holding the screen, so the gap this leaves is invisible.
+                    AppLog.w(
+                        "AapVideo: discarding a %d-byte access unit the framing audit found short",
+                        assembledSize
+                    )
+                    messageBuffer.clear()
+                    return true
+                }
+
                 if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.LOLLIPOP) {
                     if (legacyAssembledBuffer == null || legacyAssembledBuffer!!.size < assembledSize) {
                         legacyAssembledBuffer = ByteArray(assembledSize + 1024)
@@ -322,6 +353,7 @@ internal class AapVideo(private val videoDecoder: VideoDecoder, private val sett
         // Decoding is synchronous here, so there is nothing to drain - but the fragment run has to
         // be closed, or a session that ends mid-frame leaves the next one's first fragments looking
         // like a truncation.
+        discardNextAssembly = false
         assembler.reset()
         lastAnomalyReportMs = 0L
     }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AuditRecoveryPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AuditRecoveryPolicy.kt
@@ -46,4 +46,37 @@ object AuditRecoveryPolicy {
      */
     fun shouldRequestKeyframe(outcome: FragmentedMessageAudit.Outcome, channel: Int): Boolean =
         outcome == FragmentedMessageAudit.Outcome.DELTA_CHANGED && channel == Channel.ID_VID
+
+    /**
+     * Bytes a run must be short by before the assembled unit is thrown away rather than only
+     * reported.
+     *
+     * The audit's history is false positives, not false negatives, and a discarded keyframe costs
+     * a whole GOP. A genuinely missing fragment shifts the delta by that fragment's own length -
+     * hundreds of bytes at the very smallest - where the framing convention itself moves by tens
+     * of bytes per fragment. A floor an order of magnitude above the convention separates "a
+     * fragment is gone" from "the convention shifted", and errs toward decoding.
+     */
+    const val MISSING_FRAGMENT_FLOOR_BYTES = 256
+
+    /**
+     * Whether the access unit this run assembled should be discarded instead of decoded.
+     *
+     * [shouldRequestKeyframe] already decided the finding is worth a repair; this decides the
+     * stronger claim that the unit in hand is damaged enough that decoding it smears the picture.
+     * Until now the holed unit was the one damaged access unit still fed - every anomaly the
+     * reassembler can see already discards - and feeding it has been measured wedging a decoder
+     * through its whole restart budget. With render-side concealment covering the gap a discard
+     * leaves, discarding is now strictly the better trade.
+     *
+     * The delta is `declaredTotal - observed`, so a missing fragment *raises* it above the
+     * channel's expectation. A run that came in longer than expected is never a hole and is never
+     * discarded, and a channel that has not settled its convention ([expectedDelta] null) never
+     * discards either - both directions of doubt decode.
+     */
+    fun shouldDiscardAssembledUnit(result: FragmentedMessageAudit.Result): Boolean {
+        if (!shouldRequestKeyframe(result.outcome, result.channel)) return false
+        val expected = result.expectedDelta ?: return false
+        return result.delta - expected >= MISSING_FRAGMENT_FLOOR_BYTES
+    }
 }

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicy.kt
@@ -73,6 +73,11 @@ package com.andrerinas.openheadunit.aap
  * spending speculatively on a wire that may never settle, because more remain; the last one is
  * worth only what it buys at the moment the loss stops, which is a keyframe 0.5-1.6s later.
  *
+ * The hold is for *sustained* loss only. A fault with nothing after it - the corruption stamp and
+ * the arm landing together - reaches the last cycle exactly as fast as the first, because on that
+ * wire the loss has already stopped and the moment the reserve exists for is now. Checking the
+ * hold before that exemption once deferred exactly this case by a whole quiet window.
+ *
  * ### Who arms the clock
  *
  * A shed reference frame is no longer the only caller. A decoder that has just been rebuilt, and one
@@ -190,6 +195,75 @@ object KeyframeCycleEscalationPolicy {
      */
     const val DEFER_FOR_QUIET_LIMIT_MS = CYCLE_COOLDOWN_MS
 
+    /**
+     * How long the wire and the picture must both have been clean before a spent cycle comes back.
+     *
+     * [MAX_CYCLES_PER_SESSION] was sized for a bad patch, not for a drive: a session that meets an
+     * isolated fault every half hour spends the whole budget on the first three and meets the
+     * fourth with nothing, waiting the phone's own keyframe cadence out. Refunding on quiet keeps
+     * the budget a brake on bursts while letting a drive that has demonstrably settled earn the
+     * lever back.
+     *
+     * Five unbroken minutes cannot elapse inside a sustained-loss episode, so a refund can never
+     * arrive mid-fault and hand the gate a cycle to waste. It is also longer than
+     * [CYCLE_COOLDOWN_MS], [DEFER_FOR_QUIET_LIMIT_MS] and the phone's own keyframe interval, so a
+     * refund only ever lands on a stream that has repaired itself and stayed repaired past every
+     * clock this policy runs. A test pins the relations.
+     */
+    const val CYCLE_REFUND_AFTER_QUIET_MS = 5 * 60_000L
+
+    /**
+     * Cycles one session may ever spend, refunds included.
+     *
+     * [MAX_CYCLES_PER_SESSION] is the burst; this is the drive. Hardware has taken more cycles in
+     * less time than this allows without the codec ever re-initialising, so eight across a
+     * multi-hour drive, each behind five minutes of clean stream, stays inside what is measured
+     * safe while still capping the drive.
+     */
+    const val MAX_CYCLES_PER_DRIVE = 8
+
+    /**
+     * How many spent cycles a quiet stream has earned back, all-at-once at the moment the caller
+     * asks - which is when the next fault arrives, because that is the first moment a refund can
+     * matter and the last moment the quiet stretch behind it is still unbroken.
+     *
+     * Refunds accrue one per [CYCLE_REFUND_AFTER_QUIET_MS] of quiet, measured from whichever is
+     * later of the last budget movement and the last wire corruption, so a fault inside a window
+     * restarts that window. Nothing comes back while the picture is unrepaired: a held last cycle
+     * stays the last cycle, and the reserve's guarantee - being there when the loss stops - cannot
+     * be diluted mid-hold.
+     *
+     * The drive ceiling is enforced as an invariant on *potential*, not a check on spends so far:
+     * a refund is capped so that the cycles already spent plus everything the refreshed budget
+     * could still spend never exceeds [MAX_CYCLES_PER_DRIVE]. Capping on spends alone double
+     * counts the unspent headroom the budget already holds - a session at seven spends with one
+     * cycle still unspent must earn back nothing, or it could reach nine.
+     *
+     * @param cyclesSpentThisSession lifetime spends, never decremented - the counter refunds do
+     *   not touch.
+     * @param lastBudgetChangeMs when the budget last moved in either direction, or zero if it
+     *   never has (then there is nothing to refund and the answer is zero).
+     * @param pictureUnrepaired whether the escalation clock is currently armed.
+     */
+    fun cyclesToRefund(
+        nowMs: Long,
+        cyclesUsedThisSession: Int,
+        cyclesSpentThisSession: Int,
+        lastBudgetChangeMs: Long,
+        lastWireCorruptionMs: Long,
+        pictureUnrepaired: Boolean,
+    ): Int {
+        if (pictureUnrepaired) return 0
+        if (cyclesUsedThisSession <= 0) return 0
+        if (lastBudgetChangeMs == 0L) return 0
+        val quietSince = maxOf(lastBudgetChangeMs, lastWireCorruptionMs)
+        val windows = ((nowMs - quietSince) / CYCLE_REFUND_AFTER_QUIET_MS).toInt()
+        if (windows <= 0) return 0
+        val remainingDriveAllowance = MAX_CYCLES_PER_DRIVE - cyclesSpentThisSession -
+            (MAX_CYCLES_PER_SESSION - cyclesUsedThisSession)
+        return minOf(windows, cyclesUsedThisSession, remainingDriveAllowance).coerceAtLeast(0)
+    }
+
     enum class Action {
         /** Send the unsolicited focus gain, the existing behaviour. */
         NUDGE,
@@ -230,19 +304,29 @@ object KeyframeCycleEscalationPolicy {
         val wireQuiet = lastWireCorruptionMs == 0L ||
             nowMs - lastWireCorruptionMs >= CORRUPTION_QUIET_MS
         if (!wireQuiet) {
-            // The last cycle is the one that has to still be there when the loss stops, so it waits
-            // for real quiet with no ceiling. A session whose wire never settles ends with it
-            // unspent, which costs nothing: that session was not repairable by a keyframe anyway.
-            if (cyclesUsedThisSession == MAX_CYCLES_PER_SESSION - 1) return Action.WAIT_FOR_QUIET
             // An isolated dropped frame stamps the corruption at the instant the clock arms, so
             // without this it would be deferred by a whole quiet window - taxing the common case to
             // pay for the sustained-loss one. Which of the two stamps lands first is not fixed:
             // AapVideo reports the corrupt access unit, the decoder sheds the reference frame, and
             // the order depends on the decoder. Hence a tolerance rather than a strict comparison.
+            //
+            // Checked before the last-cycle hold, and that ordering is the point: the exemption
+            // covers every budget position. On a wire whose only corruption is the fault that armed
+            // the clock, the loss has already stopped, and holding the reserve against it defers
+            // the repair a whole quiet window for nothing.
             val corruptionSinceArm =
                 lastWireCorruptionMs - unrepairedSinceMs >= ESCALATE_AFTER_UNREPAIRED_MS
-            if (corruptionSinceArm && nowMs - unrepairedSinceMs < DEFER_FOR_QUIET_LIMIT_MS) {
-                return Action.WAIT_FOR_QUIET
+            if (corruptionSinceArm) {
+                // The last cycle is the one that has to still be there when the loss stops, so it
+                // waits for real quiet with no ceiling. A session whose wire never settles ends
+                // with it unspent, which costs nothing: that session was not repairable by a
+                // keyframe anyway.
+                if (cyclesUsedThisSession == MAX_CYCLES_PER_SESSION - 1) {
+                    return Action.WAIT_FOR_QUIET
+                }
+                if (nowMs - unrepairedSinceMs < DEFER_FOR_QUIET_LIMIT_MS) {
+                    return Action.WAIT_FOR_QUIET
+                }
             }
         }
         return Action.CYCLE_FOCUS

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/ProjectionWatchdogPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/ProjectionWatchdogPolicy.kt
@@ -32,6 +32,26 @@ object ProjectionWatchdogPolicy {
     const val FRAME_GAP_MS = 10_000L
 
     /**
+     * How long the display consumer may draw nothing, with video still arriving, before the
+     * projection view is torn down and rebuilt (issue #650's recovery).
+     *
+     * Named here rather than inside the activity so other code can be pinned against it:
+     * rebuilding the view costs a black flash, an EGL disconnect and touch loss, so anything that
+     * deliberately holds frames off the screen must provably finish before this watchdog can see
+     * it as a stall. The relation lives in CorruptionConcealmentPolicy's tests.
+     */
+    const val DISPLAY_FREEZE_MS = 5_000L
+
+    /**
+     * How often the projection watchdog looks. Detection runs at this granularity, so a condition
+     * is seen up to one tick *after* its threshold is crossed - never before. What the tick cannot
+     * do is shorten a deadline: anything racing [DISPLAY_FREEZE_MS] needs its margin under the
+     * threshold itself, plus whatever age the last drawn frame already had when the race started,
+     * since the watchdog measures from the draw.
+     */
+    const val WATCHDOG_TICK_MS = 2_000L
+
+    /**
      * How long the whole AAP link must *also* have been silent before a stopped picture is called a
      * lost connection.
      *

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/ServiceDiscoveryResponse.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/protocol/messages/ServiceDiscoveryResponse.kt
@@ -260,16 +260,16 @@ class ServiceDiscoveryResponse(private val context: Context)
 
         /**
          * Records whether a decoder on this device claims it can carry the profile we are about to
-         * ask the phone for.
+         * ask the phone for. Diagnostic only; nothing acts on the answer.
          *
-         * Nothing acts on the answer. It exists because this is the one place where the codec is
-         * decided - the 1440p rule above overrides the user's own choice - and until now nothing in
-         * the app asked a decoder anything before making it. A #219 reporter's Galaxy Tab S7 FE runs
-         * the resulting 2560x1440 HEVC on `c2.qti.hevc.decoder` and sheds frames in bursts, with the
-         * shedding confined to windows that also spent up to 2019ms of 5000 waiting for an input
-         * buffer. No log has ever said what that component claimed beforehand.
+         * This is the one place the codec is decided (the 1440p rule above overrides the user's
+         * choice), and nothing used to ask the decoder anything before making it - so a reporter
+         * log could never say whether the forced profile fit the hardware.
          *
-         * A WARN here from a unit that reports artifacts is what would justify revisiting the rule.
+         * A `sustains=false` WARN here is not by itself grounds to step the profile down: it has
+         * been seen from a unit whose throughput proved the decoder was keeping up, with the
+         * artifacts coming off the wire instead. Revisit the rule only when a log shows the decoder
+         * itself failing behind one of these lines.
          */
         private fun logNegotiatedCodecCapability(codec: Media.MediaCodecType, settings: com.andrerinas.openheadunit.utils.Settings) {
             val mime = when (codec) {

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/CorruptionConcealmentPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/CorruptionConcealmentPolicy.kt
@@ -1,0 +1,136 @@
+package com.andrerinas.openheadunit.decoder
+
+/**
+ * Decides, per output buffer, whether the screen shows it - so a stream that just lost an access
+ * unit freezes on the last good frame instead of melting through every P-frame that references a
+ * picture the decoder never had.
+ *
+ * ### Why the gate is on the render and nowhere else
+ *
+ * Two earlier concealment mechanisms were removed for latching, and their post-mortems set the
+ * constraints this satisfies. Gating the *feed* starved the codec outright; reading NAL types
+ * against the user's codec preference misread every keyframe in reachable configurations; and an
+ * unbounded hold froze a healthy session. So this object gates only [Outcome.renders]: the feed
+ * is untouched, the codec keeps decoding and keeps its reference state current, and the worst
+ * possible failure is the screen showing the wrong subset of frames for a bounded time. It never
+ * reads a NAL itself - the repair signal comes in from [KeyframeRepairTracker], whose scan runs
+ * against the decoder's *pinned* codec type and which carries its own escape hatch for components
+ * with unusable output timestamps.
+ *
+ * ### Why the freeze is worth having at all
+ *
+ * The protocol has no keyframe request, so an unbounded freeze would run to the phone's own
+ * roughly-a-minute GOP, which is why an earlier freeze proposal was rejected. What changed is the
+ * escalation: a corrupt access unit now earns a focus release/regain cycle that produces a
+ * keyframe in under three seconds. A freeze bounded just above that hides the melt for the whole
+ * of a successful repair and costs at most [CONCEAL_MAX_MS] of still picture when the repair does
+ * not come.
+ *
+ * ### The no-latch guarantees, each pinned by a test
+ *
+ * The window is measured from the *first* corruption report ([CONCEAL_MAX_MS] from
+ * `windowOpenedMs`); later reports never extend it. A window that expires [Outcome.CLOSE_EXPIRED]
+ * disarms this policy until a keyframe repairs the picture, so sustained loss buys exactly one
+ * freeze and then the honest smear - never a strobing alternation of the two. A lost window stamp
+ * (`windowOpenedMs == 0` while [State.CONCEALING]) reads as an expired window, so the failure
+ * mode of broken bookkeeping is *resuming*, not freezing. And the caller is expected to consult
+ * this once per output-loop tick as well as per buffer, so the cap holds even when the phone goes
+ * idle mid-window and no further buffers arrive.
+ *
+ * The caller owns the state and must consume the corruption report it passes in *whatever* the
+ * outcome is - a report arriving while [State.DISARMED] is answered with [Outcome.SHOW] and must
+ * not be kept around to reopen a window after the next repair.
+ */
+object CorruptionConcealmentPolicy {
+
+    /**
+     * Longest the picture may be held still, measured from the first corruption report.
+     *
+     * Bounded from both sides. Below: it must outlast the slowest measured escalated repair
+     * ([ESCALATED_REPAIR_OBSERVED_MS]), or the freeze ends in a smear in exactly the case it was
+     * built for. Above: it must stay clear of
+     * [com.andrerinas.openheadunit.aap.ProjectionWatchdogPolicy.DISPLAY_FREEZE_MS], because a
+     * freeze that watchdog can see is answered with a projection-view rebuild, strictly worse than
+     * the smear being hidden; that watchdog measures from the last *draw*, so the margin also
+     * absorbs the age the last drawn frame had when the window opened. Tests pin both relations;
+     * past 4000 the display-freeze margin is gone, so it widens no further.
+     */
+    const val CONCEAL_MAX_MS = 3_500L
+
+    /**
+     * Slowest escalated repair ever measured end to end, corruption to rendered keyframe. Nothing
+     * reads this at runtime; it is the number [CONCEAL_MAX_MS] is chosen against, and a test holds
+     * the two in order.
+     */
+    const val ESCALATED_REPAIR_OBSERVED_MS = 2_780L
+
+    enum class State {
+        /** Rendering, and a corruption report would open a window. */
+        ARMED,
+
+        /**
+         * Rendering, and a corruption report would not: the previous window ran out without a
+         * repair, so the stream is treated as smearing until a keyframe proves otherwise.
+         */
+        DISARMED,
+
+        /** A window is open; output buffers are decoded and not shown. */
+        CONCEALING,
+    }
+
+    /** What to do with the buffer in hand, and the state transition it carries. */
+    enum class Outcome(val renders: Boolean) {
+        /** Render. No state change. */
+        SHOW(true),
+
+        /** Render. State becomes [State.ARMED]: a keyframe repaired the picture in plain view. */
+        REARM(true),
+
+        /** Conceal. State becomes [State.CONCEALING]; the caller stamps the window open now. */
+        OPEN(false),
+
+        /** Conceal. No state change. */
+        CONCEAL(false),
+
+        /** Render - this buffer is the repaired picture. State becomes [State.ARMED]. */
+        CLOSE_REPAIRED(true),
+
+        /**
+         * Render. State becomes [State.DISARMED]: the cap ran out, and a longer freeze is worse
+         * than the smear it hides.
+         */
+        CLOSE_EXPIRED(true),
+    }
+
+    /**
+     * One step. The caller applies the transition the outcome names and, on [Outcome.OPEN], stamps
+     * `windowOpenedMs = nowMs`; on either close it may zero the stamp.
+     *
+     * @param windowOpenedMs when the current window opened; meaningful only in [State.CONCEALING].
+     * @param corruptionReported a new corruption report has arrived since the last step.
+     * @param keyframeRepaired [KeyframeRepairTracker] confirmed the repaired picture this step.
+     * @param sessionHasRendered whether any frame has reached the screen this session - before the
+     *   first one there is nothing on the surface worth holding, and the warm-start window belongs
+     *   to [com.andrerinas.openheadunit.aap.WarmRelaunchKeyframePolicy], not to this.
+     */
+    fun next(
+        nowMs: Long,
+        state: State,
+        windowOpenedMs: Long,
+        corruptionReported: Boolean,
+        keyframeRepaired: Boolean,
+        sessionHasRendered: Boolean,
+    ): Outcome {
+        if (state == State.CONCEALING) {
+            // The repair outranks the cap and outranks any new report: the buffer in hand when the
+            // repair confirms is the repaired picture, and showing it is always right.
+            if (keyframeRepaired) return Outcome.CLOSE_REPAIRED
+            if (nowMs - windowOpenedMs >= CONCEAL_MAX_MS) return Outcome.CLOSE_EXPIRED
+            return Outcome.CONCEAL
+        }
+        if (keyframeRepaired) return Outcome.REARM
+        if (!sessionHasRendered) return Outcome.SHOW
+        if (corruptionReported && state == State.ARMED) return Outcome.OPEN
+        return Outcome.SHOW
+    }
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -6,6 +6,7 @@ import android.media.MediaCodecList
 import android.media.MediaFormat
 import android.os.Build
 import android.view.Surface
+import com.andrerinas.openheadunit.aap.AuditReportPolicy
 import com.andrerinas.openheadunit.aap.CodecConfigScanner
 import com.andrerinas.openheadunit.aap.VideoKeyframeScanner
 import com.andrerinas.openheadunit.aap.VideoRecoveryPolicy
@@ -396,6 +397,118 @@ class VideoDecoder(
     // it is fed like any other and decodes to nothing. See [KeyframeRepairTracker].
     private val keyframeRepair = KeyframeRepairTracker()
 
+    // --- Corruption concealment - see CorruptionConcealmentPolicy for the design and its bounds.
+
+    /**
+     * When the transport last reported a lost or damaged access unit, and what it called it.
+     * Single writer (the transport's poll thread raises every reassembly anomaly and every
+     * framing-audit finding) and single reader (the output thread), so a volatile stamp is the
+     * whole synchronisation. If a second reporting thread ever appears, this needs more.
+     */
+    @Volatile private var corruptionReportedMs = 0L
+    @Volatile private var lastCorruptionReason = ""
+
+    // Output-thread confined, except that resetConcealment() runs from stop()/setSurface() after
+    // the output thread has been joined. framesConcealed is on the throughput line.
+    private var concealState = CorruptionConcealmentPolicy.State.ARMED
+    private var concealWindowOpenedMs = 0L
+    private var consumedCorruptionMs = 0L
+    private var framesConcealed = 0L
+    private var lastLoggedFramesConcealed = 0L
+    private var concealReports = 0
+    private var concealLastLogMs = 0L
+    private var concealSuppressed = 0
+
+    /**
+     * The stream lost an access unit; the output thread holds the last good frame on screen until
+     * a keyframe repairs the picture, bounded by [CorruptionConcealmentPolicy.CONCEAL_MAX_MS].
+     *
+     * Deliberately unthrottled: the window it opens carries its own hard bound, and the 1s
+     * throttle the callers sit behind exists to pace messages on the wire, not renders - which is
+     * why they call this *above* that throttle, so a report the throttle swallows still conceals.
+     */
+    fun noteStreamCorrupted(reason: String) {
+        lastCorruptionReason = reason
+        corruptionReportedMs = SystemClock.elapsedRealtime()
+    }
+
+    /**
+     * Back to [CorruptionConcealmentPolicy.State.ARMED] with nothing pending. Any report already
+     * stamped is marked consumed: it described a stream state the codec or surface being reset no
+     * longer carries, and opening a window on the new one for it would freeze a healthy picture.
+     */
+    private fun resetConcealment() {
+        concealState = CorruptionConcealmentPolicy.State.ARMED
+        concealWindowOpenedMs = 0L
+        consumedCorruptionMs = corruptionReportedMs
+        framesConcealed = 0L
+        lastLoggedFramesConcealed = 0L
+        concealReports = 0
+        concealLastLogMs = 0L
+        concealSuppressed = 0
+    }
+
+    /** Applies what [CorruptionConcealmentPolicy.next] decided, and narrates the window edges. */
+    private fun applyConcealmentTransition(
+        outcome: CorruptionConcealmentPolicy.Outcome,
+        nowMs: Long,
+    ) {
+        when (outcome) {
+            CorruptionConcealmentPolicy.Outcome.OPEN -> {
+                concealState = CorruptionConcealmentPolicy.State.CONCEALING
+                concealWindowOpenedMs = nowMs
+                logConcealment(
+                    nowMs,
+                    "VideoDecoder: holding the picture after $lastCorruptionReason - the last " +
+                        "good frame stays up until a keyframe"
+                )
+            }
+            CorruptionConcealmentPolicy.Outcome.CLOSE_REPAIRED -> {
+                concealState = CorruptionConcealmentPolicy.State.ARMED
+                logConcealment(
+                    nowMs,
+                    "VideoDecoder: picture restored ${nowMs - concealWindowOpenedMs}ms after " +
+                        "$lastCorruptionReason (keyframe decoded)"
+                )
+                concealWindowOpenedMs = 0L
+            }
+            CorruptionConcealmentPolicy.Outcome.CLOSE_EXPIRED -> {
+                concealState = CorruptionConcealmentPolicy.State.DISARMED
+                logConcealment(
+                    nowMs,
+                    "VideoDecoder: no keyframe within " +
+                        "${CorruptionConcealmentPolicy.CONCEAL_MAX_MS}ms of " +
+                        "$lastCorruptionReason - resuming on the damaged stream"
+                )
+                concealWindowOpenedMs = 0L
+            }
+            CorruptionConcealmentPolicy.Outcome.REARM ->
+                concealState = CorruptionConcealmentPolicy.State.ARMED
+            CorruptionConcealmentPolicy.Outcome.SHOW,
+            CorruptionConcealmentPolicy.Outcome.CONCEAL -> {}
+        }
+    }
+
+    /**
+     * Window-edge lines at WARN, because reporter captures run there, through the same refilling
+     * budget every other repeating diagnostic uses. The edges are structurally rare - a window
+     * cannot reopen until a keyframe has re-armed the policy - so the budget exists for the
+     * pathological stream, not the expected one.
+     */
+    private fun logConcealment(nowMs: Long, message: String) {
+        if (AuditReportPolicy.shouldReport(concealReports, concealLastLogMs, nowMs)) {
+            val suppressed = concealSuppressed
+            concealSuppressed = 0
+            concealReports++
+            concealLastLogMs = nowMs
+            val suffix =
+                if (suppressed > 0) " (and $suppressed window events since the last report)" else ""
+            AppLog.w(message + suffix)
+        } else {
+            concealSuppressed++
+        }
+    }
+
     // Throttle stamp for onFrameDropped. Both drop sites feed it: the transport read thread on
     // queue overflow and the feed thread on input-buffer exhaustion. A race between them costs
     // at most one extra nudge, so a volatile check-then-set is enough.
@@ -506,6 +619,7 @@ class VideoDecoder(
             mSurface = surface
             lastFrameRenderedMs = 0L
             keyframeRepair.reset()
+            resetConcealment()
         }
     }
 
@@ -628,6 +742,7 @@ class VideoDecoder(
             // Presentation timestamps restart near zero on the next configure, so a stamp left
             // pending here would be confirmed by the new codec's very first frame.
             keyframeRepair.reset()
+            resetConcealment()
             lastKeyframeStarvedAskMs = 0L
             loggedFirstSoftwareFrame = false
             loggedFirstHardwareFrame = false
@@ -1754,6 +1869,8 @@ class VideoDecoder(
         val dropped = framesDropped - lastLoggedFramesDropped
         val skipped = framesSkippedAtRender - lastLoggedFramesSkippedAtRender
         val inputWait = inputWaitMs - lastLoggedInputWaitMs
+        val concealed = framesConcealed - lastLoggedFramesConcealed
+        lastLoggedFramesConcealed = framesConcealed
         lastThroughputLogMs = now
         lastLoggedFramesRendered = framesRendered
         lastLoggedFramesFed = framesFed
@@ -1766,7 +1883,7 @@ class VideoDecoder(
         AppLog.i(
             "Throughput over ${elapsed}ms: rendered=$rendered (${renderedFps}fps), " +
                 "fed=$fed (${fedFps}fps), dropped=$dropped, skipped=$skipped, " +
-                "inputWait=${inputWait}ms, codec=$currentCodecName"
+                "concealed=$concealed, inputWait=${inputWait}ms, codec=$currentCodecName"
         )
         reportBackpressure(elapsed, inputWait, dropped)
     }
@@ -1858,8 +1975,42 @@ class VideoDecoder(
                         }
                     }
 
+                    val renderIndex = readyIndices[readyCount - 1]
+
+                    // The repair question is answered before anything is released, because whether
+                    // this pass's frame repaired the picture decides whether it is shown at all.
+                    // bufferInfo carries the last successful dequeue, which is renderIndex. The
+                    // frames released ahead of it in this pass decoded earlier and so have smaller
+                    // timestamps, and the ones the catch-up branch discarded decoded too - so this
+                    // one stamp answers for the whole pass either way.
+                    val repaired = keyframeRepair.onFrameRendered(bufferInfo.presentationTimeUs)
+                    // The report is consumed whatever the outcome is. One answered with SHOW while
+                    // the policy is disarmed must not linger, or it would reopen a window against a
+                    // stale fault the moment the next keyframe re-arms.
+                    val reportedStamp = corruptionReportedMs
+                    val reported = reportedStamp > consumedCorruptionMs
+                    if (reported) consumedCorruptionMs = reportedStamp
+                    val passNow = SystemClock.elapsedRealtime()
+                    val outcome = CorruptionConcealmentPolicy.next(
+                        passNow,
+                        concealState,
+                        concealWindowOpenedMs,
+                        corruptionReported = reported,
+                        keyframeRepaired = repaired,
+                        sessionHasRendered = renderedThisSession,
+                    )
+                    applyConcealmentTransition(outcome, passNow)
+
                     var alsoRendered = 0
-                    if (readyCount > 2) {
+                    if (!outcome.renders) {
+                        // The whole pass is withheld; the surface keeps the last good frame. These
+                        // buffers are decoded first, so the codec's reference state stays current -
+                        // the feed is never gated, only what the screen shows.
+                        for (i in 0 until readyCount - 1) {
+                            currentCodec.releaseOutputBuffer(readyIndices[i], false)
+                        }
+                        framesConcealed += (readyCount - 1).toLong()
+                    } else if (readyCount > 2) {
                         for (i in 0 until readyCount - 1) {
                             currentCodec.releaseOutputBuffer(readyIndices[i], false)
                         }
@@ -1876,57 +2027,77 @@ class VideoDecoder(
                     framesRendered += alsoRendered
                     frameCount += alsoRendered
                     framesRenderedThisSession += alsoRendered
-                    val renderIndex = readyIndices[readyCount - 1]
 
-                    currentCodec.releaseOutputBuffer(renderIndex, true)
-                    lastFrameRenderedMs = SystemClock.elapsedRealtime()
-                    renderedThisSession = true
-                    // bufferInfo carries the last successful dequeue, which is renderIndex. The
-                    // frames released ahead of it in this pass decoded earlier and so have smaller
-                    // timestamps, and the ones the catch-up branch discarded decoded too - so this
-                    // one stamp answers for the whole pass either way.
-                    if (keyframeRepair.onFrameRendered(bufferInfo.presentationTimeUs)) {
-                        if (keyframeRepair.timestampsUnusable && !loggedUnusableOutputTimestamps) {
-                            loggedUnusableOutputTimestamps = true
-                            AppLog.w(
-                                "$currentCodecName never carries a keyframe's timestamp through to its " +
-                                    "output, so a repaired picture is read from frames arriving rather " +
-                                    "than from the frame that repaired it."
-                            )
-                        }
-                        AppLog.i("VideoDecoder: keyframe decoded - the picture is repaired")
-                        onKeyframeObserved?.invoke()
-                    }
-                    framesRenderedThisSession++
+                    currentCodec.releaseOutputBuffer(renderIndex, outcome.renders)
                     consecutiveErrors = 0
-                    // The one landmark that says video actually reached the screen on the path
-                    // almost every unit runs. Driven by its own flag rather than the listener
-                    // below, which only exists while the projection activity is up — the sessions
-                    // worth timing are exactly the ones where it might not be.
-                    if (!loggedFirstHardwareFrame) {
-                        loggedFirstHardwareFrame = true
-                        AppLog.i("First frame rendered (hardware decode)")
-                    }
-                    onFirstFrameListener?.let { it(); onFirstFrameListener = null }
-
-                    frameCount++
-                    framesRendered++
-
-                    val now = System.currentTimeMillis()
-                    val elapsed = now - lastFpsLogTime
-                    if (elapsed >= 1000) {
-                        if (lastFpsLogTime != 0L) {
-                            val fps = (frameCount * 1000 / elapsed).toInt()
-                            onFpsChanged?.invoke(fps)
+                    if (outcome.renders) {
+                        lastFrameRenderedMs = SystemClock.elapsedRealtime()
+                        renderedThisSession = true
+                        // repaired implies a rendering outcome (CLOSE_REPAIRED or REARM), so the
+                        // repair announcement cannot be lost to a concealed pass.
+                        if (repaired) {
+                            if (keyframeRepair.timestampsUnusable && !loggedUnusableOutputTimestamps) {
+                                loggedUnusableOutputTimestamps = true
+                                AppLog.w(
+                                    "$currentCodecName never carries a keyframe's timestamp through to its " +
+                                        "output, so a repaired picture is read from frames arriving rather " +
+                                        "than from the frame that repaired it."
+                                )
+                            }
+                            AppLog.i("VideoDecoder: keyframe decoded - the picture is repaired")
+                            onKeyframeObserved?.invoke()
                         }
-                        frameCount = 0
-                        lastFpsLogTime = now
+                        framesRenderedThisSession++
+                        // The one landmark that says video actually reached the screen on the path
+                        // almost every unit runs. Driven by its own flag rather than the listener
+                        // below, which only exists while the projection activity is up — the sessions
+                        // worth timing are exactly the ones where it might not be.
+                        if (!loggedFirstHardwareFrame) {
+                            loggedFirstHardwareFrame = true
+                            AppLog.i("First frame rendered (hardware decode)")
+                        }
+                        onFirstFrameListener?.let { it(); onFirstFrameListener = null }
+
+                        frameCount++
+                        framesRendered++
+
+                        val now = System.currentTimeMillis()
+                        val elapsed = now - lastFpsLogTime
+                        if (elapsed >= 1000) {
+                            if (lastFpsLogTime != 0L) {
+                                val fps = (frameCount * 1000 / elapsed).toInt()
+                                onFpsChanged?.invoke(fps)
+                            }
+                            frameCount = 0
+                            lastFpsLogTime = now
+                        }
+                    } else {
+                        framesConcealed++
                     }
                 } else if (outputIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
                     handleOutputFormatChange(currentCodec.outputFormat)
                 }
 
                 logThroughput()
+
+                // A window can only close on an output buffer, and a phone that goes idle
+                // mid-window sends none - so the cap is also held on wall clock, once per loop
+                // turn (the dequeue above times out in 10ms). On expiry there is no buffer to
+                // show; the transition and its line happen now, the next buffer renders.
+                if (concealState == CorruptionConcealmentPolicy.State.CONCEALING) {
+                    val tickNow = SystemClock.elapsedRealtime()
+                    applyConcealmentTransition(
+                        CorruptionConcealmentPolicy.next(
+                            tickNow,
+                            concealState,
+                            concealWindowOpenedMs,
+                            corruptionReported = false,
+                            keyframeRepaired = false,
+                            sessionHasRendered = renderedThisSession,
+                        ),
+                        tickNow
+                    )
+                }
 
                 // Stall detection: if we rendered at least one frame but haven't
                 // produced output in SYNC_STALL_THRESHOLD_MS, check if input bytes

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -1820,6 +1820,13 @@ class VideoDecoder(
             try {
                 val outputIndex = currentCodec.dequeueOutputBuffer(bufferInfo, 10000L)
                 if (outputIndex >= 0) {
+                    // The codec produced output, whatever the screen ends up showing. This is the
+                    // stall watchdog's clock and it is deliberately not the render stamp: the two
+                    // were the same fact only while every dequeued buffer was also displayed, and
+                    // anything that legitimately holds a decoded frame off the screen must not
+                    // read as a codec that stopped decoding. lastFrameRenderedMs stays the display
+                    // watchdogs' instrument and is stamped only when a frame reaches the surface.
+                    lastOutputMs = SystemClock.elapsedRealtime()
                     // Catch up to the newest ready frame instead of replaying the backlog. A link
                     // that goes quiet for a few hundred milliseconds delivers what it owed in one
                     // burst; showing every frame of it walks the picture forward in slow motion and
@@ -1874,7 +1881,6 @@ class VideoDecoder(
                     currentCodec.releaseOutputBuffer(renderIndex, true)
                     lastFrameRenderedMs = SystemClock.elapsedRealtime()
                     renderedThisSession = true
-                    lastOutputMs = lastFrameRenderedMs
                     // bufferInfo carries the last successful dequeue, which is renderIndex. The
                     // frames released ahead of it in this pass decoded earlier and so have smaller
                     // timestamps, and the ones the catch-up branch discarded decoded too - so this

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -924,6 +924,14 @@ class VideoDecoder(
                     FeedResult.FED -> framesFed++
                     // Counted and answered where the real buffer capacity is known.
                     FeedResult.DROPPED_TOO_LARGE -> {}
+                    FeedResult.ERROR -> {
+                        // Already logged with the exception where it happened; logFeedDrop would
+                        // relabel it "Input buffer full", which is the one thing it was not. The
+                        // frame is a lost reference frame all the same, so ask for the keyframe.
+                        if (running && feedThread === self && codec != null) {
+                            notifyFrameDropped()
+                        }
+                    }
                     FeedResult.NO_INPUT_BUFFER -> {
                         // A teardown fails the same way a full queue does. Say nothing in that
                         // case: the frame is moot and the log line would appear on every
@@ -1567,6 +1575,9 @@ class VideoDecoder(
 
         /** Frame exceeds the codec's input buffer; dropped and accounted for inside. */
         DROPPED_TOO_LARGE,
+
+        /** The codec threw mid-feed; the frame is lost and the dequeued buffer was handed back. */
+        ERROR,
     }
 
     /**
@@ -1579,8 +1590,11 @@ class VideoDecoder(
      */
     private fun feedInputBuffer(buffer: ByteBuffer, arrivalNanos: Long): FeedResult {
         val currentCodec = codec ?: return FeedResult.NO_INPUT_BUFFER
+        // Outside the try so the catch can hand a dequeued buffer back, and so it can tell a
+        // throw before queueInputBuffer from one after it - the frame's fate differs.
+        var inputIndex = -1
+        var queued = false
         try {
-            var inputIndex = -1
             // ~300ms of patience. Anything much shorter gives up while the codec is merely busy:
             // at 30ms this reported a full input queue within a second of every decoder start,
             // before the component had drained its first buffers, on hardware that then went on to
@@ -1614,7 +1628,12 @@ class VideoDecoder(
                 @Suppress("DEPRECATION") inputBuffers?.get(inputIndex)
             }
 
-            if (inputBuffer == null) return FeedResult.NO_INPUT_BUFFER
+            if (inputBuffer == null) {
+                // Rare (a codec mid-flush can answer null), but the index is dequeued and must go
+                // back or the pool is one buffer shallower for the rest of the codec's life.
+                currentCodec.queueInputBuffer(inputIndex, 0, 0, 0, 0)
+                return FeedResult.NO_INPUT_BUFFER
+            }
             inputBuffer.clear()
 
             val capacity = inputBuffer.capacity()
@@ -1673,6 +1692,7 @@ class VideoDecoder(
             val pts = ((if (arrivalNanos > 0L) arrivalNanos else System.nanoTime()) - startTime) / 1000
 
             currentCodec.queueInputBuffer(inputIndex, 0, inputBuffer.limit(), pts, flags)
+            queued = true
             if (isKeyframe) {
                 // Fed, not yet repaired. The picture counts as repaired at the output side, where
                 // a keyframe that arrived holed is told apart from one that decodes.
@@ -1681,8 +1701,26 @@ class VideoDecoder(
             }
             return FeedResult.FED
         } catch (e: Exception) {
+            if (queued) {
+                // The frame reached the codec; only the bookkeeping after the queue failed. Calling
+                // it anything but fed would report a frame the codec holds as shed and spend a
+                // keyframe request on a picture that is not broken.
+                AppLog.e("Error after feeding input buffer", e)
+                return FeedResult.FED
+            }
+            if (inputIndex >= 0) {
+                // Hand the dequeued buffer back empty, or the codec's input pool is permanently one
+                // buffer shallower per throw - enough of these and every later feed times out with
+                // NO_INPUT_BUFFER, which the stall watchdog then answers with a rebuild the codec
+                // never earned.
+                try {
+                    currentCodec.queueInputBuffer(inputIndex, 0, 0, 0, 0)
+                } catch (returnError: Exception) {
+                    AppLog.e("Could not return the input buffer after a failed feed", returnError)
+                }
+            }
             AppLog.e("Error feeding input buffer", e)
-            return FeedResult.NO_INPUT_BUFFER
+            return FeedResult.ERROR
         }
     }
 

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/LogExporter.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/LogExporter.kt
@@ -2,8 +2,10 @@ package com.andrerinas.openheadunit.utils
 
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.util.Log
 import androidx.core.content.FileProvider
+import com.andrerinas.openheadunit.BuildConfig
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -72,6 +74,43 @@ object LogExporter {
         captureRestarts = 0
 
         launchLogcatPipe(file, verbosity)
+        // After the pipe, not before: logcat is spawned without -T, so it drains the ring buffer and
+        // then follows, and a line emitted here lands in the file either way.
+        AppLog.w(sessionBanner(context))
+    }
+
+    /**
+     * One line saying what produced this log and what it was configured to do.
+     *
+     * Reporter logs arrive as a file and nothing else, and none of them used to say which build or
+     * which settings wrote them: identifying a build meant fingerprinting which log lines existed,
+     * and the settings that decide the video path could at best be pieced together from scattered
+     * lines. A test-APK install can also rewrite settings through onboarding without the reporter
+     * noticing, so the log has to carry them itself. `exporterLogLevel` is included so missing
+     * lines can be told apart from a phone that sent nothing.
+     *
+     * `videoCodec` is the user's stored *choice*, not the codec that gets announced; the two differ
+     * wherever ServiceDiscoveryResponse overrides the choice, and having both in one log is the
+     * point. Nothing identifying goes in: no MAC, SSID or filesystem path.
+     *
+     * Emitted at WARN because both gates on the way out - [AppLog.isLoggable] and the `logcat`
+     * filter this object spawns - follow the same `exporterLogLevel` the banner reports, so an INFO
+     * banner would be dropped exactly on the sparse captures that need it most.
+     *
+     * Deliberately untested: it makes no decision, only a string, and the values come from `Build`,
+     * `BuildConfig` and SharedPreferences, none of which read without Robolectric.
+     */
+    private fun sessionBanner(context: Context): String {
+        val settings = Settings(context)
+        return "LogExporter: session | " +
+            "build=${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE}) " +
+            "${BuildConfig.FLAVOR}/${BuildConfig.BUILD_TYPE} | " +
+            "device=${Build.MANUFACTURER} ${Build.MODEL} board=${Build.BOARD} api=${Build.VERSION.SDK_INT} | " +
+            "video=codec:${settings.videoCodec} fps:${settings.fpsLimit} resId:${settings.resolutionId} " +
+            "view:${settings.viewMode.name} forceSw:${settings.forceSoftwareDecoding} " +
+            "swDecoder:${settings.softwareVideoDecoder.name} | " +
+            "wifi=mode:${settings.wifiConnectionMode} strategy:${settings.helperConnectionStrategy} | " +
+            "logLevel=${settings.exporterLogLevel.name}"
     }
 
     /**
@@ -157,6 +196,13 @@ object LogExporter {
             AppLog.w("LogExporter: export requested while SILENT; skipping export")
             return null
         }
+
+        // Before every path below, so the banner is in the export however it is produced: AppLog's
+        // own file, a running capture that already has one from startCapture, or a ring-buffer dump
+        // that has never seen one. A second copy in a capture file costs a line and is worth it -
+        // the ring-buffer export is the case where a missing banner would leave the whole file
+        // unattributable, and it is the case with no other chance to write one.
+        AppLog.w(sessionBanner(context))
 
         if (AppLog.logSource == Settings.LogSource.APPLOG_FILE) {
             return (AppLog.currentLogFile ?: AppLog.lastLogFile)

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/AapMessageFramingTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/AapMessageFramingTest.kt
@@ -1,0 +1,66 @@
+package com.andrerinas.openheadunit.aap
+
+import com.andrerinas.openheadunit.aap.AapMessageFraming.FLAG_BIT_ENCRYPTED
+import com.andrerinas.openheadunit.aap.AapMessageFraming.FLAG_BIT_FIRST
+import com.andrerinas.openheadunit.aap.AapMessageFraming.FLAG_BIT_LAST
+import com.andrerinas.openheadunit.aap.AapMessageFraming.carriesMessageType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The flag byte decides whether there is a message type to read, and getting it wrong costs a whole
+ * video frame - see [AapMessageFraming] for the measurement. These are the five values the protocol
+ * actually puts on the wire, so this test is the table rather than a sample of it.
+ */
+class AapMessageFramingTest {
+
+    // The four payload flags, spelled as literals on purpose: VideoFragmentAssembler writes them as
+    // decimal 11/9/8/10 and AapMediaPlayback as 0x09/0x08/0x0A, and this is the one place both
+    // spellings have to agree with the bits.
+    private val complete = 0x0b
+    private val firstFragment = 0x09
+    private val middleFragment = 0x08
+    private val lastFragment = 0x0a
+
+    /** What AapMessage.flags() emits for a control-type message on a non-control channel. */
+    private val controlOnPayloadChannel = 0x0f
+
+    @Test
+    fun `a message that begins an AAP message carries a type`() {
+        assertTrue("complete message", carriesMessageType(complete))
+        assertTrue("first fragment", carriesMessageType(firstFragment))
+        assertTrue("control type on a payload channel", carriesMessageType(controlOnPayloadChannel))
+    }
+
+    @Test
+    fun `a continuation fragment does not`() {
+        // The whole point. These two are raw payload from byte zero, which is why AapVideo appends
+        // them from offset 0 and why a one-byte last fragment is legal rather than malformed.
+        assertFalse("middle fragment", carriesMessageType(middleFragment))
+        assertFalse("last fragment", carriesMessageType(lastFragment))
+    }
+
+    @Test
+    fun `the bits are what the four flag values are made of`() {
+        // Guards the constants against the literals rather than restating them: if someone renumbers
+        // a bit, the flag values stop decomposing and this fails before any behaviour changes.
+        assertEquals(FLAG_BIT_ENCRYPTED or FLAG_BIT_FIRST or FLAG_BIT_LAST, complete)
+        assertEquals(FLAG_BIT_ENCRYPTED or FLAG_BIT_FIRST, firstFragment)
+        assertEquals(FLAG_BIT_ENCRYPTED, middleFragment)
+        assertEquals(FLAG_BIT_ENCRYPTED or FLAG_BIT_LAST, lastFragment)
+    }
+
+    @Test
+    fun `the answer comes from bit zero alone`() {
+        // Not from a value match. A flag byte with bits we have never seen set still has to answer
+        // correctly, because the guard in AapMessageIncoming.decrypt runs before anything has
+        // established that the stream is sane.
+        for (highBits in 0..0x0f) {
+            val extra = highBits shl 4
+            assertTrue("0x%02x".format(extra or FLAG_BIT_FIRST), carriesMessageType(extra or FLAG_BIT_FIRST))
+            assertFalse("0x%02x".format(extra or FLAG_BIT_LAST), carriesMessageType(extra or FLAG_BIT_LAST))
+        }
+    }
+}

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/AuditRecoveryPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/AuditRecoveryPolicyTest.kt
@@ -67,4 +67,83 @@ class AuditRecoveryPolicyTest {
             )
         }
     }
+
+    // --- The discard ------------------------------------------------------------------------
+
+    private fun result(
+        channel: Int = Channel.ID_VID,
+        outcome: Outcome = Outcome.DELTA_CHANGED,
+        delta: Int = 0,
+        expectedDelta: Int? = null,
+    ) = FragmentedMessageAudit.Result(
+        channel = channel,
+        outcome = outcome,
+        declaredTotal = 36_470,
+        observedTotal = 36_470 - delta,
+        fragments = 3,
+        delta = delta,
+        expectedDelta = expectedDelta,
+        perFragmentDelta = null,
+    )
+
+    @Test
+    fun `a run short by a whole fragment is discarded`() {
+        // The measured shape: a 3-fragment run on the wire's 16KB fragmenting loses a middle, so
+        // the delta lands a fragment's length above the channel's -29-per-fragment expectation.
+        assertTrue(
+            AuditRecoveryPolicy.shouldDiscardAssembledUnit(
+                result(delta = -87 + 16_355, expectedDelta = -87)
+            )
+        )
+    }
+
+    @Test
+    fun `a delta that shifted by less than a fragment is reported and not discarded`() {
+        // The audit's history is false positives - ten wrong DELTA_CHANGED lines in 200ms once -
+        // and a discarded keyframe costs a whole GOP. A shift on the order of the framing
+        // convention itself is a convention change, not a hole.
+        assertFalse(
+            AuditRecoveryPolicy.shouldDiscardAssembledUnit(
+                result(delta = -87 + AuditRecoveryPolicy.MISSING_FRAGMENT_FLOOR_BYTES - 1, expectedDelta = -87)
+            )
+        )
+    }
+
+    @Test
+    fun `a run longer than expected is never discarded`() {
+        // Extra bytes are not a hole. Whatever produced them, the unit in hand is not missing a
+        // fragment, and doubt decodes.
+        assertFalse(
+            AuditRecoveryPolicy.shouldDiscardAssembledUnit(
+                result(delta = -87 - 16_355, expectedDelta = -87)
+            )
+        )
+    }
+
+    @Test
+    fun `a channel that has not settled its convention never discards`() {
+        assertFalse(
+            AuditRecoveryPolicy.shouldDiscardAssembledUnit(
+                result(delta = 16_355, expectedDelta = null)
+            )
+        )
+    }
+
+    @Test
+    fun `only a video DELTA_CHANGED can discard`() {
+        // The discard is the stronger claim on top of shouldRequestKeyframe, so everything that
+        // gate refuses, this refuses too.
+        assertFalse(
+            AuditRecoveryPolicy.shouldDiscardAssembledUnit(
+                result(channel = Channel.ID_MPB, delta = 16_355, expectedDelta = -87)
+            )
+        )
+        for (outcome in listOf(Outcome.FIRST_OBSERVATION, Outcome.TRUNCATED_RUN, Outcome.ORPHANED_FRAGMENT)) {
+            assertFalse(
+                AuditRecoveryPolicy.shouldDiscardAssembledUnit(
+                    result(outcome = outcome, delta = 16_355, expectedDelta = -87)
+                )
+            )
+        }
+    }
 }

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicyTest.kt
@@ -3,6 +3,8 @@ package com.andrerinas.openheadunit.aap
 import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.Action
 import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.CORRUPTION_QUIET_MS
 import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.CYCLE_COOLDOWN_MS
+import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.CYCLE_REFUND_AFTER_QUIET_MS
+import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.MAX_CYCLES_PER_DRIVE
 import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.DEFER_FOR_QUIET_LIMIT_MS
 import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy.ESCALATE_AFTER_UNREPAIRED_MS
 import com.andrerinas.openheadunit.aap.WarmRelaunchKeyframePolicy.ESCALATE_AFTER_SURFACE_MS
@@ -458,6 +460,307 @@ class KeyframeCycleEscalationPolicyTest {
                 cyclesUsedThisSession = 1,
                 lastCycleMs = now - 1L,
                 lastWireCorruptionMs = now - 1L,
+            )
+        )
+    }
+
+    @Test
+    fun `a wire truncation later in a drive reaches the cycle`() {
+        // The shape a reporter's 2h21m session actually had, and the case this policy could not see
+        // until AapVideo's corruption path became escalatable: an isolated truncated access unit
+        // sixteen minutes after the session's first cycle. Both stamps land together, one cycle is
+        // spent, the cooldown expired long ago. Measured on that unit, the three events that never
+        // reached here stayed broken for 27.5s, 11.2s and 19.2s against the escalated one's 2.78s.
+        val firstCycle = 5_000_000L
+        val broken = firstCycle + 16 * 60_000L
+        assertEquals(
+            Action.CYCLE_FOCUS,
+            decide(
+                nowMs = broken + ESCALATE_AFTER_UNREPAIRED_MS,
+                unrepairedSinceMs = broken,
+                cyclesUsedThisSession = 1,
+                lastCycleMs = firstCycle,
+                lastWireCorruptionMs = broken,
+            )
+        )
+    }
+
+    @Test
+    fun `a truncation on a wire that is still losing frames is still held`() {
+        // The other half of the same wiring: making the video path escalatable must not cost the
+        // deferral, because it is that path's stamp the deferral reads. A second fault landing a
+        // full escalation window after the arm is sustained loss, not an isolated event, and a cycle
+        // spent on it buys a keyframe that arrives broken too.
+        val broken = 200_000L
+        assertEquals(
+            Action.WAIT_FOR_QUIET,
+            decide(
+                nowMs = broken + ESCALATE_AFTER_UNREPAIRED_MS,
+                unrepairedSinceMs = broken,
+                cyclesUsedThisSession = 1,
+                lastWireCorruptionMs = broken + ESCALATE_AFTER_UNREPAIRED_MS,
+            )
+        )
+    }
+
+    @Test
+    fun `an isolated truncation reaches the last cycle at the same instant as the first`() {
+        // The reporter's fourth event. A 141-minute session with three cycles already spent on
+        // earlier faults meets one more isolated truncation: both stamps land together, the
+        // cooldown expired long ago, and one cycle remains. The first version of the reordered
+        // gate checked the last-cycle hold before the isolated-fault exemption, so this exact
+        // shape waited out a full quiet window - repaired at ~15.5s instead of ~2.4s, on the one
+        // event of the drive where the reserve existing was the whole point.
+        val lastCycle = 5_000_000L
+        val broken = lastCycle + 16 * 60_000L
+        assertEquals(
+            Action.CYCLE_FOCUS,
+            decide(
+                nowMs = broken + ESCALATE_AFTER_UNREPAIRED_MS,
+                unrepairedSinceMs = broken,
+                cyclesUsedThisSession = MAX_CYCLES_PER_SESSION - 1,
+                lastCycleMs = lastCycle,
+                lastWireCorruptionMs = broken,
+            )
+        )
+    }
+
+    @Test
+    fun `the isolated-drop exemption holds at every budget position`() {
+        // The budget decides how much speculation a noisy wire is worth, and must decide nothing
+        // about a quiet one. Both stamp orderings, same as the isolated-drop test above, because
+        // which of the two lands first depends on the decoder.
+        val broken = 10_000L
+        for (spent in 0 until MAX_CYCLES_PER_SESSION) {
+            for (corruptionAt in listOf(broken - 250L, broken, broken + 1L)) {
+                assertEquals(
+                    "isolated drop deferred with $spent cycles spent and the corruption " +
+                        "stamped at ${corruptionAt - broken}ms",
+                    Action.CYCLE_FOCUS,
+                    decide(
+                        nowMs = broken + ESCALATE_AFTER_UNREPAIRED_MS,
+                        unrepairedSinceMs = broken,
+                        cyclesUsedThisSession = spent,
+                        lastCycleMs = if (spent == 0) 0L else broken - CYCLE_COOLDOWN_MS,
+                        lastWireCorruptionMs = corruptionAt,
+                    )
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `sustained loss is still held at every budget position`() {
+        // The exemption is for the fault that armed the clock and nothing after it. A second fault
+        // a full escalation window later is sustained loss, and moving the exemption ahead of the
+        // last-cycle hold must not have widened it to cover that.
+        val broken = 10_000L
+        for (spent in 0 until MAX_CYCLES_PER_SESSION) {
+            assertEquals(
+                "sustained loss reached the lever with $spent cycles spent",
+                Action.WAIT_FOR_QUIET,
+                decide(
+                    nowMs = broken + ESCALATE_AFTER_UNREPAIRED_MS,
+                    unrepairedSinceMs = broken,
+                    cyclesUsedThisSession = spent,
+                    lastCycleMs = if (spent == 0) 0L else broken - CYCLE_COOLDOWN_MS,
+                    lastWireCorruptionMs = broken + ESCALATE_AFTER_UNREPAIRED_MS,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `the ceiling asymmetry survives the gate reorder`() {
+        // At the deferral ceiling, under sustained loss: an earlier cycle is released to a wire
+        // that never settles, the last one is still held for real quiet. The two halves used to be
+        // separate branches; after the reorder they share one, so one test pins them side by side.
+        val broken = 10_000L
+        val now = broken + DEFER_FOR_QUIET_LIMIT_MS
+        assertEquals(
+            Action.CYCLE_FOCUS,
+            decide(
+                nowMs = now,
+                unrepairedSinceMs = broken,
+                cyclesUsedThisSession = 0,
+                lastWireCorruptionMs = now - 1L,
+            )
+        )
+        assertEquals(
+            Action.WAIT_FOR_QUIET,
+            decide(
+                nowMs = now,
+                unrepairedSinceMs = broken,
+                cyclesUsedThisSession = MAX_CYCLES_PER_SESSION - 1,
+                lastWireCorruptionMs = now - 1L,
+            )
+        )
+    }
+
+    // --- The refund -------------------------------------------------------------------------
+
+    private fun refund(
+        nowMs: Long,
+        cyclesUsedThisSession: Int = MAX_CYCLES_PER_SESSION,
+        cyclesSpentThisSession: Int = MAX_CYCLES_PER_SESSION,
+        lastBudgetChangeMs: Long = 1_000L,
+        lastWireCorruptionMs: Long = 0L,
+        pictureUnrepaired: Boolean = false,
+    ) = KeyframeCycleEscalationPolicy.cyclesToRefund(
+        nowMs, cyclesUsedThisSession, cyclesSpentThisSession,
+        lastBudgetChangeMs, lastWireCorruptionMs, pictureUnrepaired
+    )
+
+    @Test
+    fun `the refund window outlasts every other clock this policy runs`() {
+        // A refund on a shorter clock than the cooldown or the deferral ceiling would hand a cycle
+        // back inside the very episode that spent it. And it must outlast the phone's own keyframe
+        // interval - measured at ~69.4s, eight gaps, spread under 2s - so quiet always contains at
+        // least one whole natural repair before anything is earned back.
+        assertTrue(CYCLE_REFUND_AFTER_QUIET_MS > CORRUPTION_QUIET_MS)
+        assertTrue(CYCLE_REFUND_AFTER_QUIET_MS >= CYCLE_COOLDOWN_MS)
+        assertTrue(CYCLE_REFUND_AFTER_QUIET_MS >= DEFER_FOR_QUIET_LIMIT_MS)
+        assertTrue(CYCLE_REFUND_AFTER_QUIET_MS > 69_400L)
+    }
+
+    @Test
+    fun `a refund needs quiet on both clocks`() {
+        // Quiet is measured from whichever moved last: a fault restarts the window even when the
+        // budget has been still for an hour, and a fresh spend restarts it even on a clean wire.
+        val now = 10_000_000L
+        assertEquals(
+            0,
+            refund(now, lastBudgetChangeMs = 1_000L, lastWireCorruptionMs = now - 12_000L)
+        )
+        assertEquals(
+            0,
+            refund(now, lastBudgetChangeMs = now - 12_000L, lastWireCorruptionMs = 1_000L)
+        )
+        assertEquals(
+            1,
+            refund(
+                now,
+                cyclesUsedThisSession = 1,
+                lastBudgetChangeMs = now - CYCLE_REFUND_AFTER_QUIET_MS,
+                lastWireCorruptionMs = now - CYCLE_REFUND_AFTER_QUIET_MS,
+            )
+        )
+    }
+
+    @Test
+    fun `an injection cadence can never earn a refund`() {
+        // The sustained-loss round landed a fault every ~12s for 450s. Five unbroken minutes of
+        // quiet cannot occur inside that, so a build carrying the refund measures identically to
+        // one without it under any injection profile - which is what lets it ship into a rig round
+        // sized for the other commits.
+        var now = 1_000L
+        repeat(40) {
+            now += 12_000L
+            assertEquals(0, refund(now, lastWireCorruptionMs = now))
+        }
+    }
+
+    @Test
+    fun `nothing comes back while the picture is unrepaired`() {
+        // A held last cycle stays the last cycle: the reserve's guarantee is being there when the
+        // loss stops, and a refund arriving mid-hold would dilute exactly that.
+        val now = 10_000_000L
+        assertEquals(
+            0,
+            refund(now, lastBudgetChangeMs = 1_000L, pictureUnrepaired = true)
+        )
+    }
+
+    @Test
+    fun `refunds accrue one per quiet window`() {
+        val start = 1_000L
+        assertEquals(0, refund(start + CYCLE_REFUND_AFTER_QUIET_MS - 1, lastBudgetChangeMs = start))
+        assertEquals(1, refund(start + CYCLE_REFUND_AFTER_QUIET_MS, lastBudgetChangeMs = start))
+        assertEquals(2, refund(start + 2 * CYCLE_REFUND_AFTER_QUIET_MS, lastBudgetChangeMs = start))
+        assertEquals(
+            "a long quiet stretch cannot refund more than was spent",
+            MAX_CYCLES_PER_SESSION,
+            refund(start + 100 * CYCLE_REFUND_AFTER_QUIET_MS, lastBudgetChangeMs = start)
+        )
+    }
+
+    @Test
+    fun `an untouched budget has nothing to refund`() {
+        val now = 10_000_000L
+        assertEquals(0, refund(now, cyclesUsedThisSession = 0, cyclesSpentThisSession = 0))
+        assertEquals(0, refund(now, lastBudgetChangeMs = 0L))
+    }
+
+    @Test
+    fun `the drive ceiling counts what the budget could still spend`() {
+        // Capping refunds on spends alone double counts unspent headroom: at seven spends with one
+        // cycle still unspent, earning even one back allows a ninth spend. The cap is on potential
+        // - spends so far plus everything the refreshed budget could still spend - so that exact
+        // shape earns back nothing.
+        val now = 10_000_000L
+        assertEquals(
+            0,
+            refund(now, cyclesUsedThisSession = 2, cyclesSpentThisSession = 7)
+        )
+        assertEquals(
+            2,
+            refund(now, cyclesUsedThisSession = 3, cyclesSpentThisSession = 6)
+        )
+    }
+
+    @Test
+    fun `no sequence of spends and refunds exceeds the drive ceiling`() {
+        // Greedy adversary: spend everything available, wait an arbitrarily long quiet stretch,
+        // take every refund offered, repeat. The lifetime total must converge on the ceiling
+        // exactly - never past it, and not short of it either, or the ceiling is mis-set.
+        var used = 0
+        var spent = 0
+        var lastChange = 0L
+        var now = 1_000L
+        repeat(50) {
+            while (used < MAX_CYCLES_PER_SESSION && spent < MAX_CYCLES_PER_DRIVE + 5) {
+                used++
+                spent++
+                now += CYCLE_COOLDOWN_MS
+                lastChange = now
+            }
+            now += 100 * CYCLE_REFUND_AFTER_QUIET_MS
+            val r = refund(
+                now,
+                cyclesUsedThisSession = used,
+                cyclesSpentThisSession = spent,
+                lastBudgetChangeMs = lastChange,
+            )
+            used -= r
+            if (r > 0) lastChange = now
+        }
+        assertEquals(MAX_CYCLES_PER_DRIVE, spent)
+    }
+
+    @Test
+    fun `the reporter's drive shape reaches a cycle on its fourth event`() {
+        // Four isolated truncations across 141 minutes, tens of minutes apart. The first three
+        // spend the whole session budget; pre-refund, the fourth met an empty one and waited the
+        // phone's cadence out. Forty quiet minutes earn at least one cycle back, and the reordered
+        // gate then prices the event at the usual ~2.4s.
+        val thirdSpend = 80 * 60_000L
+        val fourthEvent = 120 * 60_000L
+        val earnedBack = refund(
+            fourthEvent,
+            cyclesUsedThisSession = MAX_CYCLES_PER_SESSION,
+            cyclesSpentThisSession = MAX_CYCLES_PER_SESSION,
+            lastBudgetChangeMs = thirdSpend,
+            lastWireCorruptionMs = thirdSpend,
+        )
+        assertTrue("forty quiet minutes earned nothing back", earnedBack >= 1)
+        assertEquals(
+            Action.CYCLE_FOCUS,
+            decide(
+                nowMs = fourthEvent + ESCALATE_AFTER_UNREPAIRED_MS,
+                unrepairedSinceMs = fourthEvent,
+                cyclesUsedThisSession = MAX_CYCLES_PER_SESSION - earnedBack,
+                lastCycleMs = thirdSpend,
+                lastWireCorruptionMs = fourthEvent,
             )
         )
     }

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/CorruptionConcealmentPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/CorruptionConcealmentPolicyTest.kt
@@ -1,0 +1,242 @@
+package com.andrerinas.openheadunit.decoder
+
+import com.andrerinas.openheadunit.aap.KeyframeCycleEscalationPolicy
+import com.andrerinas.openheadunit.aap.ProjectionWatchdogPolicy
+import com.andrerinas.openheadunit.decoder.CorruptionConcealmentPolicy.CONCEAL_MAX_MS
+import com.andrerinas.openheadunit.decoder.CorruptionConcealmentPolicy.ESCALATED_REPAIR_OBSERVED_MS
+import com.andrerinas.openheadunit.decoder.CorruptionConcealmentPolicy.Outcome
+import com.andrerinas.openheadunit.decoder.CorruptionConcealmentPolicy.State
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Two render-gating mechanisms were removed from this app for latching, so every guarantee here is
+ * a test rather than a promise: the window has a hard cap, the cap is measured from the first
+ * report, an expired window disarms rather than reopening, broken bookkeeping fails open, and the
+ * cap stands in a provable relation to the escalation that is supposed to beat it and to the
+ * display watchdog that must never see it.
+ */
+class CorruptionConcealmentPolicyTest {
+
+    private fun next(
+        nowMs: Long,
+        state: State = State.ARMED,
+        windowOpenedMs: Long = 0L,
+        corruptionReported: Boolean = false,
+        keyframeRepaired: Boolean = false,
+        sessionHasRendered: Boolean = true,
+    ) = CorruptionConcealmentPolicy.next(
+        nowMs, state, windowOpenedMs, corruptionReported, keyframeRepaired, sessionHasRendered
+    )
+
+    // --- The window -------------------------------------------------------------------------
+
+    @Test
+    fun `a healthy stream renders every frame`() {
+        assertEquals(Outcome.SHOW, next(nowMs = 1_000_000L))
+    }
+
+    @Test
+    fun `a corruption report holds the picture`() {
+        assertEquals(Outcome.OPEN, next(nowMs = 1_000_000L, corruptionReported = true))
+    }
+
+    @Test
+    fun `nothing is concealed before the session has rendered a frame`() {
+        // Before the first frame there is nothing on the surface worth holding, and the warm-start
+        // window belongs to WarmRelaunchKeyframePolicy. This is the same gate the dropped-frame
+        // and corruption escalations sit behind, and the boundary the #755 feed latch violated.
+        assertEquals(
+            Outcome.SHOW,
+            next(nowMs = 1_000_000L, corruptionReported = true, sessionHasRendered = false)
+        )
+    }
+
+    @Test
+    fun `the frame that repairs the picture is the frame that is shown`() {
+        val outcome = next(
+            nowMs = 1_001_000L,
+            state = State.CONCEALING,
+            windowOpenedMs = 1_000_000L,
+            keyframeRepaired = true,
+        )
+        assertEquals(Outcome.CLOSE_REPAIRED, outcome)
+        assertTrue(outcome.renders)
+    }
+
+    @Test
+    fun `the window ends itself at the cap and not before`() {
+        val opened = 1_000_000L
+        assertEquals(
+            Outcome.CONCEAL,
+            next(nowMs = opened + CONCEAL_MAX_MS - 1, state = State.CONCEALING, windowOpenedMs = opened)
+        )
+        assertEquals(
+            Outcome.CLOSE_EXPIRED,
+            next(nowMs = opened + CONCEAL_MAX_MS, state = State.CONCEALING, windowOpenedMs = opened)
+        )
+    }
+
+    @Test
+    fun `more corruption during a window never extends it`() {
+        // The cap is measured from the first report of the window. A stream losing frames
+        // continuously would otherwise hold the freeze forever, which is the latch this design
+        // exists to rule out.
+        val opened = 1_000_000L
+        assertEquals(
+            Outcome.CONCEAL,
+            next(
+                nowMs = opened + 1_000L,
+                state = State.CONCEALING,
+                windowOpenedMs = opened,
+                corruptionReported = true,
+            )
+        )
+        assertEquals(
+            Outcome.CLOSE_EXPIRED,
+            next(
+                nowMs = opened + CONCEAL_MAX_MS,
+                state = State.CONCEALING,
+                windowOpenedMs = opened,
+                corruptionReported = true,
+            )
+        )
+    }
+
+    // --- The disarm -------------------------------------------------------------------------
+
+    @Test
+    fun `a window that ran out does not open another one`() {
+        // Sustained loss buys exactly one freeze and then the honest smear. Re-opening on the next
+        // report would alternate freeze and smear at the cap's period - a strobing picture, worse
+        // than either steady state.
+        assertEquals(
+            Outcome.SHOW,
+            next(nowMs = 1_000_000L, state = State.DISARMED, corruptionReported = true)
+        )
+    }
+
+    @Test
+    fun `a keyframe re-arms the picture after a window ran out`() {
+        assertEquals(
+            Outcome.REARM,
+            next(nowMs = 1_000_000L, state = State.DISARMED, keyframeRepaired = true)
+        )
+    }
+
+    // --- Repair outranks everything ----------------------------------------------------------
+
+    @Test
+    fun `a repair outranks the cap`() {
+        val opened = 1_000_000L
+        assertEquals(
+            Outcome.CLOSE_REPAIRED,
+            next(
+                nowMs = opened + CONCEAL_MAX_MS + 10_000L,
+                state = State.CONCEALING,
+                windowOpenedMs = opened,
+                keyframeRepaired = true,
+            )
+        )
+    }
+
+    @Test
+    fun `a repair outranks a fresh report`() {
+        // The buffer in hand when the repair confirms is the repaired picture; a report arriving
+        // on the same step describes damage that keyframe has already replaced.
+        assertEquals(
+            Outcome.REARM,
+            next(nowMs = 1_000_000L, corruptionReported = true, keyframeRepaired = true)
+        )
+    }
+
+    // --- The no-latch guarantees -------------------------------------------------------------
+
+    @Test
+    fun `a lost window stamp resumes rather than freezing`() {
+        // The structural answer to the removed latches: if the caller's bookkeeping ever breaks
+        // and a window has no opening stamp, the window reads as already expired and the picture
+        // comes back. The failure mode of a bug here is a smear, never a freeze.
+        assertEquals(
+            Outcome.CLOSE_EXPIRED,
+            next(nowMs = 1_000_000L, state = State.CONCEALING, windowOpenedMs = 0L)
+        )
+    }
+
+    @Test
+    fun `every state returns to a rendered frame within the cap`() {
+        // Property, not example: from any state, with no repair ever arriving and the clock
+        // advancing, something must render inside CONCEAL_MAX_MS plus one step. A state this
+        // cannot be shown for is an absorbing state, which is the one thing this policy must not
+        // have.
+        for (start in State.values()) {
+            var state = start
+            var windowOpened = if (start == State.CONCEALING) 1_000_000L else 0L
+            var now = 1_000_000L
+            var renderedAt = -1L
+            while (now <= 1_000_000L + CONCEAL_MAX_MS + 10L) {
+                val outcome = next(nowMs = now, state = state, windowOpenedMs = windowOpened)
+                if (outcome.renders) {
+                    renderedAt = now
+                    break
+                }
+                when (outcome) {
+                    Outcome.OPEN -> { state = State.CONCEALING; windowOpened = now }
+                    Outcome.CLOSE_REPAIRED, Outcome.REARM -> state = State.ARMED
+                    Outcome.CLOSE_EXPIRED -> state = State.DISARMED
+                    else -> {}
+                }
+                now += 10L
+            }
+            assertTrue("state $start never rendered within the cap", renderedAt >= 0L)
+        }
+    }
+
+    // --- The cap in relation to everything it races -------------------------------------------
+
+    @Test
+    fun `the cap outlasts the slowest escalated repair ever measured`() {
+        // If this fails the freeze ends in a smear in exactly the case it was built for: a
+        // successful escalation. And the escalation clock must itself sit inside the measured
+        // repair, or the measurement no longer describes this code.
+        assertTrue(
+            "cap ${CONCEAL_MAX_MS}ms does not outlast the ${ESCALATED_REPAIR_OBSERVED_MS}ms repair",
+            CONCEAL_MAX_MS > ESCALATED_REPAIR_OBSERVED_MS
+        )
+        assertTrue(
+            ESCALATED_REPAIR_OBSERVED_MS > KeyframeCycleEscalationPolicy.ESCALATE_AFTER_UNREPAIRED_MS
+        )
+    }
+
+    @Test
+    fun `the freeze always ends before the projection view is torn down`() {
+        // The display-stall watchdog answers a long-undrawn surface with recreateProjectionView():
+        // a black flash, an EGL disconnect and touch loss. It measures from the last draw, so the
+        // margin also absorbs the age the last drawn frame had when the window opened - a frame
+        // interval or two, generously covered by a full second.
+        assertTrue(
+            "cap ${CONCEAL_MAX_MS}ms leaves less than 1000ms of margin under the " +
+                "${ProjectionWatchdogPolicy.DISPLAY_FREEZE_MS}ms display-freeze teardown",
+            ProjectionWatchdogPolicy.DISPLAY_FREEZE_MS - CONCEAL_MAX_MS >= 1_000L
+        )
+    }
+
+    @Test
+    fun `the freeze never reaches the projection watchdog's frame gap`() {
+        // FRAME_GAP_MS is where a stopped picture starts being treated as a possible lost
+        // connection. A concealment window must never be able to raise that machinery.
+        assertTrue(CONCEAL_MAX_MS < ProjectionWatchdogPolicy.FRAME_GAP_MS)
+    }
+
+    @Test
+    fun `the freeze outlasts the decoder's own stall threshold, so the stall clock must not be the render clock`() {
+        // SYNC_STALL_THRESHOLD_MS is 2000: a maximum-length window crosses it. This is why
+        // lastOutputMs stamps on every dequeued buffer rather than on renders - if that split is
+        // ever undone, a freeze classifies as STALLED and is answered with a codec rebuild that
+        // resumes on a P-frame, recreating the wedge the concealment exists to hide. The literal
+        // is pinned here because the threshold is private to VideoDecoder; if it gets a public
+        // name, compare against it directly.
+        assertTrue(CONCEAL_MAX_MS > 2_000L)
+    }
+}


### PR DESCRIPTION
## Why

A length guard in decrypt rejected any payload under 2 bytes on every channel, so a legal 1-byte final fragment (any access unit whose size mod 16384 is 1) was discarded, breaking that frame and every P-frame that references it. That is the on-screen melting in #219, measured seven for seven in the reporter's 141-minute log: every "Decrypted payload too short: 1" is followed within 21 ms by "Previous frame was truncated". This PR removes that corruption source, makes the one repair the protocol allows actually fire on wire corruption, and holds the last good frame while the repair runs so the user sees a short freeze instead of melting.

## What changed

- **AAP framing** (`AapMessageIncoming`, `AapMessageFraming`): the flag byte is a bitfield and only messages with bit 0x01 carry the 2-byte message type, so the minimum-length guard now applies only to type-carrying messages. Continuation fragments of any size pass through; every consumer of a 0- or 1-byte continuation was checked.
- **Keyframe escalation** (`AapTransport`, `KeyframeCycleEscalationPolicy`): wire corruption was armed with `escalatable=false` and got only a gain-only nudge measured inert across four rounds; it now reaches the escalated focus cycle. The isolated-fault exemption is checked before the last-cycle hold (a lone fault repaired in ~15.5 s instead of ~2.4 s), and a spent cycle regenerates after five unbroken quiet minutes, with a property-tested invariant capping lifetime spends at 8 per session.
- **Concealment** (`VideoDecoder`, `CorruptionConcealmentPolicy`): on a corruption report the output thread releases buffers unrendered, so the surface keeps the last good frame until the confirmed repaired keyframe arrives or a 3.5 s cap expires. An expired window disarms concealment until the next confirmed keyframe: sustained loss buys one freeze and then honest output, never a strobe. The feed path is untouched (the removed 66e59b2c latch starved the codec; this does not).
- **Watchdog clocks** (`ProjectionWatchdogPolicy`, `AapProjectionActivity`, `VideoDecoder`): the sync_stall clock now stamps on every dequeued buffer and the display clock only on rendered frames, so a deliberately held frame cannot classify as a stalled codec and trigger the rebuild-into-P-frame wedge. Behaviour preserving on its own; the deadlines move to named constants so tests can pin anything racing them.
- **Decoder feed** (`VideoDecoder`): a throw between `dequeueInputBuffer` and `queueInputBuffer` no longer leaks the input buffer. The leak drained the codec's pool until every feed timed out, which the stall watchdog answered with a rebuild the codec never earned.
- **Diagnostics** (`LogExporter`, `AapSslContext`, `AapVideo`): exported logs open with a build/device/settings banner from both export paths, a zero-produce SSL unwrap prints at WARN instead of DEBUG, and the throughput line carries `concealed=` so a capture can tell a concealment window from a wedged decoder.

## Android Auto protocol trade-offs

- **AAP has no keyframe request.** Verified four independent ways. The only repair lever is a video-focus release/regain cycle, which makes the phone send a keyframe in 0.52 to 0.78 s (~2.7 s to a repaired picture end to end). Without it, a broken picture persists until the phone's next scheduled keyframe: the GOP is ~69 s, and the reporter's session showed events broken for 27.5, 11.2 and 19.2 s.
- **The repair is a focus cycle, so it must be budgeted.** Each escalation is a real projection focus change on the phone, so it is rationed (8 per session, regenerating only after five quiet minutes) rather than fired freely. The concealment window exists to cover exactly that repair latency: the user sees a 2 to 3 s pause on the last good frame instead of the damage, and the 3.5 s cap guarantees the screen never freezes past the slowest measured repair.
- **Continuation fragments carry no message type**, so their length cannot be validated against a type. The original guard traded a crash fix for silent frame loss; the crash it prevented (fb47a323, a 2-byte read from a 1-byte array) is now unreachable because the plaintext buffer is pooled at 131080 bytes minimum and only ever grows.

## Verification

- 40 new JUnit tests across framing, escalation, audit recovery and concealment, including a property test that walks every concealment state to a rendered frame inside the cap, and a greedy spend/refund test that converges on the budget ceiling exactly. The Android CI workflow (`:app:testGithubDebugUnitTest` and `:app:assembleGithubDebug`) is the build check.
- Hardware rig, end to end: hold/restore pairs at 2651 to 2683 ms across truncation, holed-run and orphan faults, one millisecond from the pre-concealment repair on the same fault shape; the previously wedging holed-run mode left "Configuring decoder" at 1; a 30-fault storm produced exactly one freeze; 121 clean-control windows all showed `concealed=0` with zero watchdog reactions. Escalation timing: truncation-to-repair 2682/2673/2687 ms against 68.65 s and zero escalations on the previous build.

## Risks

- The concealment window races the display-freeze watchdog. The 3.5 s cap is sized a full second under the 5 s teardown deadline, both are named constants, and a test pins the margin. The watchdog clock split lands as its own behaviour-preserving commit so the race is bisectable.
- Budget regeneration adds focus-cycle headroom to long drives. The cap is an invariant on potential (spends plus refreshable headroom), not on spends, so a session can never exceed 8; nothing regenerates while the picture is unrepaired, and rig rounds measured regeneration inert under every injection cadence.
