### PR TITLE
Video: pace the transport thread instead of shedding reference frames

### DIFF
--- a/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/AapTransport.kt
@@ -344,6 +344,20 @@ class AapTransport(
                     "used, $focusCyclesSpentThisSession/${KeyframeCycleEscalationPolicy.MAX_CYCLES_PER_DRIVE} " +
                     "spent this drive)"
             )
+            // A refund granted while the clock is armed lands in a session whose check chain has
+            // ended: escalateIfStillUnrepaired() stops re-arming once the budget is spent, and
+            // the armed clock makes this call return before arming a new one. Without its own
+            // check the refunded cycle is unspendable until a keyframe happens to arrive - the
+            // very wait it exists to cut short.
+            if (unrepairedSinceMs != 0L) {
+                sendHandler?.let { handler ->
+                    handler.removeCallbacks(unrepairedCheckRunnable)
+                    handler.postDelayed(
+                        unrepairedCheckRunnable,
+                        KeyframeCycleEscalationPolicy.ESCALATE_AFTER_UNREPAIRED_MS
+                    )
+                }
+            }
         }
 
         // Stamped before the returns below, and deliberately also when this call goes on to arm

--- a/app/src/main/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicy.kt
@@ -229,9 +229,16 @@ object KeyframeCycleEscalationPolicy {
      *
      * Refunds accrue one per [CYCLE_REFUND_AFTER_QUIET_MS] of quiet, measured from whichever is
      * later of the last budget movement and the last wire corruption, so a fault inside a window
-     * restarts that window. Nothing comes back while the picture is unrepaired: a held last cycle
-     * stays the last cycle, and the reserve's guarantee - being there when the loss stops - cannot
-     * be diluted mid-hold.
+     * restarts that window. While the picture is unrepaired, nothing comes back as long as a
+     * reserve remains: a held last cycle stays the last cycle, and the reserve's guarantee - being
+     * there when the loss stops - cannot be diluted mid-hold. A session that has spent everything
+     * holds no reserve, and for it the unrepaired gate had turned "budget exhausted while broken"
+     * into a state only the phone's own keyframe, a GOP away, could exit - even though the last
+     * spend may lie minutes behind. For a fault that stamps no wire corruption (a shed frame
+     * under backpressure) the window runs from the last budget movement, so an exhausted session
+     * under a recurring fault of that kind earns at most one cycle per quiet window and re-spends
+     * it, still inside the drive ceiling; sustained wire corruption keeps its own stamp advancing
+     * and blocks refunds outright, as before.
      *
      * The drive ceiling is enforced as an invariant on *potential*, not a check on spends so far:
      * a refund is capped so that the cycles already spent plus everything the refreshed budget
@@ -253,7 +260,11 @@ object KeyframeCycleEscalationPolicy {
         lastWireCorruptionMs: Long,
         pictureUnrepaired: Boolean,
     ): Int {
-        if (pictureUnrepaired) return 0
+        // The unrepaired hold protects the reserve, and only the reserve. With cycles still
+        // unspent, granting more mid-hold would dilute the guarantee that the last one is there
+        // when the loss stops; with everything spent there is no reserve left to protect, and
+        // refusing the refund is what latched exhausted-while-broken sessions dead.
+        if (pictureUnrepaired && cyclesUsedThisSession < MAX_CYCLES_PER_SESSION) return 0
         if (cyclesUsedThisSession <= 0) return 0
         if (lastBudgetChangeMs == 0L) return 0
         val quietSince = maxOf(lastBudgetChangeMs, lastWireCorruptionMs)

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoDecoder.kt
@@ -279,19 +279,31 @@ class VideoDecoder(
     // never sent; high means frames are arriving faster than the codec drains them, which on a
     // healthy link is the signature of a burst after the link went quiet.
     @Volatile private var inputWaitMs = 0L
+    // Milliseconds decode() spent waiting for space in the feed queue, on the transport's read
+    // thread. Non-zero is the backpressure working: the read thread is being paced at the codec's
+    // real drain rate, closing the phone's unacked-message window, instead of frames being shed.
+    // Every wait counts, including one that ran out the budget and shed the frame anyway - the
+    // thread was held either way, and those are the longest waits the path can produce. Read it
+    // beside `dropped`: high here with dropped=0 is pacing, both high is a wedge.
+    // See offerWithBackpressure().
+    @Volatile private var enqueueWaitMs = 0L
     private var lastThroughputLogMs = 0L
     private var lastLoggedFramesFed = 0L
     private var lastLoggedFramesDropped = 0L
     private var lastLoggedFramesRendered = 0L
     private var lastLoggedFramesSkippedAtRender = 0L
     private var lastLoggedInputWaitMs = 0L
+    private var lastLoggedEnqueueWaitMs = 0L
 
     // Encoded frames waiting to be handed to the codec, and the thread that hands them over.
     //
     // This queue exists to keep the wait for a free codec input buffer off the transport's read
     // thread. That thread carries every channel - video, audio, microphone, control - so while it
     // sat inside dequeueInputBuffer nothing else on the link was dispatched and the socket went
-    // undrained, which turned a busy decoder into stalled audio and late keepalives. Frames are
+    // undrained, which turned a busy decoder into stalled audio and late keepalives. The one wait
+    // the read thread still takes is deliberate and different in kind: when this queue is FULL,
+    // offerWithBackpressure() paces that thread by one queue slot - one frame period in steady
+    // state - so the phone's ack window throttles it instead of frames being shed. Frames are
     // copied on the way in because the transport reuses the buffer it hands us.
     private class PendingFrame(var data: ByteArray, var size: Int, var arrivalNanos: Long)
     // Derived once per decoder rather than per session: the queue is allocated here, and fpsLimit
@@ -323,6 +335,10 @@ class VideoDecoder(
      */
     private var lastFeedDropLogMs = 0L
     private var suppressedFeedDropLogs = 0
+    // Same shape as the feed-drop pair above, for the pacing line, but owned by the transport's
+    // read thread - the two threads must not share unsynchronised counters.
+    private var lastFeedPacingLogMs = 0L
+    private var suppressedFeedPacingLogs = 0
     // Volatile and identity-checked by the loop itself: interrupt() does not abort a MediaCodec
     // call, so a feed thread parked in dequeueInputBuffer can outlive the join() below. If it
     // does, stop() goes on to release the codec and a later start() sets running back to true -
@@ -760,6 +776,7 @@ class VideoDecoder(
             framesRendered = 0L
             framesSkippedAtRender = 0L
             inputWaitMs = 0L
+            enqueueWaitMs = 0L
             lastDropKeyframeRequestMs = 0L
             lastThroughputLogMs = 0L
             lastLoggedFramesFed = 0L
@@ -767,6 +784,7 @@ class VideoDecoder(
             lastLoggedFramesRendered = 0L
             lastLoggedFramesSkippedAtRender = 0L
             lastLoggedInputWaitMs = 0L
+            lastLoggedEnqueueWaitMs = 0L
             AppLog.i("Decoder stopped: $reason")
         }
     }
@@ -779,13 +797,15 @@ class VideoDecoder(
     /**
      * Main entry point for decoding a video/control packet.
      *
-     * Reports nothing back to the caller. A frame this cannot place into the codec's input queue
-     * is lost here, and once the picture is live the loss asks the phone for a keyframe - see
-     * [notifyFrameDropped] for the shape of that ask and why it stays silent before the first
-     * rendered frame.
+     * Reports nothing back to the caller, but may pace it: with the feed queue full this blocks
+     * the calling thread for up to [VideoFeedThrottlePolicy.WAIT_BUDGET_MS], which is what
+     * throttles the phone through its ack window - see [offerWithBackpressure]. A frame that
+     * outlasts even that wait is lost here, and once the picture is live the loss asks the phone
+     * for a keyframe - see [notifyFrameDropped] for the shape of that ask and why it stays silent
+     * before the first rendered frame.
      */
     fun decode(buffer: ByteArray, offset: Int, size: Int, forceSoftware: Boolean, codecName: String) {
-        synchronized(this) {
+        val frame = synchronized(this) {
             // Input-side liveness: bytes are arriving from the phone right now.
             lastInputBytesReceivedMs = SystemClock.elapsedRealtime()
 
@@ -926,18 +946,24 @@ class VideoDecoder(
 
             if (codec == null) return
 
-            enqueueForFeed(frameData, frameOffset, size)
-        }
+            prepareFrame(frameData, frameOffset, size)
+        } ?: return
+
+        // Outside the monitor on purpose: stop() synchronizes on this object, and a wait held
+        // inside it would block the teardown for up to the whole budget. Out here stop() clears
+        // running and the wait aborts within one slice.
+        offerWithBackpressure(frame)
     }
 
     /**
-     * Copies a frame onto the feed queue. Returns immediately in every case - the caller is the
-     * transport's read thread and must get back to the socket.
+     * Copies a frame into a pooled buffer while the transport's bytes are still valid - the
+     * caller reuses the buffer it handed us the moment decode() returns, so the copy has to
+     * happen before the monitor is released.
      */
-    private fun enqueueForFeed(frameData: ByteArray, frameOffset: Int, size: Int) {
+    private fun prepareFrame(frameData: ByteArray, frameOffset: Int, size: Int): PendingFrame? {
         // An empty frame reaches the codec as nothing at all, so queueing it would only inflate
         // the fed count that the throughput line uses to say whether frames arrived.
-        if (size <= 0) return
+        if (size <= 0) return null
 
         val frame = borrowFrame(size)
 
@@ -947,18 +973,79 @@ class VideoDecoder(
         // a few milliseconds, so timestamps taken there would give a dozen frames near-identical
         // values and flatten the cadence the codec sees.
         frame.arrivalNanos = System.nanoTime()
+        return frame
+    }
 
-        if (!frameQueue.offer(frame)) {
-            // The codec has not taken a frame for as long as this queue holds. Drop the one that
-            // just arrived rather than something already queued: the older frames are what
-            // everything after them is decoded against, so dropping forward costs one frame while
-            // dropping backward corrupts every frame that referenced it until the next keyframe.
-            // The frame shed here is still a reference for what follows it, though, so ask for
-            // that keyframe rather than waiting out the phone's own cadence - see
-            // notifyFrameDropped().
-            recycleFrame(frame)
-            notifyFrameDropped()
+    /**
+     * Places the frame on the feed queue, pacing the transport's read thread when it is full.
+     *
+     * The bounded stall is the point, not a hazard. While this thread waits, no further messages
+     * are read or acked, so the phone's unacked-message window closes and the phone slows to the
+     * rate the codec actually drains - the protocol's own flow control, doing the throttling that
+     * shedding used to fake. A full queue plus an arriving frame only ever happens when the phone
+     * is outrunning the codec, so in steady state the wait per frame is one frame period, and a
+     * link-stall backlog (phone silent, queue draining) never blocks here at all.
+     *
+     * Every frame shed by the old immediate drop was a reference some later frame predicted from,
+     * so each one cost a washed-out, blocky picture until the phone's own keyframe - and the phone
+     * runs a fixed keyframe period measured at ~69s, beyond anything the focus-cycle ladder can
+     * repair when the drops keep coming.
+     *
+     * Budget expiry still sheds the frame: the feed thread's own give-up frees a slot every
+     * [VideoFeedQueuePolicy.INPUT_DEQUEUE_PATIENCE_MS], so outlasting the budget means the codec
+     * took nothing for the whole wait - a wedge, which belongs to the sync_stall watchdog, with
+     * [notifyFrameDropped]'s keyframe ask covering the picture that frame cost.
+     */
+    private fun offerWithBackpressure(frame: PendingFrame) {
+        if (frameQueue.offer(frame)) return
+
+        val waitStart = SystemClock.elapsedRealtime()
+        var accepted = false
+        var elapsed = 0L
+        while (!accepted && VideoFeedThrottlePolicy.shouldKeepWaiting(elapsed, running)) {
+            accepted = try {
+                frameQueue.offer(frame, VideoFeedThrottlePolicy.OFFER_SLICE_MS, TimeUnit.MILLISECONDS)
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+                break
+            }
+            elapsed = SystemClock.elapsedRealtime() - waitStart
         }
+
+        // Counted on both outcomes. The question this field answers is how long the transport was
+        // paced, and a wait that ran out the budget paced it for the whole budget - counting only
+        // the admitted ones would zero the largest waits there are and make a wedge read as a
+        // session that never waited at all.
+        enqueueWaitMs += SystemClock.elapsedRealtime() - waitStart
+
+        if (accepted) {
+            logFeedPacing()
+        } else {
+            recycleFrame(frame)
+            // A teardown fails the offer the same way a wedge does - stop() clears running and
+            // empties the queue. Say nothing then: the frame is moot and the keyframe ask would
+            // fire on every ordinary stop.
+            if (running) notifyFrameDropped()
+        }
+    }
+
+    /**
+     * Reports that the read thread is being paced, at most once per [FEED_DROP_LOG_INTERVAL_MS].
+     *
+     * Called from the transport's read thread only. The throughput line's `enqueueWait` carries
+     * the magnitude; this line only says it began.
+     */
+    private fun logFeedPacing() {
+        val now = SystemClock.elapsedRealtime()
+        if (lastFeedPacingLogMs != 0L && now - lastFeedPacingLogMs < FEED_DROP_LOG_INTERVAL_MS) {
+            suppressedFeedPacingLogs++
+            return
+        }
+        lastFeedPacingLogMs = now
+        val alsoSuppressed =
+            if (suppressedFeedPacingLogs > 0) " (+$suppressedFeedPacingLogs more since the last line)" else ""
+        suppressedFeedPacingLogs = 0
+        AppLog.i("Feed queue full - pacing the transport thread instead of shedding frames%s", alsoSuppressed)
     }
 
     /** Takes a buffer from the pool, growing it if this frame does not fit, or allocates one. */
@@ -1024,6 +1111,15 @@ class VideoDecoder(
             "Feed thread started (queue holds $frameQueueCapacity frames, " +
                 "${VideoFeedQueuePolicy.heldMsAt(settings.fpsLimit)}ms at ${settings.fpsLimit}fps)"
         )
+        // Read once, not per frame: this thread must not touch SharedPreferences on its hot path,
+        // and a mid-session change taking effect silently is exactly what the loud line prevents.
+        val feedHoldMs = settings.debugVideoFeedHoldMs
+        if (feedHoldMs > 0) {
+            AppLog.w(
+                "Feed thread: DEBUG hold ${feedHoldMs}ms per frame - simulating a decoder slower " +
+                    "than the stream. No real fault looks like this line."
+            )
+        }
         val self = Thread.currentThread()
         while (running && feedThread === self) {
             val frame = try {
@@ -1036,7 +1132,20 @@ class VideoDecoder(
                 if (!running || feedThread !== self || codec == null) continue
                 val buf = ByteBuffer.wrap(frame.data, 0, frame.size)
                 when (feedInputBuffer(buf, frame.arrivalNanos)) {
-                    FeedResult.FED -> framesFed++
+                    FeedResult.FED -> {
+                        framesFed++
+                        // After the feed, not inside the codec wait, so inputWait stays honest:
+                        // the hold reads as a full queue and a paced transport while the codec
+                        // itself keeps decoding and rendering - the shape of a real decoder at
+                        // its ceiling.
+                        if (feedHoldMs > 0) {
+                            try {
+                                Thread.sleep(feedHoldMs.toLong())
+                            } catch (e: InterruptedException) {
+                                Thread.currentThread().interrupt()
+                            }
+                        }
+                    }
                     // Counted and answered where the real buffer capacity is known.
                     FeedResult.DROPPED_TOO_LARGE -> {}
                     FeedResult.ERROR -> {
@@ -1869,6 +1978,7 @@ class VideoDecoder(
         val dropped = framesDropped - lastLoggedFramesDropped
         val skipped = framesSkippedAtRender - lastLoggedFramesSkippedAtRender
         val inputWait = inputWaitMs - lastLoggedInputWaitMs
+        val enqueueWait = enqueueWaitMs - lastLoggedEnqueueWaitMs
         val concealed = framesConcealed - lastLoggedFramesConcealed
         lastLoggedFramesConcealed = framesConcealed
         lastThroughputLogMs = now
@@ -1877,13 +1987,17 @@ class VideoDecoder(
         lastLoggedFramesDropped = framesDropped
         lastLoggedFramesSkippedAtRender = framesSkippedAtRender
         lastLoggedInputWaitMs = inputWaitMs
+        lastLoggedEnqueueWaitMs = enqueueWaitMs
 
         val renderedFps = rendered * 1000 / elapsed
         val fedFps = fed * 1000 / elapsed
+        // enqueueWait is appended after the pre-existing fields, never between them: this line is
+        // read by diagnostics and compared across releases, so existing fields keep name and order.
         AppLog.i(
             "Throughput over ${elapsed}ms: rendered=$rendered (${renderedFps}fps), " +
                 "fed=$fed (${fedFps}fps), dropped=$dropped, skipped=$skipped, " +
-                "concealed=$concealed, inputWait=${inputWait}ms, codec=$currentCodecName"
+                "concealed=$concealed, inputWait=${inputWait}ms, enqueueWait=${enqueueWait}ms, " +
+                "codec=$currentCodecName"
         )
         reportBackpressure(elapsed, inputWait, dropped)
     }

--- a/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoFeedThrottlePolicy.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/decoder/VideoFeedThrottlePolicy.kt
@@ -1,0 +1,48 @@
+package com.andrerinas.openheadunit.decoder
+
+/**
+ * How long the transport's read thread may wait for space in the feed queue before a frame is shed.
+ *
+ * A full queue used to shed the arriving access unit immediately. On a decoder running at its
+ * ceiling - decoding and rendering continuously, just slower than the phone sends - that turned
+ * every arrival burst into shed units, and every unit in this stream is a reference frame, so each
+ * one cost a washed-out, blocky picture until the phone's own keyframe, tens of seconds away.
+ * Measured on an MT6735 at 1080p60: two bursts of ~50 shed frames each, artifacts for the rest of
+ * the session.
+ *
+ * Waiting here instead is the protocol's own flow control. Media acks are sent after a message is
+ * processed, and the phone stops sending once its unacked-message window fills - so a read thread
+ * paced by this wait closes that window within a handful of messages and the phone throttles
+ * itself to the rate the codec actually drains. That is how the pipeline behaved before the feed
+ * queue existed, and the same hardware ran artifact-free then. The queue keeps its own job: a
+ * burst after a link stall still lands in it whole and is caught up at render time, and in steady
+ * state at the codec's ceiling the wait per frame is one frame period, not the budget.
+ *
+ * The wait is bounded because a codec can also be wedged rather than slow. Past [WAIT_BUDGET_MS]
+ * the frame is shed exactly as before, and the wedge belongs to the sync_stall watchdog.
+ */
+object VideoFeedThrottlePolicy {
+
+    /**
+     * One timed offer on the queue. Between slices the caller re-checks whether the decoder is
+     * still running, so a teardown aborts the wait within one slice rather than holding the stop
+     * to the full budget.
+     */
+    const val OFFER_SLICE_MS = 50L
+
+    /**
+     * Total per-frame bound on the read thread.
+     *
+     * Must clear [VideoFeedQueuePolicy.INPUT_DEQUEUE_PATIENCE_MS]: the feed thread gives up on a
+     * frame after that long and frees a slot, so any codec still draining at all - however slowly -
+     * frees space inside this budget, and expiry genuinely means the feed side is stuck inside the
+     * codec. Must stay under the 2s input-idle threshold the stall-cause classifier reads (a paced
+     * read thread still stamps input liveness once per frame) and far under the 10s link-quiet
+     * window the projection watchdog treats as a dead link.
+     */
+    const val WAIT_BUDGET_MS = 1_000L
+
+    /** Whether the enqueue should keep waiting for space after [elapsedMs] on a live decoder. */
+    fun shouldKeepWaiting(elapsedMs: Long, running: Boolean): Boolean =
+        running && elapsedMs < WAIT_BUDGET_MS
+}

--- a/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/main/SettingsFragment.kt
@@ -2012,6 +2012,32 @@ class SettingsFragment : Fragment() {
             }
         ))
 
+        // Slows the feed thread so the enqueue backpressure path can be exercised on a working
+        // unit - a codec that cannot drain the negotiated rate is otherwise only reachable on
+        // hardware we do not have. Applies on the next connection, and the feed thread announces
+        // the hold loudly at start. A tool, not a preference, so applied immediately.
+        val feedHolds = listOf(0, 10, 25, 40, 100)
+        val feedHoldNames = feedHolds
+            .map { if (it == 0) "Off" else "${it}ms per frame" }
+            .toTypedArray()
+        items.add(SettingItem.SettingEntry(
+            stableId = "debugVideoFeedHold",
+            nameResId = R.string.debug_video_feed_hold,
+            value = if (settings.debugVideoFeedHoldMs == 0) "Off" else "${settings.debugVideoFeedHoldMs}ms per frame",
+            searchKeywords = "slow decoder feed hold backpressure pacing test",
+            onClick = {
+                val currentIndex = feedHolds.indexOf(settings.debugVideoFeedHoldMs).coerceAtLeast(0)
+                MaterialAlertDialogBuilder(requireContext(), R.style.DarkAlertDialog)
+                    .setTitle(R.string.debug_video_feed_hold)
+                    .setSingleChoiceItems(feedHoldNames, currentIndex) { dialog, which ->
+                        settings.debugVideoFeedHoldMs = feedHolds[which]
+                        dialog.dismiss()
+                        updateSettingsList()
+                    }
+                    .show()
+            }
+        ))
+
         // Deliberately corrupts the video stream so the reassembler's failure paths can be
         // exercised on a working unit. Applies on the next connection, and every injected fault is
         // logged loudly - see VideoFaultInjector. Applied immediately rather than through the

--- a/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
+++ b/app/src/main/java/com/andrerinas/openheadunit/utils/Settings.kt
@@ -444,6 +444,24 @@ class Settings(private val context: Context) {
         get() = prefs.getBoolean("debug-video-low-latency", false)
         set(value) { prefs.edit().putBoolean("debug-video-low-latency", value).apply() }
 
+    /**
+     * Holds the feed thread for this many milliseconds after every frame it hands the codec,
+     * simulating a decoder slower than the stream.
+     *
+     * Off at 0, and meant to stay off. The backpressure path only engages when a codec cannot
+     * drain the negotiated rate, which a healthy rig never produces - so without this there is
+     * no way to show the pacing works except to wait for a reporter's next drive. The hold sits
+     * after the feed rather than inside the codec's own wait, so the codec stays healthy and
+     * rendering while the queue fills: the same shape as a real decoder at its ceiling, which
+     * keeps decoding all through the event. A session with this on announces it loudly at
+     * feed-thread start, so a captured log can never be mistaken for a log of a real fault.
+     * Capped so a forgotten setting slows a session to a crawl rather than reading as a dead
+     * decoder.
+     */
+    var debugVideoFeedHoldMs: Int
+        get() = prefs.getInt("debug-video-feed-hold-ms", 0)
+        set(value) { prefs.edit().putInt("debug-video-feed-hold-ms", value.coerceIn(0, 250)).apply() }
+
     /** One in this many of the targeted messages is faulted. See [debugVideoFaultInjection]. */
     var debugVideoFaultRate: Int
         get() = prefs.getInt("debug-video-fault-rate", VideoFaultInjector.DEFAULT_RATE)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -694,6 +694,7 @@
     <string name="p2p_legacy_5ghz_upper_description" translatable="false">Asks for channel 149 instead of 36. Try only if 36 fails, since regions allow one range or the other.</string>
     <string name="debug_video_low_latency" translatable="false">Request decoder low-latency mode</string>
     <string name="debug_video_low_latency_description" translatable="false">Sets the vendor low-latency MediaFormat key when configuring the video decoder. Falls back automatically if the decoder rejects it.</string>
+    <string name="debug_video_feed_hold" translatable="false">Simulate a slow decoder</string>
     <string name="show_fps_counter_description">Display a real-time FPS overlay in the top-left corner during projection.</string>
 
     <!-- Auto-start permission strings -->

--- a/app/src/test/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/aap/KeyframeCycleEscalationPolicyTest.kt
@@ -661,13 +661,75 @@ class KeyframeCycleEscalationPolicyTest {
     }
 
     @Test
-    fun `nothing comes back while the picture is unrepaired`() {
+    fun `nothing comes back while the picture is unrepaired and a reserve remains`() {
         // A held last cycle stays the last cycle: the reserve's guarantee is being there when the
-        // loss stops, and a refund arriving mid-hold would dilute exactly that.
+        // loss stops, and a refund arriving mid-hold would dilute exactly that. The hold is
+        // scoped to the reserve - see the exhausted-budget test below for the other half.
+        val now = 10_000_000L
+        for (used in 1 until MAX_CYCLES_PER_SESSION) {
+            assertEquals(
+                "a session at $used spends still holds a reserve",
+                0,
+                refund(
+                    now,
+                    cyclesUsedThisSession = used,
+                    cyclesSpentThisSession = used,
+                    lastBudgetChangeMs = 1_000L,
+                    pictureUnrepaired = true,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `an exhausted budget earns the refund even while the picture is unrepaired`() {
+        // With everything spent there is no reserve for the unrepaired hold to protect. Refusing
+        // the refund there latched the ladder dead: a fault that stamps no wire corruption kept
+        // the quiet clock running from the last spend, the picture stayed broken, and the only
+        // exit left was the phone's own keyframe a GOP away.
+        val start = 1_000L
+        assertEquals(
+            1,
+            refund(
+                start + CYCLE_REFUND_AFTER_QUIET_MS,
+                lastBudgetChangeMs = start,
+                pictureUnrepaired = true,
+            )
+        )
+    }
+
+    @Test
+    fun `an exhausted budget under sustained wire corruption still earns nothing back`() {
+        // The unrepaired gate narrows; the quiet gate does not. A wire still losing frames keeps
+        // its own stamp advancing, and a refund spent into that stream buys a keyframe that
+        // arrives broken too.
         val now = 10_000_000L
         assertEquals(
             0,
-            refund(now, lastBudgetChangeMs = 1_000L, pictureUnrepaired = true)
+            refund(
+                now,
+                lastBudgetChangeMs = now - CYCLE_REFUND_AFTER_QUIET_MS,
+                lastWireCorruptionMs = now - 12_000L,
+                pictureUnrepaired = true,
+            )
+        )
+    }
+
+    @Test
+    fun `the drive ceiling binds through unrepaired-exhausted refunds`() {
+        // The new refund path must not open a way past MAX_CYCLES_PER_DRIVE: a session that has
+        // spent its whole drive allowance earns nothing back no matter how long it stays quiet,
+        // broken or not.
+        val now = 100_000_000L
+        assertEquals(
+            0,
+            refund(
+                now,
+                cyclesUsedThisSession = MAX_CYCLES_PER_SESSION,
+                cyclesSpentThisSession = MAX_CYCLES_PER_DRIVE,
+                lastBudgetChangeMs = 1_000L,
+                pictureUnrepaired = true,
+            )
         )
     }
 

--- a/app/src/test/java/com/andrerinas/openheadunit/decoder/VideoFeedThrottlePolicyTest.kt
+++ b/app/src/test/java/com/andrerinas/openheadunit/decoder/VideoFeedThrottlePolicyTest.kt
@@ -1,0 +1,93 @@
+package com.andrerinas.openheadunit.decoder
+
+import com.andrerinas.openheadunit.aap.ProjectionWatchdogPolicy
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The enqueue wait exists to pace the transport's read thread against the codec's real drain rate,
+ * and every watchdog that observes that thread has an opinion about how long it may pause. These
+ * tests pin the budget inside all of them, so a throttled-but-healthy session can never be read as
+ * an idle phone, a dead link, or a stalled decoder.
+ */
+class VideoFeedThrottlePolicyTest {
+
+    @Test
+    fun `a slice is shorter than the whole budget`() {
+        // The slice is what bounds how long a teardown waits for the enqueue to notice
+        // running=false; a slice as long as the budget would make the re-check decorative.
+        assertTrue(VideoFeedThrottlePolicy.OFFER_SLICE_MS < VideoFeedThrottlePolicy.WAIT_BUDGET_MS)
+    }
+
+    @Test
+    fun `the budget outlasts the feed thread's give-up, so expiry means a wedge`() {
+        // The feed thread abandons a frame after INPUT_DEQUEUE_PATIENCE_MS and frees a slot. As
+        // long as the budget clears that, a merely-slow codec always admits the waiting frame,
+        // and budget expiry is reserved for a codec that took nothing for the whole wait.
+        assertTrue(
+            VideoFeedThrottlePolicy.WAIT_BUDGET_MS > VideoFeedQueuePolicy.INPUT_DEQUEUE_PATIENCE_MS
+        )
+    }
+
+    @Test
+    fun `the budget stays under the stall-cause classifier's input-idle threshold`() {
+        // VideoDecoder's SYNC_STALL_THRESHOLD_MS (private, 2000) doubles as the input-idle window
+        // DecoderStallCausePolicy reads. lastInputBytesReceivedMs is stamped once per decode()
+        // call, so the longest it can age while the read thread is paced is one budget - which
+        // must not be long enough to make arriving input classify as PHONE_IDLE.
+        assertTrue(VideoFeedThrottlePolicy.WAIT_BUDGET_MS < 2_000L)
+    }
+
+    @Test
+    fun `the budget stays far under the projection watchdog's link-quiet window`() {
+        // A paced read thread delays every channel's dispatch by at most one budget; the
+        // reconnecting overlay needs the link quiet for LINK_QUIET_MS to show. These must not be
+        // in the same order of magnitude.
+        assertTrue(
+            VideoFeedThrottlePolicy.WAIT_BUDGET_MS * 5 <= ProjectionWatchdogPolicy.LINK_QUIET_MS
+        )
+    }
+
+    @Test
+    fun `waits while running and inside the budget`() {
+        assertTrue(VideoFeedThrottlePolicy.shouldKeepWaiting(0L, running = true))
+        assertTrue(
+            VideoFeedThrottlePolicy.shouldKeepWaiting(
+                VideoFeedThrottlePolicy.WAIT_BUDGET_MS - 1, running = true
+            )
+        )
+    }
+
+    @Test
+    fun `stops at the budget`() {
+        assertFalse(
+            VideoFeedThrottlePolicy.shouldKeepWaiting(
+                VideoFeedThrottlePolicy.WAIT_BUDGET_MS, running = true
+            )
+        )
+        assertFalse(
+            VideoFeedThrottlePolicy.shouldKeepWaiting(
+                VideoFeedThrottlePolicy.WAIT_BUDGET_MS + 1, running = true
+            )
+        )
+    }
+
+    @Test
+    fun `never waits on a stopped decoder`() {
+        assertFalse(VideoFeedThrottlePolicy.shouldKeepWaiting(0L, running = false))
+        assertFalse(
+            VideoFeedThrottlePolicy.shouldKeepWaiting(
+                VideoFeedThrottlePolicy.WAIT_BUDGET_MS - 1, running = false
+            )
+        )
+    }
+
+    @Test
+    fun `a clock that runs backwards is treated as inside the budget, not as overflow`() {
+        // elapsed is a difference of two elapsedRealtime() reads and cannot really go negative,
+        // but a negative value must fail safe into "keep waiting" rather than into arithmetic
+        // surprise - the running flag is the abort path, not the clock.
+        assertTrue(VideoFeedThrottlePolicy.shouldKeepWaiting(-1L, running = true))
+    }
+}


### PR DESCRIPTION
Fixes #875. When the feed queue fills, the enqueue sheds the newest access unit, and since Android Auto negotiates H.264 Baseline every one of those is a reference frame, so the picture melts until the phone's own keyframe tens of seconds later. On the reporter's MT6735 that meant fifteen clean minutes at 50-60fps, then the codec's drain falling to 42-58fps against a 60fps stream, 36-56 frames shed per 5s window, and the session dying with the uplink 52% blocked. The same unit ran this negotiation artifact-free before the feed queue existed, because the synchronous feed blocked the poll thread and the phone's ack window throttled it. This restores that flow control, bounded: with the queue full, decode() waits for a slot in 50ms slices up to 1s instead of dropping, so the paced read thread stops acking and the phone slows to the codec's real drain rate. Budget expiry still sheds and asks for a keyframe, since outlasting 1s means the codec took nothing at all, which is the sync_stall watchdog's case. The second commit unlatches the escalation ladder, which could spend all three focus cycles and then refuse every refund while the picture was still broken.

Validated on hardware with a debug lever that holds the feed thread after each fed frame. At a 40ms hold the pre-fix build sheds in every one of ~123 windows, 30-164 frames each, with visible macroblocking; this build sheds nothing in any window over the same route, with enqueueWait rising to a ~4.5s plateau and rendered matching fed throughout. An H.265 arm with the lever off is untouched at 122 of 122 windows. Two 30fps drives on the reporter's own unit, 522 windows over 44 minutes, also shed nothing, which is the same margin argument from the other side. Worth flagging: the fix has not yet run on that unit at 60fps, and it was validated over wireless where the unacked window is 12 rather than USB's 16, so the mechanism is confirmed but not on the reporting hardware. The throughput line grows an enqueueWait field so a paced session is legible in a reporter log: pacing reads as enqueueWait high with dropped=0, where the old shedding read as dropped high with the picture melting.